### PR TITLE
[codex] Add bootstrap package setup flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,25 @@ You need at least one harness installed: [Claude Code](https://docs.anthropic.co
 
 ## Set Up a Project
 
+`meridian init` by itself only bootstraps Meridian project config:
+
 ```bash
-meridian init --link .claude
-meridian mars add meridian-flow/meridian-dev-workflow
+meridian init
 ```
 
-This installs a full dev team — architects, coders, reviewers, testers — and links them into Claude Code. Agent packages are managed by [mars](https://github.com/meridian-flow/mars-agents).
+To initialize Mars package content in the same step, use setup flags:
+
+```bash
+meridian init --add meridian-flow/meridian-dev-workflow --link .claude
+```
+
+For first-run onboarding, bootstrap can do setup + launch in one command:
+
+```bash
+meridian bootstrap --add meridian-flow/meridian-dev-workflow --link .claude
+```
+
+`--add` / `--link` setup flags cannot be combined with `--dry-run`.
 
 ## Usage
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -9,7 +9,7 @@ Full command surface. Use `--help` on any command for flags and options.
 | `meridian` | Launch the primary agent session with startup context, including the installed agent catalog |
 | `meridian --continue REF` | Resume a prior primary session from a chat/session ref (`c123`), spawn ref (`p123`), or raw harness session id. Chat IDs are now the preferred reference — shown in the quit message when a primary session ends. |
 | `meridian --fork REF` | Launch a new primary session by forking a prior spawn ref (`p123`), chat/session ref (`c123`), or raw harness session id |
-| `meridian bootstrap` | Launch a primary session with all installed bootstrap docs injected — guides the agent through first-time environment setup |
+| `meridian bootstrap` | Launch a primary session with all installed bootstrap docs injected — guides first-time setup |
 | `meridian spawn -a AGENT -p "task"` | Delegate work to a routed agent/model |
 | `meridian spawn list` | See running and recent spawns |
 | `meridian spawn list --primary` | Show only primary spawns (top-level sessions) |
@@ -56,7 +56,11 @@ chat. Flags:
 | `--include-primaries` | Also cancel primary (top-level) sessions |
 | `--include-others` | Opt out of subtree scoping — cancel across the full chat (matches the behavior before subtree scoping was introduced) |
 
-`meridian bootstrap` accepts the same launch flags as a primary session (`-m`, `--harness`, `-a`, `--work`, `--approval`, `--effort`, `--timeout`, `--dry-run`). Bootstrap docs are injected automatically — no extra flags needed. The `-a` flag selects the agent profile; if omitted, Meridian uses the default bootstrap agent from the installed catalog.
+`meridian bootstrap` accepts the same launch flags as a primary session (`-m`, `--harness`, `-a`, `--work`, `--approval`, `--effort`, `--timeout`, `--dry-run`) plus setup flags (`--add`, `--link`).
+
+When setup flags are present, bootstrap first runs the same setup flow as `meridian init --add/--link` (including Mars init when needed), then launches the guided bootstrap session with bootstrap docs injected. Setup flags cannot be combined with `--dry-run`.
+
+The `-a` flag explicitly selects the bootstrap agent profile. If omitted, normal primary agent resolution applies (including `primary.agent` configured by package metadata during setup).
 
 For managed Codex primary startup behavior, see [codex-tui-passthrough.md](codex-tui-passthrough.md).
 
@@ -207,7 +211,7 @@ event types, command types, reconnect/replay, persistence, and harness support m
 
 | Command | Description |
 | ------- | ----------- |
-| `meridian init [--link DIR]` | Initialize project config/runtime state; optional convenience link wiring via mars |
+| `meridian init [--add SOURCE] [--link DIR]` | Initialize project config/runtime state; optional Mars package install/link setup |
 | `meridian workspace init` | Create or update local `[workspace]` examples in `meridian.local.toml` |
 | `meridian config show` | Show resolved configuration |
 | `meridian config set KEY VALUE` | Set a config value |
@@ -304,9 +308,19 @@ only. Those events are not visible through `tail`, `query`, or `status`.
 | `meridian mars upgrade` | Fetch latest versions and sync |
 | `meridian mars doctor` | Check for drift and integrity issues |
 
-`meridian init --link DIR` is the top-level convenience path:
+`meridian init` (no setup flags) bootstraps Meridian config/runtime only.
+
+`meridian init --add ...` runs setup flow:
+- initializes Mars when `mars.toml` is missing
+- installs package sources
+- links requested targets (or package-declared defaults)
+- applies package-declared `primary.agent` when config is unset
+
+`meridian init --link DIR` without `--add` is still a top-level convenience path:
 - without `mars.toml`, it shells through `meridian mars init --link DIR`
 - with `mars.toml`, it shells through `meridian mars link DIR`
+
+`meridian bootstrap --add ... --link ...` runs this same setup flow, then launches a guided bootstrap primary session.
 
 `meridian mars sync` automatically sets `MERIDIAN_MANAGED=1` in the mars subprocess environment. Mars uses this signal to suppress native agent emission to harness directories — agents are read by Meridian from `.mars/agents/`, not duplicated into `.claude/agents/` etc.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -63,9 +63,27 @@ meridian init
 
 This creates `.meridian/` with a project UUID and default `.gitignore`. The `.gitignore` inside `.meridian/` is managed automatically — it tracks `id`, `kb/`, `work/`, and `archive/` and ignores everything else. Spawn history and session state live at the user level (`~/.meridian/projects/<uuid>/`) and are never committed.
 
+Bare `meridian init` bootstraps Meridian config/runtime only. It does not initialize Mars packages on its own.
+
 ## Tool Integration
 
-To expose installed agent packages to a harness tool directory (`.claude/`, `.cursor/`, etc.), use the top-level convenience flag:
+To initialize Mars and install packages from the top-level command, use `--add`:
+
+```bash
+meridian init --add meridian-flow/meridian-dev-workflow --link .claude
+```
+
+`meridian init --add ...` initializes Mars when needed, installs packages, and applies requested links.
+
+For first-run onboarding, `bootstrap` can do setup and launch the guided primary session in one command:
+
+```bash
+meridian bootstrap --add meridian-flow/meridian-dev-workflow --link .claude
+```
+
+Setup flags (`--add`, `--link`) cannot be combined with `--dry-run`.
+
+To expose already-installed package content to a harness tool directory (`.claude/`, `.cursor/`, etc.), use the top-level convenience flag:
 
 ```bash
 meridian init --link .claude

--- a/src/meridian/cli/bootstrap_cmd.py
+++ b/src/meridian/cli/bootstrap_cmd.py
@@ -16,6 +16,20 @@ def register_bootstrap_command(
 ) -> None:
     @app.command(name="bootstrap")
     def bootstrap(  # pyright: ignore[reportUnusedFunction]
+        add: Annotated[
+            list[str] | None,
+            Parameter(
+                name="--add",
+                help="Package specifier(s) to install before launching bootstrap. Repeatable.",
+            ),
+        ] = None,
+        link: Annotated[
+            list[str] | None,
+            Parameter(
+                name="--link",
+                help="Link target(s) to materialize before launching bootstrap. Repeatable.",
+            ),
+        ] = None,
         model: Annotated[
             str,
             Parameter(name=["--model", "-m"], help="Model id or alias for primary harness."),
@@ -71,9 +85,13 @@ def register_bootstrap_command(
         """Launch a primary agent session with installed bootstrap docs."""
 
         from meridian.cli import primary_launch
+        from meridian.cli.mars_passthrough import resolve_init_project_root
+        from meridian.lib.ops.init_ops import run_init_flow
 
         if yolo and approval is not None:
             raise ValueError("Cannot combine --yolo with --approval.")
+        if (add or link) and dry_run:
+            raise ValueError("Cannot combine setup flags (--add/--link) with --dry-run.")
 
         explicit_harness = harness.strip() if harness is not None and harness.strip() else None
         global_harness = get_global_harness()
@@ -82,8 +100,19 @@ def register_bootstrap_command(
                 f"Conflicting harness selections: '{global_harness}' and '{explicit_harness}'."
             )
 
+        project_root = None
+        if add or link:
+            project_root = resolve_init_project_root(None)
+            run_init_flow(
+                project_root=project_root,
+                add_sources=add or [],
+                link_targets=link,
+                output_format="text",
+            )
+
         emit(
             primary_launch.run_primary_launch(
+                project_root=project_root,
                 continue_ref=None,
                 fork_ref=None,
                 model=model,

--- a/src/meridian/cli/main.py
+++ b/src/meridian/cli/main.py
@@ -63,7 +63,7 @@ from meridian.cli.output import (
 from meridian.cli.output import emit as emit_output
 from meridian.cli.startup.catalog import COMMAND_CATALOG
 from meridian.cli.startup.classify import classify_invocation
-from meridian.cli.startup.policy import StartupClass
+from meridian.cli.startup.policy import StartupClass, StateRequirement
 from meridian.cli.startup.policy import TelemetryMode as StartupTelemetryMode
 from meridian.lib.core.depth import is_nested_meridian_process, is_root_side_effect_process
 from meridian.lib.core.sink import OutputSink
@@ -737,6 +737,20 @@ def _workspace_subcommand(argv: Sequence[str]) -> str | None:
     return None
 
 
+def _bootstrap_setup_requested(argv: Sequence[str]) -> bool:
+    if not argv or argv[0] != "bootstrap":
+        return False
+
+    for token in argv[1:]:
+        if token == "--":
+            break
+        if token in {"--add", "--link"}:
+            return True
+        if token.startswith("--add=") or token.startswith("--link="):
+            return True
+    return False
+
+
 def _known_child_commands(parent: str) -> set[str]:
     return {
         descriptor.command_path[1]
@@ -944,6 +958,10 @@ def main(argv: Sequence[str] | None = None) -> None:
     )
     bootstrap_skipped = any(arg in {"--help", "-h"} for arg in cleaned_args)
     state_requirement = descriptor.state_requirement if descriptor is not None else None
+    # bootstrap --add/--link must resolve root with init semantics in the handler
+    # and reject invalid --dry-run combinations before any startup writes.
+    if _bootstrap_setup_requested(cleaned_args):
+        state_requirement = StateRequirement.NONE
     project_root = None
     with manual_hook_authority_scope(
         suppress=should_suppress_manual_hook_authority(argv=cleaned_args)

--- a/tests/integration/cli/test_cli_main.py
+++ b/tests/integration/cli/test_cli_main.py
@@ -8,6 +8,8 @@ import pytest
 cli_main = importlib.import_module("meridian.cli.main")
 primary_launch = importlib.import_module("meridian.cli.primary_launch")
 init_ops = importlib.import_module("meridian.lib.ops.init_ops")
+bootstrap_services = importlib.import_module("meridian.lib.bootstrap.services")
+cli_utils = importlib.import_module("meridian.cli.utils")
 
 
 def test_main_harness_shortcut_routes_into_primary_launch(
@@ -126,6 +128,119 @@ def test_bootstrap_command_enables_bootstrap_documents(
 
     assert exc_info.value.code == 0
     assert captured["include_bootstrap_documents"] is True
+
+
+def test_bootstrap_with_setup_runs_init_flow_and_passes_project_root_to_primary_launch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured_init: dict[str, object] = {}
+    captured_launch: dict[str, object] = {}
+    repo_root = tmp_path / "repo-root"
+    repo_root.mkdir()
+    (repo_root / ".git").mkdir()
+    nested_cwd = repo_root / "nested" / "project"
+    nested_cwd.mkdir(parents=True)
+    monkeypatch.chdir(nested_cwd)
+    monkeypatch.delenv("MERIDIAN_PROJECT_DIR", raising=False)
+    monkeypatch.setattr(
+        cli_utils,
+        "require_established_project_root",
+        lambda: pytest.fail("unexpected startup root resolution"),
+    )
+    monkeypatch.setattr(
+        bootstrap_services,
+        "prepare_for_runtime_write",
+        lambda _project_root: pytest.fail("unexpected startup runtime bootstrap"),
+    )
+
+    def _fake_run_init_flow(
+        *,
+        project_root: Path,
+        add_sources: list[str],
+        link_targets: list[str] | None = None,
+        output_format: str = "text",
+    ) -> object:
+        captured_init.update(
+            {
+                "project_root": project_root.as_posix(),
+                "add_sources": add_sources,
+                "link_targets": link_targets,
+                "output_format": output_format,
+            }
+        )
+        return object()
+
+    def _fake_primary_launch(**kwargs: object) -> object:
+        captured_launch.update(kwargs)
+        return primary_launch.PrimaryLaunchOutput(message="ok", exit_code=0)
+
+    monkeypatch.setattr(init_ops, "run_init_flow", _fake_run_init_flow)
+    monkeypatch.setattr(primary_launch, "run_primary_launch", _fake_primary_launch)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(
+            [
+                "bootstrap",
+                "--add",
+                "meridian-flow/meridian-dev-workflow",
+                "--add",
+                "meridian-flow/meridian-base",
+                "--link",
+                ".claude",
+                "--link",
+                ".cursor",
+            ]
+        )
+
+    assert exc_info.value.code == 0
+    expected_root = nested_cwd.resolve().as_posix()
+    assert captured_init == {
+        "project_root": expected_root,
+        "add_sources": ["meridian-flow/meridian-dev-workflow", "meridian-flow/meridian-base"],
+        "link_targets": [".claude", ".cursor"],
+        "output_format": "text",
+    }
+    assert captured_launch["project_root"] == nested_cwd.resolve()
+    assert captured_launch["include_bootstrap_documents"] is True
+
+
+def test_bootstrap_setup_flags_reject_dry_run_before_setup(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo-root"
+    repo_root.mkdir()
+    (repo_root / ".git").mkdir()
+    nested_cwd = repo_root / "nested" / "project"
+    nested_cwd.mkdir(parents=True)
+    monkeypatch.chdir(nested_cwd)
+    monkeypatch.delenv("MERIDIAN_PROJECT_DIR", raising=False)
+    monkeypatch.setattr(
+        cli_utils,
+        "require_established_project_root",
+        lambda: pytest.fail("unexpected startup root resolution"),
+    )
+    monkeypatch.setattr(
+        bootstrap_services,
+        "prepare_for_runtime_write",
+        lambda _project_root: pytest.fail("unexpected startup runtime bootstrap"),
+    )
+    monkeypatch.setattr(init_ops, "run_init_flow", lambda **_kwargs: pytest.fail("unexpected init"))
+    monkeypatch.setattr(
+        primary_launch,
+        "run_primary_launch",
+        lambda **_kwargs: pytest.fail("unexpected primary launch"),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["bootstrap", "--add", "meridian-flow/meridian-dev-workflow", "--dry-run"])
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "error: Cannot combine setup flags (--add/--link) with --dry-run.\n"
 
 
 def test_workspace_unknown_subcommand_help_exits_non_zero(


### PR DESCRIPTION
## Summary
- add `meridian bootstrap --add/--link` as first-run setup plus guided bootstrap launch
- reuse existing init orchestration so Mars init/add/link and package-declared `primary.agent` behave like `meridian init --add`
- skip pre-handler runtime bootstrap for setup bootstrap flows so dry-run rejection and root resolution happen before setup writes
- update README/getting-started/commands docs for the new init/bootstrap flow

## Validation
- pre-push hook: `uv run ruff check .`
- pre-push hook: `uv run pyright` (0 errors, 5 existing warnings in `init_ops.py`)
- pre-push hook: `uv run pytest -x -q` (1056 passed, 2 skipped)
- focused implementation checks: `uv run pytest-llm tests/integration/cli/test_cli_main.py`
- focused bootstrap checks: `uv run pytest tests/integration/cli/test_cli_main.py -k bootstrap`
- final reviewer check: `uv run pytest-llm -p no:cacheprovider tests/integration/cli/test_cli_main.py -k 'bootstrap or init_alias_link_uses_mars_flow'`
- tmux smoke: real `bootstrap --add` setup + Codex managed primary attach succeeded in an isolated temp project
