### PR TITLE
Windows compatibility: CI, runtime fixes, and ecosystem polish

### DIFF
--- a/.github/workflows/meridian-ci.yml
+++ b/.github/workflows/meridian-ci.yml
@@ -101,3 +101,25 @@ jobs:
 
       - name: Run compatibility gate
         run: uv run pytest -n auto -m "not windows_only"
+
+  windows-gate:
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Run Windows gate
+        run: uv run pytest -n auto -m "not slow"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -58,7 +58,33 @@ uv tool list
 For the full local preflight used by pre-push and release preparation:
 
 ```bash
+# macOS / Linux
 scripts/preflight.sh
+
+# Windows (PowerShell)
+scripts\preflight.ps1
+```
+
+Fast mode (lint only):
+
+```bash
+# macOS / Linux
+scripts/preflight.sh fast
+
+# Windows (PowerShell)
+scripts\preflight.ps1 fast
+```
+
+Pre-push gate (lint + type check + all tests, with optional `--quick` to skip smoke tests):
+
+```bash
+# macOS / Linux
+scripts/check.sh
+scripts/check.sh --quick
+
+# Windows (PowerShell)
+scripts\check.ps1
+scripts\check.ps1 -quick
 ```
 
 Individual checks:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -125,6 +125,33 @@ scripts/release.sh abort
 uv run meridian --help
 ```
 
+## Windows Support
+
+Windows is a supported platform. The CLI and runtime run natively without WSL.
+
+### CI
+
+A `windows-gate` job in `.github/workflows/meridian-ci.yml` runs on `windows-latest` on every push, executing `uv run pytest -n auto -m "not slow"`.
+
+### Developer scripts
+
+PowerShell mirrors exist for the standard developer workflow:
+
+| Task | POSIX | Windows |
+|------|-------|---------|
+| Setup git hooks | `scripts/setup-hooks.sh` | `scripts\setup-hooks.ps1` |
+| Pre-push gate | `scripts/check.sh` | `scripts\check.ps1` |
+| Full preflight | `scripts/preflight.sh` | `scripts\preflight.ps1` |
+
+`scripts/release.sh` does not have a PowerShell mirror. Windows developers who need to cut releases should use WSL.
+
+### Deferred items
+
+The following are explicitly out of scope and not implemented:
+
+- **ConPTY / terminal passthrough**: Primary-session TUI capture for Claude Code and Codex session-ID extraction relies on PTY semantics. Windows ConPTY support is not implemented — harness features that depend on PTY capture may not work correctly natively on Windows. WSL is the supported path for primary-session use on Windows.
+- **Full bash script parity**: Only the three scripts above have PowerShell mirrors. `scripts/release.sh`, `scripts/quality-issues.sh`, and other helpers remain POSIX-only.
+
 ## Workspace conventions
 
 Workspace config declares sibling directories that harnesses may access during launches.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -320,7 +320,9 @@ event   = "spawn.finalized"
 failure_policy = "warn"
 ```
 
-See [hooks.md](hooks.md) for the full hook schema, event names, and builtin reference.
+Hook `command` strings run via the platform default shell — `sh -c` on POSIX, `cmd.exe /c` on Windows. Bash syntax in inline commands will not work on Windows; use a `.sh` / `.ps1` / `.bat` script file instead for cross-platform hooks.
+
+See [hooks.md](hooks.md) for the full hook schema, event names, builtin reference, and cross-platform guidance.
 
 ### `repo` → `remote`
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -82,6 +82,28 @@ event   = "spawn.finalized"
 
 `command` and `builtin` are mutually exclusive.
 
+### Shell Behavior
+
+Hook `command` strings are executed via the platform default shell: `sh -c` on POSIX (Linux/macOS) and `cmd.exe /c` on Windows. This is standard Python `subprocess(shell=True)` behavior. Inline commands that rely on bash syntax — `&&`, `||`, `$()`, `[[`, or POSIX-only tools — will fail on Windows because `cmd.exe` does not understand them.
+
+For hooks that must run on both platforms, use a script file with an appropriate extension:
+
+```toml
+# POSIX — shell script
+[[hooks]]
+name    = "check"
+command = "./scripts/check.sh"
+event   = "spawn.finalized"
+
+# Windows — batch file or PowerShell
+[[hooks]]
+name    = "check"
+command = "powershell -File scripts/check.ps1"
+event   = "spawn.finalized"
+```
+
+If you only target one platform, inline commands are fine. If portability matters, point `command` at a script file rather than embedding shell syntax in TOML.
+
 ### `repo` → `remote` Migration
 
 `repo` is accepted as a deprecated alias for `remote`. Meridian emits a warning when it sees `repo`. Update your config:

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -110,6 +110,8 @@ command = "notify-send 'spawn done'"
 event   = "spawn.finalized"
 ```
 
+**Shell behavior:** The `command` string is passed to the platform default shell — `sh -c` on POSIX and `cmd.exe /c` on Windows. Inline bash syntax will not work on Windows. For cross-platform hooks, point `command` at a script file (`.sh`, `.ps1`, or `.bat`) rather than embedding shell syntax inline.
+
 A Python builtin-style hook using the plugin API (for hooks distributed as packages):
 
 ```python

--- a/mars.lock
+++ b/mars.lock
@@ -6,25 +6,22 @@ commit = "d230a6dd6eb1a0dbee9fec55e2f00a96e28dff81"
 
 [dependencies.meridian-base]
 url = "https://github.com/meridian-flow/meridian-base"
-version = "v0.2.7"
-commit = "2e8cf6692abeb4158dd4a32f5a373eebd6ca608f"
+version = "v0.2.8"
+commit = "68cb5f00e8562d8d475ab23163dfd35a3227599c"
 
 [dependencies.meridian-dev-workflow]
 url = "https://github.com/meridian-flow/meridian-dev-workflow"
-version = "v0.3.9"
-commit = "1759097d6ba46222b914d0fb0d9cbde27336e1da"
+version = "v0.4.0"
+commit = "22a9938826762ad5ea60445f488bacf9afdfa8de"
 
 [dependencies.meridian-prompter]
 url = "https://github.com/meridian-flow/meridian-prompter"
 version = "v0.1.12"
 commit = "df83e7be065564feaeb6a2e909ab68fc83593eaf"
 
-[dependencies.microct-analysis]
-path = "/home/jimyao/gitrepos/prompts/microct-analysis"
-
 [dependencies.playwright-cli]
 url = "https://github.com/microsoft/playwright-cli"
-commit = "695107b8cd9369151838bf31168b9339afe47f2f"
+commit = "3a1bafc8b4e973c72d0364eb5b427d1ce0aa8317"
 
 [items."agent/alignment-reviewer"]
 source = "meridian-dev-workflow"
@@ -73,24 +70,24 @@ installed_checksum = "sha256:60d8dfeabda91dcee79452d12be39621013817c2d3c0efd6a5b
 [items."agent/coder"]
 source = "meridian-dev-workflow"
 kind = "agent"
-version = "v0.3.8"
-source_checksum = "sha256:528548f8d2447d8c8c685fb85aa78581ff7065aa72e5fa7355957c850b79a84c"
+version = "v0.4.0"
+source_checksum = "sha256:121c1cb5c8dd44cf58fa63ae3aa23c5a47b282846fd811fd352a9834be3accba"
 
 [[items."agent/coder".outputs]]
 target_root = ".mars"
 dest_path = "agents/coder.md"
-installed_checksum = "sha256:528548f8d2447d8c8c685fb85aa78581ff7065aa72e5fa7355957c850b79a84c"
+installed_checksum = "sha256:121c1cb5c8dd44cf58fa63ae3aa23c5a47b282846fd811fd352a9834be3accba"
 
 [items."agent/design-lead"]
 source = "meridian-dev-workflow"
 kind = "agent"
-version = "v0.3.7"
-source_checksum = "sha256:38784ac1bdb788e10c812ad56eee1987def966acd84b110af3f21c00603ba412"
+version = "v0.4.0"
+source_checksum = "sha256:4cbc9da41444797a2cfaba1666792a5ae1ec95ca96769b7f9f7c2769524cc97f"
 
 [[items."agent/design-lead".outputs]]
 target_root = ".mars"
 dest_path = "agents/design-lead.md"
-installed_checksum = "sha256:38784ac1bdb788e10c812ad56eee1987def966acd84b110af3f21c00603ba412"
+installed_checksum = "sha256:4cbc9da41444797a2cfaba1666792a5ae1ec95ca96769b7f9f7c2769524cc97f"
 
 [items."agent/design-writer"]
 source = "meridian-dev-workflow"
@@ -106,24 +103,24 @@ installed_checksum = "sha256:8572a340ed2d399d54e6e2097b457f0c37a391f0f7e4f81a354
 [items."agent/explorer"]
 source = "meridian-base"
 kind = "agent"
-version = "v0.2.1"
-source_checksum = "sha256:62b2f32eb41e976b59bec716bfb2521dfe9026956f36da2e4e6bb7cdae2103c0"
+version = "v0.2.8"
+source_checksum = "sha256:91c3390913bd1d6601ca6acf52c96277c8e155c82c9d89bd70dd003cec54b057"
 
 [[items."agent/explorer".outputs]]
 target_root = ".mars"
 dest_path = "agents/explorer.md"
-installed_checksum = "sha256:62b2f32eb41e976b59bec716bfb2521dfe9026956f36da2e4e6bb7cdae2103c0"
+installed_checksum = "sha256:91c3390913bd1d6601ca6acf52c96277c8e155c82c9d89bd70dd003cec54b057"
 
 [items."agent/frontend-coder"]
 source = "meridian-dev-workflow"
 kind = "agent"
-version = "v0.3.1"
-source_checksum = "sha256:e01682cc4269a6768483322716092ef83de1fb3c5c19f457b02db09e2fbe48a2"
+version = "v0.4.0"
+source_checksum = "sha256:e724d6e4a979bd0eae960be2fb846b32a7f3b6184f3e7347c3fee25eb71ef0a3"
 
 [[items."agent/frontend-coder".outputs]]
 target_root = ".mars"
 dest_path = "agents/frontend-coder.md"
-installed_checksum = "sha256:e01682cc4269a6768483322716092ef83de1fb3c5c19f457b02db09e2fbe48a2"
+installed_checksum = "sha256:e724d6e4a979bd0eae960be2fb846b32a7f3b6184f3e7347c3fee25eb71ef0a3"
 
 [items."agent/frontend-designer"]
 source = "meridian-dev-workflow"
@@ -213,66 +210,6 @@ target_root = ".mars"
 dest_path = "agents/meridian-subagent.md"
 installed_checksum = "sha256:72f0c5060b99af974f19d29d615af9065d49fef34a132b3e1b2b9d163c15fdd2"
 
-[items."agent/microct-analyst"]
-source = "microct-analysis"
-kind = "agent"
-source_checksum = "sha256:aa6d6cf2f7081bbf05316af899a86c4e291001f9969ff57d1d58a1e5198faa70"
-
-[[items."agent/microct-analyst".outputs]]
-target_root = ".mars"
-dest_path = "agents/microct-analyst.md"
-installed_checksum = "sha256:aa6d6cf2f7081bbf05316af899a86c4e291001f9969ff57d1d58a1e5198faa70"
-
-[items."agent/microct-cleanup"]
-source = "microct-analysis"
-kind = "agent"
-source_checksum = "sha256:d8bda16ef12103953814911a6d3592bbd2ec215505ac200ca61f62fb46859c34"
-
-[[items."agent/microct-cleanup".outputs]]
-target_root = ".mars"
-dest_path = "agents/microct-cleanup.md"
-installed_checksum = "sha256:d8bda16ef12103953814911a6d3592bbd2ec215505ac200ca61f62fb46859c34"
-
-[items."agent/microct-landmarker"]
-source = "microct-analysis"
-kind = "agent"
-source_checksum = "sha256:986134a97a74d4fc3a7a1814e2fcba3479c45abda71af26293d8e62202823e90"
-
-[[items."agent/microct-landmarker".outputs]]
-target_root = ".mars"
-dest_path = "agents/microct-landmarker.md"
-installed_checksum = "sha256:986134a97a74d4fc3a7a1814e2fcba3479c45abda71af26293d8e62202823e90"
-
-[items."agent/microct-measurer"]
-source = "microct-analysis"
-kind = "agent"
-source_checksum = "sha256:c4d30c555bea403f5faa26988a25acd1e2196b295c2b52a44ba467d2338458ef"
-
-[[items."agent/microct-measurer".outputs]]
-target_root = ".mars"
-dest_path = "agents/microct-measurer.md"
-installed_checksum = "sha256:c4d30c555bea403f5faa26988a25acd1e2196b295c2b52a44ba467d2338458ef"
-
-[items."agent/microct-segmenter"]
-source = "microct-analysis"
-kind = "agent"
-source_checksum = "sha256:72e0f90f64669d2572894107a332e6683b9e7be0b3736656a59b4de1cbea6792"
-
-[[items."agent/microct-segmenter".outputs]]
-target_root = ".mars"
-dest_path = "agents/microct-segmenter.md"
-installed_checksum = "sha256:72e0f90f64669d2572894107a332e6683b9e7be0b3736656a59b4de1cbea6792"
-
-[items."agent/microct-workflow-creator"]
-source = "microct-analysis"
-kind = "agent"
-source_checksum = "sha256:2fe15059230aa60401a2b161fac67259be7e30f65f8abc66be08a85d46f1d95b"
-
-[[items."agent/microct-workflow-creator".outputs]]
-target_root = ".mars"
-dest_path = "agents/microct-workflow-creator.md"
-installed_checksum = "sha256:2fe15059230aa60401a2b161fac67259be7e30f65f8abc66be08a85d46f1d95b"
-
 [items."agent/mockup-gen"]
 source = "meridian-dev-workflow"
 kind = "agent"
@@ -298,13 +235,13 @@ installed_checksum = "sha256:ccd5f6679f6cbc05145082bd1b9135fe51d48ba3759430996e8
 [items."agent/product-lead"]
 source = "meridian-dev-workflow"
 kind = "agent"
-version = "v0.3.1"
-source_checksum = "sha256:b90b653a03f24a48558d2882253365e9aad43a65633dd5abea1a114de3199084"
+version = "v0.4.0"
+source_checksum = "sha256:2bcd234e3127f3f1bb0f572a1b1e00ca06a84049437c37257af87b2b0e81fd90"
 
 [[items."agent/product-lead".outputs]]
 target_root = ".mars"
 dest_path = "agents/product-lead.md"
-installed_checksum = "sha256:b90b653a03f24a48558d2882253365e9aad43a65633dd5abea1a114de3199084"
+installed_checksum = "sha256:2bcd234e3127f3f1bb0f572a1b1e00ca06a84049437c37257af87b2b0e81fd90"
 
 [items."agent/prompt-dev"]
 source = "meridian-prompter"
@@ -364,24 +301,24 @@ installed_checksum = "sha256:da3c59fee3ba66fb309138eec1180e47445e6cd24937e403829
 [items."agent/refactor-coder"]
 source = "meridian-dev-workflow"
 kind = "agent"
-version = "v0.3.8"
-source_checksum = "sha256:a61e51b09d6c43d0aa701c90d215175799ffea61b8bf388cde9d2881083a6876"
+version = "v0.4.0"
+source_checksum = "sha256:8221d6a2b53c30b27c6813b52c721db14b438dde4e63fa5c545cb61b3d9e8092"
 
 [[items."agent/refactor-coder".outputs]]
 target_root = ".mars"
 dest_path = "agents/refactor-coder.md"
-installed_checksum = "sha256:a61e51b09d6c43d0aa701c90d215175799ffea61b8bf388cde9d2881083a6876"
+installed_checksum = "sha256:8221d6a2b53c30b27c6813b52c721db14b438dde4e63fa5c545cb61b3d9e8092"
 
 [items."agent/refactor-reviewer"]
 source = "meridian-dev-workflow"
 kind = "agent"
-version = "v0.3.1"
-source_checksum = "sha256:a2029af2dc2cf1f211031d95d851d51fba93c6daa650ee8d6d5055e209b25ff3"
+version = "v0.4.0"
+source_checksum = "sha256:958a2cadb6b6b88d213586dbe0651789c7ac91a23f09349aa99b957fefe358bc"
 
 [[items."agent/refactor-reviewer".outputs]]
 target_root = ".mars"
 dest_path = "agents/refactor-reviewer.md"
-installed_checksum = "sha256:a2029af2dc2cf1f211031d95d851d51fba93c6daa650ee8d6d5055e209b25ff3"
+installed_checksum = "sha256:958a2cadb6b6b88d213586dbe0651789c7ac91a23f09349aa99b957fefe358bc"
 
 [items."agent/reviewer"]
 source = "meridian-dev-workflow"
@@ -419,13 +356,13 @@ installed_checksum = "sha256:4da52caee3ce34bcd73c584b67526ddd33164eeb1be7a4fc51d
 [items."agent/tech-lead"]
 source = "meridian-dev-workflow"
 kind = "agent"
-version = "v0.3.8"
-source_checksum = "sha256:bc49cf9fa0279494f2ba814074d97a4162695846e42d87f7a75079f42a6e302b"
+version = "v0.4.0"
+source_checksum = "sha256:5df38168cfe00e13a516b4ad37a8fc09aa4b33d9a62d8e66e90317e065e77c1b"
 
 [[items."agent/tech-lead".outputs]]
 target_root = ".mars"
 dest_path = "agents/tech-lead.md"
-installed_checksum = "sha256:bc49cf9fa0279494f2ba814074d97a4162695846e42d87f7a75079f42a6e302b"
+installed_checksum = "sha256:5df38168cfe00e13a516b4ad37a8fc09aa4b33d9a62d8e66e90317e065e77c1b"
 
 [items."agent/tech-writer"]
 source = "meridian-dev-workflow"
@@ -460,17 +397,6 @@ target_root = ".mars"
 dest_path = "agents/ux-lead.md"
 installed_checksum = "sha256:07bd8daaeac477e1bc30395394fcd0ee95868beb9860f832851fe0580c40c6bc"
 
-[items."agent/verifier"]
-source = "meridian-dev-workflow"
-kind = "agent"
-version = "v0.3.1"
-source_checksum = "sha256:de6cb2f722e50ac47908e2625e351aa917d2154a172c7b7f66a1593a3924cb27"
-
-[[items."agent/verifier".outputs]]
-target_root = ".mars"
-dest_path = "agents/verifier.md"
-installed_checksum = "sha256:de6cb2f722e50ac47908e2625e351aa917d2154a172c7b7f66a1593a3924cb27"
-
 [items."agent/web-prompt-researcher"]
 source = "meridian-prompter"
 kind = "agent"
@@ -492,6 +418,17 @@ source_checksum = "sha256:6a2917f9fe71414f4a63d59118d5910571039eefdf6fea238f418c
 target_root = ".mars"
 dest_path = "agents/web-researcher.md"
 installed_checksum = "sha256:6a2917f9fe71414f4a63d59118d5910571039eefdf6fea238f418c81193fc9a8"
+
+[items."bootstrap-doc/feature-worktree"]
+source = "meridian-dev-workflow"
+kind = "bootstrapdoc"
+version = "v0.4.0"
+source_checksum = "sha256:3e83d26621b9a092a80d31fa5347be6f26663da34a760fed4d0c0810f2874894"
+
+[[items."bootstrap-doc/feature-worktree".outputs]]
+target_root = ".mars"
+dest_path = "bootstrap/feature-worktree/BOOTSTRAP.md"
+installed_checksum = "sha256:3e83d26621b9a092a80d31fa5347be6f26663da34a760fed4d0c0810f2874894"
 
 [items."bootstrap-doc/imagegen-setup"]
 source = "meridian-dev-workflow"
@@ -529,13 +466,13 @@ installed_checksum = "sha256:705a992e610ec483b391ef89ea090d1f1583357707d77bb67c4
 [items."skill/agent-staffing"]
 source = "meridian-dev-workflow"
 kind = "skill"
-version = "v0.3.5"
-source_checksum = "sha256:da9ed618372ec5b7c99515d55cbe84e50ee94ca65fb983942075b8ab27f99c25"
+version = "v0.4.0"
+source_checksum = "sha256:0fb47e5b6c15c63f8eeb226838d779ded56597de471598f457165f180e95aa64"
 
 [[items."skill/agent-staffing".outputs]]
 target_root = ".mars"
 dest_path = "skills/agent-staffing"
-installed_checksum = "sha256:da9ed618372ec5b7c99515d55cbe84e50ee94ca65fb983942075b8ab27f99c25"
+installed_checksum = "sha256:0fb47e5b6c15c63f8eeb226838d779ded56597de471598f457165f180e95aa64"
 
 [items."skill/architecture"]
 source = "meridian-dev-workflow"
@@ -558,26 +495,6 @@ source_checksum = "sha256:28211b187ef027e058dc7f460f9b82d270f895f9f8bf0fac9afda6
 target_root = ".mars"
 dest_path = "skills/browser-test"
 installed_checksum = "sha256:28211b187ef027e058dc7f460f9b82d270f895f9f8bf0fac9afda6d5ba9136d3"
-
-[items."skill/compaction-cleanup"]
-source = "microct-analysis"
-kind = "skill"
-source_checksum = "sha256:3c1e56e2b045884e89d0445fab18cea6dbb019e251f9d3524368172f353c17b7"
-
-[[items."skill/compaction-cleanup".outputs]]
-target_root = ".mars"
-dest_path = "skills/compaction-cleanup"
-installed_checksum = "sha256:3c1e56e2b045884e89d0445fab18cea6dbb019e251f9d3524368172f353c17b7"
-
-[items."skill/compute-efficiency"]
-source = "microct-analysis"
-kind = "skill"
-source_checksum = "sha256:2dbe85bf1000c95471fe6aa8c7735d10bb996027b72c21dd2a4f3bfc6082aa1a"
-
-[[items."skill/compute-efficiency".outputs]]
-target_root = ".mars"
-dest_path = "skills/compute-efficiency"
-installed_checksum = "sha256:2dbe85bf1000c95471fe6aa8c7735d10bb996027b72c21dd2a4f3bfc6082aa1a"
 
 [items."skill/decision-log"]
 source = "meridian-base"
@@ -604,13 +521,13 @@ installed_checksum = "sha256:e36065c8ea17acecaab2e875135dcf6e472fad3107e2f077b5f
 [items."skill/dev-artifacts"]
 source = "meridian-dev-workflow"
 kind = "skill"
-version = "v0.3.5"
-source_checksum = "sha256:b3b8fbf5a23e94e68b27f241ffcee378fb0c15ca15be7f502a152dd280c6e526"
+version = "v0.4.0"
+source_checksum = "sha256:cdf0d9812d72a9bb5e625e499bc9c938d5c16c160f29c61acb90e8b342daff51"
 
 [[items."skill/dev-artifacts".outputs]]
 target_root = ".mars"
 dest_path = "skills/dev-artifacts"
-installed_checksum = "sha256:b3b8fbf5a23e94e68b27f241ffcee378fb0c15ca15be7f502a152dd280c6e526"
+installed_checksum = "sha256:cdf0d9812d72a9bb5e625e499bc9c938d5c16c160f29c61acb90e8b342daff51"
 
 [items."skill/dev-principles"]
 source = "meridian-dev-workflow"
@@ -633,6 +550,17 @@ source_checksum = "sha256:671a6ac8490ba04cc82dfad7292486dc406450c231a8dadd2bca7a
 target_root = ".mars"
 dest_path = "skills/ears-parsing"
 installed_checksum = "sha256:671a6ac8490ba04cc82dfad7292486dc406450c231a8dadd2bca7a84e2fa61df"
+
+[items."skill/feature-worktree"]
+source = "meridian-dev-workflow"
+kind = "skill"
+version = "v0.4.0"
+source_checksum = "sha256:b69290864c62cac621d177cca35a8c8e2a084c83f555769ad753d86fbb96629c"
+
+[[items."skill/feature-worktree".outputs]]
+target_root = ".mars"
+dest_path = "skills/feature-worktree"
+installed_checksum = "sha256:b69290864c62cac621d177cca35a8c8e2a084c83f555769ad753d86fbb96629c"
 
 [items."skill/frontend-design"]
 source = "anthropic-skills"
@@ -699,16 +627,6 @@ target_root = ".mars"
 dest_path = "skills/llm-writing"
 installed_checksum = "sha256:dd619a72aaa413da03c4ef28cc2dba26965b8bae34e5934edc193c75d76ecd58"
 
-[items."skill/mct-visual-review"]
-source = "microct-analysis"
-kind = "skill"
-source_checksum = "sha256:afc456017537f81b0a89e706e73cc11f69efd61f7268f7f66c2af2e9cfc25c94"
-
-[[items."skill/mct-visual-review".outputs]]
-target_root = ".mars"
-dest_path = "skills/mct-visual-review"
-installed_checksum = "sha256:afc456017537f81b0a89e706e73cc11f69efd61f7268f7f66c2af2e9cfc25c94"
-
 [items."skill/md-validation"]
 source = "meridian-base"
 kind = "skill"
@@ -753,26 +671,16 @@ target_root = ".mars"
 dest_path = "skills/meridian-work-coordination"
 installed_checksum = "sha256:80f7e658559b37df8de1095c05e3129469bf1865aa7b254d2e9223a8d030ea2c"
 
-[items."skill/notebook-lineage"]
-source = "microct-analysis"
-kind = "skill"
-source_checksum = "sha256:e02e0d5563d6642a3aae239473e5a178ec693975d928925ba3d38b17e3eea8d0"
-
-[[items."skill/notebook-lineage".outputs]]
-target_root = ".mars"
-dest_path = "skills/notebook-lineage"
-installed_checksum = "sha256:e02e0d5563d6642a3aae239473e5a178ec693975d928925ba3d38b17e3eea8d0"
-
 [items."skill/planning"]
 source = "meridian-dev-workflow"
 kind = "skill"
-version = "v0.3.5"
-source_checksum = "sha256:1ecb17a639de65f99e8db834f5dc267a284f8de92f38f7bb8c7494b9e73e198e"
+version = "v0.4.0"
+source_checksum = "sha256:4ec164204f7a3cf141a04c11f887d3c66b4b9cf287510d3ee49fb606b7ac92a6"
 
 [[items."skill/planning".outputs]]
 target_root = ".mars"
 dest_path = "skills/planning"
-installed_checksum = "sha256:1ecb17a639de65f99e8db834f5dc267a284f8de92f38f7bb8c7494b9e73e198e"
+installed_checksum = "sha256:4ec164204f7a3cf141a04c11f887d3c66b4b9cf287510d3ee49fb606b7ac92a6"
 
 [items."skill/playwright-cli"]
 source = "playwright-cli"
@@ -806,26 +714,27 @@ target_root = ".mars"
 dest_path = "skills/prompt-review"
 installed_checksum = "sha256:a48a8e33a27e887de8ed86c8952818c283c01c2fbbe6f961085491e4fa795179"
 
-[items."skill/pyvista-interactive"]
-source = "microct-analysis"
-kind = "skill"
-source_checksum = "sha256:2a4fd4a2356f4d2db87c06c948341931b619ad28ef602519f691d7a08573f4dd"
-
-[[items."skill/pyvista-interactive".outputs]]
-target_root = ".mars"
-dest_path = "skills/pyvista-interactive"
-installed_checksum = "sha256:2a4fd4a2356f4d2db87c06c948341931b619ad28ef602519f691d7a08573f4dd"
-
 [items."skill/refactoring-principles"]
 source = "meridian-dev-workflow"
 kind = "skill"
-version = "v0.3.5"
-source_checksum = "sha256:b2d6793f77ee3b1ab92f9c21322c36412fdd625f4d6bb4f4fa9b53949993fdde"
+version = "v0.4.0"
+source_checksum = "sha256:ce4e741fca118f1e243ffc33b32ed93b7818d5f327af474b29825770d7107d7e"
 
 [[items."skill/refactoring-principles".outputs]]
 target_root = ".mars"
 dest_path = "skills/refactoring-principles"
-installed_checksum = "sha256:b2d6793f77ee3b1ab92f9c21322c36412fdd625f4d6bb4f4fa9b53949993fdde"
+installed_checksum = "sha256:ce4e741fca118f1e243ffc33b32ed93b7818d5f327af474b29825770d7107d7e"
+
+[items."skill/reflection"]
+source = "meridian-dev-workflow"
+kind = "skill"
+version = "v0.4.0"
+source_checksum = "sha256:c7ba7236fb65c4c2d9c99e95e20c09516b490b6d6fb7c00c47cf6e51e1f2c692"
+
+[[items."skill/reflection".outputs]]
+target_root = ".mars"
+dest_path = "skills/reflection"
+installed_checksum = "sha256:c7ba7236fb65c4c2d9c99e95e20c09516b490b6d6fb7c00c47cf6e51e1f2c692"
 
 [items."skill/review"]
 source = "meridian-dev-workflow"
@@ -837,16 +746,6 @@ source_checksum = "sha256:12b4b6835ca3dd5d208c12cfe2b609e356d4f61a1ae7757dd9c7bc
 target_root = ".mars"
 dest_path = "skills/review"
 installed_checksum = "sha256:12b4b6835ca3dd5d208c12cfe2b609e356d4f61a1ae7757dd9c7bcb539805b2d"
-
-[items."skill/session-management"]
-source = "microct-analysis"
-kind = "skill"
-source_checksum = "sha256:db4a8c0808a9fec4fe59e7d36d68d86e11d243d68068c81b4a2cca131406bb21"
-
-[[items."skill/session-management".outputs]]
-target_root = ".mars"
-dest_path = "skills/session-management"
-installed_checksum = "sha256:db4a8c0808a9fec4fe59e7d36d68d86e11d243d68068c81b4a2cca131406bb21"
 
 [items."skill/session-mining"]
 source = "meridian-base"
@@ -881,16 +780,6 @@ target_root = ".mars"
 dest_path = "skills/skill-artifacts"
 installed_checksum = "sha256:082f744d721c9ee1148a716fa16e5397bcd878ccdd30c93f390a1def56c7aa87"
 
-[items."skill/slice-examination-loop"]
-source = "microct-analysis"
-kind = "skill"
-source_checksum = "sha256:495156513944247a1ba54f1aafc0bbd1216734ab0d685c2749cb62676346b893"
-
-[[items."skill/slice-examination-loop".outputs]]
-target_root = ".mars"
-dest_path = "skills/slice-examination-loop"
-installed_checksum = "sha256:495156513944247a1ba54f1aafc0bbd1216734ab0d685c2749cb62676346b893"
-
 [items."skill/smoke-test"]
 source = "meridian-dev-workflow"
 kind = "skill"
@@ -916,13 +805,13 @@ installed_checksum = "sha256:c5326ca39a6054324078a71638879bd6b30eb7704f00409a748
 [items."skill/testing-principles"]
 source = "meridian-dev-workflow"
 kind = "skill"
-version = "v0.3.5"
-source_checksum = "sha256:e99e88a1f7b38f40725faae7e4a8a02ea7d662299565187d0b9a0ed652d3e0cc"
+version = "v0.4.0"
+source_checksum = "sha256:ad680d36b6bfd87ec7ed296733705df7c3bc0eb24459802d632d18b1f34fd142"
 
 [[items."skill/testing-principles".outputs]]
 target_root = ".mars"
 dest_path = "skills/testing-principles"
-installed_checksum = "sha256:e99e88a1f7b38f40725faae7e4a8a02ea7d662299565187d0b9a0ed652d3e0cc"
+installed_checksum = "sha256:ad680d36b6bfd87ec7ed296733705df7c3bc0eb24459802d632d18b1f34fd142"
 
 [items."skill/unit-test"]
 source = "meridian-dev-workflow"
@@ -945,13 +834,3 @@ source_checksum = "sha256:959708499a62edd9b91d5f713ca76c8b13d5e59725128c9c738534
 target_root = ".mars"
 dest_path = "skills/verification"
 installed_checksum = "sha256:959708499a62edd9b91d5f713ca76c8b13d5e59725128c9c738534366875bf53"
-
-[items."skill/workbench-session"]
-source = "microct-analysis"
-kind = "skill"
-source_checksum = "sha256:cd7ce71fe8041f60cc415036346ee7ba1bae459ff002eca74ec92b5c5ee3303b"
-
-[[items."skill/workbench-session".outputs]]
-target_root = ".mars"
-dest_path = "skills/workbench-session"
-installed_checksum = "sha256:cd7ce71fe8041f60cc415036346ee7ba1bae459ff002eca74ec92b5c5ee3303b"

--- a/mars.toml
+++ b/mars.toml
@@ -1,18 +1,8 @@
-[dependencies.meridian-base]
-url = "https://github.com/meridian-flow/meridian-base"
-
 [dependencies.meridian-dev-workflow]
 url = "https://github.com/meridian-flow/meridian-dev-workflow"
 
-[dependencies.anthropic-skills]
-url = "https://github.com/anthropics/skills"
-skills = ["frontend-design"]
-
 [dependencies.meridian-prompter]
 url = "https://github.com/meridian-flow/meridian-prompter"
-
-[dependencies.microct-analysis]
-path = "/home/jimyao/gitrepos/prompts/microct-analysis"
 
 [settings]
 targets = [

--- a/meridian.toml
+++ b/meridian.toml
@@ -45,13 +45,13 @@ opencode = "opencode-go/kimi-k2.6"  # default for OpenCode harness
 # Agent profile name for the primary session (str; unset = no profile).
 agent = "product-lead"
 
-[agents.tech-lead]
-model = "gpt55"
-effort = "medium"
+# [agents.tech-lead]
+# model = "gpt55"
+# effort = "medium"
 
-[agents.design-lead]
-model = "gpt55"
-effort = "high"
+# [agents.design-lead]
+# model = "gpt55"
+# effort = "high"
 
 # -- Output streaming -------------------------------------------------------
 [output]
@@ -85,6 +85,12 @@ builtin = "git-autosync"
 remote = "git@github.com:meridian-flow/docs.git"
 
 # -- Workspace roots ---------------------------------------------------------
+[workspace.mars-agents]
+path = "../mars-agents"
+
+[workspace.meridian-cli-worktrees]
+path = "../meridian-cli.worktrees"
+
 # Prompt repos for agent profile editing
 [workspace.prompts-base]
 path = "../prompts/meridian-base"
@@ -106,5 +112,3 @@ path = "../prompts/microct-analysis"
 
 [workspace.prompts-mouse-ct]
 path = "../prompts/mouse-ct"
-
-

--- a/scripts/check.ps1
+++ b/scripts/check.ps1
@@ -1,0 +1,45 @@
+# Pre-push gate script — runs lint, type check, and fast test suite.
+# Target: < 2 minutes on typical hardware.
+#
+# Usage:
+#   scripts\check.ps1          # Full pre-push check
+#   scripts\check.ps1 -quick   # Skip smoke tests (faster)
+
+[CmdletBinding()]
+param(
+    [switch]$quick
+)
+
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot  = Split-Path -Parent $ScriptDir
+
+Set-Location $RepoRoot
+
+Write-Host "==> Linting..."
+uv run ruff check .
+if ($LASTEXITCODE -ne 0) { throw "Linting failed" }
+
+Write-Host "==> Type checking..."
+uv run pyright
+if ($LASTEXITCODE -ne 0) { throw "Type checking failed" }
+
+Write-Host "==> Running unit tests..."
+uv run pytest tests/unit/ -q
+if ($LASTEXITCODE -ne 0) { throw "Unit tests failed" }
+
+Write-Host "==> Running contract tests..."
+uv run pytest tests/contract/ -q
+if ($LASTEXITCODE -ne 0) { throw "Contract tests failed" }
+
+if ($quick) {
+    Write-Host "==> Skipping smoke tests (--quick mode)"
+} else {
+    Write-Host "==> Running smoke tests..."
+    uv run pytest tests/smoke/ -q
+    if ($LASTEXITCODE -ne 0) { throw "Smoke tests failed" }
+}
+
+Write-Host ""
+Write-Host "✓ All checks passed"

--- a/scripts/preflight.ps1
+++ b/scripts/preflight.ps1
@@ -1,0 +1,37 @@
+# Preflight gate — same checks as preflight.sh.
+#
+# Usage:
+#   scripts\preflight.ps1          # Full preflight (default)
+#   scripts\preflight.ps1 full     # Explicit full mode
+#   scripts\preflight.ps1 fast     # Lint only (faster)
+
+[CmdletBinding()]
+param(
+    [ValidateSet('fast', 'full')]
+    [string]$Mode = 'full'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$RootDir = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+
+function Invoke-Step {
+    param([string[]]$Command)
+    [Console]::Error.WriteLine("preflight: $($Command -join ' ')")
+    $exe, $rest = $Command
+    & $exe @rest
+    if ($LASTEXITCODE -ne 0) { throw "Step failed: $($Command -join ' ')" }
+}
+
+Set-Location $RootDir
+
+switch ($Mode) {
+    'fast' {
+        Invoke-Step uv, run, ruff, check, '.'
+    }
+    'full' {
+        Invoke-Step uv, run, ruff, check, '.'
+        Invoke-Step uv, run, pyright
+        Invoke-Step uv, run, pytest, '-x', '-q'
+    }
+}

--- a/src/meridian/cli/entrypoint.py
+++ b/src/meridian/cli/entrypoint.py
@@ -40,6 +40,11 @@ def main() -> None:
 
     import sys
 
+    if sys.platform == "win32":
+        for stream in (sys.stdout, sys.stderr):
+            if hasattr(stream, "reconfigure"):
+                stream.reconfigure(encoding="utf-8", errors="replace")
+
     args = sys.argv[1:]
 
     # Keep classifier import/use on this startup-cheap path so command catalog

--- a/src/meridian/lib/harness/connections/claude_ws.py
+++ b/src/meridian/lib/harness/connections/claude_ws.py
@@ -42,6 +42,7 @@ from meridian.lib.observability.trace_helpers import (
     trace_wire_recv,
     trace_wire_send,
 )
+from meridian.lib.platform import IS_WINDOWS
 from meridian.lib.state.paths import resolve_spawn_log_dir
 
 logger = logging.getLogger(__name__)
@@ -404,7 +405,12 @@ class ClaudeConnection(HarnessConnection[ClaudeLaunchSpec]):
         if process is None or process.returncode is not None:
             return
         trace_wire_send(self._tracer, "signal_sent", "", signal=sig.name)
-        process.send_signal(sig)
+        if IS_WINDOWS:
+            # GenerateConsoleCtrlEvent(CTRL_C_EVENT) is unreliable for
+            # non-console-sharing processes; use TerminateProcess instead.
+            process.terminate()
+        else:
+            process.send_signal(sig)
 
     async def _cleanup_resources(self, *, terminate_process: bool) -> None:
         if terminate_process:

--- a/src/meridian/lib/launch/process/primary_attach.py
+++ b/src/meridian/lib/launch/process/primary_attach.py
@@ -22,6 +22,7 @@ from meridian.lib.harness.connections.errors import PortBindError
 from meridian.lib.harness.launch_spec import CodexLaunchSpec
 from meridian.lib.harness.semantics import activity_transition
 from meridian.lib.launch.launch_types import ResolvedLaunchSpec
+from meridian.lib.platform import IS_WINDOWS
 from meridian.lib.state.history import HarnessHistoryWriter
 from meridian.lib.state.primary_meta import ActivityState, PrimaryMetadata, write_primary_metadata
 
@@ -33,6 +34,29 @@ MAX_PORT_RETRY_ATTEMPTS = 3
 
 class PrimaryAttachError(Exception):
     """Managed backend startup failed; caller should fall back to black-box path."""
+
+
+def _try_assign_backend_job(pid: int) -> object:
+    """Assign *pid* to a Windows Job Object and return the handle.
+
+    The returned handle must remain alive for ``JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE``
+    to take effect — store it for the lifetime of the launcher.
+
+    Returns ``None`` on POSIX, on assignment failure, or on any exception so
+    the caller always degrades cleanly without crashing the launch.
+    """
+    if not IS_WINDOWS:
+        return None
+    try:
+        from meridian.lib.platform import windows_job
+
+        result = windows_job.assign_to_new_job(pid)
+        if result is None:
+            return None
+        _job_name, job_handle = result
+        return job_handle
+    except Exception:
+        return None
 
 
 @dataclass
@@ -128,6 +152,8 @@ class PrimaryAttachLauncher:
         self._metadata_lock = Lock()
         self._history_writer: HarnessHistoryWriter | None = None
         self._event_writer_task: asyncio.Task[None] | None = None
+        # Kept alive so KILL_ON_JOB_CLOSE terminates the backend on launcher exit.
+        self._backend_job_handle: object = None
 
     async def run(
         self,
@@ -159,6 +185,10 @@ class PrimaryAttachLauncher:
                 self._metadata.backend_pid = self._connection.subprocess_pid
                 self._metadata.backend_port = self._resolve_backend_port()
             self._write_metadata()
+
+            _backend_pid = self._connection.subprocess_pid
+            if _backend_pid is not None and _backend_pid > 0:
+                self._backend_job_handle = _try_assign_backend_job(_backend_pid)
 
             self._event_writer_task = asyncio.create_task(self._run_event_writer())
             self._set_harness_session_id(session_id)

--- a/src/meridian/lib/launch/process/subprocess_launcher.py
+++ b/src/meridian/lib/launch/process/subprocess_launcher.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import signal
 import subprocess
 import sys
 from contextlib import suppress
@@ -31,7 +30,7 @@ def _wait_for_process(process: subprocess.Popen[str] | subprocess.Popen[bytes]) 
         return process.wait()
     except KeyboardInterrupt:
         if process.poll() is None:
-            process.send_signal(signal.SIGINT)
+            process.terminate()
             return process.wait()
         return 130
 

--- a/src/meridian/lib/launch/process/subprocess_launcher.py
+++ b/src/meridian/lib/launch/process/subprocess_launcher.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import signal
 import subprocess
 import sys
 from contextlib import suppress
@@ -30,7 +31,10 @@ def _wait_for_process(process: subprocess.Popen[str] | subprocess.Popen[bytes]) 
         return process.wait()
     except KeyboardInterrupt:
         if process.poll() is None:
-            process.terminate()
+            if sys.platform == "win32":
+                process.terminate()
+            else:
+                process.send_signal(signal.SIGINT)
             return process.wait()
         return 130
 

--- a/src/meridian/lib/launch/process/windows_launcher.py
+++ b/src/meridian/lib/launch/process/windows_launcher.py
@@ -36,7 +36,7 @@ class WindowsConsoleLauncher(ProcessLauncher):
             command=command,
             cwd=cwd,
             env=env,
-            output_log_path=None,
+            output_log_path=output_log_path,
             on_child_started=on_child_started,
         )
 

--- a/src/meridian/lib/launch/streaming_runner.py
+++ b/src/meridian/lib/launch/streaming_runner.py
@@ -7,7 +7,7 @@ import json
 import os
 import signal
 import sys
-from collections.abc import Callable, Iterable
+from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
@@ -172,30 +172,40 @@ def _install_signal_handlers(
     loop: asyncio.AbstractEventLoop,
     shutdown_event: asyncio.Event,
     received_signal: list[signal.Signals | None],
-) -> list[signal.Signals]:
-    installed: list[signal.Signals] = []
+) -> Callable[[], None] | None:
+    """Install portable signal handlers that set the shutdown event.
 
-    def _handle_signal(signum: signal.Signals) -> None:
+    Uses signal.signal() instead of loop.add_signal_handler() for Windows
+    compatibility (ProactorEventLoop does not support add_signal_handler).
+
+    Returns a cleanup callable that restores previous handlers, or None if
+    installation failed (non-main thread).
+    """
+    import threading
+
+    if threading.current_thread() is not threading.main_thread():
+        return None
+
+    previous_handlers: dict[int, Any] = {}
+
+    def _handle(signum: int, frame: object) -> None:
         if received_signal[0] is None:
-            received_signal[0] = signum
-        shutdown_event.set()
+            received_signal[0] = signal.Signals(signum)
+        loop.call_soon_threadsafe(shutdown_event.set)
 
     for signum in (signal.SIGINT, signal.SIGTERM):
         try:
-            loop.add_signal_handler(signum, _handle_signal, signum)
-            installed.append(signum)
-        except (NotImplementedError, RuntimeError):
+            previous_handlers[int(signum)] = signal.getsignal(signum)
+            signal.signal(signum, _handle)
+        except (ValueError, OSError):
             continue
-    return installed
 
+    def _cleanup() -> None:
+        for signum_int, prev in previous_handlers.items():
+            with suppress(Exception):
+                signal.signal(signal.Signals(signum_int), prev)
 
-def _remove_signal_handlers(
-    loop: asyncio.AbstractEventLoop,
-    installed: Iterable[signal.Signals],
-) -> None:
-    for signum in installed:
-        with suppress(Exception):
-            loop.remove_signal_handler(signum)
+    return _cleanup
 
 
 def _truncate_attempt_logs(log_dir: Path) -> None:
@@ -377,7 +387,7 @@ async def run_streaming_spawn(
     loop = asyncio.get_running_loop()
     shutdown_event = asyncio.Event()
     received_signal: list[signal.Signals | None] = [None]
-    installed_signals = _install_signal_handlers(loop, shutdown_event, received_signal)
+    signal_cleanup = _install_signal_handlers(loop, shutdown_event, received_signal)
 
     completion_task: asyncio.Task[DrainOutcome | None] | None = None
     signal_task: asyncio.Task[bool] | None = None
@@ -460,7 +470,8 @@ async def run_streaming_spawn(
                     task.cancel()
                     with suppress(asyncio.CancelledError):
                         await task
-            _remove_signal_handlers(loop, installed_signals)
+            if signal_cleanup is not None:
+                signal_cleanup()
             with suppress(Exception):
                 await manager.shutdown(status="cancelled", exit_code=1, error="shutdown")
 
@@ -686,7 +697,7 @@ async def execute_with_streaming(
     conclusion = StreamingRunConclusion()
     lifecycle_service: SpawnLifecycleService | None = None
     manager: SpawnManager | None = None
-    installed_signals: list[signal.Signals] = []
+    signal_cleanup: Callable[[], None] | None = None
     loop: asyncio.AbstractEventLoop | None = None
     received_signal: list[signal.Signals | None] = [None]
 
@@ -796,7 +807,7 @@ async def execute_with_streaming(
 
         loop = asyncio.get_running_loop()
         shutdown_event = asyncio.Event()
-        installed_signals = _install_signal_handlers(loop, shutdown_event, received_signal)
+        signal_cleanup = _install_signal_handlers(loop, shutdown_event, received_signal)
 
         try:
             while True:
@@ -1091,8 +1102,8 @@ async def execute_with_streaming(
             harness_id=str(launch_context.harness.id),
         )
     finally:
-        if loop is not None and installed_signals:
-            _remove_signal_handlers(loop, installed_signals)
+        if signal_cleanup is not None:
+            signal_cleanup()
         if manager is not None:
             with suppress(Exception):
                 await manager.shutdown(status="cancelled", exit_code=1, error="shutdown")

--- a/src/meridian/lib/ops/worktree_ops.py
+++ b/src/meridian/lib/ops/worktree_ops.py
@@ -1,0 +1,264 @@
+"""Pure git subprocess seam for worktree operations.
+
+This module is intentionally dependency-free with respect to meridian state,
+config, and persistence layers. It accepts plain Path inputs and issues git
+subprocess calls. Callers that need meridian integration wire it in above this
+seam.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+class WorktreeError(RuntimeError):
+    """Base domain error for git worktree operations."""
+
+
+class WorktreeCreateFailed(WorktreeError):
+    """Git could not create or attach the requested worktree."""
+
+
+class WorktreeConflictError(WorktreeCreateFailed):
+    """The requested path or branch conflicts with an existing worktree state."""
+
+
+class WorktreeRemoveFailed(WorktreeError):
+    """Git could not remove the requested worktree."""
+
+
+class WorktreeUnpushedError(WorktreeError):
+    """The worktree branch has local commits that are not safely removable."""
+
+
+class WorktreeRepoResolutionError(WorktreeError):
+    """Git repository discovery failed."""
+
+
+@dataclass(frozen=True)
+class WorktreeCreateResult:
+    path: Path
+    branch: str
+    created: bool  # False if reusing existing worktree
+
+
+def _run_git(
+    cwd: Path,
+    args: list[str],
+    *,
+    error_type: type[WorktreeError],
+) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            ["git", "-C", str(cwd), *args],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            check=True,
+        )
+    except FileNotFoundError as exc:
+        raise error_type("git is not installed.") from exc
+    except subprocess.CalledProcessError as exc:
+        details = (exc.stderr or exc.stdout or str(exc)).strip()
+        raise error_type(details or f"git {' '.join(args)} failed.") from exc
+
+
+def detect_git_repo(project_root: Path) -> bool:
+    """Check if project_root is inside a git repo."""
+    try:
+        result = _run_git(
+            project_root,
+            ["rev-parse", "--is-inside-work-tree"],
+            error_type=WorktreeRepoResolutionError,
+        )
+    except WorktreeRepoResolutionError:
+        return False
+    return result.stdout.strip() == "true"
+
+
+def resolve_main_repo_root(project_root: Path) -> Path | None:
+    """Resolve the main git repo root, navigating through worktrees if needed."""
+    try:
+        result = _run_git(
+            project_root,
+            ["rev-parse", "--git-common-dir"],
+            error_type=WorktreeRepoResolutionError,
+        )
+    except WorktreeRepoResolutionError:
+        return None
+
+    git_common_dir_raw = result.stdout.strip()
+    common_dir = (project_root / git_common_dir_raw).resolve()
+    if common_dir.name == ".git":
+        return common_dir.parent
+
+    logger.debug(
+        "worktree_ops.resolve_main_repo_root.fallback",
+        common_dir=str(common_dir),
+        project_root=str(project_root),
+    )
+    try:
+        fallback = _run_git(
+            project_root,
+            ["rev-parse", "--show-toplevel"],
+            error_type=WorktreeRepoResolutionError,
+        )
+    except WorktreeRepoResolutionError:
+        return None
+    return Path(fallback.stdout.strip()).resolve()
+
+
+def resolve_worktree_path(
+    repo_root: Path,
+    work_slug: str,
+    worktree_base: str | None = None,
+) -> Path:
+    """Compute the target filesystem path for a worktree."""
+    if worktree_base is not None:
+        base_path = Path(worktree_base)
+        if not base_path.is_absolute():
+            base_path = repo_root / base_path
+        base = base_path
+    else:
+        base = repo_root.parent / f"{repo_root.name}.worktrees"
+    return (base / work_slug).resolve()
+
+
+def worktree_exists(path: Path) -> bool:
+    """Return True if *path* is a valid git worktree."""
+    return (path / ".git").is_file()
+
+
+def ensure_no_unpushed_commits(worktree_path: Path) -> None:
+    """Raise when the worktree branch has local commits not on its upstream."""
+    if not worktree_path.exists() or not worktree_exists(worktree_path):
+        return
+    try:
+        result = _run_git(
+            worktree_path,
+            ["log", "@{upstream}..HEAD", "--oneline"],
+            error_type=WorktreeUnpushedError,
+        )
+    except WorktreeUnpushedError as exc:
+        stderr = str(exc).lower()
+        if "upstream" in stderr or "no such branch" in stderr:
+            raise WorktreeUnpushedError("Worktree branch has unpushed commits.") from exc
+        raise WorktreeUnpushedError(
+            "Unable to verify whether the worktree branch is pushed."
+        ) from exc
+    if result.stdout.strip():
+        raise WorktreeUnpushedError("Worktree branch has unpushed commits.")
+
+
+def remove_worktree(repo_root: Path, worktree_path: Path, *, force: bool = False) -> None:
+    """Remove a git worktree via ``git worktree remove``."""
+    args = ["worktree", "remove", str(worktree_path)]
+    if force:
+        args.append("--force")
+    _run_git(repo_root, args, error_type=WorktreeRemoveFailed)
+    logger.info(
+        "worktree_ops.remove_worktree.done",
+        repo_root=str(repo_root),
+        worktree_path=str(worktree_path),
+        force=force,
+    )
+
+
+def _current_worktree_branch(worktree_path: Path) -> str:
+    result = _run_git(
+        worktree_path,
+        ["rev-parse", "--abbrev-ref", "HEAD"],
+        error_type=WorktreeCreateFailed,
+    )
+    return result.stdout.strip()
+
+
+def create_worktree(
+    repo_root: Path,
+    target_path: Path,
+    branch: str,
+) -> WorktreeCreateResult:
+    """Create a git worktree at *target_path* on *branch*."""
+    if target_path.exists():
+        if not worktree_exists(target_path):
+            raise WorktreeCreateFailed(
+                f"Path {target_path} already exists but is not a valid git worktree."
+            )
+
+        target_main = resolve_main_repo_root(target_path)
+        expected_main = resolve_main_repo_root(repo_root)
+        if target_main is None or expected_main is None or target_main != expected_main:
+            raise WorktreeConflictError(
+                f"Path {target_path} is a git worktree for a different repository."
+            )
+
+        current_branch = _current_worktree_branch(target_path)
+        if current_branch != branch:
+            raise WorktreeConflictError(
+                f"Worktree at {target_path} is on branch '{current_branch}', not '{branch}'."
+            )
+        logger.info(
+            "worktree_ops.create_worktree.reuse",
+            path=str(target_path),
+            branch=branch,
+        )
+        return WorktreeCreateResult(path=target_path, branch=branch, created=False)
+
+    try:
+        _run_git(
+            repo_root,
+            ["worktree", "add", str(target_path), "-b", branch],
+            error_type=WorktreeCreateFailed,
+        )
+        logger.info(
+            "worktree_ops.create_worktree.created",
+            path=str(target_path),
+            branch=branch,
+        )
+        return WorktreeCreateResult(path=target_path, branch=branch, created=True)
+    except WorktreeCreateFailed as exc:
+        if "already exists" not in str(exc):
+            raise
+
+    try:
+        _run_git(
+            repo_root,
+            ["worktree", "add", str(target_path), branch],
+            error_type=WorktreeCreateFailed,
+        )
+        logger.info(
+            "worktree_ops.create_worktree.created_existing_branch",
+            path=str(target_path),
+            branch=branch,
+        )
+        return WorktreeCreateResult(path=target_path, branch=branch, created=True)
+    except WorktreeCreateFailed as exc:
+        if "is already checked out" in str(exc):
+            raise WorktreeConflictError(
+                f"Branch '{branch}' is already checked out in another worktree."
+            ) from exc
+        raise
+
+
+__all__ = [
+    "WorktreeConflictError",
+    "WorktreeCreateFailed",
+    "WorktreeCreateResult",
+    "WorktreeError",
+    "WorktreeRemoveFailed",
+    "WorktreeRepoResolutionError",
+    "WorktreeUnpushedError",
+    "create_worktree",
+    "detect_git_repo",
+    "ensure_no_unpushed_commits",
+    "remove_worktree",
+    "resolve_main_repo_root",
+    "resolve_worktree_path",
+    "worktree_exists",
+]

--- a/src/meridian/lib/platform/terminate.py
+++ b/src/meridian/lib/platform/terminate.py
@@ -7,6 +7,22 @@ from contextlib import suppress
 
 import psutil
 
+_UNSET_EPOCH = 0.0
+
+
+def _validate_pid_birth(pid: int, created_at_epoch: float) -> bool:
+    """Return False if PID has been reused (birth time mismatch), else True.
+
+    Skips the check when created_at_epoch is 0.0 (sentinel for 'unknown').
+    """
+    if created_at_epoch == _UNSET_EPOCH:
+        return True
+    with suppress(psutil.NoSuchProcess, psutil.AccessDenied, OSError):
+        actual = psutil.Process(pid).create_time()
+        if abs(actual - created_at_epoch) > 1.0:
+            return False
+    return True
+
 
 def _snapshot_tree(pid: int) -> tuple[psutil.Process | None, list[psutil.Process]]:
     """Return a stable snapshot of root process and descendants."""
@@ -54,4 +70,46 @@ async def terminate_tree(
     await asyncio.to_thread(psutil.wait_procs, alive, timeout=1.0)
 
 
-__all__ = ["terminate_tree"]
+def terminate_tree_sync(
+    pid: int,
+    *,
+    created_at_epoch: float = _UNSET_EPOCH,
+    grace_secs: float = 5.0,
+    reason: str = "stop_called",
+    scope_id: str = "",
+) -> None:
+    """Synchronous process-tree termination for contexts without an event loop.
+
+    Sends SIGTERM/terminate to the entire process tree rooted at *pid*, waits
+    up to *grace_secs* for clean exit, then escalates to SIGKILL/kill for any
+    survivors.  Validates PID birth time when *created_at_epoch* is non-zero to
+    guard against PID reuse.
+
+    Uses psutil for cross-platform tree discovery and signal delivery (POSIX and
+    Windows compatible).  NoSuchProcess / AccessDenied errors are suppressed so
+    the function is safe to call on already-dead processes.
+    """
+    _ = reason, scope_id  # unused here; present for forward-compat with richer variants
+
+    if not _validate_pid_birth(pid, created_at_epoch):
+        return
+
+    root, children = _snapshot_tree(pid)
+    if root is None:
+        return
+
+    tree = [*children, root]
+
+    for proc in tree:
+        with suppress(psutil.NoSuchProcess, psutil.AccessDenied):
+            proc.terminate()
+
+    _, alive = psutil.wait_procs(tree, timeout=grace_secs)
+    if alive:
+        for proc in alive:
+            with suppress(psutil.NoSuchProcess, psutil.AccessDenied):
+                proc.kill()
+        psutil.wait_procs(alive, timeout=1.0)
+
+
+__all__ = ["terminate_tree", "terminate_tree_sync"]

--- a/src/meridian/lib/platform/windows_job.py
+++ b/src/meridian/lib/platform/windows_job.py
@@ -1,0 +1,102 @@
+"""Windows Job Object assignment helper.
+
+Importable on POSIX — all Windows-specific code is guarded by IS_WINDOWS.
+Uses ctypes only; no pywin32 dependency.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from meridian.lib.platform import IS_WINDOWS
+
+_JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x00002000
+_JobObjectExtendedLimitInformation = 9
+
+
+def assign_to_new_job(pid: int) -> tuple[str, Any] | None:
+    """Create a Job Object and assign *pid* to it.
+
+    Returns ``(job_name, job_handle)`` on success, or ``None`` if not on
+    Windows or if assignment fails.  The caller must keep the handle alive;
+    ``JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`` terminates all descendants when
+    the handle is closed or the process that holds it exits.
+    """
+    if not IS_WINDOWS:
+        return None
+
+    import ctypes
+    import ctypes.wintypes
+
+    kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+
+    job_name = f"meridian-scope-{uuid.uuid4().hex}"
+    job_handle = kernel32.CreateJobObjectW(None, job_name)
+    if not job_handle:
+        return None
+
+    # Configure KILL_ON_JOB_CLOSE so all processes die when handle is released.
+    class _JOBOBJECT_BASIC_LIMIT_INFORMATION(ctypes.Structure):
+        _fields_ = [
+            ("PerProcessUserTimeLimit", ctypes.c_int64),
+            ("PerJobUserTimeLimit", ctypes.c_int64),
+            ("LimitFlags", ctypes.wintypes.DWORD),
+            ("MinimumWorkingSetSize", ctypes.c_size_t),
+            ("MaximumWorkingSetSize", ctypes.c_size_t),
+            ("ActiveProcessLimit", ctypes.wintypes.DWORD),
+            ("Affinity", ctypes.POINTER(ctypes.c_ulong)),
+            ("PriorityClass", ctypes.wintypes.DWORD),
+            ("SchedulingClass", ctypes.wintypes.DWORD),
+        ]
+
+    class _IO_COUNTERS(ctypes.Structure):
+        _fields_ = [
+            ("ReadOperationCount", ctypes.c_uint64),
+            ("WriteOperationCount", ctypes.c_uint64),
+            ("OtherOperationCount", ctypes.c_uint64),
+            ("ReadTransferCount", ctypes.c_uint64),
+            ("WriteTransferCount", ctypes.c_uint64),
+            ("OtherTransferCount", ctypes.c_uint64),
+        ]
+
+    class _JOBOBJECT_EXTENDED_LIMIT_INFORMATION(ctypes.Structure):
+        _fields_ = [
+            ("BasicLimitInformation", _JOBOBJECT_BASIC_LIMIT_INFORMATION),
+            ("IoInfo", _IO_COUNTERS),
+            ("ProcessMemoryLimit", ctypes.c_size_t),
+            ("JobMemoryLimit", ctypes.c_size_t),
+            ("PeakProcessMemoryUsed", ctypes.c_size_t),
+            ("PeakJobMemoryUsed", ctypes.c_size_t),
+        ]
+
+    info = _JOBOBJECT_EXTENDED_LIMIT_INFORMATION()
+    info.BasicLimitInformation.LimitFlags = _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+
+    ok = kernel32.SetInformationJobObject(
+        job_handle,
+        _JobObjectExtendedLimitInformation,
+        ctypes.byref(info),
+        ctypes.sizeof(info),
+    )
+    if not ok:
+        kernel32.CloseHandle(job_handle)
+        return None
+
+    PROCESS_ALL_ACCESS = 0x1F0FFF
+    proc_handle = kernel32.OpenProcess(PROCESS_ALL_ACCESS, False, pid)
+    if not proc_handle:
+        kernel32.CloseHandle(job_handle)
+        return None
+
+    assigned = kernel32.AssignProcessToJobObject(job_handle, proc_handle)
+    kernel32.CloseHandle(proc_handle)
+
+    if not assigned:
+        kernel32.CloseHandle(job_handle)
+        return None
+
+    return job_name, job_handle
+
+
+__all__ = ["assign_to_new_job"]

--- a/src/meridian/lib/state/managed_primary.py
+++ b/src/meridian/lib/state/managed_primary.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import os
-import signal
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+import psutil
 
 from meridian.lib.state.liveness import is_process_alive
 from meridian.lib.state.primary_meta import PrimaryMetadata, read_primary_metadata
@@ -102,13 +103,13 @@ def read_managed_primary_snapshot(
 
 
 def _terminate_pid(pid: int) -> bool:
-    """Send SIGTERM to a single PID."""
+    """Terminate a single process by PID using psutil."""
 
     if pid <= 0 or pid == os.getpid():
         return False
     try:
-        os.kill(pid, signal.SIGTERM)
-    except (OSError, ProcessLookupError):
+        psutil.Process(pid).terminate()
+    except (psutil.NoSuchProcess, psutil.AccessDenied, OSError):
         return False
     return True
 

--- a/src/meridian/lib/streaming/signal_canceller.py
+++ b/src/meridian/lib/streaming/signal_canceller.py
@@ -125,7 +125,8 @@ class SignalCanceller:
 
         started_epoch = _started_at_epoch(record.started_at)
         with suppress(ProcessLookupError):
-            terminate_tree_sync(
+            await asyncio.to_thread(
+                terminate_tree_sync,
                 runner_pid,
                 created_at_epoch=started_epoch if started_epoch is not None else 0.0,
                 grace_secs=self._grace_seconds,

--- a/src/meridian/lib/streaming/signal_canceller.py
+++ b/src/meridian/lib/streaming/signal_canceller.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
-import signal
 import time
 from collections.abc import Awaitable, Callable
 from contextlib import suppress
@@ -21,6 +19,7 @@ from meridian.lib.core.domain import SpawnStatus
 from meridian.lib.core.spawn_lifecycle import TERMINAL_SPAWN_STATUSES
 from meridian.lib.core.types import SpawnId
 from meridian.lib.platform import IS_WINDOWS
+from meridian.lib.platform.terminate import terminate_tree_sync
 from meridian.lib.state import spawn_store
 from meridian.lib.state.liveness import is_process_alive
 from meridian.lib.state.spawn.model import APP_LAUNCH_MODE, SpawnOrigin
@@ -124,8 +123,15 @@ class SignalCanceller:
                 )
             return CancelOutcome(status="cancelled", origin="cancel", exit_code=130)
 
+        started_epoch = _started_at_epoch(record.started_at)
         with suppress(ProcessLookupError):
-            os.kill(runner_pid, signal.SIGTERM)
+            terminate_tree_sync(
+                runner_pid,
+                created_at_epoch=started_epoch if started_epoch is not None else 0.0,
+                grace_secs=self._grace_seconds,
+                reason="cancel",
+                scope_id=str(spawn_id),
+            )
 
         terminal = await self._wait_for_terminal(spawn_id)
         if terminal is not None:

--- a/src/meridian/lib/telemetry/reader.py
+++ b/src/meridian/lib/telemetry/reader.py
@@ -122,10 +122,10 @@ def tail_events(
                 if size <= offset:
                     continue
                 try:
-                    with segment.open("r", encoding="utf-8") as file:
+                    with segment.open("rb") as file:
                         file.seek(offset)
-                        for line in file:
-                            line = line.strip()
+                        for raw_line in file:
+                            line = raw_line.decode("utf-8", errors="replace").strip()
                             if not line:
                                 continue
                             try:

--- a/tests/integration/launch/test_signals.py
+++ b/tests/integration/launch/test_signals.py
@@ -107,11 +107,11 @@ async def test_streaming_runner_signal_cancel_invokes_send_cancel_once(
         loop: asyncio.AbstractEventLoop,
         shutdown_event: asyncio.Event,
         received_signal: list[signal.Signals | None],
-    ) -> list[signal.Signals]:
+    ) -> None:
         _ = loop
         received_signal[0] = signal.SIGTERM
         shutdown_event.set()
-        return []
+        return None
 
     monkeypatch.setattr(spawn_manager_module, "ControlSocketServer", _FakeControlSocketServer)
     monkeypatch.setattr(

--- a/tests/unit/cli/test_entrypoint_encoding.py
+++ b/tests/unit/cli/test_entrypoint_encoding.py
@@ -1,0 +1,141 @@
+"""Tests for Windows UTF-8 stdout/stderr reconfiguration in the CLI entrypoint."""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import meridian.cli.entrypoint as entrypoint_module
+
+
+class _FakeTextIOWrapper:
+    """Minimal stand-in for sys.stdout / sys.stderr with reconfigure support."""
+
+    def __init__(self, encoding: str = "cp1252") -> None:
+        self.encoding = encoding
+        self._reconfigure_calls: list[dict[str, object]] = []
+
+    def reconfigure(self, **kwargs: object) -> None:
+        self._reconfigure_calls.append(kwargs)
+        if "encoding" in kwargs:
+            self.encoding = str(kwargs["encoding"])
+
+    def write(self, s: str) -> int:
+        return len(s)
+
+    def flush(self) -> None:
+        pass
+
+
+def _make_fake_main_module(captured: dict[str, object]) -> types.ModuleType:
+    fake = types.ModuleType("meridian.cli.main")
+
+    def _noop(*, argv: list[str]) -> None:
+        captured["argv"] = argv
+
+    fake.main = _noop  # type: ignore[attr-defined]
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# Windows reconfiguration — active on win32
+# ---------------------------------------------------------------------------
+
+
+def test_reconfigure_called_for_stdout_and_stderr_on_win32(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both streams are reconfigured to utf-8 on Windows."""
+    fake_stdout = _FakeTextIOWrapper(encoding="cp1252")
+    fake_stderr = _FakeTextIOWrapper(encoding="cp1252")
+
+    captured: dict[str, object] = {}
+    fake_main_module = _make_fake_main_module(captured)
+    original = sys.modules.get("meridian.cli.main")
+    sys.modules["meridian.cli.main"] = fake_main_module
+
+    try:
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(sys, "stdout", fake_stdout)
+        monkeypatch.setattr(sys, "stderr", fake_stderr)
+        monkeypatch.setattr(sys, "argv", ["meridian", "spawn", "list"])
+
+        entrypoint_module.main()
+    finally:
+        if original is not None:
+            sys.modules["meridian.cli.main"] = original
+        else:
+            sys.modules.pop("meridian.cli.main", None)
+
+    assert fake_stdout._reconfigure_calls == [{"encoding": "utf-8", "errors": "replace"}]
+    assert fake_stderr._reconfigure_calls == [{"encoding": "utf-8", "errors": "replace"}]
+
+
+def test_reconfigure_not_called_on_posix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Streams are not touched on non-Windows platforms."""
+    fake_stdout = _FakeTextIOWrapper(encoding="utf-8")
+    fake_stderr = _FakeTextIOWrapper(encoding="utf-8")
+
+    captured: dict[str, object] = {}
+    fake_main_module = _make_fake_main_module(captured)
+    original = sys.modules.get("meridian.cli.main")
+    sys.modules["meridian.cli.main"] = fake_main_module
+
+    try:
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setattr(sys, "stdout", fake_stdout)
+        monkeypatch.setattr(sys, "stderr", fake_stderr)
+        monkeypatch.setattr(sys, "argv", ["meridian", "spawn", "list"])
+
+        entrypoint_module.main()
+    finally:
+        if original is not None:
+            sys.modules["meridian.cli.main"] = original
+        else:
+            sys.modules.pop("meridian.cli.main", None)
+
+    assert fake_stdout._reconfigure_calls == []
+    assert fake_stderr._reconfigure_calls == []
+
+
+def test_reconfigure_skipped_when_stream_lacks_reconfigure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Streams without reconfigure() are left alone (e.g. redirected pipes)."""
+
+    class _NoReconfigure:
+        def write(self, s: str) -> int:
+            return len(s)
+
+        def flush(self) -> None:
+            pass
+
+    fake_stdout = _NoReconfigure()
+    fake_stderr = _NoReconfigure()
+
+    captured: dict[str, object] = {}
+    fake_main_module = _make_fake_main_module(captured)
+    original = sys.modules.get("meridian.cli.main")
+    sys.modules["meridian.cli.main"] = fake_main_module
+
+    try:
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(sys, "stdout", fake_stdout)
+        monkeypatch.setattr(sys, "stderr", fake_stderr)
+        monkeypatch.setattr(sys, "argv", ["meridian", "spawn", "list"])
+
+        # Should not raise even though reconfigure is absent.
+        entrypoint_module.main()
+    finally:
+        if original is not None:
+            sys.modules["meridian.cli.main"] = original
+        else:
+            sys.modules.pop("meridian.cli.main", None)
+
+    # No attribute error means the guard worked.
+    assert not hasattr(fake_stdout, "_reconfigure_calls")

--- a/tests/unit/harness/test_claude_cancel.py
+++ b/tests/unit/harness/test_claude_cancel.py
@@ -1,0 +1,82 @@
+"""Tests for ClaudeConnection cancel behavior across platforms."""
+
+from __future__ import annotations
+
+import asyncio
+import signal
+from unittest.mock import patch
+
+from meridian.lib.harness.connections import claude_ws
+from meridian.lib.harness.connections.claude_ws import ClaudeConnection
+
+
+class _FakeProcess:
+    """Minimal fake asyncio.subprocess.Process for cancel tests."""
+
+    def __init__(self) -> None:
+        self.returncode: int | None = None
+        self.terminate_called = False
+        self.send_signal_calls: list[signal.Signals] = []
+        self.stdin = None
+        self.stdout = None
+
+    def terminate(self) -> None:
+        self.terminate_called = True
+        self.returncode = -1
+
+    def send_signal(self, sig: signal.Signals) -> None:
+        self.send_signal_calls.append(sig)
+
+
+def _make_connection_with_process(fake_process: _FakeProcess) -> ClaudeConnection:
+    conn = ClaudeConnection()
+    conn._process = fake_process  # type: ignore[assignment]
+    conn._state = "connected"
+    return conn
+
+
+def test_signal_process_windows_uses_terminate() -> None:
+    """On Windows, _signal_process must call process.terminate() not send_signal."""
+    fake = _FakeProcess()
+    conn = _make_connection_with_process(fake)
+
+    with patch.object(claude_ws, "IS_WINDOWS", True):
+        asyncio.run(conn._signal_process(signal.SIGINT))
+
+    assert fake.terminate_called, "terminate() must be called on Windows"
+    assert fake.send_signal_calls == [], "send_signal must not be called on Windows"
+
+
+def test_signal_process_posix_uses_send_signal() -> None:
+    """On POSIX, _signal_process must call process.send_signal(SIGINT) not terminate."""
+    fake = _FakeProcess()
+    conn = _make_connection_with_process(fake)
+
+    with patch.object(claude_ws, "IS_WINDOWS", False):
+        asyncio.run(conn._signal_process(signal.SIGINT))
+
+    assert not fake.terminate_called, "terminate() must not be called on POSIX"
+    assert fake.send_signal_calls == [signal.SIGINT], (
+        "send_signal(SIGINT) must be called on POSIX"
+    )
+
+
+def test_signal_process_no_op_when_process_none() -> None:
+    """_signal_process is a no-op when there is no subprocess."""
+    conn = ClaudeConnection()
+    # _process is None by default — should not raise
+    with patch.object(claude_ws, "IS_WINDOWS", False):
+        asyncio.run(conn._signal_process(signal.SIGINT))
+
+
+def test_signal_process_no_op_when_already_exited() -> None:
+    """_signal_process is a no-op when the process has already exited."""
+    fake = _FakeProcess()
+    fake.returncode = 0  # already exited
+    conn = _make_connection_with_process(fake)
+
+    with patch.object(claude_ws, "IS_WINDOWS", False):
+        asyncio.run(conn._signal_process(signal.SIGINT))
+
+    assert fake.send_signal_calls == [], "send_signal must not be called after process exit"
+    assert not fake.terminate_called, "terminate must not be called after process exit"

--- a/tests/unit/launch/process/test_primary_attach_job.py
+++ b/tests/unit/launch/process/test_primary_attach_job.py
@@ -1,0 +1,111 @@
+"""Unit tests for Windows Job Object wiring in primary_attach.
+
+Exercises _try_assign_backend_job() and assign_to_new_job() to verify:
+  - POSIX path: no job assignment, returns None
+  - Windows path: assign_to_new_job() called with backend PID
+  - Windows failure: degrade cleanly (None), never crash
+  - windows_job.assign_to_new_job() is importable and returns None on POSIX
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from meridian.lib.launch.process.primary_attach import _try_assign_backend_job
+from meridian.lib.platform.windows_job import assign_to_new_job
+
+# ---------------------------------------------------------------------------
+# windows_job.assign_to_new_job — importability and POSIX no-op
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_assign_to_new_job_returns_none_on_posix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """assign_to_new_job() is a no-op on POSIX; must return None."""
+    monkeypatch.setattr("meridian.lib.platform.windows_job.IS_WINDOWS", False)
+    assert assign_to_new_job(12345) is None
+
+
+# ---------------------------------------------------------------------------
+# _try_assign_backend_job — POSIX path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_try_assign_backend_job_posix_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """On POSIX IS_WINDOWS=False — never calls into windows_job."""
+    monkeypatch.setattr("meridian.lib.launch.process.primary_attach.IS_WINDOWS", False)
+    assert _try_assign_backend_job(99999) is None
+
+
+# ---------------------------------------------------------------------------
+# _try_assign_backend_job — Windows success path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_try_assign_backend_job_windows_returns_handle(monkeypatch: pytest.MonkeyPatch) -> None:
+    """On Windows, a successful assign_to_new_job returns the job handle."""
+    fake_handle = object()
+    monkeypatch.setattr("meridian.lib.launch.process.primary_attach.IS_WINDOWS", True)
+    monkeypatch.setattr(
+        "meridian.lib.platform.windows_job.assign_to_new_job",
+        lambda pid: ("meridian-scope-abc123", fake_handle),
+    )
+    result = _try_assign_backend_job(1234)
+    assert result is fake_handle
+
+
+@pytest.mark.unit
+def test_try_assign_backend_job_passes_correct_pid(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Backend PID is forwarded to assign_to_new_job unchanged."""
+    received: list[int] = []
+    fake_handle = object()
+    monkeypatch.setattr("meridian.lib.launch.process.primary_attach.IS_WINDOWS", True)
+    monkeypatch.setattr(
+        "meridian.lib.platform.windows_job.assign_to_new_job",
+        lambda pid: (received.append(pid) or ("job", fake_handle)),  # type: ignore[func-returns-value]
+    )
+    _try_assign_backend_job(5678)
+    assert received == [5678]
+
+
+# ---------------------------------------------------------------------------
+# _try_assign_backend_job — Windows degraded paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_try_assign_backend_job_none_from_assign_degrades(monkeypatch: pytest.MonkeyPatch) -> None:
+    """assign_to_new_job returning None means degrade: _try_assign returns None."""
+    monkeypatch.setattr("meridian.lib.launch.process.primary_attach.IS_WINDOWS", True)
+    monkeypatch.setattr(
+        "meridian.lib.platform.windows_job.assign_to_new_job",
+        lambda pid: None,
+    )
+    assert _try_assign_backend_job(999) is None
+
+
+@pytest.mark.unit
+def test_try_assign_backend_job_exception_degrades(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An exception inside assign_to_new_job must not propagate — return None."""
+
+    def _fail(pid: int) -> None:
+        raise OSError("access denied")
+
+    monkeypatch.setattr("meridian.lib.launch.process.primary_attach.IS_WINDOWS", True)
+    monkeypatch.setattr("meridian.lib.platform.windows_job.assign_to_new_job", _fail)
+    # Must not raise.
+    assert _try_assign_backend_job(111) is None
+
+
+@pytest.mark.unit
+def test_try_assign_backend_job_runtime_error_degrades(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Any unexpected error inside assign_to_new_job degrades cleanly to None."""
+
+    def _fail(pid: int) -> None:
+        raise RuntimeError("unexpected failure")
+
+    monkeypatch.setattr("meridian.lib.launch.process.primary_attach.IS_WINDOWS", True)
+    monkeypatch.setattr("meridian.lib.platform.windows_job.assign_to_new_job", _fail)
+    assert _try_assign_backend_job(333) is None

--- a/tests/unit/launch/process/test_subprocess_interrupt.py
+++ b/tests/unit/launch/process/test_subprocess_interrupt.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import signal
+from unittest.mock import patch
+
 import pytest
 
 from meridian.lib.launch.process.subprocess_launcher import _wait_for_process
@@ -22,7 +25,7 @@ class _FakeProcess:
         self._raise_interrupt = raise_interrupt
         self._wait_calls = 0
         self.terminate_called = False
-        self.send_signal_called = False
+        self.send_signal_args: list[object] = []
 
     def poll(self) -> int | None:
         return None if self._running else self._wait_exit_code
@@ -36,32 +39,46 @@ class _FakeProcess:
     def terminate(self) -> None:
         self.terminate_called = True
 
-    def send_signal(self, _sig: object) -> None:
-        self.send_signal_called = True
+    def send_signal(self, sig: object) -> None:
+        self.send_signal_args.append(sig)
 
 
 @pytest.mark.unit
-def test_interrupt_while_running_calls_terminate() -> None:
-    """KeyboardInterrupt with live process: terminate() is called, not send_signal."""
+def test_interrupt_while_running_posix_sends_sigint() -> None:
+    """On POSIX, KeyboardInterrupt with live process sends SIGINT, not terminate."""
     process = _FakeProcess(running=True, wait_exit_code=1, raise_interrupt=True)
 
-    result = _wait_for_process(process)  # type: ignore[arg-type]
+    with patch("sys.platform", "linux"):
+        result = _wait_for_process(process)  # type: ignore[arg-type]
+
+    assert process.send_signal_args == [signal.SIGINT]
+    assert process.terminate_called is False
+    assert result == 1
+
+
+@pytest.mark.unit
+def test_interrupt_while_running_windows_calls_terminate() -> None:
+    """On Windows, KeyboardInterrupt with live process calls terminate(), not send_signal."""
+    process = _FakeProcess(running=True, wait_exit_code=1, raise_interrupt=True)
+
+    with patch("sys.platform", "win32"):
+        result = _wait_for_process(process)  # type: ignore[arg-type]
 
     assert process.terminate_called is True
-    assert process.send_signal_called is False
+    assert process.send_signal_args == []
     assert result == 1
 
 
 @pytest.mark.unit
 def test_interrupt_while_already_exited_returns_130() -> None:
-    """KeyboardInterrupt after process exits: return 130 without terminate."""
+    """KeyboardInterrupt after process exits: return 130 without any signal."""
     process = _FakeProcess(running=False, wait_exit_code=0, raise_interrupt=True)
 
     result = _wait_for_process(process)  # type: ignore[arg-type]
 
     assert result == 130
     assert process.terminate_called is False
-    assert process.send_signal_called is False
+    assert process.send_signal_args == []
 
 
 @pytest.mark.unit
@@ -73,3 +90,4 @@ def test_normal_exit_returns_exit_code() -> None:
 
     assert result == 42
     assert process.terminate_called is False
+    assert process.send_signal_args == []

--- a/tests/unit/launch/process/test_subprocess_interrupt.py
+++ b/tests/unit/launch/process/test_subprocess_interrupt.py
@@ -1,0 +1,75 @@
+"""Tests for _wait_for_process KeyboardInterrupt handling."""
+
+from __future__ import annotations
+
+import pytest
+
+from meridian.lib.launch.process.subprocess_launcher import _wait_for_process
+
+
+class _FakeProcess:
+    """Minimal Popen stand-in for interrupt handler tests."""
+
+    def __init__(
+        self,
+        *,
+        running: bool,
+        wait_exit_code: int = 0,
+        raise_interrupt: bool = False,
+    ) -> None:
+        self._running = running
+        self._wait_exit_code = wait_exit_code
+        self._raise_interrupt = raise_interrupt
+        self._wait_calls = 0
+        self.terminate_called = False
+        self.send_signal_called = False
+
+    def poll(self) -> int | None:
+        return None if self._running else self._wait_exit_code
+
+    def wait(self) -> int:
+        self._wait_calls += 1
+        if self._raise_interrupt and self._wait_calls == 1:
+            raise KeyboardInterrupt
+        return self._wait_exit_code
+
+    def terminate(self) -> None:
+        self.terminate_called = True
+
+    def send_signal(self, _sig: object) -> None:
+        self.send_signal_called = True
+
+
+@pytest.mark.unit
+def test_interrupt_while_running_calls_terminate() -> None:
+    """KeyboardInterrupt with live process: terminate() is called, not send_signal."""
+    process = _FakeProcess(running=True, wait_exit_code=1, raise_interrupt=True)
+
+    result = _wait_for_process(process)  # type: ignore[arg-type]
+
+    assert process.terminate_called is True
+    assert process.send_signal_called is False
+    assert result == 1
+
+
+@pytest.mark.unit
+def test_interrupt_while_already_exited_returns_130() -> None:
+    """KeyboardInterrupt after process exits: return 130 without terminate."""
+    process = _FakeProcess(running=False, wait_exit_code=0, raise_interrupt=True)
+
+    result = _wait_for_process(process)  # type: ignore[arg-type]
+
+    assert result == 130
+    assert process.terminate_called is False
+    assert process.send_signal_called is False
+
+
+@pytest.mark.unit
+def test_normal_exit_returns_exit_code() -> None:
+    """Happy path: wait() returns the process exit code directly."""
+    process = _FakeProcess(running=True, wait_exit_code=42)
+
+    result = _wait_for_process(process)  # type: ignore[arg-type]
+
+    assert result == 42
+    assert process.terminate_called is False

--- a/tests/unit/launch/process/test_windows_launcher.py
+++ b/tests/unit/launch/process/test_windows_launcher.py
@@ -124,6 +124,6 @@ def test_windows_console_launcher_forces_console_inheritance(
         on_child_started=child_started.append,
     )
 
-    assert captured["output_log_path"] is None
+    assert captured["output_log_path"] == tmp_path / "history.jsonl"
     assert child_started == [456]
     assert result == expected

--- a/tests/unit/launch/test_signal_portable.py
+++ b/tests/unit/launch/test_signal_portable.py
@@ -24,9 +24,16 @@ from meridian.lib.launch.streaming_runner import (
 # ---------------------------------------------------------------------------
 
 
-def _send_signal(signum: signal.Signals) -> None:
-    """Send a signal to the current process."""
-    os.kill(os.getpid(), signum)
+def _invoke_handler(signum: signal.Signals) -> None:
+    """Invoke the currently installed signal handler directly, without OS delivery.
+
+    Calling os.kill(os.getpid(), signum) terminates the process on Windows instead
+    of firing the Python-level handler.  Capturing and calling the handler directly
+    exercises exactly the same code path on every platform.
+    """
+    handler = signal.getsignal(signum)
+    if callable(handler):
+        handler(signum, None)
 
 
 # ---------------------------------------------------------------------------
@@ -57,7 +64,7 @@ async def test_sigint_sets_shutdown_event() -> None:
     cleanup = _install_signal_handlers(loop, shutdown_event, received_signal)
     assert cleanup is not None
     try:
-        _send_signal(signal.SIGINT)
+        _invoke_handler(signal.SIGINT)
         # Allow the event loop to process the call_soon_threadsafe callback
         await asyncio.sleep(0)
         await asyncio.sleep(0)
@@ -77,7 +84,7 @@ async def test_sigterm_sets_shutdown_event() -> None:
     cleanup = _install_signal_handlers(loop, shutdown_event, received_signal)
     assert cleanup is not None
     try:
-        _send_signal(signal.SIGTERM)
+        _invoke_handler(signal.SIGTERM)
         await asyncio.sleep(0)
         await asyncio.sleep(0)
         assert shutdown_event.is_set()
@@ -188,8 +195,8 @@ async def test_layering_streaming_handlers_restored_after_forwarder_unregisters(
         assert restored_sigint is streaming_handler_sigint
         assert restored_sigterm is streaming_handler_sigterm
 
-        # Now send SIGINT — the streaming handler should fire
-        _send_signal(signal.SIGINT)
+        # Now invoke SIGINT — the streaming handler should fire
+        _invoke_handler(signal.SIGINT)
         await asyncio.sleep(0)
         await asyncio.sleep(0)
         assert shutdown_event.is_set()

--- a/tests/unit/launch/test_signal_portable.py
+++ b/tests/unit/launch/test_signal_portable.py
@@ -1,0 +1,198 @@
+"""Tests for portable signal handler installation in streaming_runner.py.
+
+Verifies that _install_signal_handlers uses signal.signal() (stdlib, portable)
+rather than loop.add_signal_handler() (asyncio, Windows-broken), and that the
+cleanup callable pattern correctly restores previous handlers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+import threading
+
+import pytest
+
+from meridian.lib.launch.signals import SignalForwarder
+from meridian.lib.launch.streaming_runner import (
+    _install_signal_handlers,  # pyright: ignore[reportPrivateUsage]
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _send_signal(signum: signal.Signals) -> None:
+    """Send a signal to the current process."""
+    os.kill(os.getpid(), signum)
+
+
+# ---------------------------------------------------------------------------
+# Basic installation tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_install_returns_cleanup_callable() -> None:
+    """_install_signal_handlers returns a callable from the main thread."""
+    loop = asyncio.get_running_loop()
+    shutdown_event = asyncio.Event()
+    received_signal: list[signal.Signals | None] = [None]
+
+    cleanup = _install_signal_handlers(loop, shutdown_event, received_signal)
+    assert cleanup is not None
+    assert callable(cleanup)
+    cleanup()  # restore
+
+
+@pytest.mark.asyncio
+async def test_sigint_sets_shutdown_event() -> None:
+    """SIGINT causes the shutdown_event to be set."""
+    loop = asyncio.get_running_loop()
+    shutdown_event = asyncio.Event()
+    received_signal: list[signal.Signals | None] = [None]
+
+    cleanup = _install_signal_handlers(loop, shutdown_event, received_signal)
+    assert cleanup is not None
+    try:
+        _send_signal(signal.SIGINT)
+        # Allow the event loop to process the call_soon_threadsafe callback
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert shutdown_event.is_set()
+        assert received_signal[0] == signal.SIGINT
+    finally:
+        cleanup()
+
+
+@pytest.mark.asyncio
+async def test_sigterm_sets_shutdown_event() -> None:
+    """SIGTERM causes the shutdown_event to be set."""
+    loop = asyncio.get_running_loop()
+    shutdown_event = asyncio.Event()
+    received_signal: list[signal.Signals | None] = [None]
+
+    cleanup = _install_signal_handlers(loop, shutdown_event, received_signal)
+    assert cleanup is not None
+    try:
+        _send_signal(signal.SIGTERM)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert shutdown_event.is_set()
+        assert received_signal[0] == signal.SIGTERM
+    finally:
+        cleanup()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_restores_previous_handlers() -> None:
+    """Cleanup callable restores the handlers that were in place before installation."""
+    loop = asyncio.get_running_loop()
+    shutdown_event = asyncio.Event()
+    received_signal: list[signal.Signals | None] = [None]
+
+    sentinel_called: list[int] = []
+
+    def _sentinel(signum: int, frame: object) -> None:
+        sentinel_called.append(signum)
+
+    # Install sentinel as the current handler, then install our handlers on top
+    prev_sigint = signal.signal(signal.SIGINT, _sentinel)
+    prev_sigterm = signal.signal(signal.SIGTERM, _sentinel)
+    try:
+        cleanup = _install_signal_handlers(loop, shutdown_event, received_signal)
+        assert cleanup is not None
+        # Our handler should be active now, not sentinel
+        assert signal.getsignal(signal.SIGINT) is not _sentinel
+        assert signal.getsignal(signal.SIGTERM) is not _sentinel
+
+        cleanup()
+
+        # Sentinel should be restored
+        assert signal.getsignal(signal.SIGINT) is _sentinel
+        assert signal.getsignal(signal.SIGTERM) is _sentinel
+    finally:
+        # Restore originals regardless
+        signal.signal(signal.SIGINT, prev_sigint)
+        signal.signal(signal.SIGTERM, prev_sigterm)
+
+
+def test_returns_none_from_non_main_thread() -> None:
+    """_install_signal_handlers returns None when called from a non-main thread."""
+    result: list[object] = []
+
+    async def _inner() -> None:
+        loop = asyncio.get_running_loop()
+        shutdown_event = asyncio.Event()
+        received_signal: list[signal.Signals | None] = [None]
+        cleanup = _install_signal_handlers(loop, shutdown_event, received_signal)
+        result.append(cleanup)
+
+    def _thread_target() -> None:
+        asyncio.run(_inner())
+
+    t = threading.Thread(target=_thread_target)
+    t.start()
+    t.join()
+
+    assert result == [None]
+
+
+# ---------------------------------------------------------------------------
+# Signal layering: streaming handlers + SignalCoordinator/SignalForwarder
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_layering_streaming_handlers_restored_after_forwarder_unregisters() -> None:
+    """SignalCoordinator overrides handlers while a forwarder is registered;
+    when the forwarder unregisters, the streaming handlers come back.
+    """
+    loop = asyncio.get_running_loop()
+    shutdown_event = asyncio.Event()
+    received_signal: list[signal.Signals | None] = [None]
+
+    # 1. Install streaming handlers first
+    cleanup = _install_signal_handlers(loop, shutdown_event, received_signal)
+    assert cleanup is not None
+
+    streaming_handler_sigint = signal.getsignal(signal.SIGINT)
+    streaming_handler_sigterm = signal.getsignal(signal.SIGTERM)
+
+    # Create a dummy process mock that does nothing
+    class _FakeProcess:
+        returncode: int | None = None
+        pid: int = os.getpid()
+
+        def send_signal(self, sig: signal.Signals) -> None:
+            pass
+
+    fake_proc = _FakeProcess()
+    # Satisfy the subprocess.Process type with duck-typing
+    forwarder = SignalForwarder(fake_proc)  # type: ignore[arg-type]
+
+    try:
+        with forwarder:
+            # While forwarder is registered, SignalCoordinator owns the handlers
+            active_sigint = signal.getsignal(signal.SIGINT)
+            active_sigterm = signal.getsignal(signal.SIGTERM)
+            # Coordinator installs its own handler (not the streaming one)
+            assert active_sigint is not streaming_handler_sigint
+            assert active_sigterm is not streaming_handler_sigterm
+
+        # After forwarder unregisters, coordinator restores previous (streaming) handlers
+        restored_sigint = signal.getsignal(signal.SIGINT)
+        restored_sigterm = signal.getsignal(signal.SIGTERM)
+        assert restored_sigint is streaming_handler_sigint
+        assert restored_sigterm is streaming_handler_sigterm
+
+        # Now send SIGINT — the streaming handler should fire
+        _send_signal(signal.SIGINT)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert shutdown_event.is_set()
+        assert received_signal[0] == signal.SIGINT
+    finally:
+        cleanup()

--- a/tests/unit/ops/test_worktree_encoding.py
+++ b/tests/unit/ops/test_worktree_encoding.py
@@ -1,0 +1,92 @@
+"""Tests that _run_git() passes encoding="utf-8" to subprocess.run.
+
+Without an explicit encoding, subprocess.run(text=True) inherits the locale
+code page on Windows (often cp1252), which raises UnicodeDecodeError when git
+emits branch names or commit messages containing non-ASCII characters.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from meridian.lib.ops.worktree_ops import (
+    WorktreeRepoResolutionError,
+    _run_git,
+    detect_git_repo,
+)
+
+
+def _mock_completed(stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess[str]:
+    result: subprocess.CompletedProcess[str] = MagicMock(spec=subprocess.CompletedProcess)
+    result.stdout = stdout
+    result.stderr = stderr
+    result.returncode = 0
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Encoding parameter
+# ---------------------------------------------------------------------------
+
+
+def test_run_git_passes_utf8_encoding(tmp_path: Path) -> None:
+    """subprocess.run receives encoding='utf-8', not the locale default."""
+    with patch("subprocess.run", return_value=_mock_completed(stdout="true")) as mock_run:
+        _run_git(tmp_path, ["rev-parse", "--is-inside-work-tree"], error_type=WorktreeRepoResolutionError)
+
+    call_kwargs = mock_run.call_args.kwargs
+    assert call_kwargs.get("encoding") == "utf-8", (
+        "encoding='utf-8' must be passed explicitly; "
+        "text=True alone inherits the locale code page on Windows"
+    )
+
+
+def test_run_git_uses_text_mode(tmp_path: Path) -> None:
+    """text=True is still set alongside encoding='utf-8'."""
+    with patch("subprocess.run", return_value=_mock_completed(stdout="true")) as mock_run:
+        _run_git(tmp_path, ["rev-parse", "--is-inside-work-tree"], error_type=WorktreeRepoResolutionError)
+
+    call_kwargs = mock_run.call_args.kwargs
+    assert call_kwargs.get("text") is True
+
+
+def test_run_git_captures_output(tmp_path: Path) -> None:
+    """capture_output=True is set so stdout/stderr are captured."""
+    with patch("subprocess.run", return_value=_mock_completed(stdout="true")) as mock_run:
+        _run_git(tmp_path, ["rev-parse", "--is-inside-work-tree"], error_type=WorktreeRepoResolutionError)
+
+    call_kwargs = mock_run.call_args.kwargs
+    assert call_kwargs.get("capture_output") is True
+
+
+# ---------------------------------------------------------------------------
+# Integration: detect_git_repo reads UTF-8 output correctly
+# ---------------------------------------------------------------------------
+
+
+def test_detect_git_repo_decodes_utf8_output(tmp_path: Path) -> None:
+    """detect_git_repo works correctly when git output is decoded as utf-8."""
+    with patch("subprocess.run", return_value=_mock_completed(stdout="true\n")):
+        assert detect_git_repo(tmp_path) is True
+
+    with patch("subprocess.run", return_value=_mock_completed(stdout="false\n")):
+        assert detect_git_repo(tmp_path) is False
+
+
+def test_run_git_propagates_file_not_found(tmp_path: Path) -> None:
+    """FileNotFoundError (git not installed) is wrapped in the given error_type."""
+    with patch("subprocess.run", side_effect=FileNotFoundError):
+        with pytest.raises(WorktreeRepoResolutionError, match="git is not installed"):
+            _run_git(tmp_path, ["rev-parse", "--is-inside-work-tree"], error_type=WorktreeRepoResolutionError)
+
+
+def test_run_git_propagates_called_process_error(tmp_path: Path) -> None:
+    """Non-zero exit is wrapped in the given error_type."""
+    exc = subprocess.CalledProcessError(128, ["git"], stderr="not a git repository")
+    with patch("subprocess.run", side_effect=exc):
+        with pytest.raises(WorktreeRepoResolutionError, match="not a git repository"):
+            _run_git(tmp_path, ["rev-parse", "--is-inside-work-tree"], error_type=WorktreeRepoResolutionError)

--- a/tests/unit/state/test_managed_primary_terminate.py
+++ b/tests/unit/state/test_managed_primary_terminate.py
@@ -1,0 +1,53 @@
+"""Unit tests for _terminate_pid in managed_primary."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import psutil
+import pytest
+
+from meridian.lib.state.managed_primary import _terminate_pid
+
+
+def test_rejects_zero_pid() -> None:
+    assert _terminate_pid(0) is False
+
+
+def test_rejects_negative_pid() -> None:
+    assert _terminate_pid(-1) is False
+
+
+def test_rejects_own_pid() -> None:
+    assert _terminate_pid(os.getpid()) is False
+
+
+def test_calls_psutil_terminate_and_returns_true() -> None:
+    mock_proc = MagicMock()
+    with patch("meridian.lib.state.managed_primary.psutil.Process", return_value=mock_proc) as mock_cls:
+        result = _terminate_pid(12345)
+    mock_cls.assert_called_once_with(12345)
+    mock_proc.terminate.assert_called_once()
+    assert result is True
+
+
+def test_returns_false_on_no_such_process() -> None:
+    mock_proc = MagicMock()
+    mock_proc.terminate.side_effect = psutil.NoSuchProcess(12345)
+    with patch("meridian.lib.state.managed_primary.psutil.Process", return_value=mock_proc):
+        assert _terminate_pid(12345) is False
+
+
+def test_returns_false_on_access_denied() -> None:
+    mock_proc = MagicMock()
+    mock_proc.terminate.side_effect = psutil.AccessDenied(12345)
+    with patch("meridian.lib.state.managed_primary.psutil.Process", return_value=mock_proc):
+        assert _terminate_pid(12345) is False
+
+
+def test_returns_false_on_os_error() -> None:
+    mock_proc = MagicMock()
+    mock_proc.terminate.side_effect = OSError("permission denied")
+    with patch("meridian.lib.state.managed_primary.psutil.Process", return_value=mock_proc):
+        assert _terminate_pid(12345) is False

--- a/tests/unit/streaming/test_signal_canceller_tree.py
+++ b/tests/unit/streaming/test_signal_canceller_tree.py
@@ -1,0 +1,200 @@
+"""Tests that SignalCanceller._cancel_cli_spawn uses terminate_tree_sync."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from meridian.lib.core.types import SpawnId
+from meridian.lib.state.spawn.model import SpawnRecord
+from meridian.lib.streaming.signal_canceller import SignalCanceller
+
+
+def _make_record(
+    *,
+    status: str = "running",
+    launch_mode: str = "background",
+    runner_pid: int | None = 12345,
+    worker_pid: int | None = None,
+    started_at: str | None = "2024-01-01T00:00:00Z",
+    exit_code: int | None = None,
+    terminal_origin: str | None = None,
+) -> SpawnRecord:
+    return SpawnRecord(
+        id="s-test",
+        chat_id=None,
+        parent_id=None,
+        model=None,
+        agent=None,
+        agent_path=None,
+        skills=(),
+        skill_paths=(),
+        harness=None,
+        kind="spawn",
+        desc=None,
+        work_id=None,
+        harness_session_id=None,
+        execution_cwd=None,
+        claude_config_dir=None,
+        launch_mode=launch_mode,  # type: ignore[arg-type]
+        worker_pid=worker_pid,
+        runner_pid=runner_pid,
+        status=status,  # type: ignore[arg-type]
+        prompt=None,
+        started_at=started_at,
+        exited_at=None,
+        process_exit_code=None,
+        finished_at=None,
+        exit_code=exit_code,
+        duration_secs=None,
+        total_cost_usd=None,
+        input_tokens=None,
+        output_tokens=None,
+        cache_read_input_tokens=None,
+        cache_creation_input_tokens=None,
+        reasoning_tokens=None,
+        cost_is_estimate=False,
+        error=None,
+        terminal_origin=terminal_origin,  # type: ignore[arg-type]
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancel_cli_spawn_uses_terminate_tree_sync(tmp_path: Path) -> None:
+    """terminate_tree_sync is called with the runner PID, not os.kill."""
+    spawn_id = SpawnId("s-test")
+    running_record = _make_record(runner_pid=12345)
+    cancelled_record = _make_record(
+        status="cancelled",
+        runner_pid=12345,
+        exit_code=130,
+        terminal_origin="cancel",
+    )
+
+    canceller = SignalCanceller(runtime_root=tmp_path, grace_seconds=1.0)
+
+    with (
+        patch(
+            "meridian.lib.streaming.signal_canceller.spawn_store.get_spawn",
+            side_effect=[running_record, cancelled_record],
+        ),
+        patch(
+            "meridian.lib.streaming.signal_canceller.is_process_alive",
+            return_value=True,
+        ),
+        patch(
+            "meridian.lib.streaming.signal_canceller.terminate_tree_sync",
+        ) as mock_terminate,
+    ):
+        outcome = await canceller._cancel_cli_spawn(spawn_id, running_record)
+
+    mock_terminate.assert_called_once()
+    call_kwargs = mock_terminate.call_args
+    assert call_kwargs.args[0] == 12345
+    assert call_kwargs.kwargs["grace_secs"] == 1.0
+    assert call_kwargs.kwargs["reason"] == "cancel"
+    assert call_kwargs.kwargs["scope_id"] == "s-test"
+
+    assert outcome.status == "cancelled"
+    assert outcome.exit_code == 130
+
+
+@pytest.mark.asyncio
+async def test_cancel_cli_spawn_passes_started_epoch(tmp_path: Path) -> None:
+    """created_at_epoch derived from record.started_at is forwarded."""
+    spawn_id = SpawnId("s-test")
+    running_record = _make_record(
+        runner_pid=99,
+        started_at="2024-06-15T12:00:00Z",
+    )
+    cancelled_record = _make_record(
+        status="cancelled",
+        runner_pid=99,
+        exit_code=130,
+        terminal_origin="cancel",
+    )
+
+    canceller = SignalCanceller(runtime_root=tmp_path, grace_seconds=2.0)
+
+    with (
+        patch(
+            "meridian.lib.streaming.signal_canceller.spawn_store.get_spawn",
+            side_effect=[running_record, cancelled_record],
+        ),
+        patch(
+            "meridian.lib.streaming.signal_canceller.is_process_alive",
+            return_value=True,
+        ),
+        patch(
+            "meridian.lib.streaming.signal_canceller.terminate_tree_sync",
+        ) as mock_terminate,
+    ):
+        await canceller._cancel_cli_spawn(spawn_id, running_record)
+
+    # created_at_epoch must be a non-zero float derived from started_at
+    call_kwargs = mock_terminate.call_args
+    epoch = call_kwargs.kwargs["created_at_epoch"]
+    assert isinstance(epoch, float)
+    assert epoch > 0.0
+
+
+@pytest.mark.asyncio
+async def test_cancel_cli_spawn_returns_finalizing_when_no_terminal(tmp_path: Path) -> None:
+    """Returns finalizing outcome when process exits but spawn record stays non-terminal."""
+    spawn_id = SpawnId("s-test")
+    running_record = _make_record(runner_pid=777)
+
+    canceller = SignalCanceller(runtime_root=tmp_path, grace_seconds=0.0)
+
+    with (
+        patch(
+            "meridian.lib.streaming.signal_canceller.spawn_store.get_spawn",
+            return_value=running_record,
+        ),
+        patch(
+            "meridian.lib.streaming.signal_canceller.is_process_alive",
+            return_value=True,
+        ),
+        patch(
+            "meridian.lib.streaming.signal_canceller.terminate_tree_sync",
+        ),
+    ):
+        outcome = await canceller._cancel_cli_spawn(spawn_id, running_record)
+
+    assert outcome.finalizing is True
+    assert outcome.status == "finalizing"
+
+
+@pytest.mark.asyncio
+async def test_cancel_cli_spawn_no_os_kill(tmp_path: Path) -> None:
+    """os.kill is not invoked during CLI spawn cancellation."""
+    spawn_id = SpawnId("s-test")
+    running_record = _make_record(runner_pid=12345)
+    cancelled_record = _make_record(
+        status="cancelled",
+        runner_pid=12345,
+        exit_code=130,
+        terminal_origin="cancel",
+    )
+
+    canceller = SignalCanceller(runtime_root=tmp_path, grace_seconds=1.0)
+
+    with (
+        patch(
+            "meridian.lib.streaming.signal_canceller.spawn_store.get_spawn",
+            side_effect=[running_record, cancelled_record],
+        ),
+        patch(
+            "meridian.lib.streaming.signal_canceller.is_process_alive",
+            return_value=True,
+        ),
+        patch(
+            "meridian.lib.streaming.signal_canceller.terminate_tree_sync",
+        ),
+        patch("os.kill") as mock_os_kill,
+    ):
+        await canceller._cancel_cli_spawn(spawn_id, running_record)
+
+    mock_os_kill.assert_not_called()

--- a/tests/unit/telemetry/test_reader_binary.py
+++ b/tests/unit/telemetry/test_reader_binary.py
@@ -1,0 +1,116 @@
+"""Tests that tail_events() uses binary seek/tell (byte-stable offsets).
+
+Generator initialization (snapshot) runs on the first next() call, so tests
+write events from threads with a small delay to ensure initialization sees an
+empty directory before data appears.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+
+from meridian.lib.telemetry.reader import tail_events
+
+
+def _write_event(path: Path, event: str, extra: dict | None = None) -> None:
+    payload: dict = {"ts": "2026-05-01T00:00:00Z", "domain": "test", "event": event}
+    if extra:
+        payload.update(extra)
+    with path.open("ab") as fh:
+        fh.write((json.dumps(payload) + "\n").encode("utf-8"))
+
+
+def test_tail_events_reads_new_event(tmp_path: Path) -> None:
+    """tail_events yields events written after initialization."""
+    seg = tmp_path / "seg.jsonl"
+    gen = tail_events(tmp_path, poll_interval=0.001)
+
+    # Delay lets the generator take its snapshot of an empty directory before
+    # the file appears, so the event is not included in the initial offset.
+    def writer() -> None:
+        time.sleep(0.05)
+        _write_event(seg, "new.event")
+
+    t = threading.Thread(target=writer, daemon=True)
+    t.start()
+    event = next(gen)
+    t.join(timeout=5.0)
+
+    assert event["event"] == "new.event"
+
+
+def test_tail_events_byte_stable_offset_across_handle_lifetimes(tmp_path: Path) -> None:
+    """Offset stored after one file handle is a valid byte seek for the next.
+
+    This is the core binary-mode correctness test: on Windows, text-mode
+    seek() with a cross-handle offset is not spec-guaranteed (CRLF can shift
+    byte counts).  Binary mode makes the offset unambiguously byte-based.
+
+    The second event is written after the generator has closed the first file
+    handle, forcing a new open+seek cycle.  If the stored offset were wrong
+    (char-count vs byte-count), the multibyte content would be garbled.
+    """
+    seg = tmp_path / "seg.jsonl"
+    gen = tail_events(tmp_path, poll_interval=0.001)
+    results: list[dict] = []
+
+    def writer() -> None:
+        time.sleep(0.05)  # let generator snapshot empty dir
+        _write_event(seg, "e1", {"msg": "€uro sign"})  # 3-byte € char
+        time.sleep(0.05)  # let generator process e1, close handle, store offset
+        _write_event(seg, "e2", {"msg": "naïve"})  # 2-byte ï char
+
+    t = threading.Thread(target=writer, daemon=True)
+    t.start()
+    results.append(next(gen))  # e1
+    results.append(next(gen))  # e2 — read via new handle seeked to stored offset
+    t.join(timeout=5.0)
+
+    assert results[0]["event"] == "e1"
+    assert results[0]["msg"] == "€uro sign"
+    assert results[1]["event"] == "e2"
+    assert results[1]["msg"] == "naïve"
+
+
+def test_tail_events_picks_up_new_segment(tmp_path: Path) -> None:
+    """Events in a segment that didn't exist at tail start are yielded."""
+    gen = tail_events(tmp_path, poll_interval=0.001)
+    seg = tmp_path / "new_seg.jsonl"
+
+    def writer() -> None:
+        time.sleep(0.05)
+        _write_event(seg, "fresh.event")
+
+    t = threading.Thread(target=writer, daemon=True)
+    t.start()
+    event = next(gen)
+    t.join(timeout=5.0)
+
+    assert event["event"] == "fresh.event"
+
+
+def test_tail_events_domain_filter_with_binary_mode(tmp_path: Path) -> None:
+    """domain filter is applied correctly when reading in binary mode."""
+    seg = tmp_path / "seg.jsonl"
+    gen = tail_events(tmp_path, domain="wanted", poll_interval=0.001)
+
+    def writer() -> None:
+        time.sleep(0.05)
+        _write_event(seg, "skip.event")  # domain="test", filtered out
+        wanted = {
+            "ts": "2026-05-01T00:00:00Z",
+            "domain": "wanted",
+            "event": "keep.event",
+        }
+        with seg.open("ab") as fh:
+            fh.write((json.dumps(wanted) + "\n").encode("utf-8"))
+
+    t = threading.Thread(target=writer, daemon=True)
+    t.start()
+    event = next(gen)
+    t.join(timeout=5.0)
+
+    assert event["event"] == "keep.event"


### PR DESCRIPTION
## Summary

- Add Windows CI runner (`windows-gate` job) as prerequisite for all subsequent fixes
- Fix 3 critical Windows bugs: output capture silently dropped, Claude cancel broken, asyncio signal handlers disabled
- Consolidate process termination onto existing cross-platform abstractions (psutil, terminate_tree_sync)
- Fix CLI/git encoding defaults, telemetry binary tailing, and Windows job object wiring
- Add PowerShell developer script mirrors and document Windows-specific behavior

## Changes by Phase

**Phase 0 — CI**: Added `windows-gate` job to `meridian-ci.yml` running on `windows-latest`

**Phase 1 — Blocking fixes**:
- Pass `output_log_path` through `WindowsConsoleLauncher` (was hardcoded to `None`)
- Branch Claude cancel: `process.terminate()` on Windows, SIGINT on POSIX
- UTF-8 stdout/stderr reconfigure on Windows CLI entry; `encoding="utf-8"` for git subprocess
- Rewrite `_install_signal_handlers()` from `loop.add_signal_handler()` to portable `signal.signal()` + `call_soon_threadsafe()`

**Phase 2 — Consistency**:
- Replace `os.kill(SIGTERM)` with `terminate_tree_sync()` in `SignalCanceller` (via `asyncio.to_thread`)
- Replace `os.kill(SIGTERM)` with `psutil.Process.terminate()` in managed primary
- Split subprocess interrupt: SIGINT on POSIX, terminate on Windows
- Binary-mode seek/tell in telemetry `tail_events()`
- Wire `assign_to_new_job()` into managed primary attach with graceful degradation

**Phase 3 — Ecosystem**: PowerShell mirrors for check/preflight, hook shell docs, Windows support section in DEVELOPMENT.md

## Review fixes
- Signal tests use direct handler invocation instead of `os.kill(self)` for Windows safety
- Preserved POSIX SIGINT semantics in subprocess interrupt handler
- Wrapped `terminate_tree_sync` in `asyncio.to_thread` to avoid blocking event loop

## Test plan
- [ ] Windows CI gate passes on `windows-latest`
- [ ] Ubuntu CI gates remain green (no POSIX regression)
- [ ] New unit tests pass: signal_portable, claude_cancel, subprocess_interrupt, managed_primary_terminate, signal_canceller_tree, reader_binary, primary_attach_job, entrypoint_encoding, worktree_encoding
- [ ] PowerShell scripts syntactically valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)