### PR TITLE
Candidate-aware model harness routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,23 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
-- `scripts/manually-release.sh` — emergency/backfill release helper. Runs shared preflight, blocks empty `[Unreleased]`, updates version/changelog, commits, tags, and can push.
+- Candidate-aware harness routing: `--harness opencode --model gpt-5.5` accepted when Mars reports OpenCode as a runnable candidate.
+- `RunnablePath` type and `AliasEntry.harness_candidates`/`runnable_paths` fields carry Mars multi-path data through catalog resolution.
+- `select_harness_model_id()` picks per-harness model ID (e.g. `openai/gpt-5.5`) from runnable paths at the bind boundary.
+- Model-policy `override: {harness: opencode}` validated against candidates and selects harness-specific model ID.
+- Empty `override: {}` accepted as intentional no-op in model-policy rules.
+
+### Changed
+- `validate_harness_compatibility()` checks `harness_candidates` when available; falls back to strict single-harness check when candidates unknown.
+- Validation applies to all final harness/model pairs, not just CLI same-precedence overrides.
+- Error diagnostics list supported harnesses when rejecting invalid combinations.
+- `is_policy_reroute` bypass removed — policy-derived harness overrides validated like any other route selection.
+- `ModelSelectionContext.harness_model_id` carries per-harness model string; applied only at harness command boundary, not in telemetry/display/persistence.
 
 ## [0.1.7] - 2026-05-15
+
+### Added
+- `scripts/manually-release.sh` — emergency/backfill release helper. Runs shared preflight, blocks empty `[Unreleased]`, updates version/changelog, commits, tags, and can push.
 
 ### Changed
 - Release workflow: PR merges release only with a `release:*` label. CI creates the patch release commit and `vX.Y.Z` tag, then directly runs PyPI publish. Missing labels, `release:skip`, or direct `main` pushes skip auto-release. Tag pushes remain a manual/backfill publish path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Error diagnostics list supported harnesses when rejecting invalid combinations.
 - `is_policy_reroute` bypass removed — policy-derived harness overrides validated like any other route selection.
 - `ModelSelectionContext.harness_model_id` carries per-harness model string; applied only at harness command boundary, not in telemetry/display/persistence.
+- Consolidated Mars candidate/runnable-path parsing: `parse_harness_candidates`/`parse_runnable_paths` replace duplicated inner functions in `models.py`.
 
 ## [0.1.7] - 2026-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,8 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Empty `override: {}` accepted as intentional no-op in model-policy rules.
 
 ### Changed
-- `validate_harness_compatibility()` checks `harness_candidates` when available; falls back to strict single-harness check when candidates unknown.
-- Validation applies to all final harness/model pairs, not just CLI same-precedence overrides.
-- Error diagnostics list supported harnesses when rejecting invalid combinations.
-- `is_policy_reroute` bypass removed — policy-derived harness overrides validated like any other route selection.
+- Explicit harness selection is a force — model/harness compatibility checks removed; only unavailable primary-launch adapters are rejected.
+- Launch policy no longer re-validates final model/harness pairs after harness materialization.
 - `ModelSelectionContext.harness_model_id` carries per-harness model string; applied only at harness command boundary, not in telemetry/display/persistence.
 - Consolidated Mars candidate/runnable-path parsing: `parse_harness_candidates`/`parse_runnable_paths` replace duplicated inner functions in `models.py`.
 

--- a/src/meridian/lib/catalog/agent.py
+++ b/src/meridian/lib/catalog/agent.py
@@ -144,10 +144,14 @@ def _parse_model_policies(
             if str(key).strip()
         }
         # Silently filter unknown override keys (lenient parsing).
+        raw_override_count = len(overrides)
         overrides = {
             key: value for key, value in overrides.items() if key in _MODEL_POLICY_OVERRIDE_KEYS
         }
-        # Empty overrides are valid — intentional no-op rule.
+        # Skip rules where all override keys were invalid (likely a typo).
+        # Empty/missing override is intentional no-op — only skip if keys existed but none survived.
+        if raw_override_count > 0 and not overrides:
+            continue
         parsed.append(
             ModelPolicyRule(
                 match_type=cast("Literal['model', 'alias', 'model-glob']", match_key),

--- a/src/meridian/lib/catalog/agent.py
+++ b/src/meridian/lib/catalog/agent.py
@@ -210,9 +210,13 @@ def parse_agent_profile(path: Path) -> AgentProfile:
         else:
             with suppress(ValueError):
                 autocompact_pct = cast(
-def test_parse_agent_profile_model_policies_accepts_missing_override(
-    )
+                    "int | None", validate_autocompact_pct_value(raw_autocompact_pct)
+                )
 
+
+    model_policies = _parse_model_policies(
+        model_policies_value,
+    )
     mode = str(mode_value).strip() if mode_value is not None else "subagent"
     if mode not in {"primary", "subagent"}:
         mode = "subagent"

--- a/src/meridian/lib/catalog/agent.py
+++ b/src/meridian/lib/catalog/agent.py
@@ -143,12 +143,11 @@ def _parse_model_policies(
             for key, value in cast("Mapping[object, object]", raw_override).items()
             if str(key).strip()
         }
-        is_fallback_candidate = match_key in {"alias", "model"} and not no_fallback
-        if not overrides and not is_fallback_candidate:
-            continue
+        # Silently filter unknown override keys (lenient parsing).
         overrides = {
             key: value for key, value in overrides.items() if key in _MODEL_POLICY_OVERRIDE_KEYS
         }
+        # Empty overrides are valid — intentional no-op rule.
         parsed.append(
             ModelPolicyRule(
                 match_type=cast("Literal['model', 'alias', 'model-glob']", match_key),
@@ -211,11 +210,7 @@ def parse_agent_profile(path: Path) -> AgentProfile:
         else:
             with suppress(ValueError):
                 autocompact_pct = cast(
-                    "int | None", validate_autocompact_pct_value(raw_autocompact_pct)
-                )
-
-    model_policies = _parse_model_policies(
-        model_policies_value,
+def test_parse_agent_profile_model_policies_accepts_missing_override(
     )
 
     mode = str(mode_value).strip() if mode_value is not None else "subagent"

--- a/src/meridian/lib/catalog/model_aliases.py
+++ b/src/meridian/lib/catalog/model_aliases.py
@@ -134,7 +134,7 @@ def _coerce_optional_int(value: object) -> int | None:
     return None
 
 
-def _coerce_harness_candidates(raw_candidates: object) -> tuple[str, ...]:
+def parse_harness_candidates(raw_candidates: object) -> tuple[str, ...]:
     if not isinstance(raw_candidates, list):
         return ()
     return tuple(
@@ -144,7 +144,7 @@ def _coerce_harness_candidates(raw_candidates: object) -> tuple[str, ...]:
     )
 
 
-def _coerce_runnable_paths(raw_paths: object) -> tuple[RunnablePath, ...]:
+def parse_runnable_paths(raw_paths: object) -> tuple[RunnablePath, ...]:
     if not isinstance(raw_paths, list):
         return ()
 
@@ -544,8 +544,8 @@ def _mars_list_to_entries(aliases_list: list[dict[str, object]]) -> list[AliasEn
         default_effort = item.get("default_effort")
         default_autocompact = item.get("autocompact")
         default_autocompact_pct = item.get("autocompact_pct")
-        harness_candidates = _coerce_harness_candidates(item.get("harness_candidates"))
-        runnable_paths = _coerce_runnable_paths(item.get("runnable_paths"))
+        harness_candidates = parse_harness_candidates(item.get("harness_candidates"))
+        runnable_paths = parse_runnable_paths(item.get("runnable_paths"))
 
         # Skip aliases that didn't resolve to a concrete model ID
         if not isinstance(resolved_model, str) or not resolved_model.strip():
@@ -684,6 +684,8 @@ __all__ = [
     "cached_mars_models_resolve",
     "load_mars_aliases",
     "load_mars_descriptions",
+    "parse_harness_candidates",
+    "parse_runnable_paths",
     "run_mars_models_list_all",
     "run_mars_models_resolve",
 ]

--- a/src/meridian/lib/catalog/model_aliases.py
+++ b/src/meridian/lib/catalog/model_aliases.py
@@ -26,6 +26,16 @@ from meridian.lib.core.types import HarnessId, ModelId
 logger = logging.getLogger(__name__)
 
 
+class RunnablePath(BaseModel):
+    """One runnable harness route for a model, as reported by Mars."""
+
+    model_config = ConfigDict(frozen=True)
+
+    harness: str
+    harness_model_id: str
+    provider: str = ""
+
+
 class AliasEntry(BaseModel):
     """Alias entry for model lookup."""
 
@@ -38,6 +48,8 @@ class AliasEntry(BaseModel):
     default_effort: str | None = Field(default=None, exclude=True)
     default_autocompact: int | None = Field(default=None, exclude=True)
     default_autocompact_pct: int | None = Field(default=None, exclude=True)
+    harness_candidates: tuple[str, ...] = Field(default=(), exclude=True)
+    runnable_paths: tuple[RunnablePath, ...] = Field(default=(), exclude=True)
 
     @property
     def harness(self) -> HarnessId:
@@ -48,6 +60,13 @@ class AliasEntry(BaseModel):
     @property
     def mars_provided_harness(self) -> HarnessId | None:
         return self.resolved_harness
+
+    def harness_model_id_for(self, harness: str) -> str | None:
+        """Return the harness-specific model ID for a given harness, or None."""
+        for path in self.runnable_paths:
+            if path.harness == harness:
+                return path.harness_model_id
+        return None
 
     def format_text(self, ctx: object | None = None) -> str:
         _ = ctx
@@ -70,6 +89,8 @@ def entry(
     default_effort: str | None = None,
     default_autocompact: int | None = None,
     default_autocompact_pct: int | None = None,
+    harness_candidates: tuple[str, ...] = (),
+    runnable_paths: tuple[RunnablePath, ...] = (),
 ) -> AliasEntry:
     resolved_harness: HarnessId | None = None
     if harness:
@@ -83,6 +104,8 @@ def entry(
         default_effort=default_effort,
         default_autocompact=default_autocompact,
         default_autocompact_pct=default_autocompact_pct,
+        harness_candidates=harness_candidates,
+        runnable_paths=runnable_paths,
     )
 
 
@@ -109,6 +132,41 @@ def _coerce_optional_int(value: object) -> int | None:
         except ValueError:
             return None
     return None
+
+
+def _coerce_harness_candidates(raw_candidates: object) -> tuple[str, ...]:
+    if not isinstance(raw_candidates, list):
+        return ()
+    return tuple(
+        candidate.strip()
+        for candidate in cast("list[object]", raw_candidates)
+        if isinstance(candidate, str) and candidate.strip()
+    )
+
+
+def _coerce_runnable_paths(raw_paths: object) -> tuple[RunnablePath, ...]:
+    if not isinstance(raw_paths, list):
+        return ()
+
+    runnable_paths: list[RunnablePath] = []
+    for path in cast("list[object]", raw_paths):
+        if not isinstance(path, dict):
+            continue
+        typed_path = cast("dict[str, object]", path)
+        harness = _coerce_optional_string(typed_path.get("harness"))
+        harness_model_id = _coerce_optional_string(typed_path.get("harness_model_id"))
+        if harness is None or harness_model_id is None:
+            continue
+        mars_provider = _coerce_optional_string(typed_path.get("mars_provider"))
+        provider = mars_provider or _coerce_optional_string(typed_path.get("provider"))
+        runnable_paths.append(
+            RunnablePath(
+                harness=harness,
+                harness_model_id=harness_model_id,
+                provider=provider or "",
+            )
+        )
+    return tuple(runnable_paths)
 
 
 def _normalize_project_root_key(project_root: Path | None) -> str:
@@ -486,6 +544,8 @@ def _mars_list_to_entries(aliases_list: list[dict[str, object]]) -> list[AliasEn
         default_effort = item.get("default_effort")
         default_autocompact = item.get("autocompact")
         default_autocompact_pct = item.get("autocompact_pct")
+        harness_candidates = _coerce_harness_candidates(item.get("harness_candidates"))
+        runnable_paths = _coerce_runnable_paths(item.get("runnable_paths"))
 
         # Skip aliases that didn't resolve to a concrete model ID
         if not isinstance(resolved_model, str) or not resolved_model.strip():
@@ -500,6 +560,8 @@ def _mars_list_to_entries(aliases_list: list[dict[str, object]]) -> list[AliasEn
                 default_effort=_coerce_optional_string(default_effort),
                 default_autocompact=_coerce_optional_int(default_autocompact),
                 default_autocompact_pct=_coerce_optional_int(default_autocompact_pct),
+                harness_candidates=harness_candidates,
+                runnable_paths=runnable_paths,
             )
         )
 
@@ -616,6 +678,7 @@ def load_mars_descriptions(project_root: Path | None = None) -> dict[str, str]:
 __all__ = [
     "AliasEntry",
     "MarsResultCache",
+    "RunnablePath",
     "cached_mars_models_list",
     "cached_mars_models_list_all",
     "cached_mars_models_resolve",

--- a/src/meridian/lib/catalog/models.py
+++ b/src/meridian/lib/catalog/models.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from contextlib import suppress
 from pathlib import Path
+from typing import cast
 
 from meridian.lib.catalog.model_aliases import (
     AliasEntry,
     MarsResultCache,
+    RunnablePath,
     cached_mars_models_list_all,
     cached_mars_models_resolve,
     load_mars_aliases,
@@ -48,6 +50,52 @@ def resolve_model(
     if not normalized:
         raise ValueError("Model identifier must not be empty.")
 
+    def _extract_harness_candidates(payload: dict[str, object]) -> tuple[str, ...]:
+        raw_candidates = payload.get("harness_candidates")
+        return tuple(
+            candidate.strip()
+            for candidate in (
+                cast("list[object]", raw_candidates) if isinstance(raw_candidates, list) else []
+            )
+            if isinstance(candidate, str) and candidate.strip()
+        )
+
+    def _extract_runnable_paths(payload: dict[str, object]) -> tuple[RunnablePath, ...]:
+        raw_paths = payload.get("runnable_paths")
+        runnable_paths: list[RunnablePath] = []
+        for path in (cast("list[object]", raw_paths) if isinstance(raw_paths, list) else []):
+            if not isinstance(path, dict):
+                continue
+            typed_path = cast("dict[str, object]", path)
+            raw_harness = typed_path.get("harness")
+            raw_harness_model_id = typed_path.get("harness_model_id")
+            if not (
+                isinstance(raw_harness, str)
+                and raw_harness.strip()
+                and isinstance(raw_harness_model_id, str)
+                and raw_harness_model_id.strip()
+            ):
+                continue
+            raw_provider = typed_path.get("mars_provider")
+            fallback_provider = typed_path.get("provider")
+            provider = (
+                raw_provider.strip()
+                if isinstance(raw_provider, str) and raw_provider.strip()
+                else (
+                    fallback_provider.strip()
+                    if isinstance(fallback_provider, str) and fallback_provider.strip()
+                    else ""
+                )
+            )
+            runnable_paths.append(
+                RunnablePath(
+                    harness=raw_harness.strip(),
+                    harness_model_id=raw_harness_model_id.strip(),
+                    provider=provider,
+                )
+            )
+        return tuple(runnable_paths)
+
     def exact_id_alias_entry(model: dict[str, object]) -> AliasEntry:
         harness: object = model.get("harness")
         resolved_harness: HarnessId | None = None
@@ -56,11 +104,15 @@ def resolve_model(
                 resolved_harness = HarnessId(harness.strip())
 
         description = model.get("description")
+        harness_candidates = _extract_harness_candidates(model)
+        runnable_paths = _extract_runnable_paths(model)
         return AliasEntry(
             alias="",
             model_id=ModelId(normalized),
             resolved_harness=resolved_harness,
             description=description.strip() if isinstance(description, str) else None,
+            harness_candidates=harness_candidates,
+            runnable_paths=runnable_paths,
         )
 
     def find_exact_id_match() -> dict[str, object] | None:
@@ -106,6 +158,8 @@ def resolve_model(
             and not isinstance(raw_default_autocompact_pct, bool)
             else None
         )
+        harness_candidates = _extract_harness_candidates(mars_result)
+        runnable_paths = _extract_runnable_paths(mars_result)
 
         return AliasEntry(
             alias=str(mars_result.get("name", "") or ""),
@@ -115,6 +169,8 @@ def resolve_model(
             default_effort=default_effort,
             default_autocompact=default_autocompact,
             default_autocompact_pct=default_autocompact_pct,
+            harness_candidates=harness_candidates,
+            runnable_paths=runnable_paths,
         )
 
     # Step 1: Try mars resolve (alias + harness in one call) before the

--- a/src/meridian/lib/catalog/models.py
+++ b/src/meridian/lib/catalog/models.py
@@ -4,15 +4,15 @@ from __future__ import annotations
 
 from contextlib import suppress
 from pathlib import Path
-from typing import cast
 
 from meridian.lib.catalog.model_aliases import (
     AliasEntry,
     MarsResultCache,
-    RunnablePath,
     cached_mars_models_list_all,
     cached_mars_models_resolve,
     load_mars_aliases,
+    parse_harness_candidates,
+    parse_runnable_paths,
     run_mars_models_list_all,
     run_mars_models_resolve,
 )
@@ -50,52 +50,6 @@ def resolve_model(
     if not normalized:
         raise ValueError("Model identifier must not be empty.")
 
-    def _extract_harness_candidates(payload: dict[str, object]) -> tuple[str, ...]:
-        raw_candidates = payload.get("harness_candidates")
-        return tuple(
-            candidate.strip()
-            for candidate in (
-                cast("list[object]", raw_candidates) if isinstance(raw_candidates, list) else []
-            )
-            if isinstance(candidate, str) and candidate.strip()
-        )
-
-    def _extract_runnable_paths(payload: dict[str, object]) -> tuple[RunnablePath, ...]:
-        raw_paths = payload.get("runnable_paths")
-        runnable_paths: list[RunnablePath] = []
-        for path in (cast("list[object]", raw_paths) if isinstance(raw_paths, list) else []):
-            if not isinstance(path, dict):
-                continue
-            typed_path = cast("dict[str, object]", path)
-            raw_harness = typed_path.get("harness")
-            raw_harness_model_id = typed_path.get("harness_model_id")
-            if not (
-                isinstance(raw_harness, str)
-                and raw_harness.strip()
-                and isinstance(raw_harness_model_id, str)
-                and raw_harness_model_id.strip()
-            ):
-                continue
-            raw_provider = typed_path.get("mars_provider")
-            fallback_provider = typed_path.get("provider")
-            provider = (
-                raw_provider.strip()
-                if isinstance(raw_provider, str) and raw_provider.strip()
-                else (
-                    fallback_provider.strip()
-                    if isinstance(fallback_provider, str) and fallback_provider.strip()
-                    else ""
-                )
-            )
-            runnable_paths.append(
-                RunnablePath(
-                    harness=raw_harness.strip(),
-                    harness_model_id=raw_harness_model_id.strip(),
-                    provider=provider,
-                )
-            )
-        return tuple(runnable_paths)
-
     def exact_id_alias_entry(model: dict[str, object]) -> AliasEntry:
         harness: object = model.get("harness")
         resolved_harness: HarnessId | None = None
@@ -104,8 +58,8 @@ def resolve_model(
                 resolved_harness = HarnessId(harness.strip())
 
         description = model.get("description")
-        harness_candidates = _extract_harness_candidates(model)
-        runnable_paths = _extract_runnable_paths(model)
+        harness_candidates = parse_harness_candidates(model.get("harness_candidates"))
+        runnable_paths = parse_runnable_paths(model.get("runnable_paths"))
         return AliasEntry(
             alias="",
             model_id=ModelId(normalized),
@@ -158,8 +112,8 @@ def resolve_model(
             and not isinstance(raw_default_autocompact_pct, bool)
             else None
         )
-        harness_candidates = _extract_harness_candidates(mars_result)
-        runnable_paths = _extract_runnable_paths(mars_result)
+        harness_candidates = parse_harness_candidates(mars_result.get("harness_candidates"))
+        runnable_paths = parse_runnable_paths(mars_result.get("runnable_paths"))
 
         return AliasEntry(
             alias=str(mars_result.get("name", "") or ""),

--- a/src/meridian/lib/launch/context.py
+++ b/src/meridian/lib/launch/context.py
@@ -1447,6 +1447,9 @@ def bind_launch_context(
         ids={"spawn_id": bindings.spawn_id},
         data={"model_family": model_family, "harness": harness.id.value},
     )
+    effective_model = model
+    if model_selection is not None and model_selection.harness_model_id is not None:
+        effective_model = model_selection.harness_model_id
 
     if (
         runtime.composition_surface == LaunchCompositionSurface.SPAWN_PREPARE
@@ -1469,7 +1472,7 @@ def bind_launch_context(
     materialized = materialize_launch_artifacts(
         harness=harness,
         prompt=resolved_request.prompt,
-        model=model,
+        model=effective_model,
         effort=resolved_request.execution_policy.effort,
         skills=resolved_request.skills,
         agent=resolved_request.agent,

--- a/src/meridian/lib/launch/policies.py
+++ b/src/meridian/lib/launch/policies.py
@@ -701,8 +701,9 @@ def resolve_launch_policy(surface: SurfacePolicyInput) -> ResolvedLaunchPolicy:
             )
             if computed != canonical_model_id:
                 harness_model_for_spec = computed
-            raw_harness_candidates = getattr(selected_entry, "harness_candidates", ()) or ()
-            harness_candidates = tuple(str(candidate) for candidate in raw_harness_candidates)
+            harness_candidates = tuple(
+                str(candidate) for candidate in selected_entry.harness_candidates
+            )
             if (
                 harness_model_for_spec is None
                 and str(harness_id) in harness_candidates

--- a/src/meridian/lib/launch/policies.py
+++ b/src/meridian/lib/launch/policies.py
@@ -42,6 +42,7 @@ from .resolve import (
     dedupe_skill_names,
     load_agent_profile_with_fallback,
     resolve_skills_from_profile,
+    select_harness_model_id,
     validate_harness_compatibility,
 )
 
@@ -61,6 +62,7 @@ class ModelSelectionContext:
     mars_provided_harness: HarnessId | None
     resolved_entry: AliasEntry | None
     harness_provenance: str
+    harness_model_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -216,6 +218,17 @@ def _policy_warnings(
             ),
         )
     return ()
+
+
+def _resolved_model_default_harness(model_entry: AliasEntry | None) -> HarnessId | None:
+    """Return a model entry's default harness when it can be resolved."""
+
+    if model_entry is None:
+        return None
+    try:
+        return model_entry.harness
+    except ValueError:
+        return None
 
 
 def _harness_is_available(
@@ -633,6 +646,7 @@ def resolve_launch_policy(surface: SurfacePolicyInput) -> ResolvedLaunchPolicy:
         config=surface.config,
         catalog=surface.catalog,
     )
+    resolved_model_default_harness = _resolved_model_default_harness(resolved_model_entry)
 
     if final_model and user_explicit_same_precedence:
         if model_resolution_error is not None:
@@ -643,10 +657,43 @@ def resolve_launch_policy(surface: SurfacePolicyInput) -> ResolvedLaunchPolicy:
             model_entry=resolved_model_entry,
             harness_registry=surface.harness_registry,
         )
+    if (
+        final_model
+        and not user_explicit_same_precedence
+        and resolved_model_entry is not None
+        and resolved_model_default_harness is not None
+        and harness_id != resolved_model_default_harness
+        and resolved_model_entry.harness_candidates
+    ):
+        harness_source = "model-policy" if compiler_result.matched_model_policy else "resolved"
+        validate_harness_compatibility(
+            model=final_model,
+            harness_id=harness_id,
+            model_entry=resolved_model_entry,
+            harness_registry=surface.harness_registry,
+            harness_source=harness_source,
+        )
 
     selected_entry: AliasEntry | None = resolved_model_entry
     model_selection: ModelSelectionContext | None = None
     if final_model:
+        canonical_model_id = (
+            str(selected_entry.model_id) if selected_entry is not None else final_model
+        )
+        harness_model_for_spec: str | None = None
+        selected_entry_default_harness = _resolved_model_default_harness(selected_entry)
+        if (
+            selected_entry is not None
+            and selected_entry_default_harness is not None
+            and harness_id != selected_entry_default_harness
+        ):
+            computed = select_harness_model_id(
+                model_entry=selected_entry,
+                harness_id=harness_id,
+                canonical_model_id=canonical_model_id,
+            )
+            if computed != canonical_model_id:
+                harness_model_for_spec = computed
         selected_model_token = (
             (selected_entry.alias.strip() or str(selected_entry.model_id))
             if selected_entry is not None
@@ -655,14 +702,13 @@ def resolve_launch_policy(surface: SurfacePolicyInput) -> ResolvedLaunchPolicy:
         model_selection = ModelSelectionContext(
             requested_token=requested_token_for_selection or final_model,
             selected_model_token=selected_model_token,
-            canonical_model_id=(
-                str(selected_entry.model_id) if selected_entry is not None else final_model
-            ),
+            canonical_model_id=canonical_model_id,
             mars_provided_harness=(
                 selected_entry.mars_provided_harness if selected_entry is not None else None
             ),
             resolved_entry=selected_entry,
             harness_provenance=harness_provenance or "",
+            harness_model_id=harness_model_for_spec,
         )
 
     profile_policy_rule_matched = compiler_result.matched_model_policy and (

--- a/src/meridian/lib/launch/policies.py
+++ b/src/meridian/lib/launch/policies.py
@@ -647,6 +647,7 @@ def resolve_launch_policy(surface: SurfacePolicyInput) -> ResolvedLaunchPolicy:
         catalog=surface.catalog,
     )
     resolved_model_default_harness = _resolved_model_default_harness(resolved_model_entry)
+    policy_warnings: list[CompositionWarning] = []
 
     if final_model and user_explicit_same_precedence:
         if model_resolution_error is not None:
@@ -663,9 +664,15 @@ def resolve_launch_policy(surface: SurfacePolicyInput) -> ResolvedLaunchPolicy:
         and resolved_model_entry is not None
         and resolved_model_default_harness is not None
         and harness_id != resolved_model_default_harness
-        and resolved_model_entry.harness_candidates
+        and compiler_result.field_provenance.harness_source
+        not in (ProvenanceLevel.CLI, ProvenanceLevel.ENV)
     ):
-        harness_source = "model-policy" if compiler_result.matched_model_policy else "resolved"
+        harness_source = "resolved"
+        if compiler_result.field_provenance.harness_source in (
+            ProvenanceLevel.PROFILE_MODEL_POLICY,
+            ProvenanceLevel.AGENT_OVERLAY_POLICY,
+        ):
+            harness_source = "model-policy"
         validate_harness_compatibility(
             model=final_model,
             harness_id=harness_id,
@@ -694,6 +701,22 @@ def resolve_launch_policy(surface: SurfacePolicyInput) -> ResolvedLaunchPolicy:
             )
             if computed != canonical_model_id:
                 harness_model_for_spec = computed
+            raw_harness_candidates = getattr(selected_entry, "harness_candidates", ()) or ()
+            harness_candidates = tuple(str(candidate) for candidate in raw_harness_candidates)
+            if (
+                harness_model_for_spec is None
+                and str(harness_id) in harness_candidates
+            ):
+                policy_warnings.append(
+                    CompositionWarning(
+                        code="missing_runnable_path",
+                        message=(
+                            f"Harness '{harness_id}' is a supported candidate for model "
+                            f"'{final_model}' but no harness-specific model ID is available. "
+                            "Using canonical model ID."
+                        ),
+                    )
+                )
         selected_model_token = (
             (selected_entry.alias.strip() or str(selected_entry.model_id))
             if selected_entry is not None
@@ -751,6 +774,13 @@ def resolve_launch_policy(surface: SurfacePolicyInput) -> ResolvedLaunchPolicy:
     )
 
     model_warning = "\n".join(compiler_result.warnings).strip() or None
+    policy_warnings = [
+        *_policy_warnings(
+            profile_warning=profile_warning,
+            model_warning=model_warning,
+        ),
+        *policy_warnings,
+    ]
 
     return ResolvedLaunchPolicy(
         profile=profile,
@@ -764,10 +794,7 @@ def resolve_launch_policy(surface: SurfacePolicyInput) -> ResolvedLaunchPolicy:
         field_provenance=compiler_result.field_provenance,
         model_selection=model_selection,
         fallback_chain=compiler_result.fallback_chain,
-        warnings=_policy_warnings(
-            profile_warning=profile_warning,
-            model_warning=model_warning,
-        ),
+        warnings=tuple(policy_warnings),
         alias_catalog=alias_catalog,
     )
 

--- a/src/meridian/lib/launch/policies.py
+++ b/src/meridian/lib/launch/policies.py
@@ -642,7 +642,6 @@ def resolve_launch_policy(surface: SurfacePolicyInput) -> ResolvedLaunchPolicy:
             harness_id=harness_id,
             model_entry=resolved_model_entry,
             harness_registry=surface.harness_registry,
-            is_policy_reroute=False,
         )
 
     selected_entry: AliasEntry | None = resolved_model_entry

--- a/src/meridian/lib/launch/policies.py
+++ b/src/meridian/lib/launch/policies.py
@@ -646,40 +646,7 @@ def resolve_launch_policy(surface: SurfacePolicyInput) -> ResolvedLaunchPolicy:
         config=surface.config,
         catalog=surface.catalog,
     )
-    resolved_model_default_harness = _resolved_model_default_harness(resolved_model_entry)
     policy_warnings: list[CompositionWarning] = []
-
-    if final_model and user_explicit_same_precedence:
-        if model_resolution_error is not None:
-            raise model_resolution_error
-        validate_harness_compatibility(
-            model=final_model,
-            harness_id=harness_id,
-            model_entry=resolved_model_entry,
-            harness_registry=surface.harness_registry,
-        )
-    if (
-        final_model
-        and not user_explicit_same_precedence
-        and resolved_model_entry is not None
-        and resolved_model_default_harness is not None
-        and harness_id != resolved_model_default_harness
-        and compiler_result.field_provenance.harness_source
-        not in (ProvenanceLevel.CLI, ProvenanceLevel.ENV)
-    ):
-        harness_source = "resolved"
-        if compiler_result.field_provenance.harness_source in (
-            ProvenanceLevel.PROFILE_MODEL_POLICY,
-            ProvenanceLevel.AGENT_OVERLAY_POLICY,
-        ):
-            harness_source = "model-policy"
-        validate_harness_compatibility(
-            model=final_model,
-            harness_id=harness_id,
-            model_entry=resolved_model_entry,
-            harness_registry=surface.harness_registry,
-            harness_source=harness_source,
-        )
 
     selected_entry: AliasEntry | None = resolved_model_entry
     model_selection: ModelSelectionContext | None = None

--- a/src/meridian/lib/launch/resolve.py
+++ b/src/meridian/lib/launch/resolve.py
@@ -160,9 +160,10 @@ def validate_harness_compatibility(
     harness_id: HarnessId,
     model_entry: AliasEntry | None,
     harness_registry: HarnessRegistry,
-    harness_source: str = "resolved",
 ) -> None:
-    """Validate harness/model compatibility with candidate-aware routing."""
+    """Validate that the selected harness is available for primary launch."""
+
+    _ = model, model_entry
 
     supported_primary_harnesses = tuple(
         harness_id_candidate
@@ -173,27 +174,6 @@ def validate_harness_compatibility(
     if harness_id not in supported_primary_set:
         supported_text = ", ".join(str(harness) for harness in supported_primary_harnesses)
         raise ValueError(f"Unsupported harness '{harness_id}'. Expected one of: {supported_text}.")
-
-    if model_entry is None:
-        return
-
-    harness_candidates = tuple(model_entry.harness_candidates or ())
-    if harness_candidates:
-        if str(harness_id) not in harness_candidates:
-            supported = ", ".join(harness_candidates)
-            source_note = " from model-policy override" if harness_source == "model-policy" else ""
-            raise ValueError(
-                f"Harness '{harness_id}'{source_note} is not a supported route "
-                f"for model '{model}'. Supported harnesses: {supported}."
-            )
-        return
-
-    if harness_id != model_entry.harness:
-        source_note = " from model-policy override" if harness_source == "model-policy" else ""
-        raise ValueError(
-            f"Harness '{harness_id}'{source_note} is incompatible with model '{model}' "
-            f"(routes to '{model_entry.harness}')."
-        )
 
 
 def resolve_harness(
@@ -220,7 +200,6 @@ def resolve_harness(
         harness_id=override_harness,
         model_entry=model_entry,
         harness_registry=harness_registry,
-        harness_source="resolved",
     )
     return override_harness
 

--- a/src/meridian/lib/launch/resolve.py
+++ b/src/meridian/lib/launch/resolve.py
@@ -177,7 +177,7 @@ def validate_harness_compatibility(
     if model_entry is None:
         return
 
-    harness_candidates = tuple(getattr(model_entry, "harness_candidates", ()) or ())
+    harness_candidates = tuple(model_entry.harness_candidates or ())
     if harness_candidates:
         if str(harness_id) not in harness_candidates:
             supported = ", ".join(harness_candidates)
@@ -238,11 +238,9 @@ def select_harness_model_id(
     if model_entry is None:
         return canonical_model_id
 
-    harness_model_id_for = getattr(model_entry, "harness_model_id_for", None)
-    if callable(harness_model_id_for):
-        specific_id = harness_model_id_for(str(harness_id))
-        if isinstance(specific_id, str):
-            return specific_id
+    specific_id = model_entry.harness_model_id_for(str(harness_id))
+    if isinstance(specific_id, str):
+        return specific_id
     return canonical_model_id
 
 

--- a/src/meridian/lib/launch/resolve.py
+++ b/src/meridian/lib/launch/resolve.py
@@ -160,14 +160,9 @@ def validate_harness_compatibility(
     harness_id: HarnessId,
     model_entry: AliasEntry | None,
     harness_registry: HarnessRegistry,
-    is_policy_reroute: bool = False,
+    harness_source: str = "resolved",
 ) -> None:
-    """Validate harness/model compatibility with provenance awareness.
-
-    Policy-driven reroutes intentionally override the model-derived harness, so
-    they only need the harness to be supported for primary launch. Same-layer
-    user overrides also validate that the harness matches the model route.
-    """
+    """Validate harness/model compatibility with candidate-aware routing."""
 
     supported_primary_harnesses = tuple(
         harness_id_candidate
@@ -179,11 +174,24 @@ def validate_harness_compatibility(
         supported_text = ", ".join(str(harness) for harness in supported_primary_harnesses)
         raise ValueError(f"Unsupported harness '{harness_id}'. Expected one of: {supported_text}.")
 
-    if is_policy_reroute or model_entry is None:
+    if model_entry is None:
         return
+
+    harness_candidates = tuple(getattr(model_entry, "harness_candidates", ()) or ())
+    if harness_candidates:
+        if str(harness_id) not in harness_candidates:
+            supported = ", ".join(harness_candidates)
+            source_note = " from model-policy override" if harness_source == "model-policy" else ""
+            raise ValueError(
+                f"Harness '{harness_id}'{source_note} is not a supported route "
+                f"for model '{model}'. Supported harnesses: {supported}."
+            )
+        return
+
     if harness_id != model_entry.harness:
+        source_note = " from model-policy override" if harness_source == "model-policy" else ""
         raise ValueError(
-            f"Harness '{harness_id}' is incompatible with model '{model}' "
+            f"Harness '{harness_id}'{source_note} is incompatible with model '{model}' "
             f"(routes to '{model_entry.harness}')."
         )
 
@@ -194,7 +202,6 @@ def resolve_harness(
     model_entry: AliasEntry | None,
     harness_override: str | None,
     harness_registry: HarnessRegistry,
-    is_policy_reroute: bool = False,
 ) -> HarnessId:
     """Determine final primary-launch harness from a resolved model entry."""
 
@@ -213,9 +220,30 @@ def resolve_harness(
         harness_id=override_harness,
         model_entry=model_entry,
         harness_registry=harness_registry,
-        is_policy_reroute=is_policy_reroute,
+        harness_source="resolved",
     )
     return override_harness
+
+
+def select_harness_model_id(
+    *,
+    model_entry: AliasEntry | None,
+    harness_id: HarnessId,
+    canonical_model_id: str,
+) -> str:
+    """Select the harness-specific model ID for the chosen route.
+
+    Returns canonical_model_id when no harness-specific ID is available.
+    """
+    if model_entry is None:
+        return canonical_model_id
+
+    harness_model_id_for = getattr(model_entry, "harness_model_id_for", None)
+    if callable(harness_model_id_for):
+        specific_id = harness_model_id_for(str(harness_id))
+        if isinstance(specific_id, str):
+            return specific_id
+    return canonical_model_id
 
 
 __all__ = [
@@ -227,5 +255,6 @@ __all__ = [
     "resolve_profile_path",
     "resolve_skill_paths",
     "resolve_skills_from_profile",
+    "select_harness_model_id",
     "validate_harness_compatibility",
 ]

--- a/tests/integration/catalog/test_agent.py
+++ b/tests/integration/catalog/test_agent.py
@@ -311,6 +311,25 @@ def test_parse_agent_profile_filters_unknown_model_policy_override_key(tmp_path:
     )
 
 
+def test_parse_agent_profile_skips_rule_when_all_override_keys_invalid(tmp_path: Path) -> None:
+    """A rule with only invalid override keys is silently dropped, not kept as no-op."""
+    profile_path = _write_profile(
+        tmp_path,
+        "typo.md",
+        [
+            "name: Typo",
+            "model-policies:",
+            "  - match: {model: gpt-5.5}",
+            "    override:",
+            "      harenss: opencode",
+        ],
+    )
+
+    profile = parse_agent_profile(profile_path)
+
+    assert profile.model_policies == ()
+
+
 def test_parse_agent_profile_ignores_invalid_optional_fields(tmp_path: Path) -> None:
     profile_path = _write_profile(
         tmp_path,

--- a/tests/integration/catalog/test_agent.py
+++ b/tests/integration/catalog/test_agent.py
@@ -210,7 +210,7 @@ def test_parse_agent_profile_model_policies_accepts_empty_override_with_fallback
     )
 
 
-def test_parse_agent_profile_model_policies_accepts_missing_override_with_fallback_candidate(
+def test_parse_agent_profile_model_policies_accepts_missing_override(
     tmp_path: Path,
 ) -> None:
     profile_path = _write_profile(
@@ -235,7 +235,7 @@ def test_parse_agent_profile_model_policies_accepts_missing_override_with_fallba
     )
 
 
-def test_parse_agent_profile_ignores_noop_non_fallback_policy_rule(tmp_path: Path) -> None:
+def test_parse_agent_profile_keeps_noop_non_fallback_policy_rule(tmp_path: Path) -> None:
     profile_path = _write_profile(
         tmp_path,
         "bad.md",
@@ -251,7 +251,14 @@ def test_parse_agent_profile_ignores_noop_non_fallback_policy_rule(tmp_path: Pat
 
     profile = parse_agent_profile(profile_path)
 
-    assert profile.model_policies == ()
+    assert profile.model_policies == (
+        ModelPolicyRule(
+            match_type="model",
+            match_value="gpt-5.5",
+            no_fallback=True,
+            overrides={},
+        ),
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/chat/test_chat_cli_policy.py
+++ b/tests/integration/chat/test_chat_cli_policy.py
@@ -105,7 +105,7 @@ def test_chat_policy_snapshot_resolves_alias_to_canonical_model(monkeypatch, tmp
     assert snapshot.harness == "codex"
 
 
-def test_chat_policy_snapshot_rejects_incompatible_explicit_harness(monkeypatch, tmp_path) -> None:
+def test_chat_policy_snapshot_allows_forced_explicit_harness(monkeypatch, tmp_path) -> None:
     alias_entry = _mock_alias("gptmini", "gpt-5.4-mini", HarnessId.CODEX)
 
     def fake_resolve_model(self: CatalogSession, token: str) -> AliasEntry:
@@ -117,18 +117,20 @@ def test_chat_policy_snapshot_rejects_incompatible_explicit_harness(monkeypatch,
     monkeypatch.setattr(CatalogSession, "resolve_model", fake_resolve_model)
     monkeypatch.setattr(CatalogSession, "load_aliases", lambda self: [alias_entry])
 
-    with pytest.raises(ValueError, match="incompatible"):
-        chat_cmd._resolve_chat_policy_snapshot(
-            project_root=tmp_path,
-            model="gptmini",
-            harness="claude",
-            agent=None,
-            skills=(),
-            approval=None,
-            sandbox=None,
-            effort=None,
-            autocompact=None,
-        )
+    snapshot = chat_cmd._resolve_chat_policy_snapshot(
+        project_root=tmp_path,
+        model="gptmini",
+        harness="claude",
+        agent=None,
+        skills=(),
+        approval=None,
+        sandbox=None,
+        effort=None,
+        autocompact=None,
+    )
+
+    assert snapshot.canonical_model_id == "gpt-5.4-mini"
+    assert snapshot.harness == "claude"
 
 
 def test_chat_policy_snapshot_without_model_does_not_force_catalog_lookup(

--- a/tests/unit/catalog/test_model_aliases.py
+++ b/tests/unit/catalog/test_model_aliases.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from meridian.lib.catalog.model_aliases import AliasEntry, RunnablePath
+from meridian.lib.catalog.model_policy import pattern_fallback_harness
+from meridian.lib.core.types import HarnessId, ModelId
+
+
+def test_runnable_path_constructs_with_valid_data() -> None:
+    path = RunnablePath(
+        harness="opencode",
+        harness_model_id="provider/opencode-model",
+        provider="models-dev",
+    )
+
+    assert path.harness == "opencode"
+    assert path.harness_model_id == "provider/opencode-model"
+    assert path.provider == "models-dev"
+
+
+def test_runnable_path_is_frozen() -> None:
+    path = RunnablePath(harness="codex", harness_model_id="provider/codex-model")
+
+    with pytest.raises(ValidationError, match="frozen"):
+        path.harness = "opencode"
+
+
+def test_runnable_path_provider_defaults_to_empty_string() -> None:
+    path = RunnablePath(harness="codex", harness_model_id="provider/codex-model")
+
+    assert path.provider == ""
+
+
+def test_alias_entry_defaults_harness_candidates_and_runnable_paths_to_empty_tuples() -> None:
+    alias_entry = AliasEntry(alias="fast", model_id=ModelId("fake-model"))
+
+    assert alias_entry.harness_candidates == ()
+    assert alias_entry.runnable_paths == ()
+
+
+def test_alias_entry_harness_model_id_for_returns_matching_harness_path() -> None:
+    alias_entry = AliasEntry(
+        alias="fast",
+        model_id=ModelId("fake-model"),
+        runnable_paths=(
+            RunnablePath(harness="codex", harness_model_id="provider/codex-model"),
+            RunnablePath(harness="opencode", harness_model_id="provider/opencode-model"),
+        ),
+    )
+
+    assert alias_entry.harness_model_id_for("opencode") == "provider/opencode-model"
+
+
+def test_alias_entry_harness_model_id_for_returns_none_when_path_does_not_match() -> None:
+    alias_entry = AliasEntry(
+        alias="fast",
+        model_id=ModelId("fake-model"),
+        runnable_paths=(
+            RunnablePath(harness="codex", harness_model_id="provider/codex-model"),
+        ),
+    )
+
+    assert alias_entry.harness_model_id_for("opencode") is None
+
+
+def test_alias_entry_harness_model_id_for_returns_none_with_empty_paths() -> None:
+    alias_entry = AliasEntry(alias="fast", model_id=ModelId("fake-model"))
+
+    assert alias_entry.harness_model_id_for("opencode") is None
+
+
+def test_alias_entry_harness_property_still_uses_resolved_or_pattern_fallback() -> None:
+    resolved_entry = AliasEntry(
+        alias="fast",
+        model_id=ModelId("fake-model"),
+        resolved_harness=HarnessId.OPENCODE,
+    )
+    fallback_entry = AliasEntry(
+        alias="fast",
+        model_id=ModelId("gpt-fallback-model"),
+    )
+
+    assert resolved_entry.harness == HarnessId.OPENCODE
+    assert fallback_entry.harness == pattern_fallback_harness("gpt-fallback-model")

--- a/tests/unit/launch/test_policies.py
+++ b/tests/unit/launch/test_policies.py
@@ -225,11 +225,10 @@ def test_validate_harness_compatibility_allows_model_policy_candidate_route() ->
         harness_id=HarnessId.CODEX,
         model_entry=model_entry,
         harness_registry=registry,
-        harness_source="model-policy",
     )
 
 
-def test_validate_harness_compatibility_rejects_same_layer_contradiction() -> None:
+def test_validate_harness_compatibility_allows_same_layer_contradiction() -> None:
     registry = get_default_harness_registry()
     model_entry = _mock_alias(
         alias="claude",
@@ -237,14 +236,12 @@ def test_validate_harness_compatibility_rejects_same_layer_contradiction() -> No
         harness=HarnessId.CLAUDE,
     )
 
-    with pytest.raises(ValueError, match="from model-policy override"):
-        validate_harness_compatibility(
-            model="claude-haiku-4-5",
-            harness_id=HarnessId.CODEX,
-            model_entry=model_entry,
-            harness_registry=registry,
-            harness_source="model-policy",
-        )
+    validate_harness_compatibility(
+        model="claude-haiku-4-5",
+        harness_id=HarnessId.CODEX,
+        model_entry=model_entry,
+        harness_registry=registry,
+    )
 
 
 def test_resolve_launch_policy_fallback_uses_policy_list_order(

--- a/tests/unit/launch/test_policies.py
+++ b/tests/unit/launch/test_policies.py
@@ -184,20 +184,21 @@ def test_match_model_policy_first_match_wins_by_list_order(tmp_path: Path) -> No
     assert winner.match_value == "gpt-*"
 
 
-def test_validate_harness_compatibility_allows_policy_reroute() -> None:
+def test_validate_harness_compatibility_allows_model_policy_candidate_route() -> None:
     registry = get_default_harness_registry()
     model_entry = _mock_alias(
         alias="claude",
         model_id="claude-haiku-4-5",
         harness=HarnessId.CLAUDE,
     )
+    object.__setattr__(model_entry, "harness_candidates", ("claude", "codex"))
 
     validate_harness_compatibility(
         model="claude-haiku-4-5",
         harness_id=HarnessId.CODEX,
         model_entry=model_entry,
         harness_registry=registry,
-        is_policy_reroute=True,
+        harness_source="model-policy",
     )
 
 
@@ -209,13 +210,13 @@ def test_validate_harness_compatibility_rejects_same_layer_contradiction() -> No
         harness=HarnessId.CLAUDE,
     )
 
-    with pytest.raises(ValueError, match="incompatible with model"):
+    with pytest.raises(ValueError, match="from model-policy override"):
         validate_harness_compatibility(
             model="claude-haiku-4-5",
             harness_id=HarnessId.CODEX,
             model_entry=model_entry,
             harness_registry=registry,
-            is_policy_reroute=False,
+            harness_source="model-policy",
         )
 
 

--- a/tests/unit/launch/test_policies.py
+++ b/tests/unit/launch/test_policies.py
@@ -11,6 +11,7 @@ from meridian.lib.core.overrides import RuntimeOverrides
 from meridian.lib.core.types import HarnessId, ModelId
 from meridian.lib.harness.registry import HarnessRegistry, get_default_harness_registry
 from meridian.lib.launch.policies import (
+    ModelSelectionContext,
     SurfacePolicyInput,
     match_model_policy,
     resolve_launch_policy,
@@ -67,6 +68,32 @@ def _registry_with_harnesses(*harness_ids: HarnessId) -> HarnessRegistry:
     for harness_id in harness_ids:
         registry.register(base_registry.get(harness_id))
     return registry
+
+
+def test_model_selection_context_has_harness_model_id_field() -> None:
+    context = ModelSelectionContext(
+        requested_token="fast",
+        selected_model_token="fast",
+        canonical_model_id="fake-model",
+        mars_provided_harness=HarnessId.CODEX,
+        resolved_entry=None,
+        harness_provenance="resolved",
+    )
+
+    assert hasattr(context, "harness_model_id")
+
+
+def test_model_selection_context_harness_model_id_defaults_to_none() -> None:
+    context = ModelSelectionContext(
+        requested_token="fast",
+        selected_model_token="fast",
+        canonical_model_id="fake-model",
+        mars_provided_harness=HarnessId.CODEX,
+        resolved_entry=None,
+        harness_provenance="resolved",
+    )
+
+    assert context.harness_model_id is None
 
 
 def test_resolve_policy_fields_resolves_per_field_precedence() -> None:

--- a/tests/unit/launch/test_resolve.py
+++ b/tests/unit/launch/test_resolve.py
@@ -1,7 +1,24 @@
 from __future__ import annotations
 
+import pytest
+
+from meridian.lib.catalog.model_aliases import AliasEntry, RunnablePath
+from meridian.lib.core.types import HarnessId, ModelId
+from meridian.lib.harness.registry import HarnessRegistry, get_default_harness_registry
 from meridian.lib.launch.prompt import dedupe_skill_names as prompt_dedupe_skill_names
-from meridian.lib.launch.resolve import dedupe_skill_names
+from meridian.lib.launch.resolve import (
+    dedupe_skill_names,
+    select_harness_model_id,
+    validate_harness_compatibility,
+)
+
+
+def _registry_with_harnesses(*harness_ids: HarnessId) -> HarnessRegistry:
+    base_registry = get_default_harness_registry()
+    registry = HarnessRegistry()
+    for harness_id in harness_ids:
+        registry.register(base_registry.get(harness_id))
+    return registry
 
 
 def test_dedupe_skill_names_is_importable_from_resolve() -> None:
@@ -18,3 +35,154 @@ def test_dedupe_skill_names_preserves_first_seen_order() -> None:
         "beta",
         "gamma",
     )
+
+
+def test_validate_harness_compatibility_accepts_harness_candidate_route() -> None:
+    model_entry = AliasEntry(
+        alias="fast",
+        model_id=ModelId("fake-model"),
+        resolved_harness=HarnessId.CODEX,
+        harness_candidates=("codex", "opencode"),
+    )
+
+    validate_harness_compatibility(
+        model="fake-model",
+        harness_id=HarnessId.OPENCODE,
+        model_entry=model_entry,
+        harness_registry=_registry_with_harnesses(HarnessId.CODEX, HarnessId.OPENCODE),
+    )
+
+
+def test_validate_harness_compatibility_rejects_harness_outside_candidates() -> None:
+    model_entry = AliasEntry(
+        alias="fast",
+        model_id=ModelId("fake-model"),
+        resolved_harness=HarnessId.CODEX,
+        harness_candidates=("codex", "opencode"),
+    )
+
+    with pytest.raises(ValueError, match="Supported harnesses: codex, opencode"):
+        validate_harness_compatibility(
+            model="fake-model",
+            harness_id=HarnessId.CLAUDE,
+            model_entry=model_entry,
+            harness_registry=_registry_with_harnesses(
+                HarnessId.CLAUDE,
+                HarnessId.CODEX,
+                HarnessId.OPENCODE,
+            ),
+        )
+
+
+def test_validate_harness_compatibility_empty_candidates_uses_single_harness_check() -> None:
+    model_entry = AliasEntry(
+        alias="fast",
+        model_id=ModelId("fake-model"),
+        resolved_harness=HarnessId.CODEX,
+        harness_candidates=(),
+    )
+
+    with pytest.raises(ValueError, match="incompatible with model"):
+        validate_harness_compatibility(
+            model="fake-model",
+            harness_id=HarnessId.OPENCODE,
+            model_entry=model_entry,
+            harness_registry=_registry_with_harnesses(HarnessId.CODEX, HarnessId.OPENCODE),
+        )
+
+
+def test_validate_harness_compatibility_model_policy_error_mentions_override_source() -> None:
+    model_entry = AliasEntry(
+        alias="fast",
+        model_id=ModelId("fake-model"),
+        resolved_harness=HarnessId.CODEX,
+        harness_candidates=("codex",),
+    )
+
+    with pytest.raises(ValueError, match="from model-policy override"):
+        validate_harness_compatibility(
+            model="fake-model",
+            harness_id=HarnessId.OPENCODE,
+            model_entry=model_entry,
+            harness_registry=_registry_with_harnesses(HarnessId.CODEX, HarnessId.OPENCODE),
+            harness_source="model-policy",
+        )
+
+
+def test_validate_harness_compatibility_skips_model_route_check_without_model_entry() -> None:
+    validate_harness_compatibility(
+        model="fake-model",
+        harness_id=HarnessId.OPENCODE,
+        model_entry=None,
+        harness_registry=_registry_with_harnesses(HarnessId.OPENCODE),
+    )
+
+
+def test_select_harness_model_id_returns_harness_specific_id_for_matching_path() -> None:
+    model_entry = AliasEntry(
+        alias="fast",
+        model_id=ModelId("fake-model"),
+        resolved_harness=HarnessId.CODEX,
+        runnable_paths=(
+            RunnablePath(
+                harness="opencode",
+                harness_model_id="provider/opencode-model",
+            ),
+        ),
+    )
+
+    selected = select_harness_model_id(
+        model_entry=model_entry,
+        harness_id=HarnessId.OPENCODE,
+        canonical_model_id="fake-model",
+    )
+
+    assert selected == "provider/opencode-model"
+
+
+def test_select_harness_model_id_returns_canonical_when_path_does_not_match() -> None:
+    model_entry = AliasEntry(
+        alias="fast",
+        model_id=ModelId("fake-model"),
+        resolved_harness=HarnessId.CODEX,
+        runnable_paths=(
+            RunnablePath(
+                harness="codex",
+                harness_model_id="provider/codex-model",
+            ),
+        ),
+    )
+
+    selected = select_harness_model_id(
+        model_entry=model_entry,
+        harness_id=HarnessId.OPENCODE,
+        canonical_model_id="fake-model",
+    )
+
+    assert selected == "fake-model"
+
+
+def test_select_harness_model_id_returns_canonical_without_model_entry() -> None:
+    selected = select_harness_model_id(
+        model_entry=None,
+        harness_id=HarnessId.OPENCODE,
+        canonical_model_id="fake-model",
+    )
+
+    assert selected == "fake-model"
+
+
+def test_select_harness_model_id_returns_canonical_with_empty_paths() -> None:
+    model_entry = AliasEntry(
+        alias="fast",
+        model_id=ModelId("fake-model"),
+        resolved_harness=HarnessId.CODEX,
+    )
+
+    selected = select_harness_model_id(
+        model_entry=model_entry,
+        harness_id=HarnessId.OPENCODE,
+        canonical_model_id="fake-model",
+    )
+
+    assert selected == "fake-model"

--- a/tests/unit/launch/test_resolve.py
+++ b/tests/unit/launch/test_resolve.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import pytest
-
 from meridian.lib.catalog.model_aliases import AliasEntry, RunnablePath
 from meridian.lib.core.types import HarnessId, ModelId
 from meridian.lib.harness.registry import HarnessRegistry, get_default_harness_registry
@@ -53,7 +51,7 @@ def test_validate_harness_compatibility_accepts_harness_candidate_route() -> Non
     )
 
 
-def test_validate_harness_compatibility_rejects_harness_outside_candidates() -> None:
+def test_validate_harness_compatibility_allows_harness_outside_candidates() -> None:
     model_entry = AliasEntry(
         alias="fast",
         model_id=ModelId("fake-model"),
@@ -61,20 +59,19 @@ def test_validate_harness_compatibility_rejects_harness_outside_candidates() -> 
         harness_candidates=("codex", "opencode"),
     )
 
-    with pytest.raises(ValueError, match="Supported harnesses: codex, opencode"):
-        validate_harness_compatibility(
-            model="fake-model",
-            harness_id=HarnessId.CLAUDE,
-            model_entry=model_entry,
-            harness_registry=_registry_with_harnesses(
-                HarnessId.CLAUDE,
-                HarnessId.CODEX,
-                HarnessId.OPENCODE,
-            ),
-        )
+    validate_harness_compatibility(
+        model="fake-model",
+        harness_id=HarnessId.CLAUDE,
+        model_entry=model_entry,
+        harness_registry=_registry_with_harnesses(
+            HarnessId.CLAUDE,
+            HarnessId.CODEX,
+            HarnessId.OPENCODE,
+        ),
+    )
 
 
-def test_validate_harness_compatibility_empty_candidates_uses_single_harness_check() -> None:
+def test_validate_harness_compatibility_allows_harness_with_empty_candidates() -> None:
     model_entry = AliasEntry(
         alias="fast",
         model_id=ModelId("fake-model"),
@@ -82,16 +79,15 @@ def test_validate_harness_compatibility_empty_candidates_uses_single_harness_che
         harness_candidates=(),
     )
 
-    with pytest.raises(ValueError, match="incompatible with model"):
-        validate_harness_compatibility(
-            model="fake-model",
-            harness_id=HarnessId.OPENCODE,
-            model_entry=model_entry,
-            harness_registry=_registry_with_harnesses(HarnessId.CODEX, HarnessId.OPENCODE),
-        )
+    validate_harness_compatibility(
+        model="fake-model",
+        harness_id=HarnessId.OPENCODE,
+        model_entry=model_entry,
+        harness_registry=_registry_with_harnesses(HarnessId.CODEX, HarnessId.OPENCODE),
+    )
 
 
-def test_validate_harness_compatibility_model_policy_error_mentions_override_source() -> None:
+def test_validate_harness_compatibility_allows_policy_reroute_outside_candidates() -> None:
     model_entry = AliasEntry(
         alias="fast",
         model_id=ModelId("fake-model"),
@@ -99,14 +95,12 @@ def test_validate_harness_compatibility_model_policy_error_mentions_override_sou
         harness_candidates=("codex",),
     )
 
-    with pytest.raises(ValueError, match="from model-policy override"):
-        validate_harness_compatibility(
-            model="fake-model",
-            harness_id=HarnessId.OPENCODE,
-            model_entry=model_entry,
-            harness_registry=_registry_with_harnesses(HarnessId.CODEX, HarnessId.OPENCODE),
-            harness_source="model-policy",
-        )
+    validate_harness_compatibility(
+        model="fake-model",
+        harness_id=HarnessId.OPENCODE,
+        model_entry=model_entry,
+        harness_registry=_registry_with_harnesses(HarnessId.CODEX, HarnessId.OPENCODE),
+    )
 
 
 def test_validate_harness_compatibility_skips_model_route_check_without_model_entry() -> None:


### PR DESCRIPTION
## Summary

- **Candidate-aware harness routing**: `--harness opencode --model gpt-5.5` uses the harness-specific model ID (`openai/gpt-5.5`) from Mars runnable paths at the harness command boundary.
- **Explicit harness = force**: Explicit harness selections (CLI, ENV, model-policy override) are never rejected for model incompatibility. Only missing/unavailable harness adapters fail. Users who force a harness may know something the catalog doesn't.
- **Harness-specific model IDs**: `RunnablePath` and `AliasEntry.harness_candidates`/`runnable_paths` carry Mars multi-path data. `select_harness_model_id()` picks the right model string per harness at bind time.
- **Consolidated Mars parsing**: `-45 lines` — `parse_harness_candidates`/`parse_runnable_paths` replace duplicated inner functions.
- **Invalid override key skip**: Model-policy rules where all override keys are invalid are now skipped instead of kept as shadowing no-ops.

## Work item
`candidate-aware-model-harness-routing`

## Changes

### Source
- `src/meridian/lib/launch/resolve.py` — `validate_harness_compatibility()` now only checks harness adapter availability; model compatibility checks removed
- `src/meridian/lib/launch/policies.py` — removed both post-materialization compatibility validation blocks; `ModelSelectionContext.harness_model_id` wired through
- `src/meridian/lib/catalog/model_aliases.py` — `RunnablePath`, `AliasEntry.harness_candidates`/`runnable_paths`/`harness_model_id_for()`; consolidated parsing helpers
- `src/meridian/lib/catalog/models.py` — passes candidates/paths through from Mars data
- `src/meridian/lib/launch/context.py` — applies `harness_model_id` at harness command boundary
- `src/meridian/lib/catalog/agent.py` — skip model-policy rules with all-invalid override keys

### Tests
- `tests/unit/launch/test_resolve.py` — validation tests updated for force semantics
- `tests/unit/launch/test_policies.py` — policy validation tests updated; fallback/harness-model-id tests
- `tests/unit/catalog/test_model_aliases.py` — `RunnablePath` and `AliasEntry` candidate/path tests
- `tests/integration/chat/test_chat_cli_policy.py` — forced harness acceptance test
- `tests/integration/catalog/test_agent.py` — invalid-key-skip test

## Test plan
- [x] `uv run ruff check .` — clean
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest-llm` — 1087 passed, 2 skipped
- [x] Pre-push preflight — passed
- [x] Dry-run: `--harness opencode --model gpt-5.5` → `openai/gpt-5.5` ✓
- [x] Dry-run: `--model gpt-5.5` (default) → codex harness, bare `gpt-5.5` ✓
- [x] Dry-run: `--harness claude --model gpt-5.5` (force non-candidate) → accepted, canonical `gpt-5.5` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)