### PR TITLE
Add Pi subprocess harness integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,10 @@ out
 # Pre-built frontend assets (copied during release, not tracked)
 src/meridian/web_dist/*
 !src/meridian/web_dist/__init__.py
+
+# Local Pi runtime install/build artifacts
+src/meridian/pi_runtime/node_modules/
+src/meridian/pi_runtime/package-lock.json
+src/meridian/pi_runtime/bun.lock
+src/meridian/pi_runtime/bun.lockb
+src/meridian/pi_runtime/bin/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Harness semantics now classify Pi terminal/activity/signal events (`agent_end`, `message_update`, tool execution start/update) with stopReason=`error` failure mapping.
 - Permission flag projection now explicitly emits no CLI permission flags for Pi (extension-hook permission model).
 - `meridian-pi` runtime selection now prefers `MERIDIAN_PI_BINARY`, then packaged Bun binary, then Node runner fallback.
+- Pi Bun runtime build now copies runtime metadata to `src/meridian/pi_runtime/bin/package.json` so compiled `meridian-pi` launches through the wrapper without `ENOENT` sidecar failures.
 - `meridian-pi` now fails fast with clear errors when an override/packaged runtime binary exists but cannot execute; Node fallback remains only for missing packaged binaries.
 - `meridian-pi` Node fallback now requires source/dev runtime deps (`runner.mjs` plus `node_modules/@earendil-works/pi-coding-agent`). Installed artifacts without compiled binary now fail early with explicit build/override guidance instead of Node import errors.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Permission flag projection now explicitly emits no CLI permission flags for Pi (extension-hook permission model).
 - `meridian-pi` runtime selection now prefers `MERIDIAN_PI_BINARY`, then packaged Bun binary, then Node runner fallback.
 - `meridian-pi` now fails fast with clear errors when an override/packaged runtime binary exists but cannot execute; Node fallback remains only for missing packaged binaries.
+- `meridian-pi` Node fallback now requires source/dev runtime deps (`runner.mjs` plus `node_modules/@earendil-works/pi-coding-agent`). Installed artifacts without compiled binary now fail early with explicit build/override guidance instead of Node import errors.
 
 ## [0.1.8] - 2026-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Real `meridian-pi` wrapper entrypoint: CLI command now resolves Meridian-specific agent dir (`--agent-dir` > `MERIDIAN_PI_AGENT_DIR` > `MERIDIAN_HOME/pi/agent`), creates required Pi dirs, sets `PI_CODING_AGENT_DIR`, then launches Pi via SDK runner.
 - Minimal Pi SDK runtime package scaffold under `src/meridian/pi_runtime/` with `runner.mjs` dynamic import of `@earendil-works/pi-coding-agent` and clear missing-dependency guidance.
 - Unit tests for `meridian-pi` wrapper arg stripping, agent-dir precedence, env projection, directory creation, and error handling.
+- Bun compile entrypoint/script for Pi runtime (`compile_runner.mjs`, `npm run build:binary`) targeting `src/meridian/pi_runtime/bin/meridian-pi`.
 
 ### Changed
 - Harness semantics now classify Pi terminal/activity/signal events (`agent_end`, `message_update`, tool execution start/update) with stopReason=`error` failure mapping.
 - Permission flag projection now explicitly emits no CLI permission flags for Pi (extension-hook permission model).
+- `meridian-pi` runtime selection now prefers `MERIDIAN_PI_BINARY`, then packaged Bun binary, then Node runner fallback.
 
 ## [0.1.8] - 2026-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Pi Phase 1/2 subprocess harness integration: new `HarnessId.PI`, `meridian pi` harness shortcut, `PiAdapter`, subprocess projection, extractor, and bundle registration.
 - Pi launch constants for wrapper binary: `meridian-pi` subprocess/json mode and primary base command constants.
 - Pi harness unit tests for projection, extraction, registry/contract wiring, semantics, and CLI shortcut parsing.
+- Real `meridian-pi` wrapper entrypoint: CLI command now resolves Meridian-specific agent dir (`--agent-dir` > `MERIDIAN_PI_AGENT_DIR` > `MERIDIAN_HOME/pi/agent`), creates required Pi dirs, sets `PI_CODING_AGENT_DIR`, then launches Pi via SDK runner.
+- Minimal Pi SDK runtime package scaffold under `src/meridian/pi_runtime/` with `runner.mjs` dynamic import of `@earendil-works/pi-coding-agent` and clear missing-dependency guidance.
+- Unit tests for `meridian-pi` wrapper arg stripping, agent-dir precedence, env projection, directory creation, and error handling.
 
 ### Changed
 - Harness semantics now classify Pi terminal/activity/signal events (`agent_end`, `message_update`, tool execution start/update) with stopReason=`error` failure mapping.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Pi Phase 1/2 subprocess harness integration: new `HarnessId.PI`, `meridian pi` harness shortcut, `PiAdapter`, subprocess projection, extractor, and bundle registration.
+- Pi launch constants for wrapper binary: `meridian-pi` subprocess/json mode and primary base command constants.
+- Pi harness unit tests for projection, extraction, registry/contract wiring, semantics, and CLI shortcut parsing.
+
+### Changed
+- Harness semantics now classify Pi terminal/activity/signal events (`agent_end`, `message_update`, tool execution start/update) with stopReason=`error` failure mapping.
+- Permission flag projection now explicitly emits no CLI permission flags for Pi (extension-hook permission model).
+
 ## [0.1.8] - 2026-05-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Pi Phase 1/2 subprocess harness integration: new `HarnessId.PI`, `meridian pi` harness shortcut, `PiAdapter`, subprocess projection, extractor, and bundle registration.
 - Pi launch constants for wrapper binary: `meridian-pi` subprocess/json mode and primary base command constants.
 - Pi harness unit tests for projection, extraction, registry/contract wiring, semantics, and CLI shortcut parsing.
-- Real `meridian-pi` wrapper entrypoint: CLI command now resolves Meridian-specific agent dir (`--agent-dir` > `MERIDIAN_PI_AGENT_DIR` > `MERIDIAN_HOME/pi/agent`), creates required Pi dirs, sets `PI_CODING_AGENT_DIR`, then launches Pi via SDK runner.
+- Real `meridian-pi` wrapper entrypoint: CLI command now resolves Meridian-specific agent dir (`--agent-dir` > `MERIDIAN_PI_AGENT_DIR` > `MERIDIAN_HOME/meridian-pi/agent`), creates required Pi dirs, sets `PI_CODING_AGENT_DIR`, then launches Pi via SDK runner.
 - Minimal Pi SDK runtime package scaffold under `src/meridian/pi_runtime/` with `runner.mjs` dynamic import of `@earendil-works/pi-coding-agent` and clear missing-dependency guidance.
 - Unit tests for `meridian-pi` wrapper arg stripping, agent-dir precedence, env projection, directory creation, and error handling.
 - Bun compile entrypoint/script for Pi runtime (`compile_runner.mjs`, `npm run build:binary`) targeting `src/meridian/pi_runtime/bin/meridian-pi`.
@@ -19,7 +19,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Harness semantics now classify Pi terminal/activity/signal events (`agent_end`, `message_update`, tool execution start/update) with stopReason=`error` failure mapping.
 - Permission flag projection now explicitly emits no CLI permission flags for Pi (extension-hook permission model).
 - `meridian-pi` runtime selection now prefers `MERIDIAN_PI_BINARY`, then packaged Bun binary, then Node runner fallback.
-- Pi Bun runtime build now copies runtime metadata to `src/meridian/pi_runtime/bin/package.json` so compiled `meridian-pi` launches through the wrapper without `ENOENT` sidecar failures.
+- Pi Bun runtime build now copies required sidecar assets (`package.json`, `theme/`, `assets/`, `export-html/`, docs/examples, and `photon_rs_bg.wasm`) into `src/meridian/pi_runtime/bin/` so compiled `meridian-pi` can launch without missing-runtime-asset `ENOENT` failures.
 - `meridian-pi` now fails fast with clear errors when an override/packaged runtime binary exists but cannot execute; Node fallback remains only for missing packaged binaries.
 - `meridian-pi` Node fallback now requires source/dev runtime deps (`runner.mjs` plus `node_modules/@earendil-works/pi-coding-agent`). Installed artifacts without compiled binary now fail early with explicit build/override guidance instead of Node import errors.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Minimal Pi SDK runtime package scaffold under `src/meridian/pi_runtime/` with `runner.mjs` dynamic import of `@earendil-works/pi-coding-agent` and clear missing-dependency guidance.
 - Unit tests for `meridian-pi` wrapper arg stripping, agent-dir precedence, env projection, directory creation, and error handling.
 - Bun compile entrypoint/script for Pi runtime (`compile_runner.mjs`, `npm run build:binary`) targeting `src/meridian/pi_runtime/bin/meridian-pi`.
+- `scripts/build-meridian-pi-runtime.sh` helper plus runtime README notes for local Bun binary builds and packaging caveats.
 
 ### Changed
 - Harness semantics now classify Pi terminal/activity/signal events (`agent_end`, `message_update`, tool execution start/update) with stopReason=`error` failure mapping.
 - Permission flag projection now explicitly emits no CLI permission flags for Pi (extension-hook permission model).
 - `meridian-pi` runtime selection now prefers `MERIDIAN_PI_BINARY`, then packaged Bun binary, then Node runner fallback.
+- `meridian-pi` now fails fast with clear errors when an override/packaged runtime binary exists but cannot execute; Node fallback remains only for missing packaged binaries.
 
 ## [0.1.8] - 2026-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- `docs/harness-integration.md` — end-to-end guide for adding a new harness to Meridian, using Pi as the worked example. Covers probing, adapter/projection/extraction/semantics, wrapper/runtime packaging, session parity, model/catalog/Mars integration, verification checklist, and Pi-specific gap tracking.
 - Pi Phase 1/2 subprocess harness integration: new `HarnessId.PI`, `meridian pi` harness shortcut, `PiAdapter`, subprocess projection, extractor, and bundle registration.
 - Pi launch constants for wrapper binary: `meridian-pi` subprocess/json mode and primary base command constants.
 - Pi harness unit tests for projection, extraction, registry/contract wiring, semantics, and CLI shortcut parsing.

--- a/docs/harness-integration.md
+++ b/docs/harness-integration.md
@@ -1,0 +1,884 @@
+# Adding a New Harness to Meridian
+
+This guide covers the full process of adding a new AI coding agent as a Meridian
+harness — from initial probe to distribution. Uses the Pi integration as the
+worked example, with specific notes on what differs per harness type.
+
+**Audience:** developers integrating a new harness into Meridian. Assumes
+familiarity with the Meridian architecture (`AGENTS.md`, `src/meridian/AGENTS.md`,
+`src/meridian/lib/harness/AGENTS.md`).
+
+## Table of Contents
+
+1. [Architecture Recap](#architecture-recap)
+2. [Phase 0: Probe the Harness](#phase-0-probe-the-harness)
+3. [Phase 1: Minimum Viable Spawn](#phase-1-minimum-viable-spawn)
+4. [Phase 2: Wrapper and Runtime Packaging](#phase-2-wrapper-and-runtime-packaging)
+5. [Phase 3: Session and History Parity](#phase-3-session-and-history-parity)
+6. [Phase 4: Model, Catalog, and Mars Integration](#phase-4-model-catalog-and-mars-integration)
+7. [Verification Checklist](#verification-checklist)
+8. [Pi-Specific Current Status and Remaining Gaps](#pi-specific-current-status-and-remaining-gaps)
+
+## Architecture Recap
+
+Every spawn goes through a four-step translation pipeline:
+
+```
+SpawnParams                          harness-agnostic inputs
+  ↓ adapter.resolve_launch_spec()
+HarnessLaunchSpec                    harness-specific typed struct
+  ↓ project_<harness>_spec_to_cli_args()
+list[str] + env dict                 ready to exec
+  ↓ subprocess / connection.start()
+Running process                      events → SpawnManager drain loop
+```
+
+The nine touchpoints that must be modified for any new harness are listed in
+`HARNESS_EXTENSION_TOUCHPOINTS` at `src/meridian/lib/harness/__init__.py:14`.
+Missing any causes `ImportError` at startup — the drift guards are enforcement,
+not documentation.
+
+Before diving into code, read these orientation files:
+
+- `src/meridian/lib/harness/AGENTS.md` — harness layer mental model and invariants
+- `src/meridian/lib/harness/.context/CONTEXT.md` — full contracts, bootstrap sequence,
+  session-ID chain
+- `src/meridian/lib/harness/adapter.py` — `SpawnParams`, `HarnessContract`, and
+  sub-model definitions (source of truth for what an adapter must implement)
+- `src/meridian/lib/launch/AGENTS.md` — composition seam and finalization ownership
+
+KB references for deeper context:
+
+- `$MERIDIAN_CONTEXT_KB_DIR/codebase/harness-adapters.md` — capability matrix
+- `$MERIDIAN_CONTEXT_KB_DIR/lessons/harness-integration.md` — lessons from
+  previous integrations (PTY, managed-primary, semantic IR pattern)
+
+## Phase 0: Probe the Harness
+
+Before writing a single line of Meridian code, run the harness binary and
+document its actual behavior. Design docs get things wrong — the probe catches
+flag name mismatches, missing events, and assumed capabilities before they
+become code.
+
+### What to Probe
+
+| Area | Questions | Pi Example |
+|---|---|---|
+| **CLI flags** | What are the exact flag names? What formats does the harness accept for model, output, session resume, system prompt? | `--mode json` (not `--output-format json` as assumed). `--append-system-prompt <text>` inline (not a file path). |
+| **Event schema** | What JSON/JSONL events does the harness emit? What is the terminal event? Are there error events? | `agent_end` is the terminal event (not `turn.completed`). No `session.error` — errors surface via `stopReason:"error"`. |
+| **Session ID** | How is the session ID emitted? Is it in stdout, a file, or both? | First JSONL line: `{"type":"session","id":"..."}`. Also in session files under `sessions/<cwd-escaped>/`. |
+| **Fork/resume** | Can sessions be resumed? Forked? What are the flags? | `--session <id>` for resume, `--fork <id>` for fork. Native support confirmed. |
+| **Permission model** | CLI permission flags? Approval bypass? | No CLI permission flags — permissions via extension event hooks. |
+| **Config isolation** | Can config/data directories be isolated via env var? | `PI_CODING_AGENT_DIR` env var isolates everything. |
+| **Provider list** | How many providers? Does the list evolve with releases? | 20+ providers, upstream-owned. Don't hardcode — pass `--model` through. |
+| **Skills** | Does the harness have a native skills/concepts system? How does it load them? | Pi implements Agent Skills standard (`--skill`). Deferred Meridian skill projection. |
+| **System prompt** | How is system-level instruction delivered? | `--append-system-prompt <text>` inline. Differs from Claude (temp file path). |
+| **Ambient discovery** | What ambient config/files does the harness discover at startup? | Extensions, skills, context files, prompt templates — all suppressed with `--no-*` flags for spawns. |
+
+### Probe Methodology
+
+1. Launch the harness binary directly (not through Meridian) with `--help` to
+   discover flags.
+2. Run a trivial prompt (`"Reply with exactly OK"`) in the intended spawn mode
+   and capture stdout/stderr.
+3. Examine the harness's session storage format (JSONL files, SQLite, etc.).
+4. If the harness has an RPC/streaming mode, test that too even if Phase 1
+   doesn't use it — you need to know the event schema for semantics.
+5. Cross-reference every design assumption against the probe output. Fix the
+   design before writing code.
+
+**Pi probe result**: The original design had the output flag wrong (`--output-format json`
+vs actual `--mode json`), the terminal event wrong (`turn.completed` vs `agent_end`),
+and assumed session fork was unsupported when it was native. Catching these in the
+probe saved multiple rounds of bug-fix commits.
+
+## Phase 1: Minimum Viable Spawn
+
+The goal: `meridian pi -m <model> "prompt"` launches a subprocess, Meridian
+captures the output, extracts the report/usage/session-id, and surfaces the
+result. No streaming, no interactive primary, no RPC.
+
+### 1.1 Harness Identity and CLI Routing
+
+**File: `src/meridian/lib/core/types.py`**
+
+Add the harness ID:
+
+```python
+class HarnessId(str, Enum):
+    CLAUDE = "claude"
+    CODEX = "codex"
+    OPENCODE = "opencode"
+    PI = "pi"  # add here
+```
+
+No new `TransportId` is needed for subprocess-only harnesses — use the existing
+`TransportId.STREAMING`. If the harness has a unique transport (e.g. WebSocket
+like Codex), add a new `TransportId`.
+
+**File: `src/meridian/cli/bootstrap.py`**
+
+Add to the shortcut set:
+
+```python
+HARNESS_SHORTCUT_NAMES = frozenset({"claude", "codex", "opencode", "pi"})
+```
+
+This gives `meridian pi "task"` as a shorthand for `meridian --harness pi "task"`.
+
+**File: `src/meridian/lib/launch/constants.py`**
+
+Define base commands:
+
+```python
+BASE_COMMAND_PI_SUBPROCESS: Final = ("meridian-pi", "-p", "--mode", "json")
+PRIMARY_BASE_COMMAND_PI:    Final = ("meridian-pi",)
+```
+
+`-p` is print mode (one-shot, pipe-friendly). `--mode json` enables JSONL output.
+These constants are shared between the adapter, projection, and connection.
+
+### 1.2 Adapter
+
+**File: `src/meridian/lib/harness/pi.py`**
+
+Create a class extending `BaseHarnessAdapter[ResolvedLaunchSpec]`:
+
+```python
+class PiAdapter(BaseHarnessAdapter[ResolvedLaunchSpec]):
+    BASE_COMMAND = BASE_COMMAND_PI_SUBPROCESS
+    PRIMARY_BASE_COMMAND = PRIMARY_BASE_COMMAND_PI
+```
+
+Every adapter must implement:
+
+| Method/Property | Purpose |
+|---|---|
+| `id` | Return `HarnessId.PI` |
+| `contract` | Declare `HarnessContract` with all sub-contracts |
+| `capabilities` | Boolean feature flags (`supports_stream_events`, etc.) |
+| `consumed_fields` / `explicitly_ignored_fields` | `SpawnParams` field accounting |
+| `resolve_launch_spec()` | Map `SpawnParams` → `HarnessLaunchSpec` |
+| `build_command()` | Produce the final argv list |
+| `project_content()` | Map `ComposedLaunchContent` → harness channels |
+| `env_overrides()` | Return child process env overrides |
+| `extract_usage()`, `extract_session_id()`, `extract_report()` | Delegate to extractor |
+
+**SpawnParams accounting**: Every field in `SpawnParams` must appear in
+`consumed_fields` **or** `explicitly_ignored_fields`. The merge of both sets
+for each adapter is enforced at import time by
+`_enforce_spawn_params_accounting()`. Adding a `SpawnParams` field without
+updating all adapters → `ImportError` on startup.
+
+```python
+_CONSUMED_FIELDS = frozenset({
+    "prompt", "model", "effort", "extra_args", "control_root",
+    "interactive", "continue_harness_session_id", "continue_fork",
+    "appended_system_prompt", "user_turn_content", "mcp_tools",
+    "projected_roots",
+})
+_EXPLICITLY_IGNORED_FIELDS = frozenset({
+    "skills", "agent", "adhoc_agent_payload", "report_output_path",
+    "context_from_payload", "reference_items", "task_cwd",
+})
+```
+
+**Capability decisions**:
+
+- `supports_stream_events`: `True` if the harness emits structured JSONL events
+- `supports_session_fork`: Probe this — Pi confirmed `True` with `--fork`
+- `supports_native_skills`: Set `False` if Meridian skill projection is deferred
+  (Pi has native skills but Meridian doesn't project them yet)
+- `supports_native_agents`: `False` for harnesses without a native agent concept
+  (agent body goes via `--append-system-prompt`)
+- `supports_native_file_injection`: `False` for all current harnesses — reference
+  content goes inline in the user turn
+- `terminal_surface_modes`: `PURE_STDIO` for subprocess spawns. Add `PTY_MEDIATED`
+  only if interactive primary TUI requires PTY capture
+
+**Bootstrap mode**: Phase 1 uses `BootstrapMode.SUBPROCESS_ONLY`. Upgrade to
+`BootstrapMode.MANAGED_PRIMARY_ATTACH` only when adding interactive primary
+session support (Phase 3+).
+
+**Fork materialization**: If the harness natively supports fork (like Pi's
+`--fork`), use `ForkMaterializationMode.NATIVE_CONTINUE_FORK`. If the harness
+only supports resume, Meridian materializes forks by copying the session file
+(`ForkMaterializationMode.MERIDIAN_MATERIALIZED_FORK`).
+
+**Content projection** (`project_content()`): Maps the harness-agnostic
+`ComposedLaunchContent` (system instruction, task context, user prompt) to
+harness-specific channels. For Pi:
+- System instruction → `--append-system-prompt` (inline, not a file path)
+- Task context and user prompt → inline in the user turn
+
+```python
+def project_content(self, content: ComposedLaunchContent) -> ProjectedContent:
+    system_prompt = render_system_instruction_blocks(content)
+    task_context = render_task_context(content.reference_items, ...)
+    user_turn = join_content_blocks(task_context, content.user_task_prompt)
+    return ProjectedContent(
+        system_prompt=system_prompt,
+        user_turn_content=user_turn,
+        channels=ProjectionChannels(
+            system_instruction="system-field",
+            user_task_prompt="user-turn",
+            task_context="user-turn",
+        ),
+    )
+```
+
+**Env overrides**: Set harness-specific env vars for config isolation:
+
+```python
+def env_overrides(self, config: PermissionConfig) -> dict[str, str]:
+    return {
+        "PI_CODING_AGENT_DIR": str(get_user_home() / "pi" / "agent"),
+    }
+```
+
+Pi uses `PI_CODING_AGENT_DIR` to isolate its config/sessions/extensions from
+the default `~/.pi/`. Claude uses `CLAUDE_CONFIG_DIR`. Codex uses `CODEX_HOME`.
+Every harness needs config isolation — find the env var and set it.
+
+**Bundle registration**: Register as a module-load side effect:
+
+```python
+register_harness_bundle(
+    HarnessBundle(
+        harness_id=HarnessId.PI,
+        adapter=PiAdapter(),
+        spec_cls=ResolvedLaunchSpec,
+        extractor=PI_EXTRACTOR,
+        connections={TransportId.STREAMING: PiConnection},
+        projections=HarnessProjectionPorts(
+            subprocess_cli_args=project_pi_spec_to_cli_args,
+        ),
+    )
+)
+```
+
+### 1.3 Projection
+
+**File: `src/meridian/lib/harness/projections/project_pi_subprocess.py`**
+
+Pure function: `spec` → `(argv_additions)`. Declare `_PROJECTED_FIELDS` (fields
+this projector handles) and `_DELEGATED_FIELDS` (fields owned by the caller).
+The drift guard `check_projection_drift()` runs at import time.
+
+**Command construction**:
+
+```python
+def project_pi_spec_to_cli_args(spec, *, base_command) -> list[str]:
+    command = list(base_command)
+
+    # Model with optional thinking level
+    if spec.model:
+        model = spec.model
+        if spec.effort:
+            thinking = _EFFORT_TO_THINKING.get(spec.effort)
+            if thinking:
+                model = f"{model}:{thinking}"
+        command.extend(("--model", model))
+
+    # System prompt (inline, not file path — differs from Claude)
+    if spec.appended_system_prompt:
+        command.extend(("--append-system-prompt", spec.appended_system_prompt))
+
+    # Session resume/fork
+    if spec.continue_session_id:
+        if spec.continue_fork:
+            command.extend(("--fork", spec.continue_session_id))
+        else:
+            command.extend(("--session", spec.continue_session_id))
+
+    # Suppress ambient discovery
+    command.extend(("--no-extensions", "--no-skills",
+                     "--no-context-files", "--no-prompt-templates"))
+
+    # Permission flags
+    command.extend(resolve_permission_flags(spec.permission_resolver, HarnessId.PI))
+
+    # User extra_args (passthrough, last-wins semantics for collisions)
+    command.extend(spec.extra_args)
+
+    # Prompt as final positional arg
+    if spec.prompt.strip():
+        command.append(spec.prompt)
+
+    return command
+```
+
+**Key projection decisions**:
+
+- **System prompt channel**: Pi uses inline `--append-system-prompt <text>`.
+  Claude uses `--append-system-prompt-file <path>` (temp file, avoids `ARG_MAX`).
+  Codex and OpenCode inline everything. This is a per-harness decision — know
+  the harness's channel before implementing.
+- **Model format**: Pi expects `provider/model-id` (same as OpenCode). Claude
+  uses `--model` with the full model string. Codex uses `--model` with the
+  anthropic model ID. Pass through whatever the harness expects.
+- **Effort → thinking level**: Pi accepts `:level` suffix on the model string
+  (`sonnet:high`). Map Meridian effort values to harness-specific thinking
+  levels.
+- **Isolation flags**: Every harness has ambient discovery (extensions, MCP
+  servers, context files, project config). For spawns, suppress all of it.
+  For Pi: `--no-extensions`, `--no-skills`, `--no-context-files`,
+  `--no-prompt-templates`. Find the equivalent flags for your harness.
+- **Passthrough collision**: When the user's `extra_args` contain a flag that
+  the projector also manages, the user value wins (last-wins semantics).
+  Log collisions at debug level so they're visible during integration testing.
+
+### 1.4 Extraction
+
+**File: `src/meridian/lib/harness/extractors/pi.py`**
+
+Implement `HarnessExtractor` with three core methods and one detection method:
+
+```python
+class PiHarnessExtractor(HarnessExtractor[ResolvedLaunchSpec]):
+    def extract_session_id(self, artifacts, spawn_id) -> str | None: ...
+    def extract_usage(self, artifacts, spawn_id) -> TokenUsage: ...
+    def extract_report(self, artifacts, spawn_id) -> str | None: ...
+    def detect_session_id_from_event(self, event) -> str | None: ...
+    def detect_session_id_from_artifacts(self, *, spec, launch_env,
+                                          child_cwd, runtime_root) -> str | None: ...
+```
+
+**Session ID**: Pi emits `{"type":"session","id":"..."}` as the first JSONL line.
+Parse from artifact output. Also scan the harness's session directory
+(`sessions/<cwd-escaped>/*.jsonl`) as a fallback for when stdout capture fails.
+
+**Usage**: Pi puts usage in the last `message_end` with
+`message.role=="assistant"`. Extract `message.usage.input`, `message.usage.output`,
+`message.usage.cacheRead`, `message.usage.cacheWrite`. Cost in USD is available
+at `message.usage.cost.total` if the provider reports it.
+
+**Report**: Pi's final assistant text is in `agent_end.messages[-1].content`
+(where `role=="assistant"` and `content[].type=="text"`). Walk backwards through
+the event list and extract the last assistant text.
+
+**Fallback session ID from files**: If `--continue` was used (resume, not fork),
+the session ID was already known. For fresh spawns where stdout capture fails,
+scan `$PI_CODING_AGENT_DIR/sessions/<cwd-escaped>/` for the most recently
+modified JSONL file and read its session header. CWD escaping: slashes `/`
+become `--`, directory name ends with `--`.
+
+### 1.5 Connection/Streaming Runner
+
+**File: `src/meridian/lib/harness/connections/pi_rpc.py`**
+
+Even in Phase 1 subprocess-only mode, implement a `HarnessConnection` subclass
+that drains JSONL events through Meridian's streaming runner. The SpawnManager
+drain loop calls `terminal_outcome(event)` on each event; when that returns
+non-None, the drain breaks.
+
+```python
+class PiConnection(HarnessConnection[ResolvedLaunchSpec]):
+    async def start(self, config, spec): ...
+    async def stop(self): ...
+    async def events(self) -> AsyncIterator[HarnessEvent]: ...
+    async def send_cancel(self): ...        # Signal the process
+    async def send_user_message(self): ...  # Raise ConnectionNotReady in Phase 1
+```
+
+**Event stream reading**: Read JSONL lines from `process.stdout`,
+parse each as JSON, extract `type` field, emit `HarnessEvent(event_type, payload, harness_id)`.
+
+**stderr handling**: Redirect `stderr` to `<spawn_dir>/stderr.log`. Never parse stderr
+for structured data — it's diagnostic only.
+
+**cwd**: Launch in `config.task_cwd` (the agent's working directory) when provided,
+falling back to `config.control_root`.
+
+**Process cancellation**: On `send_cancel()`, send SIGINT (POSIX) or
+`process.terminate()` (Windows). Wait up to 5 seconds for graceful shutdown,
+then SIGKILL/`process.kill()`.
+
+**Windows**: Use `asyncio.create_subprocess_exec()` with `PIPE` for stdin/stdout.
+On Windows, `signal.SIGINT` is not supported — use `process.terminate()` instead.
+Check `IS_WINDOWS` from `meridian.lib.platform`.
+
+**Env propagation**: Inherit parent env, apply adapter env overrides, block
+`MERIDIAN_ACTIVE_WORK_ID` and `MERIDIAN_ACTIVE_WORK_DIR` from child scope.
+
+### 1.6 Event Semantics
+
+**File: `src/meridian/lib/harness/semantics.py`**
+
+Three functions must handle the new harness:
+
+**`terminal_outcome(event)`** — classifies whether an event completes a spawn drain:
+
+```python
+if event.harness_id == HarnessId.PI.value and event.event_type == "agent_end":
+    messages = event.payload.get("messages", [])
+    last_assistant = next(
+        (m for m in reversed(messages) if m.get("role") == "assistant"), None
+    )
+    if last_assistant and last_assistant.get("stopReason") == "error":
+        return TerminalEventOutcome(status="failed", exit_code=1, error="pi_stop_error")
+    return TerminalEventOutcome(status="succeeded", exit_code=0)
+```
+
+**`activity_transition(event)`** — maps events to `"turn_active"` or `"idle"`:
+
+```python
+if event.harness_id == HarnessId.PI.value:
+    if event.event_type in {"agent_start", "turn_start", "message_start",
+                             "message_update", "tool_execution_start",
+                             "tool_execution_update"}:
+        return "turn_active"
+    if event.event_type in {"turn_end", "agent_end"}:
+        return "idle"
+```
+
+**`clears_signal(event)`** — which event clears a pending user signal:
+
+```python
+if event.harness_id == HarnessId.PI.value:
+    return event.event_type == "agent_end"
+```
+
+**Golden rule of semantics**: `event_type` is NOT globally unique. Always qualify
+by `event.harness_id` first. `turn/completed` is Codex; OpenCode uses
+`session.idle` for the same semantic.
+
+### 1.7 Permission Flag Projection
+
+**File: `src/meridian/lib/harness/projections/permission_flags.py`**
+
+Return the CLI permission/approval flags for the harness:
+
+```python
+if harness_id == HarnessId.PI:
+    return ()  # Pi: permissions via extension event hooks, not CLI flags
+```
+
+Claude returns `--dangerously-skip-permissions` when appropriate. Codex returns
+flags from its own permission model. Map the `PermissionResolver` config to
+whatever the harness expects.
+
+### 1.8 Registry
+
+**File: `src/meridian/lib/harness/registry.py`**
+
+Register in `with_defaults()`:
+
+```python
+registry.register(PiAdapter())
+```
+
+### 1.9 Bootstrap Import Wiring
+
+**File: `src/meridian/lib/harness/__init__.py`**
+
+Add imports to `_run_bootstrap()`:
+
+```python
+from meridian.lib.harness import pi as _pi
+from meridian.lib.harness.projections import project_pi_subprocess as _project_pi_subprocess
+from meridian.lib.harness.extractors import pi as _pi_extractor
+```
+
+Import order is load-bearing: adapters first (bundle side effects), then
+projections (drift guards), then extractors, then accounting enforcement.
+Do not import individual adapter modules before `ensure_bootstrap()` completes.
+
+### 1.10 Launch Spec Accounting
+
+**File: `src/meridian/lib/harness/launch_spec.py`**
+
+The `_enforce_spawn_params_accounting()` function runs after all adapters are
+registered. It checks that for each adapter, every `SpawnParams` field appears
+in `consumed_fields | explicitly_ignored_fields`. If a field is added to
+`SpawnParams` without updating the adapter, startup raises `ImportError`.
+
+This is automatic — the new adapter's fields are checked like any other.
+Just make sure both sets are complete.
+
+## Phase 2: Wrapper and Runtime Packaging
+
+Not every harness needs a wrapper binary. You need one when:
+
+- The harness is not installed as a system binary (e.g. npm package that needs a
+  Node/Bun runtime)
+- The harness needs config isolation that can't be set purely via env vars
+  passed to a subprocess
+- The harness needs custom extension/builtin injection that can't be done via
+  CLI flags alone
+
+### 2.1 Wrapper Entrypoint
+
+**File: `src/meridian/cli/pi_entrypoint.py`**
+
+The Python wrapper is installed as a console script via `pyproject.toml`:
+
+```toml
+[project.scripts]
+meridian-pi = "meridian.cli.pi_entrypoint:main"
+```
+
+The wrapper:
+1. Strips wrapper-only flags (`--agent-dir`) from argv
+2. Resolves agent directory (CLI flag > env var > default)
+3. Creates required subdirectories (`sessions/`, `extensions/`, `bin/`)
+4. Sets `PI_CODING_AGENT_DIR` in child environment
+5. Passes all other args through to the Pi runtime binary
+
+**Agent dir resolution precedence**:
+
+```python
+def _resolve_agent_dir(cli_agent_dir, env):
+    if cli_agent_dir is not None:
+        return Path(cli_agent_dir).expanduser()
+    env_agent_dir = env.get("MERIDIAN_PI_AGENT_DIR", "").strip()
+    if env_agent_dir:
+        return Path(env_agent_dir).expanduser()
+    meridian_home = env.get("MERIDIAN_HOME", "").strip()
+    if meridian_home:
+        return Path(meridian_home).expanduser() / "pi" / "agent"
+    return get_user_home() / "pi" / "agent"
+```
+
+### 2.2 Runtime Binary Selection
+
+Decide what the wrapper actually executes:
+
+1. **`MERIDIAN_PI_BINARY` env override** — user-supplied binary path (for
+   development and custom installs)
+2. **Packaged compiled binary** — e.g. `src/meridian/pi_runtime/bin/meridian-pi`
+   (Bun-compiled)
+3. **Node fallback** — source/dev only, runs `runner.mjs` with `node`
+
+The wrapper should fail fast with a clear message when no runtime is available:
+
+```
+compiled meridian-pi runtime is not installed; build it with
+scripts/build-meridian-pi-runtime.sh or set MERIDIAN_PI_BINARY;
+source/dev fallback requires runtime deps installed.
+```
+
+### 2.3 Compiled Runtime (Bun)
+
+**File: `src/meridian/pi_runtime/package.json`**
+
+```json
+{
+  "scripts": {
+    "build:binary": "bun build ./compile_runner.mjs --compile --outfile ./bin/meridian-pi && bun run copy:runtime-metadata",
+    "copy:runtime-metadata": "...copies package.json to bin/package.json..."
+  }
+}
+```
+
+The compile entrypoint (`compile_runner.mjs`) dynamically imports the harness
+SDK and calls its `main()` function:
+
+```js
+import { main } from "@earendil-works/pi-coding-agent";
+main(process.argv.slice(2), {});
+```
+
+### 2.4 Sidecar Asset Requirements
+
+**Critical discovery from Pi**: The Bun-compiled binary expected `package.json`
+adjacent to the executable at runtime. Without it, the wrapper failed with
+`ENOENT: no such file or directory, open '.../bin/package.json'`.
+
+**Fix**: The build script now copies `package.json` to `bin/` after compilation:
+
+```bash
+bun build ./compile_runner.mjs --compile --outfile ./bin/meridian-pi
+cp package.json bin/package.json
+```
+
+**Lesson**: Always smoke-test the compiled binary path from the wrapper, because
+the harness runtime may expect sidecar assets (package.json, theme files,
+config templates) adjacent to the executable. For Pi, a **theme asset gap**
+was recently discovered: `bin/theme/dark.json` and likely `light.json` are
+also needed. This remains unfixed as of this writing.
+
+### 2.5 Distribution Caveats
+
+**Generated binaries are not committed** (`src/meridian/pi_runtime/bin/` is in
+`.gitignore`). Built binaries are OS/arch-specific — a Linux x86-64 binary
+doesn't work on macOS ARM64 or Windows. The universal Python wheel intentionally
+does not ship a single prebuilt binary.
+
+Future release path (deferred):
+- Build per-platform binaries in CI (linux-x64, macos-arm64, macos-x64, win-x64)
+- Lazy-download on first `meridian pi` use
+- `meridian doctor --fix` to install/verify the runtime
+
+The Node fallback path exists for source/dev environments where npm deps are
+installed. For production installs without a compiled binary, the wrapper fails
+fast with clear instructions.
+
+## Phase 3: Session and History Parity
+
+### 3.1 Generic `history.jsonl` Event Persistence
+
+Every spawn writes `history.jsonl` in the spawn log directory. This is the
+generic event persistence layer — raw JSONL events from the harness, one
+per line, with Meridian-added metadata. This works automatically for any
+harness that uses the streaming runner drain loop.
+
+### 3.2 Native Session File Resolution
+
+Harnesses store their own session files independently. For Pi, session files
+live under `$PI_CODING_AGENT_DIR/sessions/<cwd-escaped>/<timestamp>_<uuid>.jsonl`.
+
+The extractor needs to:
+1. Know where the harness stores session files
+2. Know the file naming convention
+3. Know how to map the Meridian spawn's CWD to the harness's session directory
+
+This is harness-specific and must be implemented in the extractor's
+`detect_session_id_from_artifacts()` method. Pi's CWD encoding: slashes become
+`--`, directory name ends with `--`.
+
+### 3.3 Readable `meridian session log` Translation
+
+`meridian session log` renders a human-readable transcript from `history.jsonl`.
+This works through the `TranscriptProvider`/`TranscriptEventParser` system in
+`src/meridian/lib/harness/transcript.py`.
+
+Each harness needs:
+1. A `TranscriptProvider` that knows how to iterate events from its native
+   session files (or falls back to `history.jsonl`)
+2. A `TranscriptEventParser` that extracts `TranscriptMessage(role, content)`
+   from harness-specific event schemas
+
+**Pi current status**: Pi has generic `history.jsonl` persistence working, but
+**full `meridian session log` parity is not yet implemented**. The session file
+resolution/translation for Pi session files is incomplete. Spawns are tracked,
+but `meridian session log <pi-spawn-id>` does not yet produce a readable
+transcript from Pi's native session JSONL format.
+
+Users who need readable transcripts from Pi spawns must currently read the raw
+`history.jsonl` or Pi's native session files directly.
+
+### 3.4 Export/Search Implications
+
+When session log parity is incomplete:
+- `meridian session log` shows raw events or falls back to generic rendering
+- Session search (`meridian session search`) may miss content stored only in
+  native session files
+- Export formats that depend on transcript parsing will be incomplete
+
+**Lesson**: Session log parity should be treated as a Phase 2 requirement, not
+deferred indefinitely. Without it, the harness is a second-class citizen in
+Meridian's observability surface.
+
+## Phase 4: Model, Catalog, and Mars Integration
+
+### 4.1 Model Aliases Are Harness-Specific
+
+Do not assume that model aliases from one harness work with another. `sonnet`
+maps to `anthropic/claude-sonnet-4` in Claude; it may map to
+`anthropic/claude-sonnet-4-6` in Pi, or not be recognized at all.
+
+Each harness has its own provider registry and model namespace. A model string
+that works with `--harness claude` may need a different format for
+`--harness pi`.
+
+**Current Pi status**: Pi supports 20+ providers with model resolution built in.
+The harness passes `--model <string>` through to Pi, which handles resolution.
+However, **Mars model aliases do not yet include Pi-compatible model paths**.
+Users must currently pass explicit Pi-compatible model strings
+(e.g. `anthropic/claude-sonnet-4`).
+
+### 4.2 What Mars Needs to Support a Harness
+
+For Mars to fully support a harness, the following are needed:
+
+1. **Model alias mapping**: Mars model entries need `harness_candidates` /
+   `runnable_paths` entries for the new harness. Each entry maps a Meridian
+   model alias (e.g. `sonnet`) to a harness-specific model ID string
+   (e.g. `anthropic/claude-sonnet-4`).
+
+2. **Provider discovery**: Mars needs to know which providers the harness
+   supports and how to validate model strings.
+
+3. **Catalog agent profiles**: Agent profiles should be able to specify
+   `harness: pi` and `model: sonnet` and have resolution produce the correct
+   Pi model string.
+
+4. **`meridian mars models list`**: Should show which models are available
+   through the Pi harness.
+
+**Current Pi status**: None of the above is implemented. Pi-compatible model
+aliases, provider discovery, and catalog integration are deferred. Users
+must use explicit model strings with `--harness pi`.
+
+### 4.3 Interim Workaround
+
+Until Mars supports the harness:
+
+```bash
+# Use explicit provider/model-id strings
+meridian pi -m anthropic/claude-sonnet-4 "task"
+meridian pi -m openai/gpt-5.4-mini "task"
+
+# Or discover available models from the harness directly
+meridian-pi --list-models
+```
+
+## Verification Checklist
+
+Run these in order. Each step gates the next.
+
+### Unit Tests
+
+- [ ] Adapter resolves `SpawnParams` correctly
+- [ ] Projection maps all spec fields to CLI args
+- [ ] Extraction parses session ID, usage, report from sample JSONL
+- [ ] Semantics classify terminal/activity/signal events correctly
+- [ ] CLI shortcut parsing (`meridian pi`) routes to the right harness
+- [ ] Registry returns the adapter, contract, and extractor
+- [ ] Drift guards pass (both SpawnParams accounting and projection field coverage)
+
+```bash
+uv run pytest tests/unit/harness/test_pi_projection.py
+uv run pytest tests/unit/harness/test_pi_extractor.py
+uv run pytest tests/unit/harness/test_pi_integration.py
+uv run pytest tests/unit/cli/test_bootstrap_pi_shortcut.py
+```
+
+### Fake Harness Smoke
+
+- [ ] `meridian spawn --harness pi -m <model> "Reply with exactly OK"` succeeds
+  with a fake `meridian-pi` binary that emits minimal JSONL and exits 0
+- [ ] Report text extracted correctly
+- [ ] Usage (tokens) extracted correctly
+- [ ] Session ID captured
+
+Use a shell script as a fake `meridian-pi` that writes a session header and a
+trivial `agent_end` event to stdout.
+
+### Real Wrapper Smoke
+
+- [ ] `meridian-pi --help` exits 0 and shows Pi help text
+- [ ] `meridian-pi --version` exits 0 and shows version
+- [ ] Wrapper creates agent dirs (`sessions/`, `extensions/`, `bin/`)
+- [ ] `MERIDIAN_PI_AGENT_DIR=<tmp>` overrides agent dir
+- [ ] `MERIDIAN_PI_BINARY=<path>` overrides runtime binary
+- [ ] Missing runtime fails fast with clear error
+- [ ] Compiled binary path works (if Bun is installed)
+
+### Real Harness Spawn Smoke
+
+- [ ] `meridian pi -m <cheap-model> "Reply with exactly OK"` exits 0
+- [ ] `meridian spawn --harness pi -m <cheap-model> "Reply with exactly OK"`
+  exits 0 and reports status `succeeded`
+- [ ] `meridian spawn show <spawn-id>` shows report, usage, session ID
+- [ ] Resume works: `meridian pi --continue <session-id> "continue"`
+- [ ] Fork works: `meridian pi --fork <session-id> "fork"`
+
+Use a cheap model (e.g. `gpt-5.4-mini`, `haiku`) for these — reserve
+expensive models for reasoning-heavy tasks.
+
+### Session Log / Transcript Smoke
+
+- [ ] `meridian session log <pi-spawn-id>` produces readable output
+- [ ] Native session files are discoverable from spawn metadata
+- [ ] Export formats include Pi session content
+
+**Pi status**: This is a known gap. Generic `history.jsonl` works but native
+transcript translation is incomplete.
+
+### Packaging / Wheel Smoke
+
+- [ ] `uv build --no-sources` succeeds
+- [ ] Installed wheel: `uv run --isolated --no-project --with <wheel> meridian-pi --help`
+  shows appropriate error (runtime not installed) or succeeds if runtime available
+- [ ] `pyright` reports 0 errors
+- [ ] `ruff check .` passes
+
+### Pre-Push
+
+```bash
+uv run ruff check .
+uv run pyright
+uv run pytest -x -q
+uv build --no-sources
+```
+
+All must pass. The pre-push hook enforces this automatically.
+
+## Pi-Specific Current Status and Remaining Gaps
+
+### Implemented (Phases 1-2)
+
+| Area | Status | Notes |
+|---|---|---|
+| `HarnessId.PI` + CLI shortcut | Done | `meridian pi "task"` works |
+| PiAdapter + bundle registration | Done | Full `HarnessContract`, SpawnParams accounting |
+| Subprocess projection | Done | `meridian-pi -p --mode json`, inline system prompt, isolation flags |
+| PiConnection (JSONL drain) | Done | Streaming runner drain loop, session ID capture, stderr logging |
+| PiExtractor | Done | Session ID, usage, report from artifacts + events |
+| Event semantics | Done | `agent_end` terminal, activity transitions, signal clearing |
+| Permission flags | Done | Empty tuple (Pi uses extension hooks) |
+| Real `meridian-pi` wrapper | Done | Python entrypoint, config isolation, runtime selection |
+| Bun-compiled runtime | Done | Build script, binary path in wrapper, sidecar metadata fix |
+| Runtime fallback | Done | Node fallback for source/dev, clear fail-fast for missing runtime |
+
+### Remaining Gaps
+
+| Gap | Severity | What's needed |
+|---|---|---|
+| **Theme sidecar packaging** | Medium | `bin/theme/dark.json` (and likely `light.json`) must be packaged alongside the compiled binary, same as `package.json`. Currently Pi fails on launch due to missing theme assets. Fix: extend the `build:binary` script to copy `node_modules/@earendil-works/pi-coding-agent/theme/` to `bin/theme/`. |
+| **Full `meridian session log` parity** | Medium | Pi's native JSONL session files are not translated to readable transcripts. A `TranscriptProvider` for Pi session files and a `TranscriptEventParser` for Pi's event schema are needed. Until then, `meridian session log <pi-spawn-id>` falls back to generic rendering. |
+| **Mars model aliases/catalog** | Medium | Mars does not yet include Pi-compatible model paths in its alias resolution. Users must pass explicit `provider/model-id` strings. Need: `harness_candidates` / `runnable_paths` entries in Mars model definitions, provider discovery, and agent profile resolution for `harness: pi`. |
+| **Web extensions/tools** | Deferred | Built-in `web_search` and `web_fetch` extensions were part of the original requirements. These are Pi-native extensions that need authoring and bundling with the wrapper. |
+| **Notifications** | Deferred | Meridian spawn completion notifications surfaced through Pi's UI. |
+| **RPC managed-primary** | Deferred | Phase 3: `meridian-pi --mode rpc` with full `HarnessConnection` — mid-turn steering, prompt injection, session queries over JSONL-over-stdio. |
+| **Lazy download distribution** | Deferred | Phase 5: Per-platform binary downloads. Currently the wrapper expects the binary at a known path or falls back to Node. |
+| **`meridian doctor` integration** | Deferred | Health checks for Pi binary, version, extensions, provider availability. |
+
+### Quickest Next Fixes
+
+1. **Theme sidecar**: Add `bun run copy:theme-assets` step to `build:binary`
+   that copies the theme directory from the Pi SDK `node_modules` to `bin/theme/`.
+2. **Session log**: Implement `PiTranscriptProvider` (reads Pi session JSONL
+   files) and `PiTranscriptParser` (extracts `TranscriptMessage` from Pi event
+   schema), then register in `transcript.py`.
+3. **Model aliases**: Add `harness_candidates` with Pi runnable paths to Mars
+   model definitions for commonly used models.
+
+## Reference: Pi Integration Files
+
+### Created
+
+```
+src/meridian/lib/harness/pi.py                                          # Adapter + bundle
+src/meridian/lib/harness/projections/project_pi_subprocess.py           # CLI arg projection
+src/meridian/lib/harness/extractors/pi.py                               # Artifact extraction
+src/meridian/lib/harness/connections/pi_rpc.py                          # JSONL event drain
+src/meridian/cli/pi_entrypoint.py                                       # Wrapper entrypoint
+src/meridian/pi_runtime/package.json                                    # Runtime package
+src/meridian/pi_runtime/runner.mjs                                      # Node SDK runner
+src/meridian/pi_runtime/compile_runner.mjs                              # Bun compile entry
+src/meridian/pi_runtime/README.md                                       # Runtime readme
+scripts/build-meridian-pi-runtime.sh                                    # Build helper
+tests/unit/cli/test_bootstrap_pi_shortcut.py                            # CLI shortcut tests
+tests/unit/cli/test_pi_entrypoint.py                                    # Wrapper tests
+tests/unit/harness/test_pi_projection.py                                # Projection tests
+tests/unit/harness/test_pi_extractor.py                                 # Extractor tests
+tests/unit/harness/test_pi_integration.py                               # Integration tests
+```
+
+### Modified
+
+```
+src/meridian/lib/core/types.py                                          # + HarnessId.PI
+src/meridian/cli/bootstrap.py                                           # + 'pi' shortcut
+src/meridian/lib/launch/constants.py                                    # + PI base commands
+src/meridian/lib/harness/__init__.py                                    # + pi bootstrap import
+src/meridian/lib/harness/registry.py                                    # + PiAdapter registration
+src/meridian/lib/harness/semantics.py                                   # + Pi event cases
+src/meridian/lib/harness/projections/permission_flags.py                # + Pi empty tuple
+src/meridian/lib/launch/launch_types.py                                 # + TerminalSurfaceMode
+src/meridian/lib/safety/permissions.py                                  # + pi_launch_config_path
+```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,8 @@ exclude = [
   "/src/meridian/pi_runtime/package-lock.json",
   "/src/meridian/pi_runtime/bun.lock",
   "/src/meridian/pi_runtime/bun.lockb",
+  "/src/meridian/pi_runtime/bin",
+  "/src/meridian/pi_runtime/bin/**",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -96,6 +98,8 @@ exclude = [
   "src/meridian/pi_runtime/package-lock.json",
   "src/meridian/pi_runtime/bun.lock",
   "src/meridian/pi_runtime/bun.lockb",
+  "src/meridian/pi_runtime/bin",
+  "src/meridian/pi_runtime/bin/**",
 ]
 
 [tool.pyright]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ Issues = "https://github.com/haowjy/meridian-cli/issues"
 
 [project.scripts]
 meridian = "meridian.cli.entrypoint:main"
+meridian-pi = "meridian.cli.pi_entrypoint:main"
 pyright = "pyright.cli:entrypoint"
 pytests = "meridian.dev.pytests:main"
 pytest-llm = "meridian.dev.pytests:main"
@@ -79,9 +80,19 @@ include = [
   "/LICENSE",
   "/pyproject.toml",
 ]
+exclude = [
+  "/src/meridian/pi_runtime/node_modules",
+  "/src/meridian/pi_runtime/node_modules/**",
+  "/src/meridian/pi_runtime/package-lock.json",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/meridian"]
+exclude = [
+  "src/meridian/pi_runtime/node_modules",
+  "src/meridian/pi_runtime/node_modules/**",
+  "src/meridian/pi_runtime/package-lock.json",
+]
 
 [tool.pyright]
 pythonVersion = "3.12"
@@ -103,7 +114,7 @@ reportUnknownArgumentType = "warning"
 venvPath = "."
 venv = ".venv"
 include = ["src"]
-exclude = [".venv", "build", "dist"]
+exclude = [".venv", "build", "dist", "src/meridian/pi_runtime/node_modules"]
 
 [tool.ruff]
 target-version = "py312"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,8 @@ exclude = [
   "/src/meridian/pi_runtime/node_modules",
   "/src/meridian/pi_runtime/node_modules/**",
   "/src/meridian/pi_runtime/package-lock.json",
+  "/src/meridian/pi_runtime/bun.lock",
+  "/src/meridian/pi_runtime/bun.lockb",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -92,6 +94,8 @@ exclude = [
   "src/meridian/pi_runtime/node_modules",
   "src/meridian/pi_runtime/node_modules/**",
   "src/meridian/pi_runtime/package-lock.json",
+  "src/meridian/pi_runtime/bun.lock",
+  "src/meridian/pi_runtime/bun.lockb",
 ]
 
 [tool.pyright]

--- a/scripts/build-meridian-pi-runtime.sh
+++ b/scripts/build-meridian-pi-runtime.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUNTIME_DIR="$ROOT_DIR/src/meridian/pi_runtime"
+
+if ! command -v bun >/dev/null 2>&1; then
+  echo "bun is required to build the meridian-pi runtime binary." >&2
+  echo "Install Bun, then rerun this script." >&2
+  exit 1
+fi
+
+cd "$RUNTIME_DIR"
+bun run build:binary

--- a/src/meridian/cli/bootstrap.py
+++ b/src/meridian/cli/bootstrap.py
@@ -52,7 +52,7 @@ _TOP_LEVEL_BOOL_FLAGS = frozenset(
         "--no-dry-run",
     }
 )
-HARNESS_SHORTCUT_NAMES = frozenset({"claude", "codex", "opencode"})
+HARNESS_SHORTCUT_NAMES = frozenset({"claude", "codex", "opencode", "pi"})
 _CHAT_MANAGEMENT_SUBCOMMANDS = frozenset({"ls", "show", "log", "close"})
 
 

--- a/src/meridian/cli/pi_entrypoint.py
+++ b/src/meridian/cli/pi_entrypoint.py
@@ -115,6 +115,15 @@ def _resolve_packaged_binary() -> Path | None:
     return None
 
 
+def _first_present_packaged_binary() -> Path | None:
+    """Return the first packaged Bun binary candidate that exists on disk."""
+
+    for candidate in _compiled_binary_candidates():
+        if candidate.is_file():
+            return candidate
+    return None
+
+
 def _build_child_env(base_env: Mapping[str, str], agent_dir: Path) -> dict[str, str]:
     """Build child environment with the resolved Pi agent dir."""
 
@@ -147,6 +156,7 @@ def main() -> None:
     child_env = _build_child_env(os.environ, agent_dir)
     binary_override = child_env.get(_WRAPPER_BINARY_ENV, "").strip()
     used_node_fallback = False
+    command_kind = "pi-runtime-binary"
     if binary_override:
         command = [str(Path(binary_override).expanduser()), *passthrough_args]
     else:
@@ -154,7 +164,15 @@ def main() -> None:
         if packaged_binary is not None:
             command = [str(packaged_binary), *passthrough_args]
         else:
+            present_packaged_binary = _first_present_packaged_binary()
+            if present_packaged_binary is not None:
+                _print_error(
+                    "packaged Pi runtime binary is present but not executable on this host: "
+                    f"{present_packaged_binary}"
+                )
+                raise SystemExit(1)
             used_node_fallback = True
+            command_kind = "node-runtime"
             node_bin = child_env.get(_NODE_BIN_ENV, "node").strip() or "node"
             runner_path = _runner_path()
             command = [node_bin, str(runner_path), *passthrough_args]
@@ -169,6 +187,12 @@ def main() -> None:
         else:
             _print_error(f"Pi runtime binary not found: {command[0]}")
         raise SystemExit(1) from error
+    except OSError as error:
+        if command_kind == "node-runtime":
+            _print_error(f"failed to execute Node.js runtime command '{command[0]}': {error}")
+        else:
+            _print_error(f"failed to execute Pi runtime binary '{command[0]}': {error}")
+        raise SystemExit(1) from error
 
     raise SystemExit(completed.returncode)
 
@@ -177,6 +201,7 @@ __all__ = [
     "_build_child_env",
     "_compiled_binary_candidates",
     "_ensure_agent_dir_layout",
+    "_first_present_packaged_binary",
     "_is_runnable_binary",
     "_resolve_agent_dir",
     "_resolve_packaged_binary",

--- a/src/meridian/cli/pi_entrypoint.py
+++ b/src/meridian/cli/pi_entrypoint.py
@@ -66,9 +66,9 @@ def _resolve_agent_dir(cli_agent_dir: str | None, env: Mapping[str, str]) -> Pat
 
     meridian_home = env.get("MERIDIAN_HOME", "").strip()
     if meridian_home:
-        return Path(meridian_home).expanduser() / "pi" / "agent"
+        return Path(meridian_home).expanduser() / "meridian-pi" / "agent"
 
-    return get_user_home() / "pi" / "agent"
+    return get_user_home() / "meridian-pi" / "agent"
 
 
 def _ensure_agent_dir_layout(agent_dir: Path) -> None:

--- a/src/meridian/cli/pi_entrypoint.py
+++ b/src/meridian/cli/pi_entrypoint.py
@@ -89,9 +89,20 @@ def _compiled_binary_candidates() -> tuple[Path, ...]:
     """Return candidate paths for the Bun-compiled Pi binary."""
 
     runtime_dir = Path(__file__).resolve().parents[1] / "pi_runtime" / "bin"
-    base_path = runtime_dir / _PI_BINARY_NAME
-    windows_path = runtime_dir / f"{_PI_BINARY_NAME}.exe"
-    return (base_path, windows_path)
+    return tuple(
+        runtime_dir / candidate_name
+        for candidate_name in _compiled_binary_candidate_names(os.name)
+    )
+
+
+def _compiled_binary_candidate_names(os_name: str) -> tuple[str, str]:
+    """Return OS-ordered runtime binary candidate names."""
+
+    base_name = _PI_BINARY_NAME
+    windows_name = f"{_PI_BINARY_NAME}.exe"
+    if os_name == "nt":
+        return (windows_name, base_name)
+    return (base_name, windows_name)
 
 
 def _is_runnable_binary(candidate: Path) -> bool:
@@ -130,6 +141,15 @@ def _build_child_env(base_env: Mapping[str, str], agent_dir: Path) -> dict[str, 
     child_env = dict(base_env)
     child_env[_PI_AGENT_DIR_ENV] = str(agent_dir)
     return child_env
+
+
+def _node_fallback_available(runner_path: Path) -> bool:
+    """Return whether source/dev Node fallback dependencies are available."""
+
+    runtime_dependency_dir = (
+        runner_path.parent / "node_modules" / "@earendil-works" / "pi-coding-agent"
+    )
+    return runner_path.is_file() and runtime_dependency_dir.is_dir()
 
 
 def _print_error(message: str) -> None:
@@ -171,10 +191,17 @@ def main() -> None:
                     f"{present_packaged_binary}"
                 )
                 raise SystemExit(1)
+            runner_path = _runner_path()
+            if not _node_fallback_available(runner_path):
+                _print_error(
+                    "compiled meridian-pi runtime is not installed; build it with "
+                    "scripts/build-meridian-pi-runtime.sh or set MERIDIAN_PI_BINARY; "
+                    "source/dev fallback requires runtime deps installed."
+                )
+                raise SystemExit(1)
             used_node_fallback = True
             command_kind = "node-runtime"
             node_bin = child_env.get(_NODE_BIN_ENV, "node").strip() or "node"
-            runner_path = _runner_path()
             command = [node_bin, str(runner_path), *passthrough_args]
 
     try:
@@ -199,10 +226,12 @@ def main() -> None:
 
 __all__ = [
     "_build_child_env",
+    "_compiled_binary_candidate_names",
     "_compiled_binary_candidates",
     "_ensure_agent_dir_layout",
     "_first_present_packaged_binary",
     "_is_runnable_binary",
+    "_node_fallback_available",
     "_resolve_agent_dir",
     "_resolve_packaged_binary",
     "_runner_path",

--- a/src/meridian/cli/pi_entrypoint.py
+++ b/src/meridian/cli/pi_entrypoint.py
@@ -1,0 +1,138 @@
+"""Entrypoint for the ``meridian-pi`` wrapper binary."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+from meridian.lib.state.user_paths import get_user_home
+
+_WRAPPER_AGENT_DIR_FLAG = "--agent-dir"
+_WRAPPER_AGENT_DIR_ENV = "MERIDIAN_PI_AGENT_DIR"
+_PI_AGENT_DIR_ENV = "PI_CODING_AGENT_DIR"
+_NODE_BIN_ENV = "MERIDIAN_PI_NODE_BIN"
+_REQUIRED_AGENT_SUBDIRECTORIES: tuple[str, ...] = ("sessions", "extensions", "bin")
+
+
+def _strip_agent_dir_flag(argv: Sequence[str]) -> tuple[list[str], str | None]:
+    """Strip wrapper-only ``--agent-dir`` flag and return passthrough args."""
+
+    passthrough: list[str] = []
+    cli_agent_dir: str | None = None
+
+    i = 0
+    while i < len(argv):
+        token = argv[i]
+
+        if token == _WRAPPER_AGENT_DIR_FLAG:
+            next_index = i + 1
+            if next_index >= len(argv):
+                raise ValueError("--agent-dir requires a path value")
+            candidate = argv[next_index].strip()
+            if not candidate:
+                raise ValueError("--agent-dir requires a non-empty path value")
+            cli_agent_dir = candidate
+            i += 2
+            continue
+
+        if token.startswith(f"{_WRAPPER_AGENT_DIR_FLAG}="):
+            candidate = token.split("=", 1)[1].strip()
+            if not candidate:
+                raise ValueError("--agent-dir requires a non-empty path value")
+            cli_agent_dir = candidate
+            i += 1
+            continue
+
+        passthrough.append(token)
+        i += 1
+
+    return passthrough, cli_agent_dir
+
+
+def _resolve_agent_dir(cli_agent_dir: str | None, env: Mapping[str, str]) -> Path:
+    """Resolve ``PI_CODING_AGENT_DIR`` using CLI > env > default precedence."""
+
+    if cli_agent_dir is not None:
+        return Path(cli_agent_dir).expanduser()
+
+    env_agent_dir = env.get(_WRAPPER_AGENT_DIR_ENV, "").strip()
+    if env_agent_dir:
+        return Path(env_agent_dir).expanduser()
+
+    meridian_home = env.get("MERIDIAN_HOME", "").strip()
+    if meridian_home:
+        return Path(meridian_home).expanduser() / "pi" / "agent"
+
+    return get_user_home() / "pi" / "agent"
+
+
+def _ensure_agent_dir_layout(agent_dir: Path) -> None:
+    """Create base Pi agent directory and required subdirectories."""
+
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    for subdirectory in _REQUIRED_AGENT_SUBDIRECTORIES:
+        (agent_dir / subdirectory).mkdir(parents=True, exist_ok=True)
+
+
+def _runner_path() -> Path:
+    """Return the Node runner path for SDK-backed Pi execution."""
+
+    return Path(__file__).resolve().parents[1] / "pi_runtime" / "runner.mjs"
+
+
+def _build_child_env(base_env: Mapping[str, str], agent_dir: Path) -> dict[str, str]:
+    """Build child environment with the resolved Pi agent dir."""
+
+    child_env = dict(base_env)
+    child_env[_PI_AGENT_DIR_ENV] = str(agent_dir)
+    return child_env
+
+
+def _print_error(message: str) -> None:
+    print(f"meridian-pi: {message}", file=sys.stderr)
+
+
+def main() -> None:
+    """Launch Pi via SDK with Meridian config defaults."""
+
+    try:
+        passthrough_args, cli_agent_dir = _strip_agent_dir_flag(sys.argv[1:])
+    except ValueError as error:
+        _print_error(str(error))
+        raise SystemExit(2) from error
+
+    agent_dir = _resolve_agent_dir(cli_agent_dir, os.environ)
+
+    try:
+        _ensure_agent_dir_layout(agent_dir)
+    except OSError as error:
+        _print_error(f"failed to create agent directory '{agent_dir}': {error}")
+        raise SystemExit(1) from error
+
+    child_env = _build_child_env(os.environ, agent_dir)
+    node_bin = child_env.get(_NODE_BIN_ENV, "node").strip() or "node"
+    runner_path = _runner_path()
+    command = [node_bin, str(runner_path), *passthrough_args]
+
+    try:
+        completed = subprocess.run(command, env=child_env, check=False)
+    except FileNotFoundError as error:
+        _print_error(
+            "Node.js runtime is required for meridian-pi (install Node.js 20+ and retry)."
+        )
+        raise SystemExit(1) from error
+
+    raise SystemExit(completed.returncode)
+
+
+__all__ = [
+    "_build_child_env",
+    "_ensure_agent_dir_layout",
+    "_resolve_agent_dir",
+    "_runner_path",
+    "_strip_agent_dir_flag",
+    "main",
+]

--- a/src/meridian/cli/pi_entrypoint.py
+++ b/src/meridian/cli/pi_entrypoint.py
@@ -12,8 +12,10 @@ from meridian.lib.state.user_paths import get_user_home
 
 _WRAPPER_AGENT_DIR_FLAG = "--agent-dir"
 _WRAPPER_AGENT_DIR_ENV = "MERIDIAN_PI_AGENT_DIR"
+_WRAPPER_BINARY_ENV = "MERIDIAN_PI_BINARY"
 _PI_AGENT_DIR_ENV = "PI_CODING_AGENT_DIR"
 _NODE_BIN_ENV = "MERIDIAN_PI_NODE_BIN"
+_PI_BINARY_NAME = "meridian-pi"
 _REQUIRED_AGENT_SUBDIRECTORIES: tuple[str, ...] = ("sessions", "extensions", "bin")
 
 
@@ -83,6 +85,36 @@ def _runner_path() -> Path:
     return Path(__file__).resolve().parents[1] / "pi_runtime" / "runner.mjs"
 
 
+def _compiled_binary_candidates() -> tuple[Path, ...]:
+    """Return candidate paths for the Bun-compiled Pi binary."""
+
+    runtime_dir = Path(__file__).resolve().parents[1] / "pi_runtime" / "bin"
+    base_path = runtime_dir / _PI_BINARY_NAME
+    windows_path = runtime_dir / f"{_PI_BINARY_NAME}.exe"
+    return (base_path, windows_path)
+
+
+def _is_runnable_binary(candidate: Path) -> bool:
+    """Return whether ``candidate`` is runnable on this host."""
+
+    if not candidate.is_file():
+        return False
+
+    if os.name == "nt":
+        return True
+
+    return os.access(candidate, os.X_OK)
+
+
+def _resolve_packaged_binary() -> Path | None:
+    """Return the packaged Bun binary path when present and runnable."""
+
+    for candidate in _compiled_binary_candidates():
+        if _is_runnable_binary(candidate):
+            return candidate
+    return None
+
+
 def _build_child_env(base_env: Mapping[str, str], agent_dir: Path) -> dict[str, str]:
     """Build child environment with the resolved Pi agent dir."""
 
@@ -113,16 +145,29 @@ def main() -> None:
         raise SystemExit(1) from error
 
     child_env = _build_child_env(os.environ, agent_dir)
-    node_bin = child_env.get(_NODE_BIN_ENV, "node").strip() or "node"
-    runner_path = _runner_path()
-    command = [node_bin, str(runner_path), *passthrough_args]
+    binary_override = child_env.get(_WRAPPER_BINARY_ENV, "").strip()
+    used_node_fallback = False
+    if binary_override:
+        command = [str(Path(binary_override).expanduser()), *passthrough_args]
+    else:
+        packaged_binary = _resolve_packaged_binary()
+        if packaged_binary is not None:
+            command = [str(packaged_binary), *passthrough_args]
+        else:
+            used_node_fallback = True
+            node_bin = child_env.get(_NODE_BIN_ENV, "node").strip() or "node"
+            runner_path = _runner_path()
+            command = [node_bin, str(runner_path), *passthrough_args]
 
     try:
         completed = subprocess.run(command, env=child_env, check=False)
     except FileNotFoundError as error:
-        _print_error(
-            "Node.js runtime is required for meridian-pi (install Node.js 20+ and retry)."
-        )
+        if used_node_fallback:
+            _print_error(
+                "Node.js runtime is required for meridian-pi (install Node.js 20+ and retry)."
+            )
+        else:
+            _print_error(f"Pi runtime binary not found: {command[0]}")
         raise SystemExit(1) from error
 
     raise SystemExit(completed.returncode)
@@ -130,8 +175,11 @@ def main() -> None:
 
 __all__ = [
     "_build_child_env",
+    "_compiled_binary_candidates",
     "_ensure_agent_dir_layout",
+    "_is_runnable_binary",
     "_resolve_agent_dir",
+    "_resolve_packaged_binary",
     "_runner_path",
     "_strip_agent_dir_flag",
     "main",

--- a/src/meridian/lib/core/types.py
+++ b/src/meridian/lib/core/types.py
@@ -10,6 +10,7 @@ class HarnessId(StrEnum):
     CLAUDE = "claude"
     CODEX = "codex"
     OPENCODE = "opencode"
+    PI = "pi"
 
 
 class TransportId(StrEnum):

--- a/src/meridian/lib/harness/.context/CONTEXT.md
+++ b/src/meridian/lib/harness/.context/CONTEXT.md
@@ -155,6 +155,11 @@ from `meridian.lib.launch.workspace_projection`.
 
 ### Adding a Harness
 
+The full end-to-end guide is at [`docs/harness-integration.md`](../../../../docs/harness-integration.md).
+It covers probing, adapter implementation, projection, extraction, connection/semantics,
+wrapper/runtime packaging, session parity, model/catalog/Mars integration, and a
+verification checklist — using Pi as the worked example.
+
 Touch every file in `HARNESS_EXTENSION_TOUCHPOINTS` (listed in `__init__.py`):
 1. `core/types.py` — register `HarnessId`/`TransportId`
 2. `<new_harness>.py` — adapter with `HarnessContract`, bundle registration, transport map side effect

--- a/src/meridian/lib/harness/AGENTS.md
+++ b/src/meridian/lib/harness/AGENTS.md
@@ -94,6 +94,11 @@ unique — always check `event.harness_id`. `turn/completed` is Codex; OpenCode 
 
 ## Adding a Harness
 
+Full guide: [`docs/harness-integration.md`](../../../docs/harness-integration.md) —
+end-to-end with Pi as the worked example. Covers probing, adapter, projection,
+extraction, connection, semantics, wrapper/runtime, session parity, model/catalog,
+and verification.
+
 Touch every file in `HARNESS_EXTENSION_TOUCHPOINTS` (`__init__.py`). Missing any
 causes `ImportError` or `ValueError` at startup — the drift guards make omissions loud.
 See [.context/CONTEXT.md](.context/CONTEXT.md) for the full checklist.

--- a/src/meridian/lib/harness/__init__.py
+++ b/src/meridian/lib/harness/__init__.py
@@ -67,6 +67,7 @@ def _run_bootstrap() -> None:
     from meridian.lib.harness import claude as _claude
     from meridian.lib.harness import codex as _codex
     from meridian.lib.harness import opencode as _opencode
+    from meridian.lib.harness import pi as _pi
 
     from meridian.lib.harness.projections import project_claude as _project_claude
     from meridian.lib.harness.projections import (
@@ -81,10 +82,14 @@ def _run_bootstrap() -> None:
     from meridian.lib.harness.projections import (
         project_opencode_subprocess as _project_opencode_subprocess,
     )
+    from meridian.lib.harness.projections import (
+        project_pi_subprocess as _project_pi_subprocess,
+    )
 
     from meridian.lib.harness.extractors import claude as _claude_extractor
     from meridian.lib.harness.extractors import codex as _codex_extractor
     from meridian.lib.harness.extractors import opencode as _opencode_extractor
+    from meridian.lib.harness.extractors import pi as _pi_extractor
 
     from meridian.lib.harness.launch_spec import _enforce_spawn_params_accounting
 
@@ -92,14 +97,17 @@ def _run_bootstrap() -> None:
         _claude,
         _codex,
         _opencode,
+        _pi,
         _project_claude,
         _project_codex_subprocess,
         _project_codex_streaming,
         _project_opencode_subprocess,
         _project_opencode_streaming,
+        _project_pi_subprocess,
         _claude_extractor,
         _codex_extractor,
         _opencode_extractor,
+        _pi_extractor,
     )
     _enforce_spawn_params_accounting()
     _bootstrapped = True

--- a/src/meridian/lib/harness/connections/pi_rpc.py
+++ b/src/meridian/lib/harness/connections/pi_rpc.py
@@ -1,0 +1,351 @@
+"""Pi subprocess-backed connection.
+
+Phase 1/2 uses Pi print mode (``meridian-pi -p --mode json``) rather than RPC.
+The connection still implements Meridian's streaming connection contract so the
+spawn runner can durably drain Pi JSONL events through the same path as other
+harnesses.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import signal
+from asyncio.subprocess import PIPE, Process
+from collections.abc import AsyncIterator
+from io import BufferedWriter
+from typing import Final, cast
+
+from meridian.lib.core.telemetry import StartupPhase, StartupPhaseEmitter
+from meridian.lib.core.types import HarnessId, SpawnId
+from meridian.lib.harness.bundle import project_subprocess_spec
+from meridian.lib.harness.connections.base import (
+    ConnectionCapabilities,
+    ConnectionConfig,
+    ConnectionNotReady,
+    ConnectionState,
+    HarnessConnection,
+    HarnessEvent,
+    validate_prompt_size,
+)
+from meridian.lib.harness.errors import HarnessBinaryNotFound
+from meridian.lib.harness.semantics import clears_signal
+from meridian.lib.launch.constants import BASE_COMMAND_PI_SUBPROCESS
+from meridian.lib.launch.env import inherit_child_env
+from meridian.lib.launch.launch_types import ResolvedLaunchSpec
+from meridian.lib.observability.trace_helpers import (
+    trace_parse_error,
+    trace_state_change,
+    trace_wire_recv,
+    trace_wire_send,
+)
+from meridian.lib.platform import IS_WINDOWS
+from meridian.lib.state.paths import resolve_spawn_log_dir
+
+logger = logging.getLogger(__name__)
+_HARNESS_NAME: Final = HarnessId.PI.value
+_STDOUT_READLINE_LIMIT: Final[int] = 10 * 1024 * 1024
+_PROCESS_KILL_GRACE_SECONDS: Final[float] = 5.0
+_BLOCKED_CHILD_ENV_VARS: Final[frozenset[str]] = frozenset(
+    {
+        "MERIDIAN_ACTIVE_WORK_ID",
+        "MERIDIAN_ACTIVE_WORK_DIR",
+    }
+)
+
+
+class PiConnection(HarnessConnection[ResolvedLaunchSpec]):
+    """Drain Pi print-mode JSONL through Meridian's streaming runner."""
+
+    _CAPABILITIES = ConnectionCapabilities(
+        mid_turn_injection="queue",
+        supports_steer=False,
+        supports_cancel=True,
+        runtime_model_switch=False,
+        structured_reasoning=True,
+        supports_primary_observer=False,
+        supports_runtime_hitl=False,
+        supported_startup_phases=frozenset(
+            phase.value
+            for phase in (
+                StartupPhase.WAITING_FOR_CONNECTION,
+                StartupPhase.HARNESS_READY,
+            )
+        ),
+    )
+    _ALLOWED_TRANSITIONS: Final[dict[ConnectionState, set[ConnectionState]]] = {
+        "created": {"starting", "stopping", "stopped", "failed"},
+        "starting": {"connected", "stopping", "stopped", "failed"},
+        "connected": {"stopping", "failed"},
+        "stopping": {"stopped", "failed"},
+        "failed": {"stopped"},
+        "stopped": set(),
+    }
+
+    def __init__(self) -> None:
+        self._state: ConnectionState = "created"
+        self._spawn_id: SpawnId = SpawnId("")
+        self._process: Process | None = None
+        self._stderr_handle: BufferedWriter | None = None
+        self._event_stream_started = False
+        self._session_id: str | None = None
+        self._tracer = None
+        self._startup_emitter: StartupPhaseEmitter | None = None
+
+    @property
+    def state(self) -> ConnectionState:
+        return self._state
+
+    @property
+    def harness_id(self) -> HarnessId:
+        return HarnessId.PI
+
+    @property
+    def spawn_id(self) -> SpawnId:
+        return self._spawn_id
+
+    @property
+    def capabilities(self) -> ConnectionCapabilities:
+        return self._CAPABILITIES
+
+    @property
+    def session_id(self) -> str | None:
+        return self._session_id
+
+    @property
+    def subprocess_pid(self) -> int | None:
+        process = self._process
+        if process is None:
+            return None
+        return process.pid
+
+    async def start(self, config: ConnectionConfig, spec: ResolvedLaunchSpec) -> None:
+        if self._state != "created":
+            raise RuntimeError(f"Connection can only start from 'created', got '{self._state}'")
+
+        validate_prompt_size(config)
+        self._spawn_id = config.spawn_id
+        self._tracer = config.debug_tracer
+        self._startup_emitter = StartupPhaseEmitter(
+            str(config.spawn_id),
+            harness_id=config.harness_id.value,
+            model=spec.model,
+            agent=spec.agent_name,
+        )
+        self._set_state("starting")
+
+        try:
+            await self._start_subprocess(config, spec)
+            self._emit_startup_phase(StartupPhase.WAITING_FOR_CONNECTION)
+            self._set_state("connected")
+        except Exception:
+            self._mark_failed("Pi connection startup failed.")
+            await self._cleanup_resources(terminate_process=True)
+            raise
+
+    async def stop(self) -> None:
+        if self._state == "stopped":
+            return
+        if self._state not in {"stopping", "failed"}:
+            self._set_state("stopping")
+        await self._cleanup_resources(terminate_process=True)
+        self._set_state("stopped")
+
+    def health(self) -> bool:
+        return self._state == "connected"
+
+    async def send_user_message(self, text: str) -> None:
+        _ = text
+        raise ConnectionNotReady("Pi Phase 1/2 subprocess mode does not support injection.")
+
+    async def send_cancel(self) -> None:
+        if self._state in {"stopping", "stopped", "failed"}:
+            return
+        self._set_state("stopping")
+        await self._signal_process(signal.SIGINT)
+
+    async def events(self) -> AsyncIterator[HarnessEvent]:
+        process = self._process
+        if process is None or process.stdout is None:
+            return
+        if self._event_stream_started:
+            raise RuntimeError("events() iterator already consumed")
+        self._event_stream_started = True
+
+        try:
+            while True:
+                try:
+                    line_bytes = await process.stdout.readline()
+                except Exception as exc:
+                    if self._state not in {"stopping", "stopped"}:
+                        detail = f"Failed to read Pi stdout: {exc}"
+                        self._mark_failed(detail)
+                        yield self._error_event(detail)
+                    return
+
+                if not line_bytes:
+                    return_code = process.returncode
+                    if return_code is None:
+                        return_code = await process.wait()
+                    if return_code != 0 and self._state not in {"stopping", "stopped"}:
+                        detail = f"Pi subprocess exited with code {return_code}."
+                        self._mark_failed(detail)
+                        yield self._error_event(detail)
+                    return
+
+                raw_text = line_bytes.decode("utf-8", errors="replace").rstrip("\n")
+                if not raw_text.strip():
+                    continue
+
+                trace_wire_recv(self._tracer, "stdout_line", raw_text, bytes=len(line_bytes))
+                event = self._parse_stdout_line(raw_text)
+                if event is None:
+                    continue
+                if event.event_type == "session":
+                    session_id = event.payload.get("id")
+                    if isinstance(session_id, str) and session_id.strip():
+                        self._session_id = session_id.strip()
+                    self._emit_startup_phase(StartupPhase.HARNESS_READY)
+                if clears_signal(event):
+                    self._set_state("stopping")
+                yield event
+        finally:
+            await self._cleanup_resources(terminate_process=False)
+
+    async def _start_subprocess(self, config: ConnectionConfig, spec: ResolvedLaunchSpec) -> None:
+        spawn_dir = resolve_spawn_log_dir(config.control_root, config.spawn_id)
+        spawn_dir.mkdir(parents=True, exist_ok=True)
+
+        stderr_path = spawn_dir / "stderr.log"
+        self._stderr_handle = stderr_path.open("ab")
+
+        command = project_subprocess_spec(
+            self.harness_id,
+            spec,
+            base_command=BASE_COMMAND_PI_SUBPROCESS,
+        )
+        env = inherit_child_env(
+            os.environ,
+            config.env_overrides,
+            blocked=_BLOCKED_CHILD_ENV_VARS,
+        )
+
+        try:
+            self._process = await asyncio.create_subprocess_exec(
+                *command,
+                cwd=str(config.task_cwd or config.control_root),
+                env=env,
+                stdin=PIPE,
+                stdout=PIPE,
+                stderr=self._stderr_handle,
+                limit=_STDOUT_READLINE_LIMIT,
+            )
+        except (FileNotFoundError, NotADirectoryError) as exc:
+            raise HarnessBinaryNotFound.from_os_error(
+                harness_id=self.harness_id,
+                error=exc,
+                binary_name=command[0],
+            ) from exc
+
+    def _parse_stdout_line(self, line: str) -> HarnessEvent | None:
+        payload_text = line.strip()
+        if not payload_text:
+            return None
+        try:
+            payload_obj = json.loads(payload_text)
+        except json.JSONDecodeError:
+            logger.warning("Skipping malformed Pi stdout line: %s", payload_text)
+            trace_parse_error(self._tracer, "pi", payload_text, error="malformed_json")
+            return None
+        if not isinstance(payload_obj, dict):
+            logger.warning("Skipping non-object Pi stdout line: %s", payload_text)
+            trace_parse_error(self._tracer, "pi", payload_text, error="non_object")
+            return None
+
+        payload = cast("dict[str, object]", payload_obj)
+        event_type = payload.get("type")
+        if not isinstance(event_type, str) or not event_type.strip():
+            logger.warning("Skipping Pi stdout line without string 'type': %s", payload_text)
+            trace_parse_error(self._tracer, "pi", payload_text, error="missing_type")
+            return None
+
+        return HarnessEvent(
+            event_type=event_type,
+            payload=payload,
+            harness_id=_HARNESS_NAME,
+            raw_text=line,
+        )
+
+    def _set_state(self, next_state: ConnectionState) -> None:
+        if next_state == self._state:
+            return
+        allowed = self._ALLOWED_TRANSITIONS[self._state]
+        if next_state not in allowed:
+            raise RuntimeError(
+                f"Invalid connection state transition: {self._state} -> {next_state}"
+            )
+        trace_state_change(self._tracer, "pi", self._state, next_state)
+        self._state = next_state
+
+    def _mark_failed(self, reason: str) -> None:
+        if self._state not in {"failed", "stopped"}:
+            try:
+                self._set_state("failed")
+            except RuntimeError:
+                logger.exception("Failed to transition Pi connection into failed state")
+        logger.warning("Pi connection failed: %s", reason)
+
+    def _error_event(self, message: str) -> HarnessEvent:
+        return HarnessEvent(
+            event_type="error/connectionClosed",
+            payload={"type": "error/connectionClosed", "message": message},
+            harness_id=_HARNESS_NAME,
+        )
+
+    async def _signal_process(self, sig: signal.Signals) -> None:
+        process = self._process
+        if process is None or process.returncode is not None:
+            return
+        trace_wire_send(self._tracer, "signal_sent", "", signal=sig.name)
+        if IS_WINDOWS:
+            process.terminate()
+        else:
+            process.send_signal(sig)
+
+    async def _cleanup_resources(self, *, terminate_process: bool) -> None:
+        if terminate_process:
+            await self._terminate_process()
+        self._close_log_handles()
+
+    async def _terminate_process(self) -> None:
+        process = self._process
+        if process is None:
+            return
+        if process.returncode is None:
+            if process.stdin is not None:
+                try:
+                    process.stdin.close()
+                except Exception:
+                    logger.debug("Failed to close Pi subprocess stdin", exc_info=True)
+            process.terminate()
+            try:
+                await asyncio.wait_for(process.wait(), timeout=_PROCESS_KILL_GRACE_SECONDS)
+            except TimeoutError:
+                process.kill()
+                await process.wait()
+        self._process = None
+
+    def _close_log_handles(self) -> None:
+        if self._stderr_handle is not None:
+            self._stderr_handle.close()
+            self._stderr_handle = None
+
+    def _emit_startup_phase(self, phase: StartupPhase) -> None:
+        emitter = self._startup_emitter
+        if emitter is not None:
+            emitter.emit(phase)
+
+
+__all__ = ["PiConnection"]

--- a/src/meridian/lib/harness/extractors/pi.py
+++ b/src/meridian/lib/harness/extractors/pi.py
@@ -1,0 +1,224 @@
+"""Pi harness extractor."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import cast
+
+from meridian.lib.core.domain import TokenUsage
+from meridian.lib.core.types import SpawnId
+from meridian.lib.harness.adapter import ArtifactStore
+from meridian.lib.harness.common import (
+    OUTPUT_FILENAME,
+    _coerce_optional_int,  # pyright: ignore[reportPrivateUsage]
+    _iter_json_lines_artifact,  # pyright: ignore[reportPrivateUsage]
+)
+from meridian.lib.harness.connections.base import HarnessEvent
+from meridian.lib.launch.launch_types import ResolvedLaunchSpec
+from meridian.lib.state.user_paths import get_user_home
+
+from .base import HarnessExtractor
+
+
+def _safe_resolve(path: Path) -> Path:
+    try:
+        return path.expanduser().resolve()
+    except OSError:
+        return path.expanduser().absolute()
+
+
+def _encode_cwd_for_session_dir(cwd: Path) -> str:
+    normalized = str(_safe_resolve(cwd)).replace("\\", "/")
+    encoded = normalized.replace("/", "--")
+    if not encoded.endswith("--"):
+        encoded = f"{encoded}--"
+    return encoded
+
+
+def _pi_session_root(launch_env: Mapping[str, str]) -> Path:
+    session_dir_override = launch_env.get("PI_CODING_AGENT_SESSION_DIR", "").strip()
+    if session_dir_override:
+        return Path(session_dir_override).expanduser()
+
+    agent_dir = launch_env.get("PI_CODING_AGENT_DIR", "").strip()
+    if agent_dir:
+        return Path(agent_dir).expanduser() / "sessions"
+
+    return get_user_home() / "pi" / "agent" / "sessions"
+
+
+def _iter_session_id_candidates_from_artifacts(
+    artifacts: ArtifactStore,
+    spawn_id: SpawnId,
+) -> list[str]:
+    payloads = _iter_json_lines_artifact(artifacts, spawn_id, OUTPUT_FILENAME)
+    session_ids: list[str] = []
+    for payload in payloads:
+        if str(payload.get("type", "")).strip().lower() != "session":
+            continue
+        session_id = payload.get("id")
+        if isinstance(session_id, str) and session_id.strip():
+            session_ids.append(session_id.strip())
+    return session_ids
+
+
+def _session_id_from_session_files(
+    *,
+    launch_env: Mapping[str, str],
+    child_cwd: Path,
+) -> str | None:
+    root = _pi_session_root(launch_env)
+    if not root.is_dir():
+        return None
+
+    session_dir = root / _encode_cwd_for_session_dir(child_cwd)
+    if not session_dir.is_dir():
+        return None
+
+    candidates: list[tuple[float, Path]] = []
+    for session_file in session_dir.glob("*.jsonl"):
+        try:
+            modified_at = session_file.stat().st_mtime
+        except OSError:
+            continue
+        candidates.append((modified_at, session_file))
+
+    for _, path in sorted(candidates, key=lambda item: item[0], reverse=True):
+        try:
+            first_line = path.read_text(
+                encoding="utf-8",
+                errors="ignore",
+            ).splitlines()[0]
+        except (OSError, IndexError):
+            continue
+        try:
+            payload_obj = json.loads(first_line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload_obj, dict):
+            continue
+        payload = cast("dict[str, object]", payload_obj)
+        if str(payload.get("type", "")).strip().lower() != "session":
+            continue
+        session_id = payload.get("id")
+        if isinstance(session_id, str) and session_id.strip():
+            return session_id.strip()
+
+    return None
+
+
+def _extract_usage_from_message_end(payloads: list[dict[str, object]]) -> TokenUsage:
+    for payload in reversed(payloads):
+        if str(payload.get("type", "")).strip().lower() != "message_end":
+            continue
+        message_obj = payload.get("message")
+        if not isinstance(message_obj, dict):
+            continue
+        message = cast("dict[str, object]", message_obj)
+        if str(message.get("role", "")).strip().lower() != "assistant":
+            continue
+        usage_obj = message.get("usage")
+        if not isinstance(usage_obj, dict):
+            continue
+        usage = cast("dict[str, object]", usage_obj)
+        return TokenUsage(
+            input_tokens=_coerce_optional_int(usage.get("input")),
+            output_tokens=_coerce_optional_int(usage.get("output")),
+            cache_read_input_tokens=_coerce_optional_int(usage.get("cacheRead")),
+            cache_creation_input_tokens=_coerce_optional_int(usage.get("cacheWrite")),
+            total_cost_usd=(
+                float(total)
+                if isinstance((cost := usage.get("cost")), dict)
+                and (total := cast("dict[str, object]", cost).get("total")) is not None
+                and isinstance(total, int | float)
+                else None
+            ),
+        )
+    return TokenUsage()
+
+
+def _assistant_message_text(message: Mapping[str, object]) -> str | None:
+    if str(message.get("role", "")).strip().lower() != "assistant":
+        return None
+
+    content_obj = message.get("content")
+    if not isinstance(content_obj, list):
+        return None
+
+    texts: list[str] = []
+    for part_obj in cast("list[object]", content_obj):
+        if not isinstance(part_obj, dict):
+            continue
+        part = cast("dict[str, object]", part_obj)
+        if str(part.get("type", "")).strip().lower() != "text":
+            continue
+        text = part.get("text")
+        if isinstance(text, str) and text:
+            texts.append(text)
+
+    if not texts:
+        return None
+    return "\n".join(texts)
+
+
+class PiHarnessExtractor(HarnessExtractor[ResolvedLaunchSpec]):
+    """Extractor implementation for Pi artifacts and events."""
+
+    def detect_session_id_from_event(self, event: HarnessEvent) -> str | None:
+        if event.event_type != "session":
+            return None
+        session_id = event.payload.get("id")
+        if isinstance(session_id, str) and session_id.strip():
+            return session_id.strip()
+        return None
+
+    def detect_session_id_from_artifacts(
+        self,
+        *,
+        spec: ResolvedLaunchSpec,
+        launch_env: Mapping[str, str],
+        child_cwd: Path,
+        runtime_root: Path,
+    ) -> str | None:
+        _ = runtime_root
+        if (
+            spec.continue_session_id
+            and spec.continue_session_id.strip()
+            and not spec.continue_fork
+        ):
+            return spec.continue_session_id.strip()
+
+        return _session_id_from_session_files(launch_env=launch_env, child_cwd=child_cwd)
+
+    def extract_usage(self, artifacts: ArtifactStore, spawn_id: SpawnId) -> TokenUsage:
+        payloads = _iter_json_lines_artifact(artifacts, spawn_id, OUTPUT_FILENAME)
+        return _extract_usage_from_message_end(payloads)
+
+    def extract_session_id(self, artifacts: ArtifactStore, spawn_id: SpawnId) -> str | None:
+        candidates = _iter_session_id_candidates_from_artifacts(artifacts, spawn_id)
+        if not candidates:
+            return None
+        return candidates[0]
+
+    def extract_report(self, artifacts: ArtifactStore, spawn_id: SpawnId) -> str | None:
+        payloads = _iter_json_lines_artifact(artifacts, spawn_id, OUTPUT_FILENAME)
+        for payload in reversed(payloads):
+            if str(payload.get("type", "")).strip().lower() != "agent_end":
+                continue
+            messages_obj = payload.get("messages")
+            if not isinstance(messages_obj, list):
+                continue
+            for message_obj in reversed(cast("list[object]", messages_obj)):
+                if not isinstance(message_obj, dict):
+                    continue
+                text = _assistant_message_text(cast("dict[str, object]", message_obj))
+                if text:
+                    return text
+        return None
+
+
+PI_EXTRACTOR = PiHarnessExtractor()
+
+__all__ = ["PI_EXTRACTOR", "PiHarnessExtractor", "_encode_cwd_for_session_dir"]

--- a/src/meridian/lib/harness/pi.py
+++ b/src/meridian/lib/harness/pi.py
@@ -1,0 +1,230 @@
+"""Pi CLI harness adapter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import ClassVar
+
+from meridian.lib.core.domain import TokenUsage
+from meridian.lib.core.types import HarnessId, SpawnId, TransportId
+from meridian.lib.harness.adapter import (
+    ApprovalContract,
+    ArtifactStore,
+    BaseHarnessAdapter,
+    BootstrapContract,
+    BootstrapMode,
+    ExtractionContract,
+    ForkMaterializationMode,
+    HarnessCapabilities,
+    HarnessContract,
+    McpConfig,
+    PermissionResolver,
+    ProjectionContract,
+    ProjectionMode,
+    SpawnParams,
+    TransportContract,
+)
+from meridian.lib.harness.bundle import (
+    HarnessBundle,
+    HarnessProjectionPorts,
+    project_subprocess_spec,
+    register_harness_bundle,
+)
+from meridian.lib.harness.connections.pi_rpc import PiConnection
+from meridian.lib.harness.extractors.pi import PI_EXTRACTOR
+from meridian.lib.harness.projections.project_pi_subprocess import (
+    project_pi_spec_to_cli_args,
+)
+from meridian.lib.launch.composition import (
+    ComposedLaunchContent,
+    ProjectedContent,
+    ProjectionChannels,
+    build_reference_routing,
+    join_content_blocks,
+    render_system_instruction_blocks,
+    render_task_context,
+)
+from meridian.lib.launch.constants import BASE_COMMAND_PI_SUBPROCESS, PRIMARY_BASE_COMMAND_PI
+from meridian.lib.launch.launch_types import ResolvedLaunchSpec, TerminalSurfaceMode
+from meridian.lib.safety.permissions import PermissionConfig
+from meridian.lib.state.user_paths import get_user_home
+
+
+class PiAdapter(BaseHarnessAdapter[ResolvedLaunchSpec]):
+    """Subprocess harness implementation for ``meridian-pi``."""
+
+    BASE_COMMAND: ClassVar[tuple[str, ...]] = BASE_COMMAND_PI_SUBPROCESS
+    PRIMARY_BASE_COMMAND: ClassVar[tuple[str, ...]] = PRIMARY_BASE_COMMAND_PI
+    _CONSUMED_FIELDS: ClassVar[frozenset[str]] = frozenset(
+        {
+            "prompt",
+            "model",
+            "effort",
+            "extra_args",
+            "control_root",
+            "interactive",
+            "continue_harness_session_id",
+            "continue_fork",
+            "appended_system_prompt",
+            "user_turn_content",
+            "mcp_tools",
+            "projected_roots",
+        }
+    )
+    _EXPLICITLY_IGNORED_FIELDS: ClassVar[frozenset[str]] = frozenset(
+        {
+            "skills",
+            "agent",
+            "adhoc_agent_payload",
+            "report_output_path",
+            "context_from_payload",
+            "reference_items",
+            "task_cwd",
+        }
+    )
+
+    @property
+    def id(self) -> HarnessId:
+        return HarnessId.PI
+
+    @property
+    def contract(self) -> HarnessContract:
+        return HarnessContract(
+            capabilities=self.capabilities,
+            transport=TransportContract(
+                transport_ids=(TransportId.STREAMING,),
+                observer_controller_required=False,
+            ),
+            projection=ProjectionContract(
+                launch_spec_cls="ResolvedLaunchSpec",
+                mode=ProjectionMode.SYSTEM_FIELD_WITH_USER_TURN,
+            ),
+            extraction=ExtractionContract(
+                session_observation_order=("artifacts", "current_session"),
+            ),
+            approval=ApprovalContract(
+                subprocess_permission_flags_projected_by_shared_policy=False,
+            ),
+            bootstrap=BootstrapContract(
+                mode=BootstrapMode.SUBPROCESS_ONLY,
+                fork_materialization=ForkMaterializationMode.NATIVE_CONTINUE_FORK,
+            ),
+        )
+
+    @property
+    def consumed_fields(self) -> frozenset[str]:
+        return self._CONSUMED_FIELDS
+
+    @property
+    def explicitly_ignored_fields(self) -> frozenset[str]:
+        return self._EXPLICITLY_IGNORED_FIELDS
+
+    @property
+    def capabilities(self) -> HarnessCapabilities:
+        return HarnessCapabilities(
+            supports_stream_events=True,
+            supports_stdin_prompt=True,
+            supports_session_resume=True,
+            supports_session_fork=True,
+            supports_native_skills=False,
+            supports_native_agents=False,
+            supports_primary_launch=True,
+            supports_native_file_injection=False,
+            terminal_surface_modes=(TerminalSurfaceMode.PURE_STDIO,),
+            default_terminal_surface_mode=TerminalSurfaceMode.PURE_STDIO,
+        )
+
+    def resolve_launch_spec(
+        self,
+        run: SpawnParams,
+        perms: PermissionResolver,
+    ) -> ResolvedLaunchSpec:
+        continue_session_id = (run.continue_harness_session_id or "").strip() or None
+        return ResolvedLaunchSpec(
+            harness=HarnessId.PI,
+            model=str(run.model).strip() if run.model else None,
+            effort=run.effort,
+            prompt=run.user_turn_content or run.prompt,
+            continue_session_id=continue_session_id,
+            continue_fork=run.continue_fork and continue_session_id is not None,
+            permission_resolver=perms,
+            extra_args=run.extra_args,
+            interactive=run.interactive,
+            mcp_tools=run.mcp_tools,
+            projected_roots=run.projected_roots,
+            appended_system_prompt=run.appended_system_prompt,
+            agent_name=None,
+            skills=(),
+        )
+
+    def build_command(self, run: SpawnParams, perms: PermissionResolver) -> list[str]:
+        spec = self.resolve_launch_spec(run, perms)
+        base_command = self.PRIMARY_BASE_COMMAND if spec.interactive else self.BASE_COMMAND
+        return project_subprocess_spec(self.id, spec, base_command=base_command)
+
+    def mcp_config(self, run: SpawnParams) -> McpConfig | None:
+        _ = run
+        return None
+
+    def project_content(self, content: ComposedLaunchContent) -> ProjectedContent:
+        system_prompt = render_system_instruction_blocks(content)
+        reference_routing = build_reference_routing(content.reference_items)
+        task_context = render_task_context(
+            content.reference_items,
+            reference_routing,
+            content.prior_output,
+        )
+        user_turn = join_content_blocks(task_context, content.user_task_prompt)
+
+        return ProjectedContent(
+            system_prompt=system_prompt,
+            user_turn_content=user_turn,
+            reference_routing=reference_routing,
+            channels=ProjectionChannels(
+                system_instruction="system-field" if system_prompt.strip() else "none",
+                user_task_prompt="user-turn",
+                task_context="user-turn",
+            ),
+        )
+
+    def env_overrides(self, config: PermissionConfig) -> dict[str, str]:
+        overrides: dict[str, str] = {
+            "PI_CODING_AGENT_DIR": str(get_user_home() / "pi" / "agent"),
+        }
+        if config.pi_launch_config_path:
+            overrides["MERIDIAN_PI_LAUNCH_CONFIG"] = config.pi_launch_config_path
+        return overrides
+
+    def extract_usage(self, artifacts: ArtifactStore, spawn_id: SpawnId) -> TokenUsage:
+        return PI_EXTRACTOR.extract_usage(artifacts, spawn_id)
+
+    def extract_session_id(self, artifacts: ArtifactStore, spawn_id: SpawnId) -> str | None:
+        return PI_EXTRACTOR.extract_session_id(artifacts, spawn_id)
+
+    def extract_report(self, artifacts: ArtifactStore, spawn_id: SpawnId) -> str | None:
+        return PI_EXTRACTOR.extract_report(artifacts, spawn_id)
+
+    def detect_primary_session_id(
+        self,
+        *,
+        project_root: Path,
+        started_at_epoch: float,
+        started_at_local_iso: str | None,
+        expected_session_id: str | None = None,
+    ) -> str | None:
+        _ = project_root, started_at_epoch, started_at_local_iso, expected_session_id
+        return None
+
+
+register_harness_bundle(
+    HarnessBundle(
+        harness_id=HarnessId.PI,
+        adapter=PiAdapter(),
+        spec_cls=ResolvedLaunchSpec,
+        extractor=PI_EXTRACTOR,
+        connections={TransportId.STREAMING: PiConnection},
+        projections=HarnessProjectionPorts(
+            subprocess_cli_args=project_pi_spec_to_cli_args,
+        ),
+    )
+)

--- a/src/meridian/lib/harness/pi.py
+++ b/src/meridian/lib/harness/pi.py
@@ -189,7 +189,7 @@ class PiAdapter(BaseHarnessAdapter[ResolvedLaunchSpec]):
 
     def env_overrides(self, config: PermissionConfig) -> dict[str, str]:
         overrides: dict[str, str] = {
-            "PI_CODING_AGENT_DIR": str(get_user_home() / "pi" / "agent"),
+            "PI_CODING_AGENT_DIR": str(get_user_home() / "meridian-pi" / "agent"),
         }
         if config.pi_launch_config_path:
             overrides["MERIDIAN_PI_LAUNCH_CONFIG"] = config.pi_launch_config_path

--- a/src/meridian/lib/harness/projections/permission_flags.py
+++ b/src/meridian/lib/harness/projections/permission_flags.py
@@ -35,6 +35,10 @@ def _permission_flags_for_harness(
     harness_id: HarnessId,
     config: PermissionConfig,
 ) -> tuple[str, ...]:
+    if harness_id == HarnessId.PI:
+        # Pi permissions are mediated through extension UI hooks, not CLI flags.
+        return ()
+
     # New harness families that need approval/sandbox projection belong here.
     if config.approval == "yolo":
         if harness_id == HarnessId.CLAUDE:

--- a/src/meridian/lib/harness/projections/project_pi_subprocess.py
+++ b/src/meridian/lib/harness/projections/project_pi_subprocess.py
@@ -1,0 +1,202 @@
+"""Pi subprocess command projection from ``ResolvedLaunchSpec``."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+
+from meridian.lib.core.types import HarnessId
+from meridian.lib.harness.projections._guards import (
+    check_projection_drift as _check_projection_drift,
+)
+from meridian.lib.harness.projections.permission_flags import resolve_permission_flags
+from meridian.lib.launch.launch_types import ResolvedLaunchSpec
+
+logger = logging.getLogger(__name__)
+
+_PROJECTED_FIELDS: frozenset[str] = frozenset(
+    {
+        "model",
+        "effort",
+        "prompt",
+        "continue_session_id",
+        "continue_fork",
+        "permission_resolver",
+        "extra_args",
+        "interactive",
+        "mcp_tools",
+        "projected_roots",
+        "appended_system_prompt",
+    }
+)
+
+_DELEGATED_FIELDS: frozenset[str] = frozenset(
+    {
+        "harness",
+        "agent_name",
+        "agents_payload",
+        "prompt_file_path",
+        "base_instructions",
+        "developer_instructions",
+        "report_output_path",
+        "user_turn_content",
+        "skills",
+        "reference_items",
+    }
+)
+
+_MANAGED_FLAG_ALIASES: dict[str, tuple[str, ...]] = {
+    "--model": ("--model", "-m"),
+    "--append-system-prompt": ("--append-system-prompt",),
+    "--session": ("--session",),
+    "--fork": ("--fork",),
+    "--no-extensions": ("--no-extensions",),
+    "--no-skills": ("--no-skills",),
+    "--no-context-files": ("--no-context-files",),
+    "--no-prompt-templates": ("--no-prompt-templates",),
+}
+
+_EFFORT_TO_THINKING: dict[str, str] = {
+    "low": "minimal",
+    "medium": "medium",
+    "high": "high",
+    "max": "xhigh",
+    "xhigh": "xhigh",
+}
+
+
+def _has_flag(args: Sequence[str], flag: str) -> bool:
+    return any(token == flag or token.startswith(f"{flag}=") for token in args)
+
+
+def _log_collision_if_needed(
+    *,
+    managed_flag: str,
+    has_managed_value: bool,
+    passthrough_tail: tuple[str, ...],
+) -> None:
+    if not has_managed_value:
+        return
+
+    aliases = _MANAGED_FLAG_ALIASES.get(managed_flag, (managed_flag,))
+    if not any(_has_flag(passthrough_tail, alias) for alias in aliases):
+        return
+
+    logger.debug(
+        "Pi projection known managed flag %s also present in extra_args; "
+        "user tail value wins by last-wins semantics",
+        managed_flag,
+    )
+
+
+def _project_model_arg(spec: ResolvedLaunchSpec) -> str | None:
+    model = (spec.model or "").strip()
+    if not model:
+        return None
+
+    thinking = _EFFORT_TO_THINKING.get((spec.effort or "").strip().lower())
+    if thinking:
+        return f"{model}:{thinking}"
+    return model
+
+
+def project_pi_spec_to_cli_args(
+    spec: ResolvedLaunchSpec,
+    *,
+    base_command: tuple[str, ...],
+) -> list[str]:
+    """Project one ``ResolvedLaunchSpec`` into an ordered subprocess command list."""
+
+    command: list[str] = list(base_command)
+
+    model_arg = _project_model_arg(spec)
+    if model_arg is not None:
+        command.extend(("--model", model_arg))
+
+    if spec.appended_system_prompt:
+        command.extend(("--append-system-prompt", spec.appended_system_prompt))
+
+    continue_session_id = (spec.continue_session_id or "").strip()
+    has_continue_session = bool(continue_session_id)
+    has_continue_fork = has_continue_session and spec.continue_fork
+
+    passthrough_tail = spec.extra_args
+    _log_collision_if_needed(
+        managed_flag="--model",
+        has_managed_value=model_arg is not None,
+        passthrough_tail=passthrough_tail,
+    )
+    _log_collision_if_needed(
+        managed_flag="--append-system-prompt",
+        has_managed_value=bool(spec.appended_system_prompt),
+        passthrough_tail=passthrough_tail,
+    )
+    _log_collision_if_needed(
+        managed_flag="--session",
+        has_managed_value=has_continue_session,
+        passthrough_tail=passthrough_tail,
+    )
+    _log_collision_if_needed(
+        managed_flag="--fork",
+        has_managed_value=has_continue_fork,
+        passthrough_tail=passthrough_tail,
+    )
+    _log_collision_if_needed(
+        managed_flag="--no-extensions",
+        has_managed_value=True,
+        passthrough_tail=passthrough_tail,
+    )
+    _log_collision_if_needed(
+        managed_flag="--no-skills",
+        has_managed_value=True,
+        passthrough_tail=passthrough_tail,
+    )
+    _log_collision_if_needed(
+        managed_flag="--no-context-files",
+        has_managed_value=True,
+        passthrough_tail=passthrough_tail,
+    )
+    _log_collision_if_needed(
+        managed_flag="--no-prompt-templates",
+        has_managed_value=True,
+        passthrough_tail=passthrough_tail,
+    )
+
+    if has_continue_session:
+        if has_continue_fork:
+            command.extend(("--fork", continue_session_id))
+        else:
+            command.extend(("--session", continue_session_id))
+
+    command.extend(
+        (
+            "--no-extensions",
+            "--no-skills",
+            "--no-context-files",
+            "--no-prompt-templates",
+        )
+    )
+
+    command.extend(resolve_permission_flags(spec.permission_resolver, HarnessId.PI))
+    command.extend(passthrough_tail)
+
+    prompt = spec.prompt or ""
+    if prompt.strip():
+        command.append(prompt)
+
+    return command
+
+
+_check_projection_drift(
+    ResolvedLaunchSpec,
+    projected=_PROJECTED_FIELDS,
+    delegated=_DELEGATED_FIELDS,
+)
+
+
+__all__ = [
+    "_DELEGATED_FIELDS",
+    "_PROJECTED_FIELDS",
+    "_check_projection_drift",
+    "project_pi_spec_to_cli_args",
+]

--- a/src/meridian/lib/harness/registry.py
+++ b/src/meridian/lib/harness/registry.py
@@ -34,11 +34,13 @@ class HarnessRegistry(BaseModel):
         from meridian.lib.harness.claude import ClaudeAdapter
         from meridian.lib.harness.codex import CodexAdapter
         from meridian.lib.harness.opencode import OpenCodeAdapter
+        from meridian.lib.harness.pi import PiAdapter
 
         registry = cls()
         registry.register(ClaudeAdapter())
         registry.register(CodexAdapter())
         registry.register(OpenCodeAdapter())
+        registry.register(PiAdapter())
         return registry
 
     def register(self, adapter: HarnessEntry) -> None:

--- a/src/meridian/lib/harness/semantics.py
+++ b/src/meridian/lib/harness/semantics.py
@@ -92,6 +92,25 @@ def terminal_outcome(event: HarnessEvent) -> TerminalEventOutcome | None:
                 error=error or "opencode_session_error",
             )
 
+    if event.harness_id == HarnessId.PI.value and event.event_type == "agent_end":
+        messages_obj = event.payload.get("messages")
+        if isinstance(messages_obj, list):
+            for message_obj in reversed(cast("list[object]", messages_obj)):
+                if not isinstance(message_obj, dict):
+                    continue
+                message = cast("dict[str, object]", message_obj)
+                if str(message.get("role", "")).strip().lower() != "assistant":
+                    continue
+                stop_reason = str(message.get("stopReason", "")).strip().lower()
+                if stop_reason == "error":
+                    return TerminalEventOutcome(
+                        status="failed",
+                        exit_code=1,
+                        error="pi_stop_error",
+                    )
+                return TerminalEventOutcome(status="succeeded", exit_code=0)
+        return TerminalEventOutcome(status="succeeded", exit_code=0)
+
     return None
 
 
@@ -108,6 +127,18 @@ def activity_transition(event: HarnessEvent) -> ActivityState | None:
         return "turn_active"
     if event.event_type in {"turn/completed", "session.idle"}:
         return "idle"
+    if event.harness_id == HarnessId.PI.value:
+        if event.event_type in {
+            "agent_start",
+            "turn_start",
+            "message_start",
+            "message_update",
+            "tool_execution_start",
+            "tool_execution_update",
+        }:
+            return "turn_active"
+        if event.event_type in {"turn_end", "agent_end"}:
+            return "idle"
     return None
 
 
@@ -120,6 +151,8 @@ def clears_signal(event: HarnessEvent) -> bool:
         return event.event_type == "turn/completed"
     if event.harness_id == HarnessId.OPENCODE.value:
         return event.event_type in {"session.idle", "session.error"}
+    if event.harness_id == HarnessId.PI.value:
+        return event.event_type == "agent_end"
     return False
 
 

--- a/src/meridian/lib/launch/constants.py
+++ b/src/meridian/lib/launch/constants.py
@@ -45,10 +45,13 @@ BASE_COMMAND_CODEX_SUBPROCESS: Final[tuple[str, ...]] = ("codex", "exec", "--jso
 BASE_COMMAND_CODEX_STREAMING: Final[tuple[str, ...]] = ("codex", "app-server")
 BASE_COMMAND_OPENCODE_SUBPROCESS: Final[tuple[str, ...]] = ("opencode", "run")
 BASE_COMMAND_OPENCODE_STREAMING: Final[tuple[str, ...]] = ("opencode", "serve")
+BASE_COMMAND_PI_SUBPROCESS: Final[tuple[str, ...]] = ("meridian-pi", "-p", "--mode", "json")
+BASE_COMMAND_PI_STREAMING: Final[tuple[str, ...]] = ("meridian-pi", "--mode", "rpc")
 
 PRIMARY_BASE_COMMAND_CLAUDE: Final[tuple[str, ...]] = ("claude",)
 PRIMARY_BASE_COMMAND_CODEX: Final[tuple[str, ...]] = ("codex",)
 PRIMARY_BASE_COMMAND_OPENCODE: Final[tuple[str, ...]] = ("opencode",)
+PRIMARY_BASE_COMMAND_PI: Final[tuple[str, ...]] = ("meridian-pi",)
 
 __all__ = [
     "BASE_COMMAND_CLAUDE_STREAMING",
@@ -57,6 +60,8 @@ __all__ = [
     "BASE_COMMAND_CODEX_SUBPROCESS",
     "BASE_COMMAND_OPENCODE_STREAMING",
     "BASE_COMMAND_OPENCODE_SUBPROCESS",
+    "BASE_COMMAND_PI_STREAMING",
+    "BASE_COMMAND_PI_SUBPROCESS",
     "BLOCKED_CHILD_ENV_VARS",
     "DEFAULT_INFRA_EXIT_CODE",
     "HISTORY_FILENAME",
@@ -65,6 +70,7 @@ __all__ = [
     "PRIMARY_BASE_COMMAND_CLAUDE",
     "PRIMARY_BASE_COMMAND_CODEX",
     "PRIMARY_BASE_COMMAND_OPENCODE",
+    "PRIMARY_BASE_COMMAND_PI",
     "PRIMARY_META_FILENAME",
     "REPORT_FILENAME",
     "REPORT_WATCHDOG_GRACE_SECONDS",

--- a/src/meridian/lib/launch/launch_types.py
+++ b/src/meridian/lib/launch/launch_types.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 class TerminalSurfaceMode(StrEnum):
     """How Meridian surfaces an interactive harness terminal."""
 
+    PURE_STDIO = "pure_stdio"
     PTY_MEDIATED = "pty_mediated"
     NATIVE_INHERIT = "native_inherit"
 

--- a/src/meridian/lib/launch/streaming/terminal_arbitrator.py
+++ b/src/meridian/lib/launch/streaming/terminal_arbitrator.py
@@ -15,6 +15,7 @@ from meridian.lib.core.domain import SpawnStatus
 from meridian.lib.harness.semantics import TerminalEventOutcome
 
 _TERMINAL_EVENT_GRACE_SECONDS = 0.5
+_TIMEOUT_COMPLETION_GRACE_SECONDS = 5.0
 
 
 class TriggerKind(Enum):
@@ -92,6 +93,13 @@ async def arbitrate_terminal(
         )
 
     if timeout_task is not None and timeout_task in done:
+        completion_after_timeout = await _completion_after_timeout_decision(
+            completion_task=completion_task,
+            terminal_event_future=terminal_event_future,
+            grace_seconds=grace_seconds,
+        )
+        if completion_after_timeout is not None:
+            return completion_after_timeout
         return ArbitrationDecision(
             trigger=TriggerKind.TIMEOUT,
             terminal_outcome=None,
@@ -159,6 +167,42 @@ async def _completion_decision(
         synthetic_exit_code=None,
         synthetic_error=None,
     )
+
+
+async def _completion_after_timeout_decision(
+    *,
+    completion_task: asyncio.Future[Any],
+    terminal_event_future: asyncio.Future[TerminalEventOutcome],
+    grace_seconds: float,
+) -> ArbitrationDecision | None:
+    """Prefer completion when timeout and completion race at the boundary."""
+
+    if terminal_event_future.done():
+        return _terminal_frame_decision(terminal_event_future.result())
+
+    if completion_task.done():
+        return await _completion_decision(terminal_event_future, grace_seconds)
+
+    timeout_window = max(grace_seconds, _TIMEOUT_COMPLETION_GRACE_SECONDS)
+    done: set[asyncio.Future[object]]
+    try:
+        done, _ = await asyncio.wait(
+            {
+                cast("asyncio.Future[object]", completion_task),
+                cast("asyncio.Future[object]", terminal_event_future),
+            },
+            timeout=timeout_window,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+    except TimeoutError:  # pragma: no cover - defensive; asyncio.wait does not raise here.
+        done = set()
+
+    if terminal_event_future in done:
+        return _terminal_frame_decision(terminal_event_future.result())
+    if completion_task in done:
+        return await _completion_decision(terminal_event_future, grace_seconds)
+
+    return None
 
 
 async def _completion_grace(

--- a/src/meridian/lib/launch/streaming/terminal_arbitrator.py
+++ b/src/meridian/lib/launch/streaming/terminal_arbitrator.py
@@ -14,9 +14,6 @@ from typing import Any, cast
 from meridian.lib.core.domain import SpawnStatus
 from meridian.lib.harness.semantics import TerminalEventOutcome
 
-_TERMINAL_EVENT_GRACE_SECONDS = 0.5
-_TIMEOUT_COMPLETION_GRACE_SECONDS = 5.0
-
 
 class TriggerKind(Enum):
     """Trigger that won terminal arbitration."""
@@ -50,7 +47,6 @@ async def arbitrate_terminal(
     timeout_task: asyncio.Future[None] | None = None,
     budget_task: asyncio.Future[Any] | None = None,
     watchdog_task: asyncio.Future[bool] | None = None,
-    grace_seconds: float = _TERMINAL_EVENT_GRACE_SECONDS,
 ) -> ArbitrationDecision:
     """Return the terminal decision for the first completed trigger set.
 
@@ -59,7 +55,7 @@ async def arbitrate_terminal(
     2. budget exceeded
     3. timeout
     4. watchdog report termination
-    5. completion, including a bounded late-terminal grace window
+    5. completion
     6. signal
 
     Optional triggers are absent from the race when their task is ``None``.
@@ -93,13 +89,10 @@ async def arbitrate_terminal(
         )
 
     if timeout_task is not None and timeout_task in done:
-        completion_after_timeout = await _completion_after_timeout_decision(
-            completion_task=completion_task,
-            terminal_event_future=terminal_event_future,
-            grace_seconds=grace_seconds,
-        )
-        if completion_after_timeout is not None:
-            return completion_after_timeout
+        if terminal_event_future.done():
+            return _terminal_frame_decision(terminal_event_future.result())
+        if completion_task.done():
+            return _completion_decision(terminal_event_future)
         return ArbitrationDecision(
             trigger=TriggerKind.TIMEOUT,
             terminal_outcome=None,
@@ -122,13 +115,13 @@ async def arbitrate_terminal(
         )
 
     if completion_task in done:
-        return await _completion_decision(terminal_event_future, grace_seconds)
+        return _completion_decision(terminal_event_future)
 
     if signal_task in done:
         # Signal has the lowest precedence.  If completion resolved in the same
-        # scheduling turn, preserve the completion/grace behavior.
+        # scheduling turn, preserve completion-derived behavior.
         if completion_task.done():
-            return await _completion_decision(terminal_event_future, grace_seconds)
+            return _completion_decision(terminal_event_future)
         return ArbitrationDecision(
             trigger=TriggerKind.SIGNAL,
             terminal_outcome=None,
@@ -152,13 +145,11 @@ def _terminal_frame_decision(outcome: TerminalEventOutcome) -> ArbitrationDecisi
     )
 
 
-async def _completion_decision(
+def _completion_decision(
     terminal_event_future: asyncio.Future[TerminalEventOutcome],
-    grace_seconds: float,
 ) -> ArbitrationDecision:
-    terminal_outcome = await _completion_grace(terminal_event_future, grace_seconds)
-    if terminal_outcome is not None:
-        return _terminal_frame_decision(terminal_outcome)
+    if terminal_event_future.done():
+        return _terminal_frame_decision(terminal_event_future.result())
     return ArbitrationDecision(
         trigger=TriggerKind.COMPLETION,
         terminal_outcome=None,
@@ -167,59 +158,6 @@ async def _completion_decision(
         synthetic_exit_code=None,
         synthetic_error=None,
     )
-
-
-async def _completion_after_timeout_decision(
-    *,
-    completion_task: asyncio.Future[Any],
-    terminal_event_future: asyncio.Future[TerminalEventOutcome],
-    grace_seconds: float,
-) -> ArbitrationDecision | None:
-    """Prefer completion when timeout and completion race at the boundary."""
-
-    if terminal_event_future.done():
-        return _terminal_frame_decision(terminal_event_future.result())
-
-    if completion_task.done():
-        return await _completion_decision(terminal_event_future, grace_seconds)
-
-    timeout_window = max(grace_seconds, _TIMEOUT_COMPLETION_GRACE_SECONDS)
-    done: set[asyncio.Future[object]]
-    try:
-        done, _ = await asyncio.wait(
-            {
-                cast("asyncio.Future[object]", completion_task),
-                cast("asyncio.Future[object]", terminal_event_future),
-            },
-            timeout=timeout_window,
-            return_when=asyncio.FIRST_COMPLETED,
-        )
-    except TimeoutError:  # pragma: no cover - defensive; asyncio.wait does not raise here.
-        done = set()
-
-    if terminal_event_future in done:
-        return _terminal_frame_decision(terminal_event_future.result())
-    if completion_task in done:
-        return await _completion_decision(terminal_event_future, grace_seconds)
-
-    return None
-
-
-async def _completion_grace(
-    terminal_event_future: asyncio.Future[TerminalEventOutcome],
-    grace_seconds: float,
-) -> TerminalEventOutcome | None:
-    """Wait briefly for a terminal frame after completion."""
-
-    if terminal_event_future.done():
-        return terminal_event_future.result()
-    try:
-        return await asyncio.wait_for(
-            asyncio.shield(terminal_event_future),
-            timeout=grace_seconds,
-        )
-    except TimeoutError:
-        return None
 
 
 __all__ = [

--- a/src/meridian/lib/launch/streaming_runner.py
+++ b/src/meridian/lib/launch/streaming_runner.py
@@ -26,7 +26,7 @@ from meridian.lib.core.spawn_lifecycle import (
     ExecutionTerminalFacts,
     has_durable_report_completion,
 )
-from meridian.lib.core.types import SpawnId
+from meridian.lib.core.types import HarnessId, SpawnId
 from meridian.lib.harness.adapter import StreamEvent
 from meridian.lib.harness.bundle import get_harness_bundle
 from meridian.lib.harness.common import parse_json_stream_event, unwrap_event_payload
@@ -424,6 +424,9 @@ async def run_streaming_spawn(
             raise RuntimeError("failed to subscribe to spawn stream")
 
         terminal_event_future = loop.create_future()
+        terminal_event_capture = (
+            terminal_event_future if config.harness_id != HarnessId.PI else None
+        )
         completion_task = asyncio.create_task(manager.wait_for_completion(spawn_id))
         consume_task = asyncio.create_task(
             _consume_subscriber_events(
@@ -433,7 +436,7 @@ async def run_streaming_spawn(
                 budget_breach_holder=[None],
                 event_observer=None,
                 stream_stdout_to_terminal=stream_to_terminal,
-                terminal_event_future=terminal_event_future,
+                terminal_event_future=terminal_event_capture,
             )
         )
         signal_task = asyncio.create_task(shutdown_event.wait())
@@ -519,6 +522,9 @@ async def _run_streaming_attempt(
     terminal_event_future: asyncio.Future[TerminalEventOutcome] = (
         asyncio.get_running_loop().create_future()
     )
+    terminal_event_capture = (
+        terminal_event_future if config.harness_id != HarnessId.PI else None
+    )
     subscriber: asyncio.Queue[HarnessEvent | None] | None = None
     connection: HarnessConnection[Any] | None = None
     drain_exit_code = DEFAULT_INFRA_EXIT_CODE
@@ -553,7 +559,7 @@ async def _run_streaming_attempt(
                 budget_breach_holder=budget_breach_holder,
                 event_observer=event_observer,
                 stream_stdout_to_terminal=stream_stdout_to_terminal,
-                terminal_event_future=terminal_event_future,
+                terminal_event_future=terminal_event_capture,
             )
         )
         signal_task = asyncio.create_task(signal_event.wait())
@@ -620,6 +626,8 @@ async def _run_streaming_attempt(
             drain_error = drain_outcome.error
             if timed_out and drain_outcome.status == "succeeded":
                 timed_out = False
+            if drain_outcome.error == "report_watchdog":
+                terminated_by_report_watchdog = True
 
         # The watchdog resolves the completion future mid-flight inside
         # stop_spawn(), so completion_task can finish before watchdog_task.
@@ -628,7 +636,7 @@ async def _run_streaming_attempt(
             if watchdog_task.done():
                 with suppress(Exception):
                     terminated_by_report_watchdog = bool(watchdog_task.result())
-            elif drain_outcome is not None and drain_outcome.error == "report_watchdog":
+            else:
                 try:
                     await asyncio.wait_for(asyncio.shield(watchdog_task), timeout=2.0)
                     terminated_by_report_watchdog = bool(watchdog_task.result())

--- a/src/meridian/lib/launch/streaming_runner.py
+++ b/src/meridian/lib/launch/streaming_runner.py
@@ -594,6 +594,7 @@ async def _run_streaming_attempt(
                 status="failed",
                 exit_code=3,
                 error="timeout",
+                prefer_drain_outcome=True,
             )
             drain_exit_code = 3
         elif decision.trigger == TriggerKind.WATCHDOG:
@@ -617,6 +618,8 @@ async def _run_streaming_attempt(
         if drain_outcome is not None and terminal_outcome is None:
             drain_exit_code = drain_outcome.exit_code
             drain_error = drain_outcome.error
+            if timed_out and drain_outcome.status == "succeeded":
+                timed_out = False
 
         # The watchdog resolves the completion future mid-flight inside
         # stop_spawn(), so completion_task can finish before watchdog_task.

--- a/src/meridian/lib/safety/permissions.py
+++ b/src/meridian/lib/safety/permissions.py
@@ -58,6 +58,8 @@ class PermissionConfig(BaseModel):
     approval: ApprovalMode = "default"
     # Optional OpenCode permission map JSON derived from ToolsField.
     opencode_permission_override: str | None = None
+    # Optional Meridian-compiled launch config path consumed by meridian-pi.
+    pi_launch_config_path: str | None = None
 
 
 def _install_readonly_permission_field(field_name: str) -> None:
@@ -71,7 +73,12 @@ def _install_readonly_permission_field(field_name: str) -> None:
     setattr(PermissionConfig, field_name, property(_get, _set))
 
 
-for _field_name in ("sandbox", "approval", "opencode_permission_override"):
+for _field_name in (
+    "sandbox",
+    "approval",
+    "opencode_permission_override",
+    "pi_launch_config_path",
+):
     _install_readonly_permission_field(_field_name)
 
 

--- a/src/meridian/lib/streaming/spawn_manager.py
+++ b/src/meridian/lib/streaming/spawn_manager.py
@@ -774,6 +774,7 @@ class SpawnManager:
         status: SpawnStatus = "cancelled",
         exit_code: int = 1,
         error: str | None = None,
+        prefer_drain_outcome: bool = False,
     ) -> DrainOutcome | None:
         """Stop one managed spawn and clean up all associated resources."""
 
@@ -796,14 +797,16 @@ class SpawnManager:
                     error=error,
                 )
 
-        outcome = self._resolve_completion_future(
-            session,
-            DrainOutcome(
-                status=status,
-                exit_code=exit_code,
-                error=error,
-                duration_secs=max(0.0, time.monotonic() - session.started_monotonic),
-            ),
+        fallback_outcome = DrainOutcome(
+            status=status,
+            exit_code=exit_code,
+            error=error,
+            duration_secs=max(0.0, time.monotonic() - session.started_monotonic),
+        )
+        outcome = (
+            self._resolve_completion_future(session, fallback_outcome)
+            if not prefer_drain_outcome
+            else fallback_outcome
         )
 
         if session.debug_tracer is not None:
@@ -856,6 +859,8 @@ class SpawnManager:
         if session.drain_task.done() and not session.drain_task.cancelled():
             with suppress(Exception):
                 session.drain_task.result()
+        if prefer_drain_outcome:
+            outcome = self._resolve_completion_future(session, fallback_outcome)
         await self._observers.shutdown(spawn_id)
 
         with suppress(Exception):

--- a/src/meridian/lib/streaming/spawn_manager.py
+++ b/src/meridian/lib/streaming/spawn_manager.py
@@ -57,6 +57,19 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 InjectResultCallback = Callable[[InjectResult], None]
 
+_PI_SUBSPAWN_START_EVENTS: frozenset[str] = frozenset(
+    {
+        "meridian_subspawn_start",
+        "meridian.subspawn.start",
+    }
+)
+_PI_SUBSPAWN_END_EVENTS: frozenset[str] = frozenset(
+    {
+        "meridian_subspawn_end",
+        "meridian.subspawn.end",
+    }
+)
+
 StartConnectionPort = Callable[
     ["ConnectionConfig", ResolvedLaunchSpec],
     Awaitable["HarnessConnection[Any]"],
@@ -88,6 +101,62 @@ class SpawnSession:
     cancel_sent: bool = False
     cancel_event_emitted: bool = False
     control_actions: ControlActionCoordinator | None = None
+
+
+def _normalized_event_label(event: HarnessEvent) -> str:
+    candidates: list[str] = [event.event_type]
+    payload_type = event.payload.get("type")
+    if isinstance(payload_type, str):
+        candidates.append(payload_type)
+    for raw in candidates:
+        normalized = raw.strip().lower().replace("-", "_").replace("/", ".")
+        if normalized:
+            return normalized
+    return ""
+
+
+def _pi_subspawn_id(payload: dict[str, object]) -> str | None:
+    for key in ("subspawn_id", "spawn_id", "child_spawn_id", "id"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            normalized = value.strip()
+            if normalized:
+                return normalized
+    return None
+
+
+@dataclass
+class _PiSubspawnTracker:
+    active_ids: set[str]
+    anonymous_active_count: int = 0
+
+    @classmethod
+    def empty(cls) -> _PiSubspawnTracker:
+        return cls(active_ids=set())
+
+    def observe(self, event: HarnessEvent) -> None:
+        if event.harness_id != HarnessId.PI.value:
+            return
+
+        label = _normalized_event_label(event)
+        if label in _PI_SUBSPAWN_START_EVENTS:
+            subspawn_id = _pi_subspawn_id(event.payload)
+            if subspawn_id is not None:
+                self.active_ids.add(subspawn_id)
+            else:
+                self.anonymous_active_count += 1
+            return
+
+        if label in _PI_SUBSPAWN_END_EVENTS:
+            subspawn_id = _pi_subspawn_id(event.payload)
+            if subspawn_id is not None:
+                self.active_ids.discard(subspawn_id)
+                return
+            if self.anonymous_active_count > 0:
+                self.anonymous_active_count -= 1
+
+    def has_pending(self) -> bool:
+        return bool(self.active_ids) or self.anonymous_active_count > 0
 
 
 def _ensure_harness_bootstrap() -> None:
@@ -371,9 +440,12 @@ class SpawnManager:
         drain_cancelled = False
         drain_error: Exception | None = None
         recorded_terminal_outcome: TerminalEventOutcome | None = None
+        pending_terminal_outcome: TerminalEventOutcome | None = None
+        pi_subspawn_tracker = _PiSubspawnTracker.empty()
         policy = drain_policy if drain_policy is not None else SingleTurnDrainPolicy()
         try:
             async for event in receiver.events():
+                pi_subspawn_tracker.observe(event)
                 if tracer is not None:
                     tracer.emit(
                         "drain",
@@ -428,10 +500,25 @@ class SpawnManager:
                 if event_outcome is not None:
                     action: DrainAction = policy.classify(event_outcome)
                     if action.terminate:
-                        recorded_terminal_outcome = event_outcome
-                        break
+                        if pi_subspawn_tracker.has_pending():
+                            pending_terminal_outcome = event_outcome
+                            logger.info(
+                                "Pi terminal event deferred until subspawn drain boundary "
+                                "for spawn %s "
+                                "(active_subspawns=%s anonymous_subspawns=%d)",
+                                spawn_id,
+                                sorted(pi_subspawn_tracker.active_ids),
+                                pi_subspawn_tracker.anonymous_active_count,
+                            )
+                        else:
+                            recorded_terminal_outcome = event_outcome
+                            break
                     if action.emit_turn_boundary:
                         await self._fan_out_turn_boundary(spawn_id, event_outcome)
+                    continue
+                if pending_terminal_outcome is not None and not pi_subspawn_tracker.has_pending():
+                    recorded_terminal_outcome = pending_terminal_outcome
+                    break
         except asyncio.CancelledError:
             drain_cancelled = True
             raise
@@ -853,6 +940,8 @@ class SpawnManager:
         try:
             await asyncio.wait_for(asyncio.shield(session.drain_task), timeout=2.0)
         except (TimeoutError, asyncio.CancelledError, Exception):
+            if prefer_drain_outcome:
+                self._resolve_completion_future(session, fallback_outcome)
             session.drain_task.cancel()
             with suppress(asyncio.CancelledError, Exception):
                 await session.drain_task

--- a/src/meridian/pi_runtime/README.md
+++ b/src/meridian/pi_runtime/README.md
@@ -24,3 +24,8 @@ Generated Bun binaries are intentionally **not committed**.
 `meridian-cli` wheel is universal Python. A future release step can package
 platform-specific binaries (or lazy-download them), but the current universal wheel
 must not blindly ship a single prebuilt binary.
+
+When a compiled binary is absent, `meridian-pi` only falls back to the Node runner
+for source/dev layouts where both `runner.mjs` and
+`node_modules/@earendil-works/pi-coding-agent` are present. Installed artifacts
+without those runtime deps now fail fast with a clear build/override error.

--- a/src/meridian/pi_runtime/README.md
+++ b/src/meridian/pi_runtime/README.md
@@ -1,0 +1,26 @@
+# meridian-pi runtime
+
+This folder contains the Node/Bun runtime wrapper used by `meridian-pi`.
+
+## Build
+
+The compiled Bun binary is built locally:
+
+```bash
+scripts/build-meridian-pi-runtime.sh
+```
+
+or directly:
+
+```bash
+cd src/meridian/pi_runtime
+bun run build:binary
+```
+
+## Release caveat
+
+Generated Bun binaries are intentionally **not committed**.  
+`src/meridian/pi_runtime/bin/meridian-pi` is OS/arch specific, while the default
+`meridian-cli` wheel is universal Python. A future release step can package
+platform-specific binaries (or lazy-download them), but the current universal wheel
+must not blindly ship a single prebuilt binary.

--- a/src/meridian/pi_runtime/README.md
+++ b/src/meridian/pi_runtime/README.md
@@ -17,8 +17,17 @@ cd src/meridian/pi_runtime
 bun run build:binary
 ```
 
-`build:binary` also copies `package.json` to `bin/package.json`. The Bun-compiled
-runtime expects that metadata file next to the executable at runtime.
+`build:binary` also copies required Pi sidecar assets next to the executable:
+
+- `bin/package.json`
+- `bin/theme/`
+- `bin/assets/`
+- `bin/export-html/`
+- `bin/docs/`
+- `bin/examples/`
+- `bin/photon_rs_bg.wasm`
+
+The Bun-compiled runtime resolves these assets relative to the executable.
 
 ## Release caveat
 

--- a/src/meridian/pi_runtime/README.md
+++ b/src/meridian/pi_runtime/README.md
@@ -17,6 +17,9 @@ cd src/meridian/pi_runtime
 bun run build:binary
 ```
 
+`build:binary` also copies `package.json` to `bin/package.json`. The Bun-compiled
+runtime expects that metadata file next to the executable at runtime.
+
 ## Release caveat
 
 Generated Bun binaries are intentionally **not committed**.  

--- a/src/meridian/pi_runtime/__init__.py
+++ b/src/meridian/pi_runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Runtime assets for the meridian-pi wrapper."""

--- a/src/meridian/pi_runtime/compile_runner.mjs
+++ b/src/meridian/pi_runtime/compile_runner.mjs
@@ -1,0 +1,11 @@
+#!/usr/bin/env bun
+
+import { main as piMain } from "@earendil-works/pi-coding-agent";
+
+if (typeof piMain !== "function") {
+  console.error("meridian-pi: Pi SDK main(args, options?) export is unavailable.");
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+await piMain(args, {});

--- a/src/meridian/pi_runtime/package.json
+++ b/src/meridian/pi_runtime/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build:binary": "bun build ./compile_runner.mjs --compile --outfile ./bin/meridian-pi"
+    "build:binary": "bun build ./compile_runner.mjs --compile --outfile ./bin/meridian-pi && bun run copy:runtime-metadata",
+    "copy:runtime-metadata": "bun -e \"import { copyFileSync, mkdirSync } from 'node:fs'; mkdirSync('./bin', { recursive: true }); copyFileSync('./package.json', './bin/package.json');\""
   },
   "dependencies": {
     "@earendil-works/pi-coding-agent": "^0.74.0"

--- a/src/meridian/pi_runtime/package.json
+++ b/src/meridian/pi_runtime/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build:binary": "bun build ./compile_runner.mjs --compile --outfile ./bin/meridian-pi && bun run copy:runtime-metadata",
-    "copy:runtime-metadata": "bun -e \"import { copyFileSync, mkdirSync } from 'node:fs'; mkdirSync('./bin', { recursive: true }); copyFileSync('./package.json', './bin/package.json');\""
+    "build:binary": "bun build ./compile_runner.mjs --compile --outfile ./bin/meridian-pi && bun run copy:runtime-assets",
+    "copy:runtime-assets": "bun -e \"import { copyFileSync, cpSync, existsSync, mkdirSync } from 'node:fs'; import { dirname } from 'node:path'; const runtimeDist = './node_modules/@earendil-works/pi-coding-agent/dist'; const runtimePackageRoot = './node_modules/@earendil-works/pi-coding-agent'; const copyFile = (from, to) => { if (!existsSync(from)) throw new Error('missing runtime asset: ' + from); mkdirSync(dirname(to), { recursive: true }); copyFileSync(from, to); }; const copyDir = (from, to) => { if (!existsSync(from)) throw new Error('missing runtime asset: ' + from); mkdirSync(dirname(to), { recursive: true }); cpSync(from, to, { recursive: true, force: true }); }; copyFile('./package.json', './bin/package.json'); copyFile(runtimePackageRoot + '/README.md', './bin/README.md'); copyFile(runtimePackageRoot + '/CHANGELOG.md', './bin/CHANGELOG.md'); copyDir(runtimeDist + '/modes/interactive/theme', './bin/theme'); copyDir(runtimeDist + '/modes/interactive/assets', './bin/assets'); copyDir(runtimeDist + '/core/export-html', './bin/export-html'); copyDir(runtimePackageRoot + '/docs', './bin/docs'); copyDir(runtimePackageRoot + '/examples', './bin/examples'); copyFile('./node_modules/@silvia-odwyer/photon-node/photon_rs_bg.wasm', './bin/photon_rs_bg.wasm');\""
   },
   "dependencies": {
     "@earendil-works/pi-coding-agent": "^0.74.0"

--- a/src/meridian/pi_runtime/package.json
+++ b/src/meridian/pi_runtime/package.json
@@ -2,6 +2,9 @@
   "name": "meridian-pi-runtime",
   "private": true,
   "type": "module",
+  "scripts": {
+    "build:binary": "bun build ./compile_runner.mjs --compile --outfile ./bin/meridian-pi"
+  },
   "dependencies": {
     "@earendil-works/pi-coding-agent": "^0.74.0"
   }

--- a/src/meridian/pi_runtime/package.json
+++ b/src/meridian/pi_runtime/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "meridian-pi-runtime",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@earendil-works/pi-coding-agent": "^0.74.0"
+  }
+}

--- a/src/meridian/pi_runtime/runner.mjs
+++ b/src/meridian/pi_runtime/runner.mjs
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+let piMain;
+
+try {
+  ({ main: piMain } = await import("@earendil-works/pi-coding-agent"));
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(
+    "meridian-pi: failed to import @earendil-works/pi-coding-agent. " +
+      "Install wrapper deps with `npm install --prefix src/meridian/pi_runtime`."
+  );
+  console.error(`meridian-pi: cause: ${message}`);
+  process.exit(1);
+}
+
+if (typeof piMain !== "function") {
+  console.error("meridian-pi: Pi SDK main(args, options?) export is unavailable.");
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+await piMain(args, {});

--- a/tests/integration/launch/test_spawn_manager_lifecycle.py
+++ b/tests/integration/launch/test_spawn_manager_lifecycle.py
@@ -28,10 +28,15 @@ from meridian.lib.telemetry import init_telemetry
 from tests.support.fakes import RecordingTelemetrySink, wait_for_telemetry
 
 
-def _build_config(spawn_id: SpawnId, project_root: Path) -> ConnectionConfig:
+def _build_config(
+    spawn_id: SpawnId,
+    project_root: Path,
+    *,
+    harness_id: HarnessId = HarnessId.CODEX,
+) -> ConnectionConfig:
     return ConnectionConfig(
         spawn_id=spawn_id,
-        harness_id=HarnessId.CODEX,
+        harness_id=harness_id,
         prompt="hello",
         control_root=project_root,
         env_overrides={},
@@ -100,6 +105,10 @@ async def test_wait_for_completion_survives_cleanup_without_private_hooks(
         @property
         def spawn_id(self) -> SpawnId:
             return self._spawn_id
+
+        @property
+        def subprocess_pid(self) -> int | None:
+            return 7373
 
         async def start(self, config: ConnectionConfig, spec: ResolvedLaunchSpec) -> None:
             _ = spec
@@ -179,6 +188,133 @@ async def test_wait_for_completion_survives_cleanup_without_private_hooks(
     finally:
         release_cleanup.set()
         await asyncio.sleep(0)
+        await manager.stop_spawn(spawn_id)
+
+
+@pytest.mark.asyncio
+async def test_pi_terminal_waits_for_extension_subspawn_drain_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path
+    runtime_root = resolve_runtime_paths(project_root).root_dir
+    allow_child_drain = asyncio.Event()
+
+    class FakeControlSocketServer:
+        def __init__(self, spawn_id: SpawnId, socket_path: Path, manager: SpawnManager) -> None:
+            _ = spawn_id, manager
+            self.socket_path = socket_path
+
+        async def start(self) -> None:
+            self.socket_path.parent.mkdir(parents=True, exist_ok=True)
+
+        async def stop(self) -> None:
+            return None
+
+    class FakePiConnection:
+        def __init__(self) -> None:
+            self._spawn_id = SpawnId("")
+            self.state = "created"
+            self.capabilities = ConnectionCapabilities(
+                mid_turn_injection="queue",
+                supports_steer=False,
+                supports_cancel=True,
+                runtime_model_switch=False,
+                structured_reasoning=True,
+            )
+
+        @property
+        def harness_id(self) -> HarnessId:
+            return HarnessId.PI
+
+        @property
+        def spawn_id(self) -> SpawnId:
+            return self._spawn_id
+
+        @property
+        def subprocess_pid(self) -> int | None:
+            return 7373
+
+        async def start(self, config: ConnectionConfig, spec: ResolvedLaunchSpec) -> None:
+            _ = spec
+            self._spawn_id = config.spawn_id
+            self.state = "connected"
+
+        async def stop(self) -> None:
+            self.state = "stopped"
+
+        def health(self) -> bool:
+            return self.state == "connected"
+
+        async def send_user_message(self, text: str) -> None:
+            _ = text
+
+        async def send_cancel(self) -> None:
+            return None
+
+        async def events(self):  # type: ignore[no-untyped-def]
+            yield HarnessEvent(
+                event_type="session",
+                harness_id="pi",
+                payload={"type": "session", "id": "ses-1"},
+            )
+            yield HarnessEvent(
+                event_type="meridian_subspawn_start",
+                harness_id="pi",
+                payload={"type": "meridian_subspawn_start", "subspawn_id": "child-1"},
+            )
+            yield HarnessEvent(
+                event_type="agent_end",
+                harness_id="pi",
+                payload={
+                    "type": "agent_end",
+                    "messages": [{"role": "assistant", "stopReason": "stop"}],
+                },
+            )
+            await allow_child_drain.wait()
+            yield HarnessEvent(
+                event_type="meridian_subspawn_end",
+                harness_id="pi",
+                payload={"type": "meridian_subspawn_end", "subspawn_id": "child-1"},
+            )
+
+    monkeypatch.setattr(spawn_manager_module, "ControlSocketServer", FakeControlSocketServer)
+    monkeypatch.setattr(
+        "meridian.lib.harness.connections.get_connection_class",
+        lambda _harness_id: FakePiConnection,
+    )
+
+    spawn_id = start_spawn(
+        runtime_root,
+        chat_id="c-pi-child-drain",
+        model="openai-codex/gpt-5.4-mini",
+        agent="coder",
+        harness="pi",
+        kind="streaming",
+        prompt="hello",
+        launch_mode="foreground",
+        status="running",
+    )
+    manager = SpawnManager(runtime_root=runtime_root, project_root=project_root)
+    await manager.start_spawn(
+        _build_config(spawn_id, project_root, harness_id=HarnessId.PI),
+        _build_spec(),
+    )
+
+    try:
+        with pytest.raises(TimeoutError):
+            await asyncio.wait_for(
+                asyncio.shield(manager.wait_for_completion(spawn_id)),
+                timeout=0.1,
+            )
+
+        allow_child_drain.set()
+        outcome = await asyncio.wait_for(manager.wait_for_completion(spawn_id), timeout=1.0)
+        assert outcome is not None
+        assert outcome.status == "succeeded"
+        assert outcome.exit_code == 0
+        assert outcome.error is None
+    finally:
         await manager.stop_spawn(spawn_id)
 
 

--- a/tests/integration/launch/test_streaming_runner_watchdog.py
+++ b/tests/integration/launch/test_streaming_runner_watchdog.py
@@ -199,6 +199,68 @@ class _PiTimeoutThenTerminalConnection:
         )
 
 
+class _PiTimeoutWithoutTerminalConnection:
+    def __init__(self) -> None:
+        self.state = "created"
+        self._spawn_id = SpawnId("")
+        self._project_root: Path | None = None
+        self._session_id = "session-pi-timeout-no-terminal"
+        self.capabilities = ConnectionCapabilities(
+            mid_turn_injection="queue",
+            supports_steer=False,
+            supports_cancel=True,
+            runtime_model_switch=False,
+            structured_reasoning=True,
+        )
+
+    @property
+    def harness_id(self) -> HarnessId:
+        return HarnessId.PI
+
+    @property
+    def spawn_id(self) -> SpawnId:
+        return self._spawn_id
+
+    @property
+    def session_id(self) -> str | None:
+        return self._session_id
+
+    @property
+    def subprocess_pid(self) -> int | None:
+        return 6262
+
+    async def start(self, config: ConnectionConfig, spec: ResolvedLaunchSpec) -> None:
+        _ = spec
+        self._spawn_id = config.spawn_id
+        self._project_root = config.control_root
+        self.state = "connected"
+
+    async def stop(self) -> None:
+        self.state = "stopped"
+
+    def health(self) -> bool:
+        return self.state == "connected"
+
+    async def send_user_message(self, text: str) -> None:
+        _ = text
+
+    async def send_cancel(self) -> None:
+        return None
+
+    async def events(self):  # type: ignore[no-untyped-def]
+        project_root = self._project_root
+        assert project_root is not None
+        spawn_dir = resolve_spawn_log_dir(project_root, self._spawn_id)
+        spawn_dir.mkdir(parents=True, exist_ok=True)
+        yield HarnessEvent(
+            event_type="session",
+            harness_id="pi",
+            payload={"type": "session", "id": self._session_id},
+        )
+        while True:
+            await asyncio.sleep(3600)
+
+
 class _EndMonotonicFailsClock(FakeClock):
     def __init__(self, start: float = 0.0) -> None:
         super().__init__(start=start)
@@ -384,6 +446,213 @@ async def test_execute_with_streaming_prefers_pi_terminal_after_timeout_interrup
     assert row.status == "succeeded"
     assert row.exit_code == 0
     assert row.error is None
+
+
+@pytest.mark.asyncio
+async def test_execute_with_streaming_waits_for_pi_subspawn_drain_after_parent_terminal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime_root = resolve_project_runtime_root(tmp_path)
+    artifacts = LocalStore(root_dir=tmp_path / ".artifacts")
+    registry = HarnessRegistry.with_defaults()
+    fake_clock = FakeClock(start=1_000.0)
+    fake_heartbeat = FakeHeartbeat()
+    fake_heartbeat.set_clock(fake_clock)
+    release_subspawn_drain = asyncio.Event()
+
+    class _PiTerminalBeforeSubspawnDrainConnection:
+        def __init__(self) -> None:
+            self.state = "created"
+            self._spawn_id = SpawnId("")
+            self._project_root: Path | None = None
+            self._session_id = "session-pi-subspawn-drain"
+            self.capabilities = ConnectionCapabilities(
+                mid_turn_injection="queue",
+                supports_steer=False,
+                supports_cancel=True,
+                runtime_model_switch=False,
+                structured_reasoning=True,
+            )
+
+        @property
+        def harness_id(self) -> HarnessId:
+            return HarnessId.PI
+
+        @property
+        def spawn_id(self) -> SpawnId:
+            return self._spawn_id
+
+        @property
+        def session_id(self) -> str | None:
+            return self._session_id
+
+        @property
+        def subprocess_pid(self) -> int | None:
+            return 5353
+
+        async def start(self, config: ConnectionConfig, spec: ResolvedLaunchSpec) -> None:
+            _ = spec
+            self._spawn_id = config.spawn_id
+            self._project_root = config.control_root
+            self.state = "connected"
+
+        async def stop(self) -> None:
+            self.state = "stopped"
+
+        def health(self) -> bool:
+            return self.state == "connected"
+
+        async def send_user_message(self, text: str) -> None:
+            _ = text
+
+        async def send_cancel(self) -> None:
+            return None
+
+        async def events(self):  # type: ignore[no-untyped-def]
+            project_root = self._project_root
+            assert project_root is not None
+            spawn_dir = resolve_spawn_log_dir(project_root, self._spawn_id)
+            spawn_dir.mkdir(parents=True, exist_ok=True)
+            (spawn_dir / "report.md").write_text(
+                "# Auto-extracted Report\n\nOK\n",
+                encoding="utf-8",
+            )
+            yield HarnessEvent(
+                event_type="session",
+                harness_id="pi",
+                payload={"type": "session", "id": self._session_id},
+            )
+            yield HarnessEvent(
+                event_type="meridian_subspawn_start",
+                harness_id="pi",
+                payload={"type": "meridian_subspawn_start", "subspawn_id": "child-1"},
+            )
+            yield HarnessEvent(
+                event_type="agent_end",
+                harness_id="pi",
+                payload={
+                    "type": "agent_end",
+                    "messages": [{"role": "assistant", "stopReason": "stop"}],
+                },
+            )
+            await release_subspawn_drain.wait()
+            yield HarnessEvent(
+                event_type="meridian_subspawn_end",
+                harness_id="pi",
+                payload={"type": "meridian_subspawn_end", "subspawn_id": "child-1"},
+            )
+
+    monkeypatch.setattr(spawn_manager_module, "ControlSocketServer", _FakeControlSocketServer)
+    monkeypatch.setattr(
+        "meridian.lib.harness.connections.get_connection_class",
+        lambda _harness_id: _PiTerminalBeforeSubspawnDrainConnection,
+    )
+
+    run = Spawn(
+        spawn_id=SpawnId("r-pi-subspawn-drain"),
+        prompt="Reply with exactly: OK",
+        model=ModelId("openai-codex/gpt-5.4-mini"),
+        status="queued",
+    )
+    spawn_store.start_spawn(
+        runtime_root,
+        chat_id="test-chat-pi-subspawn-drain",
+        model=str(run.model),
+        agent="",
+        harness=HarnessId.PI.value,
+        kind="streaming",
+        prompt=run.prompt,
+        spawn_id=run.spawn_id,
+        launch_mode="foreground",
+        status="queued",
+    )
+
+    run_task = asyncio.create_task(
+        _execute_with_context(
+            run,
+            request=_build_pi_timeout_request(timeout_secs=30),
+            project_root=tmp_path,
+            runtime_root=runtime_root,
+            artifacts=artifacts,
+            registry=registry,
+            clock=fake_clock,
+            heartbeat_touch=fake_heartbeat.touch,
+            heartbeat_interval_secs=0.001,
+        )
+    )
+    with pytest.raises(TimeoutError):
+        await asyncio.wait_for(asyncio.shield(run_task), timeout=0.1)
+
+    release_subspawn_drain.set()
+    exit_code = await asyncio.wait_for(run_task, timeout=15.0)
+
+    assert exit_code == 0
+    row = spawn_store.get_spawn(runtime_root, run.spawn_id)
+    assert row is not None
+    assert row.status == "succeeded"
+    assert row.exit_code == 0
+    assert row.error is None
+
+
+@pytest.mark.asyncio
+async def test_execute_with_streaming_times_out_when_no_terminal_or_drain_outcome(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime_root = resolve_project_runtime_root(tmp_path)
+    artifacts = LocalStore(root_dir=tmp_path / ".artifacts")
+    registry = HarnessRegistry.with_defaults()
+    fake_clock = FakeClock(start=1_000.0)
+    fake_heartbeat = FakeHeartbeat()
+    fake_heartbeat.set_clock(fake_clock)
+
+    monkeypatch.setattr(spawn_manager_module, "ControlSocketServer", _FakeControlSocketServer)
+    monkeypatch.setattr(
+        "meridian.lib.harness.connections.get_connection_class",
+        lambda _harness_id: _PiTimeoutWithoutTerminalConnection,
+    )
+
+    run = Spawn(
+        spawn_id=SpawnId("r-pi-timeout-no-terminal"),
+        prompt="Reply with exactly: OK",
+        model=ModelId("openai-codex/gpt-5.4-mini"),
+        status="queued",
+    )
+    spawn_store.start_spawn(
+        runtime_root,
+        chat_id="test-chat-pi-timeout-no-terminal",
+        model=str(run.model),
+        agent="",
+        harness=HarnessId.PI.value,
+        kind="streaming",
+        prompt=run.prompt,
+        spawn_id=run.spawn_id,
+        launch_mode="foreground",
+        status="queued",
+    )
+
+    exit_code = await asyncio.wait_for(
+        _execute_with_context(
+            run,
+            request=_build_pi_timeout_request(timeout_secs=1),
+            project_root=tmp_path,
+            runtime_root=runtime_root,
+            artifacts=artifacts,
+            registry=registry,
+            clock=fake_clock,
+            heartbeat_touch=fake_heartbeat.touch,
+            heartbeat_interval_secs=0.001,
+        ),
+        timeout=20.0,
+    )
+
+    assert exit_code == 3
+    row = spawn_store.get_spawn(runtime_root, run.spawn_id)
+    assert row is not None
+    assert row.status == "failed"
+    assert row.exit_code == 3
+    assert row.error == "timeout"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/launch/test_streaming_runner_watchdog.py
+++ b/tests/integration/launch/test_streaming_runner_watchdog.py
@@ -20,7 +20,12 @@ from meridian.lib.harness.launch_spec import ResolvedLaunchSpec
 from meridian.lib.harness.registry import HarnessRegistry
 from meridian.lib.launch import constants as launch_constants
 from meridian.lib.launch.context import build_launch_context
-from meridian.lib.launch.request import LaunchArgvIntent, LaunchRuntime, SpawnRequest
+from meridian.lib.launch.request import (
+    ExecutionBudget,
+    LaunchArgvIntent,
+    LaunchRuntime,
+    SpawnRequest,
+)
 from meridian.lib.state import spawn_store
 from meridian.lib.state.artifact_store import LocalStore
 from meridian.lib.state.paths import (
@@ -115,6 +120,85 @@ class _ReportThenHangConnection:
             await asyncio.sleep(3600)
 
 
+class _PiTimeoutThenTerminalConnection:
+    def __init__(self) -> None:
+        self.state = "created"
+        self._spawn_id = SpawnId("")
+        self._project_root: Path | None = None
+        self._session_id = "session-pi-timeout-race"
+        self._stop_event = asyncio.Event()
+        self.capabilities = ConnectionCapabilities(
+            mid_turn_injection="queue",
+            supports_steer=False,
+            supports_cancel=True,
+            runtime_model_switch=False,
+            structured_reasoning=True,
+        )
+
+    @property
+    def harness_id(self) -> HarnessId:
+        return HarnessId.PI
+
+    @property
+    def spawn_id(self) -> SpawnId:
+        return self._spawn_id
+
+    @property
+    def session_id(self) -> str | None:
+        return self._session_id
+
+    @property
+    def subprocess_pid(self) -> int | None:
+        return 5252
+
+    async def start(self, config: ConnectionConfig, spec: ResolvedLaunchSpec) -> None:
+        _ = spec
+        self._spawn_id = config.spawn_id
+        self._project_root = config.control_root
+        self.state = "connected"
+
+    async def stop(self) -> None:
+        self.state = "stopped"
+        self._stop_event.set()
+
+    def health(self) -> bool:
+        return self.state == "connected"
+
+    async def send_user_message(self, text: str) -> None:
+        _ = text
+
+    async def send_cancel(self) -> None:
+        return None
+
+    async def events(self):  # type: ignore[no-untyped-def]
+        project_root = self._project_root
+        assert project_root is not None
+        spawn_dir = resolve_spawn_log_dir(project_root, self._spawn_id)
+        spawn_dir.mkdir(parents=True, exist_ok=True)
+        (spawn_dir / "report.md").write_text("# Auto-extracted Report\n\nOK\n", encoding="utf-8")
+        yield HarnessEvent(
+            event_type="session",
+            harness_id="pi",
+            payload={"type": "session", "id": self._session_id},
+        )
+        yield HarnessEvent(
+            event_type="turn_start",
+            harness_id="pi",
+            payload={"type": "turn_start"},
+        )
+        await self._stop_event.wait()
+        yield HarnessEvent(
+            event_type="agent_end",
+            harness_id="pi",
+            payload={
+                "type": "agent_end",
+                "messages": [
+                    {"role": "assistant", "stopReason": "stop"},
+                ],
+            },
+        )
+
+
 class _EndMonotonicFailsClock(FakeClock):
     def __init__(self, start: float = 0.0) -> None:
         super().__init__(start=start)
@@ -132,6 +216,15 @@ def _build_request() -> SpawnRequest:
         model="gpt-5.3-codex",
         harness=HarnessId.CODEX.value,
         prompt="hello",
+    )
+
+
+def _build_pi_timeout_request(timeout_secs: int) -> SpawnRequest:
+    return SpawnRequest(
+        model="openai-codex/gpt-5.4-mini",
+        harness=HarnessId.PI.value,
+        prompt="Reply with exactly: OK",
+        budget=ExecutionBudget(timeout_secs=timeout_secs),
     )
 
 
@@ -231,6 +324,66 @@ async def test_execute_with_streaming_succeeds_after_report_watchdog_cleanup(
     assert fake_heartbeat.touches
     report = (runtime_root / "spawns" / str(run.spawn_id) / "report.md").read_text(encoding="utf-8")
     assert "Watchdog fallback completed." in report
+
+
+@pytest.mark.asyncio
+async def test_execute_with_streaming_prefers_pi_terminal_after_timeout_interrupt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime_root = resolve_project_runtime_root(tmp_path)
+    artifacts = LocalStore(root_dir=tmp_path / ".artifacts")
+    registry = HarnessRegistry.with_defaults()
+    fake_clock = FakeClock(start=1_000.0)
+    fake_heartbeat = FakeHeartbeat()
+    fake_heartbeat.set_clock(fake_clock)
+
+    monkeypatch.setattr(spawn_manager_module, "ControlSocketServer", _FakeControlSocketServer)
+    monkeypatch.setattr(
+        "meridian.lib.harness.connections.get_connection_class",
+        lambda _harness_id: _PiTimeoutThenTerminalConnection,
+    )
+
+    run = Spawn(
+        spawn_id=SpawnId("r-pi-timeout-terminal-race"),
+        prompt="Reply with exactly: OK",
+        model=ModelId("openai-codex/gpt-5.4-mini"),
+        status="queued",
+    )
+    spawn_store.start_spawn(
+        runtime_root,
+        chat_id="test-chat-pi-timeout-race",
+        model=str(run.model),
+        agent="",
+        harness=HarnessId.PI.value,
+        kind="streaming",
+        prompt=run.prompt,
+        spawn_id=run.spawn_id,
+        launch_mode="foreground",
+        status="queued",
+    )
+
+    exit_code = await asyncio.wait_for(
+        _execute_with_context(
+            run,
+            request=_build_pi_timeout_request(timeout_secs=1),
+            project_root=tmp_path,
+            runtime_root=runtime_root,
+            artifacts=artifacts,
+            registry=registry,
+            clock=fake_clock,
+            heartbeat_touch=fake_heartbeat.touch,
+            heartbeat_interval_secs=0.001,
+        ),
+        timeout=15.0,
+    )
+
+    assert exit_code == 0
+    row = spawn_store.get_spawn(runtime_root, run.spawn_id)
+    assert row is not None
+    assert row.status == "succeeded"
+    assert row.exit_code == 0
+    assert row.error is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cli/test_bootstrap_pi_shortcut.py
+++ b/tests/unit/cli/test_bootstrap_pi_shortcut.py
@@ -1,0 +1,25 @@
+"""CLI bootstrap harness shortcut tests for Pi."""
+
+from __future__ import annotations
+
+from meridian.cli.bootstrap import HARNESS_SHORTCUT_NAMES, extract_global_options
+
+
+def _normalize_output_format(value: str | None, json_mode: bool) -> str:
+    if value:
+        return value
+    return "json" if json_mode else "text"
+
+
+def test_pi_shortcut_is_registered() -> None:
+    assert "pi" in HARNESS_SHORTCUT_NAMES
+
+
+def test_extract_global_options_parses_pi_shortcut() -> None:
+    cleaned, options = extract_global_options(
+        ["pi", "spawn", "do work"],
+        normalize_output_format=_normalize_output_format,
+    )
+
+    assert cleaned == ["spawn", "do work"]
+    assert options.harness == "pi"

--- a/tests/unit/cli/test_pi_entrypoint.py
+++ b/tests/unit/cli/test_pi_entrypoint.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 
@@ -111,6 +112,11 @@ def test_main_sets_pi_agent_dir_and_passes_remaining_args(
 
     monkeypatch.setattr(pi_entrypoint.subprocess, "run", fake_run)
     monkeypatch.setattr(pi_entrypoint, "_runner_path", lambda: runner_path)
+    monkeypatch.setattr(
+        pi_entrypoint,
+        "_compiled_binary_candidates",
+        lambda: (tmp_path / "missing-packaged-binary",),
+    )
     monkeypatch.setenv("MERIDIAN_HOME", str(tmp_path / "meridian-home"))
     monkeypatch.setattr(
         pi_entrypoint.sys,
@@ -270,6 +276,11 @@ def test_main_reports_missing_node_runtime(
 
     monkeypatch.setattr(pi_entrypoint.subprocess, "run", fake_run)
     monkeypatch.setattr(pi_entrypoint, "_runner_path", lambda: runner_path)
+    monkeypatch.setattr(
+        pi_entrypoint,
+        "_compiled_binary_candidates",
+        lambda: (tmp_path / "missing-packaged-binary",),
+    )
     monkeypatch.setattr(pi_entrypoint.sys, "argv", ["meridian-pi", "--help"])
 
     with pytest.raises(SystemExit) as raised:
@@ -367,3 +378,15 @@ def test_main_reports_invalid_wrapper_flag(
 
     assert raised.value.code == 2
     assert "--agent-dir requires" in capsys.readouterr().err
+
+
+def test_runtime_build_script_copies_package_metadata_to_binary_layout() -> None:
+    runtime_package_json = (
+        Path(__file__).resolve().parents[3] / "src" / "meridian" / "pi_runtime" / "package.json"
+    )
+    package_doc = json.loads(runtime_package_json.read_text(encoding="utf-8"))
+    scripts = package_doc["scripts"]
+
+    assert "copy:runtime-metadata" in scripts
+    assert "bin/package.json" in scripts["copy:runtime-metadata"]
+    assert "copy:runtime-metadata" in scripts["build:binary"]

--- a/tests/unit/cli/test_pi_entrypoint.py
+++ b/tests/unit/cli/test_pi_entrypoint.py
@@ -10,6 +10,17 @@ import pytest
 from meridian.cli import pi_entrypoint
 
 
+def _create_source_runtime_layout(runtime_dir: Path) -> Path:
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    runner_path = runtime_dir / "runner.mjs"
+    runner_path.write_text("// runner")
+    (runtime_dir / "node_modules" / "@earendil-works" / "pi-coding-agent").mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+    return runner_path
+
+
 def test_strip_agent_dir_flag_removes_wrapper_only_flag() -> None:
     passthrough, agent_dir = pi_entrypoint._strip_agent_dir_flag(
         [
@@ -71,11 +82,24 @@ def test_ensure_agent_dir_layout_creates_required_subdirectories(tmp_path: Path)
     assert (agent_dir / "bin").is_dir()
 
 
+def test_compiled_binary_candidates_prefers_posix_binary_first() -> None:
+    candidate_names = pi_entrypoint._compiled_binary_candidate_names("posix")
+
+    assert candidate_names == ("meridian-pi", "meridian-pi.exe")
+
+
+def test_compiled_binary_candidates_prefers_windows_binary_first() -> None:
+    candidate_names = pi_entrypoint._compiled_binary_candidate_names("nt")
+
+    assert candidate_names == ("meridian-pi.exe", "meridian-pi")
+
+
 def test_main_sets_pi_agent_dir_and_passes_remaining_args(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     captured: dict[str, object] = {}
+    runner_path = _create_source_runtime_layout(tmp_path / "pi-runtime")
 
     def fake_run(
         command: list[str], *, env: dict[str, str], check: bool
@@ -86,7 +110,7 @@ def test_main_sets_pi_agent_dir_and_passes_remaining_args(
         return subprocess.CompletedProcess(command, 0)
 
     monkeypatch.setattr(pi_entrypoint.subprocess, "run", fake_run)
-    monkeypatch.setattr(pi_entrypoint, "_runner_path", lambda: tmp_path / "runner.mjs")
+    monkeypatch.setattr(pi_entrypoint, "_runner_path", lambda: runner_path)
     monkeypatch.setenv("MERIDIAN_HOME", str(tmp_path / "meridian-home"))
     monkeypatch.setattr(
         pi_entrypoint.sys,
@@ -98,7 +122,7 @@ def test_main_sets_pi_agent_dir_and_passes_remaining_args(
         pi_entrypoint.main()
 
     assert raised.value.code == 0
-    assert captured["command"] == ["node", str(tmp_path / "runner.mjs"), "--help"]
+    assert captured["command"] == ["node", str(runner_path), "--help"]
     captured_env = captured["env"]
     assert isinstance(captured_env, dict)
     assert captured_env["PI_CODING_AGENT_DIR"] == str(tmp_path / "agent-dir")
@@ -175,6 +199,7 @@ def test_main_falls_back_to_node_runner_when_packaged_binary_absent(
     tmp_path: Path,
 ) -> None:
     captured: dict[str, object] = {}
+    runner_path = _create_source_runtime_layout(tmp_path / "pi-runtime")
 
     def fake_run(
         command: list[str], *, env: dict[str, str], check: bool
@@ -185,7 +210,7 @@ def test_main_falls_back_to_node_runner_when_packaged_binary_absent(
         return subprocess.CompletedProcess(command, 0)
 
     monkeypatch.setattr(pi_entrypoint.subprocess, "run", fake_run)
-    monkeypatch.setattr(pi_entrypoint, "_runner_path", lambda: tmp_path / "runner.mjs")
+    monkeypatch.setattr(pi_entrypoint, "_runner_path", lambda: runner_path)
     monkeypatch.setattr(
         pi_entrypoint,
         "_compiled_binary_candidates",
@@ -197,7 +222,37 @@ def test_main_falls_back_to_node_runner_when_packaged_binary_absent(
         pi_entrypoint.main()
 
     assert raised.value.code == 0
-    assert captured["command"] == ["node", str(tmp_path / "runner.mjs"), "--help"]
+    assert captured["command"] == ["node", str(runner_path), "--help"]
+
+
+def test_main_reports_missing_compiled_runtime_and_source_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    runner_path = tmp_path / "missing-runner.mjs"
+
+    def should_not_run(
+        command: list[str], *, env: dict[str, str], check: bool
+    ) -> subprocess.CompletedProcess[str]:
+        raise AssertionError(f"unexpected subprocess invocation: {command!r}, {env!r}, {check!r}")
+
+    monkeypatch.setattr(pi_entrypoint, "_runner_path", lambda: runner_path)
+    monkeypatch.setattr(pi_entrypoint.subprocess, "run", should_not_run)
+    monkeypatch.setattr(
+        pi_entrypoint,
+        "_compiled_binary_candidates",
+        lambda: (tmp_path / "missing-binary",),
+    )
+    monkeypatch.setattr(pi_entrypoint.sys, "argv", ["meridian-pi", "--help"])
+
+    with pytest.raises(SystemExit) as raised:
+        pi_entrypoint.main()
+
+    assert raised.value.code == 1
+    stderr = capsys.readouterr().err
+    assert "compiled meridian-pi runtime is not installed" in stderr
+    assert "build-meridian-pi-runtime.sh" in stderr
 
 
 def test_main_reports_missing_node_runtime(
@@ -205,6 +260,8 @@ def test_main_reports_missing_node_runtime(
     capsys: pytest.CaptureFixture[str],
     tmp_path: Path,
 ) -> None:
+    runner_path = _create_source_runtime_layout(tmp_path / "pi-runtime")
+
     def fake_run(
         command: list[str], *, env: dict[str, str], check: bool
     ) -> subprocess.CompletedProcess[str]:
@@ -212,7 +269,7 @@ def test_main_reports_missing_node_runtime(
         raise FileNotFoundError("node")
 
     monkeypatch.setattr(pi_entrypoint.subprocess, "run", fake_run)
-    monkeypatch.setattr(pi_entrypoint, "_runner_path", lambda: tmp_path / "runner.mjs")
+    monkeypatch.setattr(pi_entrypoint, "_runner_path", lambda: runner_path)
     monkeypatch.setattr(pi_entrypoint.sys, "argv", ["meridian-pi", "--help"])
 
     with pytest.raises(SystemExit) as raised:

--- a/tests/unit/cli/test_pi_entrypoint.py
+++ b/tests/unit/cli/test_pi_entrypoint.py
@@ -245,6 +245,60 @@ def test_main_reports_missing_binary_override(
     assert "Node.js runtime is required" not in stderr
 
 
+def test_main_reports_binary_override_execution_error(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    def fake_run(
+        command: list[str], *, env: dict[str, str], check: bool
+    ) -> subprocess.CompletedProcess[str]:
+        _ = command, env, check
+        raise PermissionError("permission denied")
+
+    binary_override = tmp_path / "override-pi"
+    binary_override.write_text("binary")
+
+    monkeypatch.setattr(pi_entrypoint.subprocess, "run", fake_run)
+    monkeypatch.setenv("MERIDIAN_PI_BINARY", str(binary_override))
+    monkeypatch.setattr(pi_entrypoint.sys, "argv", ["meridian-pi", "--help"])
+
+    with pytest.raises(SystemExit) as raised:
+        pi_entrypoint.main()
+
+    assert raised.value.code == 1
+    stderr = capsys.readouterr().err
+    assert "failed to execute Pi runtime binary" in stderr
+    assert "Node.js runtime is required" not in stderr
+
+
+def test_main_fails_fast_for_non_executable_packaged_binary(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    packaged_binary = tmp_path / "meridian-pi"
+    packaged_binary.write_text("binary")
+    packaged_binary.chmod(0o644)
+
+    def should_not_run(
+        command: list[str], *, env: dict[str, str], check: bool
+    ) -> subprocess.CompletedProcess[str]:
+        raise AssertionError(f"unexpected subprocess invocation: {command!r}, {env!r}, {check!r}")
+
+    monkeypatch.setattr(pi_entrypoint, "_compiled_binary_candidates", lambda: (packaged_binary,))
+    monkeypatch.setattr(pi_entrypoint.subprocess, "run", should_not_run)
+    monkeypatch.setattr(pi_entrypoint.sys, "argv", ["meridian-pi", "--help"])
+
+    with pytest.raises(SystemExit) as raised:
+        pi_entrypoint.main()
+
+    assert raised.value.code == 1
+    stderr = capsys.readouterr().err
+    assert "present but not executable on this host" in stderr
+    assert str(packaged_binary) in stderr
+
+
 def test_main_reports_invalid_wrapper_flag(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],

--- a/tests/unit/cli/test_pi_entrypoint.py
+++ b/tests/unit/cli/test_pi_entrypoint.py
@@ -57,7 +57,7 @@ def test_resolve_agent_dir_precedence(tmp_path: Path) -> None:
     env_default = {"MERIDIAN_HOME": str(tmp_path / "home")}
     default_dir = pi_entrypoint._resolve_agent_dir(None, env_default)
 
-    assert default_dir == tmp_path / "home" / "pi" / "agent"
+    assert default_dir == tmp_path / "home" / "meridian-pi" / "agent"
 
     env_override = {
         "MERIDIAN_HOME": str(tmp_path / "home"),
@@ -380,13 +380,18 @@ def test_main_reports_invalid_wrapper_flag(
     assert "--agent-dir requires" in capsys.readouterr().err
 
 
-def test_runtime_build_script_copies_package_metadata_to_binary_layout() -> None:
+def test_runtime_build_script_copies_sidecar_assets_to_binary_layout() -> None:
     runtime_package_json = (
         Path(__file__).resolve().parents[3] / "src" / "meridian" / "pi_runtime" / "package.json"
     )
     package_doc = json.loads(runtime_package_json.read_text(encoding="utf-8"))
     scripts = package_doc["scripts"]
 
-    assert "copy:runtime-metadata" in scripts
-    assert "bin/package.json" in scripts["copy:runtime-metadata"]
-    assert "copy:runtime-metadata" in scripts["build:binary"]
+    assert "copy:runtime-assets" in scripts
+    copy_assets_script = scripts["copy:runtime-assets"]
+    assert "bin/package.json" in copy_assets_script
+    assert "bin/theme" in copy_assets_script
+    assert "bin/assets" in copy_assets_script
+    assert "bin/export-html" in copy_assets_script
+    assert "bin/photon_rs_bg.wasm" in copy_assets_script
+    assert "copy:runtime-assets" in scripts["build:binary"]

--- a/tests/unit/cli/test_pi_entrypoint.py
+++ b/tests/unit/cli/test_pi_entrypoint.py
@@ -1,0 +1,140 @@
+"""Tests for the meridian-pi wrapper entrypoint."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from meridian.cli import pi_entrypoint
+
+
+def test_strip_agent_dir_flag_removes_wrapper_only_flag() -> None:
+    passthrough, agent_dir = pi_entrypoint._strip_agent_dir_flag(
+        [
+            "-p",
+            "--agent-dir",
+            "~/custom-agent-dir",
+            "--mode",
+            "json",
+            "prompt",
+        ]
+    )
+
+    assert passthrough == ["-p", "--mode", "json", "prompt"]
+    assert agent_dir == "~/custom-agent-dir"
+
+
+def test_strip_agent_dir_flag_supports_equals_syntax() -> None:
+    passthrough, agent_dir = pi_entrypoint._strip_agent_dir_flag(
+        ["--agent-dir=/tmp/agent", "--help"]
+    )
+
+    assert passthrough == ["--help"]
+    assert agent_dir == "/tmp/agent"
+
+
+@pytest.mark.parametrize("argv", [["--agent-dir"], ["--agent-dir="]])
+def test_strip_agent_dir_flag_requires_value(argv: list[str]) -> None:
+    with pytest.raises(ValueError, match="--agent-dir requires"):
+        pi_entrypoint._strip_agent_dir_flag(argv)
+
+
+def test_resolve_agent_dir_precedence(tmp_path: Path) -> None:
+    env_default = {"MERIDIAN_HOME": str(tmp_path / "home")}
+    default_dir = pi_entrypoint._resolve_agent_dir(None, env_default)
+
+    assert default_dir == tmp_path / "home" / "pi" / "agent"
+
+    env_override = {
+        "MERIDIAN_HOME": str(tmp_path / "home"),
+        "MERIDIAN_PI_AGENT_DIR": str(tmp_path / "env-override"),
+    }
+    env_dir = pi_entrypoint._resolve_agent_dir(None, env_override)
+
+    assert env_dir == tmp_path / "env-override"
+
+    cli_dir = pi_entrypoint._resolve_agent_dir(str(tmp_path / "cli-override"), env_override)
+
+    assert cli_dir == tmp_path / "cli-override"
+
+
+def test_ensure_agent_dir_layout_creates_required_subdirectories(tmp_path: Path) -> None:
+    agent_dir = tmp_path / "agent"
+
+    pi_entrypoint._ensure_agent_dir_layout(agent_dir)
+
+    assert agent_dir.is_dir()
+    assert (agent_dir / "sessions").is_dir()
+    assert (agent_dir / "extensions").is_dir()
+    assert (agent_dir / "bin").is_dir()
+
+
+def test_main_sets_pi_agent_dir_and_passes_remaining_args(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run(
+        command: list[str], *, env: dict[str, str], check: bool
+    ) -> subprocess.CompletedProcess[str]:
+        captured["command"] = command
+        captured["env"] = env
+        captured["check"] = check
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(pi_entrypoint.subprocess, "run", fake_run)
+    monkeypatch.setattr(pi_entrypoint, "_runner_path", lambda: tmp_path / "runner.mjs")
+    monkeypatch.setenv("MERIDIAN_HOME", str(tmp_path / "meridian-home"))
+    monkeypatch.setattr(
+        pi_entrypoint.sys,
+        "argv",
+        ["meridian-pi", "--agent-dir", str(tmp_path / "agent-dir"), "--help"],
+    )
+
+    with pytest.raises(SystemExit) as raised:
+        pi_entrypoint.main()
+
+    assert raised.value.code == 0
+    assert captured["command"] == ["node", str(tmp_path / "runner.mjs"), "--help"]
+    captured_env = captured["env"]
+    assert isinstance(captured_env, dict)
+    assert captured_env["PI_CODING_AGENT_DIR"] == str(tmp_path / "agent-dir")
+    assert (tmp_path / "agent-dir" / "sessions").is_dir()
+
+
+def test_main_reports_missing_node_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    def fake_run(
+        command: list[str], *, env: dict[str, str], check: bool
+    ) -> subprocess.CompletedProcess[str]:
+        _ = command, env, check
+        raise FileNotFoundError("node")
+
+    monkeypatch.setattr(pi_entrypoint.subprocess, "run", fake_run)
+    monkeypatch.setattr(pi_entrypoint, "_runner_path", lambda: tmp_path / "runner.mjs")
+    monkeypatch.setattr(pi_entrypoint.sys, "argv", ["meridian-pi", "--help"])
+
+    with pytest.raises(SystemExit) as raised:
+        pi_entrypoint.main()
+
+    assert raised.value.code == 1
+    assert "Node.js runtime is required" in capsys.readouterr().err
+
+
+def test_main_reports_invalid_wrapper_flag(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(pi_entrypoint.sys, "argv", ["meridian-pi", "--agent-dir"])
+
+    with pytest.raises(SystemExit) as raised:
+        pi_entrypoint.main()
+
+    assert raised.value.code == 2
+    assert "--agent-dir requires" in capsys.readouterr().err

--- a/tests/unit/cli/test_pi_entrypoint.py
+++ b/tests/unit/cli/test_pi_entrypoint.py
@@ -105,6 +105,101 @@ def test_main_sets_pi_agent_dir_and_passes_remaining_args(
     assert (tmp_path / "agent-dir" / "sessions").is_dir()
 
 
+def test_main_prefers_packaged_binary_when_available(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, object] = {}
+    packaged_binary = tmp_path / "meridian-pi"
+    packaged_binary.write_text("binary")
+    packaged_binary.chmod(0o755)
+
+    def fake_run(
+        command: list[str], *, env: dict[str, str], check: bool
+    ) -> subprocess.CompletedProcess[str]:
+        captured["command"] = command
+        captured["env"] = env
+        captured["check"] = check
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(pi_entrypoint.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        pi_entrypoint,
+        "_compiled_binary_candidates",
+        lambda: (packaged_binary,),
+    )
+    monkeypatch.setattr(pi_entrypoint.sys, "argv", ["meridian-pi", "--help"])
+
+    with pytest.raises(SystemExit) as raised:
+        pi_entrypoint.main()
+
+    assert raised.value.code == 0
+    assert captured["command"] == [str(packaged_binary), "--help"]
+
+
+def test_main_prefers_binary_override_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, object] = {}
+    override_binary = tmp_path / "override-pi"
+    override_binary.write_text("binary")
+    override_binary.chmod(0o755)
+
+    def fake_run(
+        command: list[str], *, env: dict[str, str], check: bool
+    ) -> subprocess.CompletedProcess[str]:
+        captured["command"] = command
+        captured["env"] = env
+        captured["check"] = check
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(pi_entrypoint.subprocess, "run", fake_run)
+    monkeypatch.setenv("MERIDIAN_PI_BINARY", str(override_binary))
+    monkeypatch.setattr(
+        pi_entrypoint,
+        "_compiled_binary_candidates",
+        lambda: (tmp_path / "ignored-packaged-binary",),
+    )
+    monkeypatch.setattr(pi_entrypoint.sys, "argv", ["meridian-pi", "--help"])
+
+    with pytest.raises(SystemExit) as raised:
+        pi_entrypoint.main()
+
+    assert raised.value.code == 0
+    assert captured["command"] == [str(override_binary), "--help"]
+
+
+def test_main_falls_back_to_node_runner_when_packaged_binary_absent(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run(
+        command: list[str], *, env: dict[str, str], check: bool
+    ) -> subprocess.CompletedProcess[str]:
+        captured["command"] = command
+        captured["env"] = env
+        captured["check"] = check
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(pi_entrypoint.subprocess, "run", fake_run)
+    monkeypatch.setattr(pi_entrypoint, "_runner_path", lambda: tmp_path / "runner.mjs")
+    monkeypatch.setattr(
+        pi_entrypoint,
+        "_compiled_binary_candidates",
+        lambda: (tmp_path / "missing-binary",),
+    )
+    monkeypatch.setattr(pi_entrypoint.sys, "argv", ["meridian-pi", "--help"])
+
+    with pytest.raises(SystemExit) as raised:
+        pi_entrypoint.main()
+
+    assert raised.value.code == 0
+    assert captured["command"] == ["node", str(tmp_path / "runner.mjs"), "--help"]
+
+
 def test_main_reports_missing_node_runtime(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -125,6 +220,29 @@ def test_main_reports_missing_node_runtime(
 
     assert raised.value.code == 1
     assert "Node.js runtime is required" in capsys.readouterr().err
+
+
+def test_main_reports_missing_binary_override(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def fake_run(
+        command: list[str], *, env: dict[str, str], check: bool
+    ) -> subprocess.CompletedProcess[str]:
+        _ = command, env, check
+        raise FileNotFoundError("missing-pi-binary")
+
+    monkeypatch.setattr(pi_entrypoint.subprocess, "run", fake_run)
+    monkeypatch.setenv("MERIDIAN_PI_BINARY", "/missing/meridian-pi")
+    monkeypatch.setattr(pi_entrypoint.sys, "argv", ["meridian-pi", "--help"])
+
+    with pytest.raises(SystemExit) as raised:
+        pi_entrypoint.main()
+
+    assert raised.value.code == 1
+    stderr = capsys.readouterr().err
+    assert "Pi runtime binary not found" in stderr
+    assert "Node.js runtime is required" not in stderr
 
 
 def test_main_reports_invalid_wrapper_flag(

--- a/tests/unit/harness/test_pi_extractor.py
+++ b/tests/unit/harness/test_pi_extractor.py
@@ -1,0 +1,145 @@
+"""Pi extractor tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from meridian.lib.core.types import ArtifactKey, SpawnId
+from meridian.lib.harness.connections.base import HarnessEvent
+from meridian.lib.harness.extractors.pi import PI_EXTRACTOR, _encode_cwd_for_session_dir
+from meridian.lib.launch.launch_types import ResolvedLaunchSpec
+from meridian.lib.safety.permissions import UnsafeNoOpPermissionResolver
+
+
+class _MemoryArtifactStore:
+    def __init__(self, payloads: dict[str, bytes]) -> None:
+        self._payloads = payloads
+
+    def get(self, key: ArtifactKey) -> bytes:
+        return self._payloads[str(key)]
+
+    def exists(self, key: ArtifactKey) -> bool:
+        return str(key) in self._payloads
+
+
+def _artifact_store_from_lines(
+    spawn_id: SpawnId,
+    lines: list[dict[str, object]],
+) -> _MemoryArtifactStore:
+    encoded = "\n".join(json.dumps(line) for line in lines).encode("utf-8")
+    return _MemoryArtifactStore({f"{spawn_id}/output.jsonl": encoded})
+
+
+def test_pi_extractor_reads_session_usage_and_report_from_output_jsonl() -> None:
+    spawn_id = SpawnId("p-pi-extractor")
+    store = _artifact_store_from_lines(
+        spawn_id,
+        [
+            {
+                "type": "session",
+                "id": "019e3113-edc8-7751-bb29-9648304465d5",
+            },
+            {
+                "type": "message_end",
+                "message": {
+                    "role": "assistant",
+                    "usage": {
+                        "input": 123,
+                        "output": 45,
+                        "cacheRead": 7,
+                        "cacheWrite": 8,
+                    },
+                },
+            },
+            {
+                "type": "agent_end",
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "final report"}],
+                    }
+                ],
+            },
+        ],
+    )
+
+    usage = PI_EXTRACTOR.extract_usage(store, spawn_id)
+
+    assert (
+        PI_EXTRACTOR.extract_session_id(store, spawn_id)
+        == "019e3113-edc8-7751-bb29-9648304465d5"
+    )
+    assert usage.input_tokens == 123
+    assert usage.output_tokens == 45
+    assert usage.cache_read_input_tokens == 7
+    assert usage.cache_creation_input_tokens == 8
+    assert PI_EXTRACTOR.extract_report(store, spawn_id) == "final report"
+
+
+def test_pi_extractor_detects_session_event_from_live_payload() -> None:
+    event = HarnessEvent(
+        event_type="session",
+        payload={"id": "ses-pi-123"},
+        harness_id="pi",
+    )
+
+    assert PI_EXTRACTOR.detect_session_id_from_event(event) == "ses-pi-123"
+
+
+def test_pi_extractor_detects_session_id_from_pi_session_storage(tmp_path: Path) -> None:
+    child_cwd = tmp_path / "repo"
+    child_cwd.mkdir()
+    agent_dir = tmp_path / "agent"
+    session_dir = agent_dir / "sessions" / _encode_cwd_for_session_dir(child_cwd)
+    session_dir.mkdir(parents=True)
+    session_file = session_dir / "20260516_abc.jsonl"
+    session_file.write_text(
+        '{"type":"session","id":"ses-from-file"}\n{"type":"message"}\n',
+        encoding="utf-8",
+    )
+
+    spec = ResolvedLaunchSpec(
+        harness="pi",
+        prompt="",
+        permission_resolver=UnsafeNoOpPermissionResolver(_suppress_warning=True),
+    )
+
+    detected = PI_EXTRACTOR.detect_session_id_from_artifacts(
+        spec=spec,
+        launch_env={"PI_CODING_AGENT_DIR": str(agent_dir)},
+        child_cwd=child_cwd,
+        runtime_root=tmp_path,
+    )
+
+    assert detected == "ses-from-file"
+
+
+def test_pi_extractor_does_not_return_source_session_for_native_fork(tmp_path: Path) -> None:
+    child_cwd = tmp_path / "repo"
+    child_cwd.mkdir()
+    agent_dir = tmp_path / "agent"
+    session_dir = agent_dir / "sessions" / _encode_cwd_for_session_dir(child_cwd)
+    session_dir.mkdir(parents=True)
+    session_file = session_dir / "20260516_fork.jsonl"
+    session_file.write_text(
+        '{"type":"session","id":"ses-fork-child"}\n',
+        encoding="utf-8",
+    )
+
+    spec = ResolvedLaunchSpec(
+        harness="pi",
+        prompt="",
+        continue_session_id="ses-source",
+        continue_fork=True,
+        permission_resolver=UnsafeNoOpPermissionResolver(_suppress_warning=True),
+    )
+
+    detected = PI_EXTRACTOR.detect_session_id_from_artifacts(
+        spec=spec,
+        launch_env={"PI_CODING_AGENT_DIR": str(agent_dir)},
+        child_cwd=child_cwd,
+        runtime_root=tmp_path,
+    )
+
+    assert detected == "ses-fork-child"

--- a/tests/unit/harness/test_pi_integration.py
+++ b/tests/unit/harness/test_pi_integration.py
@@ -33,7 +33,7 @@ def test_pi_adapter_registered_with_expected_phase12_contract() -> None:
             pi_launch_config_path="/tmp/pi-launch-config.json",
         )
     )
-    assert Path(overrides["PI_CODING_AGENT_DIR"]).parts[-2:] == ("pi", "agent")
+    assert Path(overrides["PI_CODING_AGENT_DIR"]).parts[-2:] == ("meridian-pi", "agent")
     assert overrides["MERIDIAN_PI_LAUNCH_CONFIG"] == "/tmp/pi-launch-config.json"
 
 

--- a/tests/unit/harness/test_pi_integration.py
+++ b/tests/unit/harness/test_pi_integration.py
@@ -1,0 +1,167 @@
+"""Pi harness wiring tests."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from meridian.lib.core.types import HarnessId, SpawnId
+from meridian.lib.harness.adapter import BootstrapMode, ForkMaterializationMode
+from meridian.lib.harness.connections.base import ConnectionConfig, HarnessEvent
+from meridian.lib.harness.connections.pi_rpc import PiConnection
+from meridian.lib.harness.registry import HarnessRegistry
+from meridian.lib.harness.semantics import activity_transition, clears_signal, terminal_outcome
+from meridian.lib.launch.launch_types import ResolvedLaunchSpec, TerminalSurfaceMode
+from meridian.lib.safety.permissions import PermissionConfig, UnsafeNoOpPermissionResolver
+
+
+def test_pi_adapter_registered_with_expected_phase12_contract() -> None:
+    registry = HarnessRegistry.with_defaults()
+    contract = registry.get_contract(HarnessId.PI)
+
+    assert contract.bootstrap.mode is BootstrapMode.SUBPROCESS_ONLY
+    assert contract.bootstrap.fork_materialization is ForkMaterializationMode.NATIVE_CONTINUE_FORK
+    assert contract.capabilities.supports_session_fork is True
+    assert contract.capabilities.terminal_surface_modes == (TerminalSurfaceMode.PURE_STDIO,)
+
+    adapter = registry.get_subprocess_harness(HarnessId.PI)
+    overrides = adapter.env_overrides(
+        PermissionConfig(
+            pi_launch_config_path="/tmp/pi-launch-config.json",
+        )
+    )
+    assert Path(overrides["PI_CODING_AGENT_DIR"]).parts[-2:] == ("pi", "agent")
+    assert overrides["MERIDIAN_PI_LAUNCH_CONFIG"] == "/tmp/pi-launch-config.json"
+
+
+def test_pi_semantics_terminal_outcome_and_activity_mapping() -> None:
+    success_event = HarnessEvent(
+        event_type="agent_end",
+        harness_id="pi",
+        payload={
+            "messages": [
+                {
+                    "role": "assistant",
+                    "stopReason": "stop",
+                }
+            ]
+        },
+    )
+    error_event = HarnessEvent(
+        event_type="agent_end",
+        harness_id="pi",
+        payload={
+            "messages": [
+                {
+                    "role": "assistant",
+                    "stopReason": "error",
+                }
+            ]
+        },
+    )
+
+    assert terminal_outcome(success_event) is not None
+    assert terminal_outcome(success_event).status == "succeeded"
+    assert terminal_outcome(error_event) is not None
+    assert terminal_outcome(error_event).status == "failed"
+    assert activity_transition(
+        HarnessEvent(event_type="message_update", harness_id="pi", payload={})
+    ) == "turn_active"
+    assert (
+        activity_transition(HarnessEvent(event_type="agent_end", harness_id="pi", payload={}))
+        == "idle"
+    )
+    assert clears_signal(HarnessEvent(event_type="agent_end", harness_id="pi", payload={})) is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(sys.platform == "win32", reason="uses POSIX executable shim")
+async def test_pi_connection_starts_print_mode_subprocess_and_drains_jsonl(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    shim = bin_dir / "meridian-pi"
+    shim.write_text(
+        "#!/bin/sh\n"
+        "printf '%s\\n' '{\"type\":\"session\",\"id\":\"ses-pi\"}'\n"
+        "printf '%s\\n' "
+        "'{\"type\":\"agent_end\",\"messages\":[{\"role\":\"assistant\","
+        "\"stopReason\":\"stop\"}]}'\n",
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+
+    connection = PiConnection()
+    await connection.start(
+        ConnectionConfig(
+            spawn_id=SpawnId("p-pi-connection"),
+            harness_id=HarnessId.PI,
+            prompt="hello",
+            control_root=tmp_path,
+            env_overrides={},
+        ),
+        ResolvedLaunchSpec(
+            harness=HarnessId.PI,
+            prompt="hello",
+            permission_resolver=UnsafeNoOpPermissionResolver(_suppress_warning=True),
+        ),
+    )
+
+    events = [event async for event in connection.events()]
+
+    assert [event.event_type for event in events] == ["session", "agent_end"]
+    assert connection.session_id == "ses-pi"
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(sys.platform == "win32", reason="uses POSIX executable shim")
+async def test_pi_connection_launches_in_task_cwd_when_provided(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    observed_cwd = tmp_path / "observed-cwd.txt"
+    task_cwd = tmp_path / "task"
+    task_cwd.mkdir()
+    control_root = tmp_path / "control"
+    control_root.mkdir()
+    shim = bin_dir / "meridian-pi"
+    shim.write_text(
+        "#!/bin/sh\n"
+        "pwd > \"$PI_TEST_CWD_FILE\"\n"
+        "printf '%s\\n' '{\"type\":\"session\",\"id\":\"ses-task-cwd\"}'\n"
+        "printf '%s\\n' "
+        "'{\"type\":\"agent_end\",\"messages\":[{\"role\":\"assistant\","
+        "\"stopReason\":\"stop\"}]}'\n",
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+    monkeypatch.setenv("PI_TEST_CWD_FILE", str(observed_cwd))
+
+    connection = PiConnection()
+    await connection.start(
+        ConnectionConfig(
+            spawn_id=SpawnId("p-pi-task-cwd"),
+            harness_id=HarnessId.PI,
+            prompt="hello",
+            control_root=control_root,
+            env_overrides={},
+            task_cwd=task_cwd,
+        ),
+        ResolvedLaunchSpec(
+            harness=HarnessId.PI,
+            prompt="hello",
+            permission_resolver=UnsafeNoOpPermissionResolver(_suppress_warning=True),
+        ),
+    )
+    _ = [event async for event in connection.events()]
+
+    assert observed_cwd.read_text(encoding="utf-8").strip() == str(task_cwd)

--- a/tests/unit/harness/test_pi_projection.py
+++ b/tests/unit/harness/test_pi_projection.py
@@ -1,0 +1,60 @@
+"""Pi subprocess projection tests."""
+
+from __future__ import annotations
+
+from meridian.lib.core.types import HarnessId
+from meridian.lib.harness.projections.project_pi_subprocess import project_pi_spec_to_cli_args
+from meridian.lib.launch.constants import BASE_COMMAND_PI_SUBPROCESS
+from meridian.lib.launch.launch_types import ResolvedLaunchSpec
+from meridian.lib.safety.permissions import UnsafeNoOpPermissionResolver
+
+
+def test_pi_subprocess_projection_includes_isolation_resume_and_inline_system_prompt() -> None:
+    spec = ResolvedLaunchSpec(
+        harness=HarnessId.PI,
+        model="anthropic/claude-sonnet-4",
+        effort="high",
+        prompt="solve this",
+        continue_session_id="019e3113",
+        continue_fork=True,
+        appended_system_prompt="You are meridian worker",
+        extra_args=("--provider", "anthropic"),
+        permission_resolver=UnsafeNoOpPermissionResolver(_suppress_warning=True),
+    )
+
+    command = project_pi_spec_to_cli_args(spec, base_command=BASE_COMMAND_PI_SUBPROCESS)
+
+    assert command == [
+        "meridian-pi",
+        "-p",
+        "--mode",
+        "json",
+        "--model",
+        "anthropic/claude-sonnet-4:high",
+        "--append-system-prompt",
+        "You are meridian worker",
+        "--fork",
+        "019e3113",
+        "--no-extensions",
+        "--no-skills",
+        "--no-context-files",
+        "--no-prompt-templates",
+        "--provider",
+        "anthropic",
+        "solve this",
+    ]
+
+
+def test_pi_subprocess_projection_uses_session_without_fork_when_continue_fork_false() -> None:
+    spec = ResolvedLaunchSpec(
+        harness=HarnessId.PI,
+        prompt="hello",
+        continue_session_id="abc1234",
+        continue_fork=False,
+        permission_resolver=UnsafeNoOpPermissionResolver(_suppress_warning=True),
+    )
+
+    command = project_pi_spec_to_cli_args(spec, base_command=BASE_COMMAND_PI_SUBPROCESS)
+
+    assert "--session" in command
+    assert "--fork" not in command

--- a/tests/unit/launch/test_terminal_arbitrator.py
+++ b/tests/unit/launch/test_terminal_arbitrator.py
@@ -5,6 +5,7 @@ import asyncio
 import pytest
 
 from meridian.lib.harness.semantics import TerminalEventOutcome
+from meridian.lib.launch.streaming import terminal_arbitrator as terminal_arbitrator_module
 from meridian.lib.launch.streaming.terminal_arbitrator import (
     TriggerKind,
     arbitrate_terminal,
@@ -110,11 +111,18 @@ async def test_budget_beats_completion_when_both_ready() -> None:
 
 
 @pytest.mark.asyncio
-async def test_timeout_beats_late_terminal_frame() -> None:
+async def test_timeout_beats_terminal_frame_that_misses_timeout_grace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        terminal_arbitrator_module,
+        "_TIMEOUT_COMPLETION_GRACE_SECONDS",
+        0.05,
+    )
     loop = asyncio.get_running_loop()
     terminal_future = _terminal_future()
     loop.call_later(
-        0.01,
+        0.2,
         terminal_future.set_result,
         TerminalEventOutcome(status="succeeded", exit_code=0),
     )
@@ -124,7 +132,7 @@ async def test_timeout_beats_late_terminal_frame() -> None:
         terminal_event_future=terminal_future,
         signal_task=_future(),
         timeout_task=_future(None, done=True),
-        grace_seconds=0.1,
+        grace_seconds=0.01,
     )
 
     assert decision.trigger is TriggerKind.TIMEOUT
@@ -132,6 +140,28 @@ async def test_timeout_beats_late_terminal_frame() -> None:
     assert decision.synthetic_status == "failed"
     assert decision.synthetic_exit_code == 3
     assert decision.synthetic_error == "timeout"
+
+
+@pytest.mark.asyncio
+async def test_terminal_frame_beats_timeout_when_it_lands_within_timeout_grace() -> None:
+    loop = asyncio.get_running_loop()
+    completion_future = _future()
+    terminal_future = _terminal_future()
+    outcome = TerminalEventOutcome(status="succeeded", exit_code=0)
+    loop.call_later(0.01, terminal_future.set_result, outcome)
+
+    decision = await arbitrate_terminal(
+        completion_task=completion_future,
+        terminal_event_future=terminal_future,
+        signal_task=_future(),
+        timeout_task=_future(None, done=True),
+        grace_seconds=0.1,
+    )
+
+    assert decision.trigger is TriggerKind.TERMINAL_FRAME
+    assert decision.terminal_outcome == outcome
+    assert decision.stop_required is True
+    assert completion_future.done() is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/launch/test_terminal_arbitrator.py
+++ b/tests/unit/launch/test_terminal_arbitrator.py
@@ -5,7 +5,6 @@ import asyncio
 import pytest
 
 from meridian.lib.harness.semantics import TerminalEventOutcome
-from meridian.lib.launch.streaming import terminal_arbitrator as terminal_arbitrator_module
 from meridian.lib.launch.streaming.terminal_arbitrator import (
     TriggerKind,
     arbitrate_terminal,
@@ -46,17 +45,12 @@ async def test_terminal_frame_wins_immediately() -> None:
 
 
 @pytest.mark.asyncio
-async def test_completion_waits_for_late_terminal_frame_within_grace() -> None:
-    loop = asyncio.get_running_loop()
-    terminal_future = _terminal_future()
+async def test_completion_uses_already_observed_terminal_frame() -> None:
     outcome = TerminalEventOutcome(status="failed", exit_code=1, error="late_frame")
-    loop.call_later(0.01, terminal_future.set_result, outcome)
-
     decision = await arbitrate_terminal(
         completion_task=_future(None, done=True),
-        terminal_event_future=terminal_future,
+        terminal_event_future=_terminal_future(outcome),
         signal_task=_future(),
-        grace_seconds=0.1,
     )
 
     assert decision.trigger is TriggerKind.TERMINAL_FRAME
@@ -65,12 +59,11 @@ async def test_completion_waits_for_late_terminal_frame_within_grace() -> None:
 
 
 @pytest.mark.asyncio
-async def test_completion_without_late_terminal_frame_completes_normally() -> None:
+async def test_completion_without_terminal_frame_completes_normally() -> None:
     decision = await arbitrate_terminal(
         completion_task=_future(None, done=True),
         terminal_event_future=_terminal_future(),
         signal_task=_future(),
-        grace_seconds=0.001,
     )
 
     assert decision.trigger is TriggerKind.COMPLETION
@@ -100,7 +93,6 @@ async def test_budget_beats_completion_when_both_ready() -> None:
         terminal_event_future=_terminal_future(),
         signal_task=_future(),
         budget_task=_future(True, done=True),
-        grace_seconds=0.001,
     )
 
     assert decision.trigger is TriggerKind.BUDGET
@@ -111,28 +103,12 @@ async def test_budget_beats_completion_when_both_ready() -> None:
 
 
 @pytest.mark.asyncio
-async def test_timeout_beats_terminal_frame_that_misses_timeout_grace(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        terminal_arbitrator_module,
-        "_TIMEOUT_COMPLETION_GRACE_SECONDS",
-        0.05,
-    )
-    loop = asyncio.get_running_loop()
-    terminal_future = _terminal_future()
-    loop.call_later(
-        0.2,
-        terminal_future.set_result,
-        TerminalEventOutcome(status="succeeded", exit_code=0),
-    )
-
+async def test_timeout_returns_timeout_when_no_terminal_or_completion() -> None:
     decision = await arbitrate_terminal(
         completion_task=_future(),
-        terminal_event_future=terminal_future,
+        terminal_event_future=_terminal_future(),
         signal_task=_future(),
         timeout_task=_future(None, done=True),
-        grace_seconds=0.01,
     )
 
     assert decision.trigger is TriggerKind.TIMEOUT
@@ -143,25 +119,31 @@ async def test_timeout_beats_terminal_frame_that_misses_timeout_grace(
 
 
 @pytest.mark.asyncio
-async def test_terminal_frame_beats_timeout_when_it_lands_within_timeout_grace() -> None:
-    loop = asyncio.get_running_loop()
-    completion_future = _future()
-    terminal_future = _terminal_future()
+async def test_timeout_prefers_terminal_when_already_observed() -> None:
     outcome = TerminalEventOutcome(status="succeeded", exit_code=0)
-    loop.call_later(0.01, terminal_future.set_result, outcome)
-
     decision = await arbitrate_terminal(
-        completion_task=completion_future,
-        terminal_event_future=terminal_future,
+        completion_task=_future(),
+        terminal_event_future=_terminal_future(outcome),
         signal_task=_future(),
         timeout_task=_future(None, done=True),
-        grace_seconds=0.1,
     )
 
     assert decision.trigger is TriggerKind.TERMINAL_FRAME
     assert decision.terminal_outcome == outcome
     assert decision.stop_required is True
-    assert completion_future.done() is False
+
+
+@pytest.mark.asyncio
+async def test_timeout_prefers_completion_when_already_done() -> None:
+    decision = await arbitrate_terminal(
+        completion_task=_future(None, done=True),
+        terminal_event_future=_terminal_future(),
+        signal_task=_future(),
+        timeout_task=_future(None, done=True),
+    )
+
+    assert decision.trigger is TriggerKind.COMPLETION
+    assert decision.stop_required is False
 
 
 @pytest.mark.asyncio
@@ -198,7 +180,6 @@ async def test_completion_beats_signal_when_both_ready() -> None:
         completion_task=_future(None, done=True),
         terminal_event_future=_terminal_future(),
         signal_task=_future(True, done=True),
-        grace_seconds=0.001,
     )
 
     assert decision.trigger is TriggerKind.COMPLETION
@@ -207,8 +188,6 @@ async def test_completion_beats_signal_when_both_ready() -> None:
 
 @pytest.mark.asyncio
 async def test_optional_triggers_are_absent_when_not_passed() -> None:
-    # This would be a timeout if the optional timeout future were passed.  Leaving
-    # it absent keeps the minimal runner race limited to terminal/completion/signal.
     decision = await arbitrate_terminal(
         completion_task=_future(),
         terminal_event_future=_terminal_future(),


### PR DESCRIPTION
## Why

Meridian Pi needs a first-class subprocess harness path so `meridian spawn --harness pi` can run Pi print-mode JSONL and persist session/report/usage.

## Goal

Pi Phase 1/2 minimum harness integration: launch `meridian-pi -p --mode json`, isolate spawned sessions from ambient Pi discovery, and extract session id, report, and usage from Pi JSONL.

## Summary

- Added `HarnessId.PI`, `meridian pi` shortcut registration, Pi constants, bootstrap wiring, registry entry, and explicit Pi no-op permission flag projection.
- Added `PiAdapter`, Pi subprocess projection, Pi extractor, and subprocess-backed `PiConnection` for print-mode JSONL drain through the streaming runner.
- Added Pi event semantics for `agent_end`, activity transitions, and signal clearing.
- Added focused tests for projection, extraction, connection startup/cwd, registry/contract wiring, semantics, and shortcut parsing.

## Work Item

meridian-pi

## Changes

- Pi subprocess command projects to `meridian-pi -p --mode json`.
- Spawn isolation flags are projected: `--no-extensions --no-skills --no-context-files --no-prompt-templates`.
- System prompt uses Pi inline `--append-system-prompt`.
- Resume/fork projects to `--session <id>` or `--fork <id>`.
- Pi config env sets `PI_CODING_AGENT_DIR` to `get_user_home()/pi/agent` and forwards `MERIDIAN_PI_LAUNCH_CONFIG` when configured.
- Pi JSONL extraction reads session id from `session`, usage from assistant `message_end.message.usage`, and report from final assistant text in `agent_end.messages`.
- Deferred: full `meridian-pi` wrapper package, built-in web extensions, doctor/download distribution, and RPC managed-primary integration.

## Verification

- `uv run ruff check .`
- `uv run pyright`
- `uv run pytest tests/unit/harness/test_pi_projection.py tests/unit/harness/test_pi_extractor.py tests/unit/harness/test_pi_integration.py tests/unit/cli/test_bootstrap_pi_shortcut.py tests/contract/harness/test_adapter_contracts.py tests/contract/harness/test_typed_contracts.py -q` — 31 passed
- Fake `meridian-pi` smoke via `uv run meridian spawn --harness pi ... --json` — spawn `p657` succeeded; `spawn show` reported extracted usage and report.
- Pre-push hook: `ruff`, `pyright`, full `pytest -x -q` — 1099 passed, 2 skipped; `uv build --no-sources` succeeded.

## Knowledge Updates

- `CHANGELOG.md` updated under `[Unreleased]`.
- No KB/.context updates; this is new harness code with tests and design docs already in the work item.

## Spawn Trace

- p649 coder — implemented Pi subprocess harness integration and tests
- p652 reviewer — found initial launch/permission/isolation risks
- p654 reviewer — found native-fork and task-cwd recovery blockers
- p655 smoke-tester — verified fake `meridian-pi` dry-run/spawn/report/usage/session extraction
- p658 reviewer — approved focused fixes for fork fallback and task-cwd launch
