### PR TITLE
feat: one-line init with --add and flexible content scanning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "cyclopts>=3.0",
   "fastapi>=0.115",
   "markdown-it-py>=4.0",
-  "mars-agents==0.4.2",
+  "mars-agents==0.4.3",
   "mcp>=1.0",
   "pathspec>=1.1.0",
   "psutil>=7.2.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "cyclopts>=3.0",
   "fastapi>=0.115",
   "markdown-it-py>=4.0",
-  "mars-agents==0.4.0",
+  "mars-agents==0.4.1",
   "mcp>=1.0",
   "pathspec>=1.1.0",
   "psutil>=7.2.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "cyclopts>=3.0",
   "fastapi>=0.115",
   "markdown-it-py>=4.0",
-  "mars-agents==0.4.1",
+  "mars-agents==0.4.2",
   "mcp>=1.0",
   "pathspec>=1.1.0",
   "psutil>=7.2.2",

--- a/src/meridian/cli/.context/CONTEXT.md
+++ b/src/meridian/cli/.context/CONTEXT.md
@@ -91,6 +91,21 @@ than `isinstance` branches in `main.py`. This keeps the root CLI module
 free of spawn-op and output-model imports. Each result type implements
 the small protocol to produce its wire-shaped output.
 
+## `init` Command Routing
+
+`init_alias` in `main.py` has two branches:
+
+- **With `--add` or `--link`** → routes through `init_ops.run_init_flow`, which
+  handles package installation, config bootstrap, and tool directory linking in
+  one call. Mars is invoked internally by `init_ops`, not via `mars_passthrough`.
+- **Bare `meridian init`** (no flags) → calls `config_init_sync` directly to
+  bootstrap the project config only.
+
+There is no passthrough path in this command. `resolve_init_link_mars_command`
+was deleted when `init_ops` took over the `--link` case — do not recreate it.
+Auto-link is the default behavior; there are no confirmation prompts in the init
+flow, so `--yes` has no meaning here and was removed.
+
 ## Related KB
 
 → [KB: architecture/startup-pipeline.md](/home/jimyao/.meridian/git/meridian-flow-docs/kb/architecture/startup-pipeline.md)

--- a/src/meridian/cli/main.py
+++ b/src/meridian/cli/main.py
@@ -478,63 +478,28 @@ def init_alias(
             help="Package specifier(s) to install (e.g. owner/repo). Repeatable.",
         ),
     ] = None,
-    yes: Annotated[
-        bool,
-        Parameter(
-            name=["-y", "--yes"],
-            help="Suppress all confirmation prompts.",
-        ),
-    ] = False,
 ) -> None:
     """Initialize meridian in the current project or provided path."""
 
     from meridian.cli import mars_passthrough
     from meridian.lib.ops.config import ConfigInitInput, config_init_sync
 
-    if add:
+    project_root = mars_passthrough.resolve_init_project_root(path)
+
+    if add or link:
         from meridian.lib.ops.init_ops import run_init_flow
 
-        project_root = mars_passthrough.resolve_init_project_root(path)
-        output_format = get_global_options().output.format
         result = run_init_flow(
             project_root=project_root,
-            add_sources=add,
+            add_sources=add or [],
             link_targets=link,
-            yes=yes,
-            output_format=output_format,
+            output_format=get_global_options().output.format,
         )
         emit(result)
         return
 
-    # Bare init (no --add)
-    project_root = mars_passthrough.resolve_init_project_root(path)
-    result = config_init_sync(ConfigInitInput(project_root=project_root.as_posix()))
-
-    if not link:
-        emit(result)
-        return
-
-    # init + --link (without --add): passthrough to mars per target
-    output_format = get_global_options().output.format
-    executable = mars_passthrough.resolve_mars_executable()
-    if executable is None:
-        print(
-            "error: Failed to execute 'mars'. Install meridian with dependencies and retry.",
-            file=sys.stderr,
-        )
-        raise SystemExit(1)
-    for link_target in link:
-        _, mars_args = mars_passthrough.resolve_init_link_mars_command(project_root, link_target)
-        request = mars_passthrough.parse_mars_passthrough(
-            mars_args, output_format=output_format, executable=executable
-        )
-        link_result = _execute_mars_passthrough(request)
-        if request.wants_json and link_result.stdout_text:
-            sys.stdout.write(link_result.stdout_text)
-        if link_result.stderr_text:
-            sys.stderr.write(link_result.stderr_text)
-        if link_result.returncode != 0:
-            raise SystemExit(link_result.returncode)
+    # Truly bare init (no --add, no --link): bootstrap config only
+    emit(config_init_sync(ConfigInitInput(project_root=project_root.as_posix())))
 
 
 def _first_command_token(argv: Sequence[str]) -> str | None:

--- a/src/meridian/cli/main.py
+++ b/src/meridian/cli/main.py
@@ -458,29 +458,6 @@ def _run_primary_launch(
     )
 
 
-def _run_init_link_flow_json(
-    *,
-    executable: str,
-    mars_mode: str,
-    mars_args: Sequence[str],
-    link: str,
-    config_result: BaseModel,
-) -> None:
-    from meridian.cli import mars_passthrough
-
-    return mars_passthrough.run_init_link_flow_json(
-        executable=executable,
-        mars_mode=mars_mode,
-        mars_args=mars_args,
-        link=link,
-        config_result=config_result,
-        emit=emit,
-        parse_request=mars_passthrough.parse_mars_passthrough,
-        execute_request=_execute_mars_passthrough,
-        decode_values=mars_passthrough.decode_json_values,
-    )
-
-
 @app.command(name="init")
 def init_alias(
     path: Annotated[
@@ -488,43 +465,76 @@ def init_alias(
         Parameter(name="path", help="Optional project path to initialize."),
     ] = None,
     link: Annotated[
-        str | None,
+        list[str] | None,
         Parameter(
             name="--link",
             help="Link .mars/ into tool directory after config bootstrap (for example .claude).",
         ),
     ] = None,
+    add: Annotated[
+        list[str] | None,
+        Parameter(
+            name="--add",
+            help="Package specifier(s) to install (e.g. owner/repo). Repeatable.",
+        ),
+    ] = None,
+    yes: Annotated[
+        bool,
+        Parameter(
+            name=["-y", "--yes"],
+            help="Suppress all confirmation prompts.",
+        ),
+    ] = False,
 ) -> None:
     """Initialize meridian in the current project or provided path."""
 
     from meridian.cli import mars_passthrough
     from meridian.lib.ops.config import ConfigInitInput, config_init_sync
 
-    project_root = mars_passthrough.resolve_init_project_root(path)
-    result = config_init_sync(ConfigInitInput(project_root=project_root.as_posix()))
-    if link is None:
+    if add:
+        from meridian.lib.ops.init_ops import run_init_flow
+
+        project_root = mars_passthrough.resolve_init_project_root(path)
+        output_format = get_global_options().output.format
+        result = run_init_flow(
+            project_root=project_root,
+            add_sources=add,
+            link_targets=link,
+            yes=yes,
+            output_format=output_format,
+        )
         emit(result)
         return
 
-    mars_mode, mars_args = mars_passthrough.resolve_init_link_mars_command(project_root, link)
-    output_format = get_global_options().output.format
-    if output_format == "json":
-        executable = mars_passthrough.resolve_mars_executable()
-        if executable is None:
-            print(
-                "error: Failed to execute 'mars'. Install meridian with dependencies and retry.",
-                file=sys.stderr,
-            )
-            raise SystemExit(1)
-        _run_init_link_flow_json(
-            executable=executable,
-            mars_mode=mars_mode,
-            mars_args=mars_args,
-            link=link,
-            config_result=result,
-        )
+    # Bare init (no --add)
+    project_root = mars_passthrough.resolve_init_project_root(path)
+    result = config_init_sync(ConfigInitInput(project_root=project_root.as_posix()))
+
+    if not link:
+        emit(result)
         return
-    _run_mars_passthrough(mars_args, output_format=output_format)
+
+    # init + --link (without --add): passthrough to mars per target
+    output_format = get_global_options().output.format
+    executable = mars_passthrough.resolve_mars_executable()
+    if executable is None:
+        print(
+            "error: Failed to execute 'mars'. Install meridian with dependencies and retry.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    for link_target in link:
+        _, mars_args = mars_passthrough.resolve_init_link_mars_command(project_root, link_target)
+        request = mars_passthrough.parse_mars_passthrough(
+            mars_args, output_format=output_format, executable=executable
+        )
+        link_result = _execute_mars_passthrough(request)
+        if request.wants_json and link_result.stdout_text:
+            sys.stdout.write(link_result.stdout_text)
+        if link_result.stderr_text:
+            sys.stderr.write(link_result.stderr_text)
+        if link_result.returncode != 0:
+            raise SystemExit(link_result.returncode)
 
 
 def _first_command_token(argv: Sequence[str]) -> str | None:

--- a/src/meridian/cli/mars_passthrough.py
+++ b/src/meridian/cli/mars_passthrough.py
@@ -191,9 +191,3 @@ def resolve_init_project_root(path: str | None) -> Path:
     env_root = os.getenv("MERIDIAN_PROJECT_DIR", "").strip()
     return Path(env_root).expanduser().resolve() if env_root else Path.cwd().resolve()
 
-
-def resolve_init_link_mars_command(project_root: Path, link: str) -> tuple[str, list[str]]:
-    root_arg = project_root.as_posix()
-    if (project_root / "mars.toml").is_file():
-        return "link", ["--root", root_arg, "link", link]
-    return "init", ["--root", root_arg, "init", "--link", link]

--- a/src/meridian/cli/mars_passthrough.py
+++ b/src/meridian/cli/mars_passthrough.py
@@ -9,12 +9,9 @@ import sys
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, TextIO
+from typing import TextIO
 
 from meridian.lib.ops.mars import resolve_mars_executable
-
-if TYPE_CHECKING:
-    from pydantic import BaseModel
 
 
 @dataclass(frozen=True)
@@ -200,46 +197,3 @@ def resolve_init_link_mars_command(project_root: Path, link: str) -> tuple[str, 
     if (project_root / "mars.toml").is_file():
         return "link", ["--root", root_arg, "link", link]
     return "init", ["--root", root_arg, "init", "--link", link]
-
-
-def run_init_link_flow_json(
-    *,
-    executable: str,
-    mars_mode: str,
-    mars_args: Sequence[str],
-    link: str,
-    config_result: BaseModel,
-    emit: Callable[[object], None],
-    parse_request: Callable[..., MarsPassthroughRequest] = parse_mars_passthrough,
-    execute_request: Callable[[MarsPassthroughRequest], MarsPassthroughResult] = (
-        execute_mars_passthrough
-    ),
-    decode_values: Callable[[str], list[object] | None] = decode_json_values,
-) -> None:
-    request = parse_request(mars_args, output_format="json", executable=executable)
-    result = execute_request(request)
-    parsed_events = decode_values(result.stdout_text)
-    if parsed_events is None:
-        mars_output: object = result.stdout_text
-    elif len(parsed_events) == 1:
-        mars_output = parsed_events[0]
-    else:
-        mars_output = parsed_events
-
-    mars_payload: dict[str, object] = {
-        "mode": mars_mode,
-        "target": link,
-        "exit_code": result.returncode,
-        "output": mars_output,
-    }
-    if result.stderr_text:
-        mars_payload["stderr"] = result.stderr_text
-    emit(
-        {
-            "ok": result.returncode == 0,
-            "config": config_result.model_dump(),
-            "mars": mars_payload,
-        }
-    )
-    if result.returncode != 0:
-        raise SystemExit(result.returncode)

--- a/src/meridian/lib/ops/.context/CONTEXT.md
+++ b/src/meridian/lib/ops/.context/CONTEXT.md
@@ -75,6 +75,30 @@ For the REST path, `SpawnApplicationService.prepare_spawn()` enforces:
 argv — it populates `cli_command` for dry-run display. All actual execution paths
 use `SPEC_ONLY`. Do not set `REQUIRED` on execution paths.
 
+### ops/init_ops.py — Init Orchestration
+
+`init_ops.py` is the single entry point for all `meridian init --add` and
+`meridian init --link` invocations. `run_init_flow()` sequences:
+
+1. `config_init_sync()` — bootstrap `meridian.toml` (idempotent)
+2. `mars init` — create `mars.toml` if absent
+3. `mars add <sources>` — skipped when no sources requested
+4. `mars link <target>` — once per resolved target
+5. `maybe_set_primary_agent()` — write `primary.agent` to `meridian.toml` if the
+   package declares one and the config field is currently unset
+
+**`_run_mars_json()` helper** consolidates all mars subprocess invocations.
+Takes `command: str` and `args: list[str]`, passes `--json`, returns parsed output.
+`run_mars_add_json()` is a typed wrapper on top that also calls `_scan_mars_content()`.
+
+**`_scan_mars_content()` uses filesystem scanning, not JSON model parsing.**
+It discovers content by walking `.mars/` subdirectories — skills are stored as
+directories (containing `SKILL.md`), agents as files, so the scan uses
+`f.is_file() or f.is_dir()`. Returns `dict[str, list[str]]` keyed by content
+type (e.g., `{"agents": [...], "skills": [...]}`). This avoids coupling Python
+to the mars JSON report shape — new content types (hooks, MCP servers, etc.) are
+automatically counted without Python model changes.
+
 ## Contracts
 
 ### OperationRuntime

--- a/src/meridian/lib/ops/init_ops.py
+++ b/src/meridian/lib/ops/init_ops.py
@@ -1,0 +1,265 @@
+"""Init-with-add orchestration for meridian project setup."""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+from meridian.lib.core.util import FormatContext
+
+
+@dataclass(frozen=True)
+class InitAddResult:
+    """Parsed result from mars add --json."""
+
+    declared_targets: list[str]
+    declared_primary_agent: str | None
+    add_report: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class PrimaryAgentAction:
+    action: str  # "none", "set", "already_set", "differs"
+    agent: str | None = None
+    current: str | None = None
+    message: str | None = None
+
+
+class InitResult(BaseModel):
+    """Output from run_init_flow. Supports text and JSON output."""
+
+    model_config = ConfigDict(frozen=True)
+
+    ok: bool = True
+    project_root: str
+    config_created: bool
+    packages_added: list[str]
+    packages_resolved: list[str]
+    targets_linked: list[str]
+    content_count: int
+    primary_agent: PrimaryAgentAction | None = None
+    next_step: str = "Run `meridian` to start."
+
+    def format_text(self, ctx: FormatContext | None = None) -> str:
+        _ = ctx
+        lines = [f"Initialized {self.project_root}", ""]
+        if self.packages_resolved:
+            pkg_str = ", ".join(self.packages_resolved)
+            lines.append(f"  Packages:   {pkg_str} ({len(self.packages_resolved)} packages)")
+        if self.targets_linked:
+            lines.append(f"  Targets:    {', '.join(self.targets_linked)}")
+        lines.append(f"  Content:    {self.content_count} items")
+        if self.primary_agent and self.primary_agent.action == "set":
+            lines.append(f"  Primary:    {self.primary_agent.agent} (set in meridian.toml)")
+        elif self.primary_agent and self.primary_agent.action == "differs":
+            lines.append(f"  Primary:    {self.primary_agent.message}")
+        lines.append("")
+        lines.append(f"{self.next_step}")
+        return "\n".join(lines)
+
+
+def run_mars_add_json(
+    project_root: Path,
+    sources: list[str],
+    *,
+    executable: str,
+) -> InitAddResult:
+    """Run mars add with JSON output and parse declared_targets."""
+
+    from meridian.cli.mars_passthrough import (
+        execute_mars_passthrough,
+        parse_mars_passthrough,
+    )
+
+    args = ["--root", project_root.as_posix(), "--json", "add", *sources]
+    request = parse_mars_passthrough(args, executable=executable, output_format="json")
+    result = execute_mars_passthrough(request)
+    if result.returncode != 0:
+        if result.stderr_text:
+            sys.stderr.write(result.stderr_text)
+        raise SystemExit(result.returncode)
+    parsed: dict[str, Any] = json.loads(result.stdout_text)
+    return InitAddResult(
+        declared_targets=parsed.get("declared_targets", []),
+        declared_primary_agent=parsed.get("declared_primary_agent"),
+        add_report=parsed,
+    )
+
+
+def run_mars_link_json(
+    project_root: Path,
+    target: str,
+    *,
+    executable: str,
+) -> dict[str, Any]:
+    """Run mars link for a single target with JSON output."""
+
+    from meridian.cli.mars_passthrough import (
+        execute_mars_passthrough,
+        parse_mars_passthrough,
+    )
+
+    args = ["--root", project_root.as_posix(), "--json", "link", target]
+    request = parse_mars_passthrough(args, executable=executable, output_format="json")
+    result = execute_mars_passthrough(request)
+    if result.returncode != 0:
+        if result.stderr_text:
+            sys.stderr.write(result.stderr_text)
+        raise SystemExit(result.returncode)
+    result_data: dict[str, Any] = json.loads(result.stdout_text) if result.stdout_text else {}
+    return result_data
+
+
+def run_mars_init_json(
+    project_root: Path,
+    *,
+    executable: str,
+) -> dict[str, Any]:
+    """Run mars init with JSON output. Idempotent."""
+
+    from meridian.cli.mars_passthrough import (
+        execute_mars_passthrough,
+        parse_mars_passthrough,
+    )
+
+    args = ["--root", project_root.as_posix(), "--json", "init"]
+    request = parse_mars_passthrough(args, executable=executable, output_format="json")
+    result = execute_mars_passthrough(request)
+    if result.returncode != 0:
+        if result.stderr_text:
+            sys.stderr.write(result.stderr_text)
+        raise SystemExit(result.returncode)
+    result_data: dict[str, Any] = json.loads(result.stdout_text) if result.stdout_text else {}
+    return result_data
+
+
+def maybe_set_primary_agent(
+    project_root: Path,
+    declared_primary_agent: str | None,
+) -> PrimaryAgentAction:
+    """Set primary.agent if unset. Returns what happened."""
+
+    if not declared_primary_agent:
+        return PrimaryAgentAction(action="none")
+
+    config_path = project_root / "meridian.toml"
+    if not config_path.is_file():
+        return PrimaryAgentAction(action="none")
+
+    content = config_path.read_text(encoding="utf-8")
+
+    import tomlkit
+
+    doc = tomlkit.parse(content)
+    primary_table = doc.get("primary")
+    if isinstance(primary_table, dict):
+        current_agent = primary_table.get("agent")
+        if isinstance(current_agent, str) and current_agent.strip():
+            if current_agent == declared_primary_agent:
+                return PrimaryAgentAction(action="already_set", agent=declared_primary_agent)
+            return PrimaryAgentAction(
+                action="differs",
+                agent=declared_primary_agent,
+                current=current_agent,
+                message=(
+                    f"Package recommends '{declared_primary_agent}' as primary agent. "
+                    f"Current primary is '{current_agent}'. "
+                    f"Run `meridian -a {declared_primary_agent}` to try it, "
+                    f"or update `meridian.toml` to change your default."
+                ),
+            )
+
+    from meridian.lib.config.preserving_edit import set_scalar_option
+    from meridian.lib.config.settings import OPTION_CATALOG
+    from meridian.lib.state.atomic import atomic_write_text
+
+    option = OPTION_CATALOG.resolve_key("primary.agent")
+    edit_result = set_scalar_option(content, option=option, value=declared_primary_agent)
+    atomic_write_text(config_path, edit_result.text)
+    return PrimaryAgentAction(action="set", agent=declared_primary_agent)
+
+
+def run_init_flow(
+    *,
+    project_root: Path,
+    add_sources: list[str],
+    link_targets: list[str] | None = None,
+    yes: bool = False,
+    output_format: str = "text",
+) -> InitResult | dict[str, Any]:
+    """Full init-with-add orchestration.
+
+    Sequence:
+    1. Bootstrap meridian.toml (config_init_sync)
+    2. mars init if no mars.toml
+    3. mars add <sources>
+    4. Determine targets (--link overrides, else declared)
+    5. mars link for each target
+    6. Set primary agent if applicable
+    7. Return result
+    """
+
+    from meridian.cli.mars_passthrough import resolve_mars_executable
+    from meridian.lib.ops.config import ConfigInitInput, config_init_sync
+
+    _ = yes  # reserved for future interactive prompts
+
+    # 1. Bootstrap meridian.toml
+    config_result = config_init_sync(ConfigInitInput(project_root=project_root.as_posix()))
+
+    # Resolve mars executable
+    executable = resolve_mars_executable()
+    if executable is None:
+        sys.stderr.write(
+            "error: Failed to execute 'mars'. Install meridian with dependencies and retry.\n"
+        )
+        raise SystemExit(1)
+
+    # 2. mars init if no mars.toml
+    mars_toml = project_root / "mars.toml"
+    if not mars_toml.is_file():
+        run_mars_init_json(project_root, executable=executable)
+
+    # 3. mars add
+    add_result = run_mars_add_json(project_root, add_sources, executable=executable)
+
+    # 4. Determine targets
+    targets: list[str] = link_targets or add_result.declared_targets
+
+    # 5. mars link for each target
+    for target in targets:
+        run_mars_link_json(project_root, target, executable=executable)
+
+    # 6. Primary agent
+    primary_action = maybe_set_primary_agent(project_root, add_result.declared_primary_agent)
+
+    # 7. Build result
+    report = add_result.add_report
+    targets_data = report.get("targets", {})
+    if isinstance(targets_data, dict) and targets_data:
+        content_count = sum(
+            int(t.get("synced", 0))
+            for t in targets_data.values()
+            if isinstance(t, dict)
+        )
+    else:
+        content_count = int(report.get("installed", 0)) + int(report.get("updated", 0))
+
+    result = InitResult(
+        project_root=project_root.as_posix(),
+        config_created=config_result.created,
+        packages_added=add_sources,
+        packages_resolved=add_sources,
+        targets_linked=targets,
+        content_count=content_count,
+        primary_agent=primary_action,
+    )
+
+    if output_format == "json":
+        return result.model_dump()
+    return result

--- a/src/meridian/lib/ops/init_ops.py
+++ b/src/meridian/lib/ops/init_ops.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -15,11 +15,11 @@ from meridian.lib.core.util import FormatContext
 
 @dataclass(frozen=True)
 class InitAddResult:
-    """Parsed result from mars add --json."""
+    """What we extracted from mars add --json + post-sync filesystem."""
 
     declared_targets: list[str]
     declared_primary_agent: str | None
-    add_report: dict[str, Any]
+    content: dict[str, list[str]] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -39,21 +39,23 @@ class InitResult(BaseModel):
     project_root: str
     config_created: bool
     packages_added: list[str]
-    packages_resolved: list[str]
+    packages_requested: list[str]
     targets_linked: list[str]
-    content_count: int
+    content: dict[str, list[str]]
     primary_agent: PrimaryAgentAction | None = None
     next_step: str = "Run `meridian` to start."
 
     def format_text(self, ctx: FormatContext | None = None) -> str:
         _ = ctx
         lines = [f"Initialized {self.project_root}", ""]
-        if self.packages_resolved:
-            pkg_str = ", ".join(self.packages_resolved)
-            lines.append(f"  Packages:   {pkg_str} ({len(self.packages_resolved)} packages)")
+        if self.packages_requested:
+            pkg_str = ", ".join(self.packages_requested)
+            lines.append(f"  Packages:   {pkg_str} ({len(self.packages_requested)} packages)")
         if self.targets_linked:
             lines.append(f"  Targets:    {', '.join(self.targets_linked)}")
-        lines.append(f"  Content:    {self.content_count} items")
+        if self.content:
+            parts = [f"{len(items)} {kind}" for kind, items in self.content.items()]
+            lines.append(f"  Content:    {', '.join(parts)}")
         if self.primary_agent and self.primary_agent.action == "set":
             lines.append(f"  Primary:    {self.primary_agent.agent} (set in meridian.toml)")
         elif self.primary_agent and self.primary_agent.action == "differs":
@@ -63,79 +65,72 @@ class InitResult(BaseModel):
         return "\n".join(lines)
 
 
+def _run_mars_json(
+    project_root: Path,
+    command: str,
+    args: list[str],
+    *,
+    executable: str,
+) -> dict[str, Any]:
+    """Run a mars command with --json and return parsed output."""
+
+    from meridian.cli.mars_passthrough import (
+        execute_mars_passthrough,
+        parse_mars_passthrough,
+    )
+
+    full_args = ["--root", project_root.as_posix(), "--json", command, *args]
+    request = parse_mars_passthrough(full_args, executable=executable, output_format="json")
+    result = execute_mars_passthrough(request)
+    if result.returncode != 0:
+        if result.stderr_text:
+            sys.stderr.write(result.stderr_text)
+        raise SystemExit(result.returncode)
+    return json.loads(result.stdout_text) if result.stdout_text else {}
+
+
+def _scan_mars_content(project_root: Path) -> dict[str, list[str]]:
+    """Scan .mars/ for materialized content by type.
+
+    Returns a dict like {"agents": ["coder", "reviewer"], "skills": ["spawn", ...]}.
+    Discovers content types dynamically from subdirectory names.
+    """
+    mars_dir = project_root / ".mars"
+    if not mars_dir.is_dir():
+        return {}
+    # Dirs that are internal implementation state, not user-visible content.
+    _SKIP_DIRS = {"cache"}
+    content: dict[str, list[str]] = {}
+    for subdir in sorted(mars_dir.iterdir()):
+        if not subdir.is_dir():
+            continue
+        if subdir.name in _SKIP_DIRS:
+            continue
+        # Skills and bootstrap are stored as directories; agents are stored as files.
+        # Include both so all content types are counted correctly.
+        items = sorted(f.stem for f in subdir.iterdir() if f.is_file() or f.is_dir())
+        if items:
+            content[subdir.name] = items
+    return content
+
+
 def run_mars_add_json(
     project_root: Path,
     sources: list[str],
     *,
     executable: str,
 ) -> InitAddResult:
-    """Run mars add with JSON output and parse declared_targets."""
+    """Run mars add with JSON output and scan materialized content."""
 
-    from meridian.cli.mars_passthrough import (
-        execute_mars_passthrough,
-        parse_mars_passthrough,
-    )
-
-    args = ["--root", project_root.as_posix(), "--json", "add", *sources]
-    request = parse_mars_passthrough(args, executable=executable, output_format="json")
-    result = execute_mars_passthrough(request)
-    if result.returncode != 0:
-        if result.stderr_text:
-            sys.stderr.write(result.stderr_text)
-        raise SystemExit(result.returncode)
-    parsed: dict[str, Any] = json.loads(result.stdout_text)
+    parsed = _run_mars_json(project_root, "add", sources, executable=executable)
+    content = _scan_mars_content(project_root)
+    declared_targets: list[str] = parsed.get("declared_targets", [])
+    declared_primary_agent: str | None = parsed.get("declared_primary_agent")
     return InitAddResult(
-        declared_targets=parsed.get("declared_targets", []),
-        declared_primary_agent=parsed.get("declared_primary_agent"),
-        add_report=parsed,
+        declared_targets=declared_targets,
+        declared_primary_agent=declared_primary_agent,
+        content=content,
     )
-
-
-def run_mars_link_json(
-    project_root: Path,
-    target: str,
-    *,
-    executable: str,
-) -> dict[str, Any]:
-    """Run mars link for a single target with JSON output."""
-
-    from meridian.cli.mars_passthrough import (
-        execute_mars_passthrough,
-        parse_mars_passthrough,
-    )
-
-    args = ["--root", project_root.as_posix(), "--json", "link", target]
-    request = parse_mars_passthrough(args, executable=executable, output_format="json")
-    result = execute_mars_passthrough(request)
-    if result.returncode != 0:
-        if result.stderr_text:
-            sys.stderr.write(result.stderr_text)
-        raise SystemExit(result.returncode)
-    result_data: dict[str, Any] = json.loads(result.stdout_text) if result.stdout_text else {}
-    return result_data
-
-
-def run_mars_init_json(
-    project_root: Path,
-    *,
-    executable: str,
-) -> dict[str, Any]:
-    """Run mars init with JSON output. Idempotent."""
-
-    from meridian.cli.mars_passthrough import (
-        execute_mars_passthrough,
-        parse_mars_passthrough,
-    )
-
-    args = ["--root", project_root.as_posix(), "--json", "init"]
-    request = parse_mars_passthrough(args, executable=executable, output_format="json")
-    result = execute_mars_passthrough(request)
-    if result.returncode != 0:
-        if result.stderr_text:
-            sys.stderr.write(result.stderr_text)
-        raise SystemExit(result.returncode)
-    result_data: dict[str, Any] = json.loads(result.stdout_text) if result.stdout_text else {}
-    return result_data
 
 
 def maybe_set_primary_agent(
@@ -170,7 +165,8 @@ def maybe_set_primary_agent(
                     f"Package recommends '{declared_primary_agent}' as primary agent. "
                     f"Current primary is '{current_agent}'. "
                     f"Run `meridian -a {declared_primary_agent}` to try it, "
-                    f"or update `meridian.toml` to change your default."
+                    f"or `meridian config set primary.agent {declared_primary_agent}` "
+                    f"to change your default."
                 ),
             )
 
@@ -189,7 +185,6 @@ def run_init_flow(
     project_root: Path,
     add_sources: list[str],
     link_targets: list[str] | None = None,
-    yes: bool = False,
     output_format: str = "text",
 ) -> InitResult | dict[str, Any]:
     """Full init-with-add orchestration.
@@ -197,7 +192,7 @@ def run_init_flow(
     Sequence:
     1. Bootstrap meridian.toml (config_init_sync)
     2. mars init if no mars.toml
-    3. mars add <sources>
+    3. mars add <sources>  (skipped when add_sources is empty)
     4. Determine targets (--link overrides, else declared)
     5. mars link for each target
     6. Set primary agent if applicable
@@ -206,8 +201,6 @@ def run_init_flow(
 
     from meridian.cli.mars_passthrough import resolve_mars_executable
     from meridian.lib.ops.config import ConfigInitInput, config_init_sync
-
-    _ = yes  # reserved for future interactive prompts
 
     # 1. Bootstrap meridian.toml
     config_result = config_init_sync(ConfigInitInput(project_root=project_root.as_posix()))
@@ -223,40 +216,35 @@ def run_init_flow(
     # 2. mars init if no mars.toml
     mars_toml = project_root / "mars.toml"
     if not mars_toml.is_file():
-        run_mars_init_json(project_root, executable=executable)
+        _run_mars_json(project_root, "init", [], executable=executable)
 
-    # 3. mars add
-    add_result = run_mars_add_json(project_root, add_sources, executable=executable)
+    # 3. mars add (skipped when no sources requested)
+    add_result: InitAddResult | None = None
+    if add_sources:
+        add_result = run_mars_add_json(project_root, add_sources, executable=executable)
 
     # 4. Determine targets
-    targets: list[str] = link_targets or add_result.declared_targets
+    declared_targets = add_result.declared_targets if add_result else []
+    targets: list[str] = link_targets if link_targets is not None else declared_targets
 
     # 5. mars link for each target
     for target in targets:
-        run_mars_link_json(project_root, target, executable=executable)
+        _run_mars_json(project_root, "link", [target], executable=executable)
 
     # 6. Primary agent
-    primary_action = maybe_set_primary_agent(project_root, add_result.declared_primary_agent)
+    declared_primary_agent = add_result.declared_primary_agent if add_result else None
+    primary_action = maybe_set_primary_agent(project_root, declared_primary_agent)
 
     # 7. Build result
-    report = add_result.add_report
-    targets_data = report.get("targets", {})
-    if isinstance(targets_data, dict) and targets_data:
-        content_count = sum(
-            int(t.get("synced", 0))
-            for t in targets_data.values()
-            if isinstance(t, dict)
-        )
-    else:
-        content_count = int(report.get("installed", 0)) + int(report.get("updated", 0))
+    content = add_result.content if add_result else {}
 
     result = InitResult(
         project_root=project_root.as_posix(),
         config_created=config_result.created,
         packages_added=add_sources,
-        packages_resolved=add_sources,
+        packages_requested=add_sources,
         targets_linked=targets,
-        content_count=content_count,
+        content=content,
         primary_agent=primary_action,
     )
 

--- a/tests/integration/cli/test_cli_main.py
+++ b/tests/integration/cli/test_cli_main.py
@@ -6,9 +6,8 @@ from typing import Any
 import pytest
 
 cli_main = importlib.import_module("meridian.cli.main")
-mars_passthrough = importlib.import_module("meridian.cli.mars_passthrough")
 primary_launch = importlib.import_module("meridian.cli.primary_launch")
-config_ops = importlib.import_module("meridian.lib.ops.config")
+init_ops = importlib.import_module("meridian.lib.ops.init_ops")
 
 
 def test_main_harness_shortcut_routes_into_primary_launch(
@@ -31,62 +30,81 @@ def test_main_harness_shortcut_routes_into_primary_launch(
     assert captured["dry_run"] is True
 
 
-def test_init_alias_link_uses_mars_init_when_mars_toml_missing(
+def test_init_alias_link_uses_mars_flow_with_full_link_target_when_called_directly(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    captured_project_root: dict[str, str] = {}
-    captured_mars: list[tuple[tuple[str, ...], str | None]] = []
+    captured: dict[str, Any] = {}
 
-    def _fake_config_init(payload: Any) -> object:
-        captured_project_root["value"] = payload.project_root
+    def _fake_run_init_flow(
+        *,
+        project_root: Path,
+        add_sources: list[str],
+        link_targets: list[str] | None = None,
+        output_format: str = "text",
+    ) -> object:
+        captured.update(
+            {
+                "project_root": project_root.as_posix(),
+                "add_sources": add_sources,
+                "link_targets": link_targets,
+                "output_format": output_format,
+            }
+        )
         return object()
 
-    def _fake_run_mars_passthrough(
-        args: list[str] | tuple[str, ...],
-        *,
-        output_format: str | None = None,
-        **_kwargs: object,
-    ) -> None:
-        captured_mars.append((tuple(args), output_format))
+    monkeypatch.setattr(init_ops, "run_init_flow", _fake_run_init_flow)
+    monkeypatch.setattr(cli_main, "emit", lambda _payload: None)
 
-    monkeypatch.setattr(config_ops, "config_init_sync", _fake_config_init)
-    monkeypatch.setattr(mars_passthrough, "run_mars_passthrough", _fake_run_mars_passthrough)
-
-    cli_main.init_alias(path=tmp_path.as_posix(), link=".claude")
+    cli_main.init_alias(path=tmp_path.as_posix(), link=[".claude"])
 
     expected_root = tmp_path.resolve().as_posix()
-    assert captured_project_root["value"] == expected_root
-    assert captured_mars == [
-        (("--root", expected_root, "init", "--link", ".claude"), "text"),
-    ]
+    assert captured == {
+        "project_root": expected_root,
+        "add_sources": [],
+        "link_targets": [".claude"],
+        "output_format": "text",
+    }
 
 
-def test_init_alias_link_uses_mars_link_when_mars_toml_exists(
+def test_init_alias_link_uses_mars_flow_with_cli_parsed_single_target_not_characters(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    captured_mars: list[tuple[tuple[str, ...], str | None]] = []
-    (tmp_path / "mars.toml").write_text("", encoding="utf-8")
+    captured: dict[str, Any] = {}
 
-    monkeypatch.setattr(config_ops, "config_init_sync", lambda _payload: object())
-
-    def _fake_run_mars_passthrough(
-        args: list[str] | tuple[str, ...],
+    def _fake_run_init_flow(
         *,
-        output_format: str | None = None,
-        **_kwargs: object,
-    ) -> None:
-        captured_mars.append((tuple(args), output_format))
+        project_root: Path,
+        add_sources: list[str],
+        link_targets: list[str] | None = None,
+        output_format: str = "text",
+    ) -> object:
+        captured.update(
+            {
+                "project_root": project_root.as_posix(),
+                "add_sources": add_sources,
+                "link_targets": link_targets,
+                "output_format": output_format,
+            }
+        )
+        return object()
 
-    monkeypatch.setattr(mars_passthrough, "run_mars_passthrough", _fake_run_mars_passthrough)
+    monkeypatch.setattr(init_ops, "run_init_flow", _fake_run_init_flow)
+    monkeypatch.setattr(cli_main, "maybe_bootstrap_runtime_state", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(cli_main, "emit", lambda _payload: None)
 
-    cli_main.init_alias(path=tmp_path.as_posix(), link=".claude")
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["init", "--link", ".claude", tmp_path.as_posix()])
+    assert exc_info.value.code == 0
 
     expected_root = tmp_path.resolve().as_posix()
-    assert captured_mars == [
-        (("--root", expected_root, "link", ".claude"), "text"),
-    ]
+    assert captured == {
+        "project_root": expected_root,
+        "add_sources": [],
+        "link_targets": [".claude"],
+        "output_format": "text",
+    }
 
 
 def test_bootstrap_command_enables_bootstrap_documents(

--- a/tests/smoke/init-add.md
+++ b/tests/smoke/init-add.md
@@ -1,0 +1,90 @@
+# Smoke: init --add
+
+`meridian init --add` orchestration: config bootstrap, package install, auto-link, and primary agent setup in one command.
+
+## Prerequisites
+
+`mars` binary must be in PATH. If not installed, the mars-dependent tests will error on the mars executable check.
+
+## Setup
+
+```bash
+. tests/smoke/scripts/setup.sh --git
+```
+
+Create a local test package to avoid network dependency:
+
+```bash
+PKG=$(mktemp -d)
+cat > "$PKG/mars.toml" << 'EOF'
+[package]
+name = "smoke-test-pkg"
+version = "0.1.0"
+primary_agent = "test-agent"
+
+[package.targets]
+required = [".claude"]
+EOF
+
+mkdir -p "$PKG/agents"
+printf '# test-agent\n' > "$PKG/agents/test-agent.md"
+```
+
+## Full init --add flow
+
+```bash
+uv run meridian init --add "$PKG" "$SCRATCH"
+```
+- [ ] Exit 0
+- [ ] `$SCRATCH/meridian.toml` exists
+- [ ] `$SCRATCH/mars.toml` exists
+- [ ] `$SCRATCH/.claude/` directory exists (auto-linked from package target)
+- [ ] `$SCRATCH/meridian.toml` contains `agent = "test-agent"` (primary agent set)
+- [ ] stdout contains `Initialized`
+- [ ] stdout contains `agents` (content summary line)
+
+## Idempotent re-run
+
+```bash
+uv run meridian init --add "$PKG" "$SCRATCH"
+```
+- [ ] Exit 0
+- [ ] stderr is empty
+- [ ] `$SCRATCH/meridian.toml` still exists
+- [ ] `$SCRATCH/.claude/` still exists
+
+## Explicit --link overrides auto-link
+
+```bash
+SCRATCH2=$(mktemp -d)
+export MERIDIAN_PROJECT_DIR=$SCRATCH2
+uv run meridian init --add "$PKG" --link .codex "$SCRATCH2"
+```
+- [ ] Exit 0
+- [ ] `$SCRATCH2/.codex/` exists
+- [ ] `$SCRATCH2/.claude/` does NOT exist (explicit --link overrides package targets)
+
+## Bare init regression (no --add)
+
+```bash
+SCRATCH3=$(mktemp -d)
+export MERIDIAN_PROJECT_DIR=$SCRATCH3
+uv run meridian init "$SCRATCH3"
+```
+- [ ] Exit 0
+- [ ] `$SCRATCH3/meridian.toml` exists
+- [ ] `$SCRATCH3/mars.toml` does NOT exist (bare init does not touch mars)
+
+## JSON output
+
+```bash
+SCRATCH4=$(mktemp -d)
+export MERIDIAN_PROJECT_DIR=$SCRATCH4
+uv run meridian --json init --add "$PKG" "$SCRATCH4"
+```
+- [ ] Exit 0
+- [ ] stdout is valid JSON
+- [ ] JSON contains `"ok": true`
+- [ ] JSON contains `"targets_linked"` array
+- [ ] JSON contains `"content"` object with content type keys (e.g. `"agents"`)
+- [ ] JSON contains `"primary_agent"` object


### PR DESCRIPTION
## Summary

- Add `meridian init --add <source>` for one-line project setup: bootstraps meridian.toml, runs mars init/add/link, sets primary agent, reports content summary
- Flexible content scanning (`_scan_mars_content`) reads `.mars/` filesystem dynamically instead of rigid Pydantic model — auto-discovers agents, skills, hooks, MCP servers without code changes
- Consolidate two init code paths (--add via init_ops, bare --link via old passthrough) into single `run_init_flow` path; delete `resolve_init_link_mars_command`
- Remove dead `-y`/`--yes` flag (no confirmation prompts exist); rename `packages_resolved` → `packages_requested` (honest naming)
- Extract `_run_mars_json` helper replacing 3 near-identical functions
- Add smoke test (`tests/smoke/init-add.md`) with 5 scenarios
- Add `.context/CONTEXT.md` docs for init_ops and CLI routing

## Test plan

- [ ] `uv run pyright` — 0 errors
- [ ] `uv run ruff check .` — clean
- [ ] Smoke: `meridian init --add <package> <tmpdir>` creates meridian.toml, mars.toml, links targets, sets primary agent
- [ ] Smoke: `meridian --json init --add <package> <tmpdir>` returns `content` as object with agents/skills keys, `packages_requested` field
- [ ] Smoke: bare `meridian init <tmpdir>` still works (regression)
- [ ] Smoke: `meridian init --link .claude <tmpdir>` works through new consolidated path
- [ ] Smoke: idempotent re-run exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)