### PR TITLE
[codex] Report spawn results by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,16 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- `meridian spawn --metadata` and `meridian spawn wait --metadata` — inline detailed spawn accounting while preserving report body and transcript pointer.
+- Spawn output smoke guide and boundary tests for report-first create/wait behavior.
 - `scripts/manually-release.sh` — emergency/backfill release helper. Runs shared preflight, blocks empty `[Unreleased]`, updates version/changelog, commits, tags, and can push.
 - `--fork-fresh [REF]` on both `meridian` (primary) and `meridian spawn` surfaces. It forks transcript lineage while allowing identity overrides (`-m`, `-a`, `--skills` on spawn). Bare `--fork-fresh` now defaults to `$MERIDIAN_SPAWN_ID` inside Meridian-managed sessions.
 - `meridian --from [REF]` starts a fresh primary session with prior spawn or chat/session context as user-turn reference material. Bare `--from` defaults to `$MERIDIAN_SPAWN_ID` inside Meridian-managed sessions.
 - Bare `--from` on `meridian spawn` defaults to `$MERIDIAN_SPAWN_ID` inside Meridian-managed sessions. Same argv normalization as `--fork` / `--fork-fresh`.
 
 ### Changed
+- Foreground `meridian spawn` and single-spawn `spawn wait` default to report-first compact output: status, report body, transcript command. Agent-mode defaults match compact text; explicit JSON carries report/transcript fields.
+- `spawn wait` includes report body by default; use `--no-report` to suppress it.
 - `--fork` is now identity-preserving on both primary and spawn CLIs. It rejects identity-shaping overrides with: `--fork preserves launch identity. Use --fork-fresh to change agent, model, or skills.`
 - Bare `--fork` now defaults to `$MERIDIAN_SPAWN_ID` inside Meridian-managed sessions. Outside a managed session it fails with: `Cannot infer --fork target: not inside a Meridian-managed session. Pass --fork REF explicitly.`
 - CLI argv normalization now rewrites bare/equals forms for `--fork` and `--fork-fresh` before bootstrap and Cyclopts parsing, so forms like `--fork`, `--fork=`, and `--fork --bg` parse consistently.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -16,7 +16,7 @@ Full command surface. Use `--help` on any command for flags and options.
 | `meridian spawn list` | See running and recent spawns |
 | `meridian spawn list --profile reviewer` | Show spawns launched with the `reviewer` profile |
 | `meridian spawn list --primary` | Show only primary spawns (top-level sessions) |
-| `meridian spawn wait ID` | Block until a spawn completes |
+| `meridian spawn wait ID` | Block until a spawn completes; report body included by default, `--no-report` to suppress |
 | `meridian spawn show ID` | Read a spawn's report and status |
 | `meridian spawn --continue ID -p "more"` | Resume a prior spawn with new input |
 | `meridian spawn --fork [REF] -p "next"` | Start a new spawn by forking while preserving launch identity (agent/model/skills) |
@@ -46,6 +46,9 @@ Common `spawn` flags:
 | `--profile NAME` | `spawn list` only: filter by stored agent/profile name |
 | `--primary` | `spawn list` only: include only `kind=primary` spawns |
 | `--approval MODE` | `default` \| `confirm` \| `auto` \| `yolo` |
+| `--metadata` | Show detailed inline accounting (model, cost, tokens, duration, report path). Still includes report body and transcript command. |
+| `--no-report` | Suppress report body from output (default is now to show it) |
+| `--verbose` | Debug/runtime verbosity |
 
 `--fork` is identity-preserving by design. It rejects `-m`, `-a`, and `--skills`:
 
@@ -56,6 +59,30 @@ Common `spawn` flags:
 `--fork-fresh` is the identity-changing variant. It is useful for role/model swaps, but can reduce prompt-cache locality because the profile/system prompt may change.
 
 Session initiation modes: `--continue` resumes the same transcript, `--fork` branches with identity lock, `--fork-fresh` branches with identity overrides, and `--from [REF]` starts an independent transcript seeded by references only.
+
+### Spawn Output
+
+Foreground `spawn` and single-spawn `spawn wait` default to compact output:
+one-line status + report body + transcript pointer. Metadata (tokens, cost,
+timestamps, paths, model) is hidden by default.
+
+| Mode | Output |
+|------|--------|
+| Default (no format flag) | Compact text: status + report body + `Transcript: meridian session log <id>` |
+| `--metadata` | Compact text + inline accounting (model, cost, tokens, duration, report path) |
+| `--verbose` | Debug/runtime verbosity |
+| `--no-report` | Status line only; report body suppressed |
+| `--format json` | Structured JSON with report body and transcript command fields |
+| `--bg` | Spawn ID + wait instructions (unchanged) |
+
+Progressive disclosure:
+
+```bash
+meridian spawn -a reviewer -p "task"              # compact: status + report
+meridian spawn -a reviewer -p "task" --metadata   # adds model/cost/tokens/path inline
+meridian spawn show p123                           # full detailed record (unchanged)
+meridian session log p123                          # full transcript (unchanged)
+```
 
 `spawn show` includes primary-session metadata when available from `primary_meta.json`:
 `kind`, `activity`, `managed_backend`, `backend_pid`, `tui_pid`, `backend_port`,

--- a/src/meridian/cli/.context/CONTEXT.md
+++ b/src/meridian/cli/.context/CONTEXT.md
@@ -200,6 +200,33 @@ argv
 → [concepts/session-initiation.md](../../../../../../../.meridian/git/haowjy-meridian-cli-kb/kb/concepts/session-initiation.md) — four-mode session initiation semantics, identity lock, bare flag inference, and `--from` placement
 → [decisions/launch.md](../../../../../../../.meridian/git/haowjy-meridian-cli-kb/kb/decisions/launch.md) — rationale for the launch-mode split and argv normalization
 
+## Spawn Output Mode Changes (spawn-return-report)
+
+### Catalog default_output_mode for spawn
+
+`("spawn",)` and `("spawn", "wait")` have `default_output_mode="text"` in `catalog.py`. This means agent mode (no explicit `--format`) uses compact text output, not JSON. All other spawn subcommands retain `"json"`.
+
+Rule: if you add a new spawn subcommand, default to `"json"` unless it surfaces content agents need to read directly.
+
+### `--metadata` flag
+
+Added to `_spawn_create` and `_spawn_wait` handlers. In text mode, shows detailed inline accounting (model, harness, exit code, duration, cost, tokens, report path) while still including report body and transcript pointer.
+
+Pattern: compact default → `--metadata` inline accounting → `spawn show` full record.
+
+### Verbose threading at emit point
+
+Both `_spawn_create` and `_spawn_wait` thread `--verbose` and `--metadata` into `FormatContext` at the emit point:
+
+```python
+if output_format != "json" and (metadata or verbose):
+    emit(result.format_text(FormatContext(verbosity=1)))
+else:
+    emit(result)
+```
+
+This avoids touching the global emit pipeline. Use this same pattern if you add new spawn subcommands that need context-aware text formatting.
+
 ## Lateral Links
 
 → [../../lib/bootstrap/.context/CONTEXT.md](../../lib/bootstrap/.context/CONTEXT.md) — bootstrap functions invoked after classification

--- a/src/meridian/cli/main.py
+++ b/src/meridian/cli/main.py
@@ -183,6 +183,19 @@ def agent_mode_enabled() -> bool:
     return is_nested_meridian_process()
 
 
+def _spawn_background_requested(argv: Sequence[str]) -> bool:
+    if not argv or argv[0] != "spawn":
+        return False
+    for token in argv[1:]:
+        if token == "--":
+            break
+        if token in {"--background", "--bg"}:
+            return True
+        if token.startswith("--background="):
+            return True
+    return False
+
+
 def _resolve_output_format_for_command(
     *,
     argv: Sequence[str],
@@ -198,6 +211,14 @@ def _resolve_output_format_for_command(
     descriptor = classify_invocation(argv, COMMAND_CATALOG)
     if descriptor is not None and descriptor.default_output_mode in {"text", "json"}:
         agent_default_format = cast("Literal['text', 'json']", descriptor.default_output_mode)
+        if (
+            agent_mode
+            and explicit_format is None
+            and descriptor.command_path in {("spawn",), ("spawn", "create")}
+            and _spawn_background_requested(argv)
+        ):
+            # Keep background submission wire output stable for agent-mode callers.
+            agent_default_format = "json"
 
     return resolve_effective_format(
         explicit_format=explicit_format,

--- a/src/meridian/cli/spawn.py
+++ b/src/meridian/cli/spawn.py
@@ -22,6 +22,7 @@ from meridian.lib.bootstrap.services import (
 from meridian.lib.core.context import RuntimeContext
 from meridian.lib.core.domain import SpawnStatus
 from meridian.lib.core.spawn_lifecycle import ACTIVE_SPAWN_STATUSES
+from meridian.lib.core.util import FormatContext
 from meridian.lib.extensions.registry import get_first_party_registry
 from meridian.lib.ops.spawn.api import (
     SpawnActionOutput,
@@ -292,6 +293,16 @@ def _spawn_create(
         bool,
         Parameter(name="--verbose", help="Enable verbose spawn logging.", show=True),
     ] = False,
+    metadata: Annotated[
+        bool,
+        Parameter(
+            name="--metadata",
+            help=(
+                "Include detailed spawn metadata in text output "
+                "(report-first view remains primary)."
+            ),
+        ),
+    ] = False,
     quiet: Annotated[
         bool,
         Parameter(name="--quiet", help="Reduce non-essential command output.", show=True),
@@ -508,7 +519,17 @@ def _spawn_create(
             sink=_current_output_sink(),
             prepared=_prepare_spawn_runtime_write(),
         )
-    emit(result)
+    output_format = _get_global_options().output.format
+    if output_format != "json" and metadata:
+        detailed_output = _spawn_create_metadata_output(result)
+        if detailed_output is not None:
+            emit(detailed_output.format_text(FormatContext(verbosity=1)))
+        else:
+            emit(result.format_text(FormatContext(verbosity=1)))
+    elif output_format != "json" and verbose:
+        emit(result.format_text(FormatContext(verbosity=1)))
+    else:
+        emit(result)
     exit_code = _spawn_create_exit_code(result)
     if exit_code != 0:
         raise SystemExit(exit_code)
@@ -732,6 +753,16 @@ def _spawn_wait(
         bool,
         Parameter(name="--verbose", help="Enable verbose wait status output.", show=True),
     ] = False,
+    metadata: Annotated[
+        bool,
+        Parameter(
+            name="--metadata",
+            help=(
+                "Include detailed spawn metadata in text output "
+                "(report-first view remains primary)."
+            ),
+        ),
+    ] = False,
     quiet: Annotated[
         bool,
         Parameter(name="--quiet", help="Suppress wait progress output.", show=True),
@@ -740,9 +771,9 @@ def _spawn_wait(
         bool,
         Parameter(
             name="--report",
-            help="Include full report body in output (default: omitted).",
+            help="Include full report body in output (default: enabled). Use --no-report to omit.",
         ),
-    ] = False,
+    ] = True,
 ) -> None:
     result = spawn_wait_sync(
         SpawnWaitInput(
@@ -757,11 +788,31 @@ def _spawn_wait(
         sink=_current_output_sink(),
         prepared=_prepare_spawn_runtime_read(),
     )
-    emit(result)
+    output_format = _get_global_options().output.format
+    if output_format != "json" and (metadata or verbose):
+        emit(result.format_text(FormatContext(verbosity=1)))
+    else:
+        emit(result)
     if result.checkpoint:
         return
     if result.any_failed:
         raise SystemExit(1)
+
+
+def _spawn_create_metadata_output(result: SpawnActionOutput) -> Any | None:
+    if result.spawn_id is None or result.background or result.status == "dry-run":
+        return None
+    try:
+        return spawn_show_sync(
+            SpawnShowInput(
+                spawn_id=result.spawn_id,
+                include_report_body=True,
+            ),
+            sink=_current_output_sink(),
+            prepared=_prepare_spawn_runtime_read(),
+        )
+    except (KeyError, RuntimeError, ValueError, FileNotFoundError, OSError):
+        return None
 
 
 def _spawn_files(

--- a/src/meridian/cli/startup/catalog.py
+++ b/src/meridian/cli/startup/catalog.py
@@ -287,13 +287,13 @@ _COMMAND_DESCRIPTORS: tuple[CommandDescriptor, ...] = (
     _write_runtime(
         ("spawn",),
         "Create a spawn via spawn default route.",
-        default_output_mode="json",
+        default_output_mode="text",
         extension_ref="meridian.spawn.create",
     ),
     _write_runtime(
         ("spawn", "create"),
         "Create a spawn.",
-        default_output_mode="json",
+        default_output_mode="text",
         extension_ref="meridian.spawn.create",
     ),
     _write_runtime(
@@ -317,7 +317,7 @@ _COMMAND_DESCRIPTORS: tuple[CommandDescriptor, ...] = (
     _read_runtime(
         ("spawn", "wait"),
         "Wait for spawns.",
-        default_output_mode="json",
+        default_output_mode="text",
         extension_ref="meridian.spawn.wait",
     ),
     _write_runtime(

--- a/src/meridian/lib/ops/spawn/.context/CONTEXT.md
+++ b/src/meridian/lib/ops/spawn/.context/CONTEXT.md
@@ -116,6 +116,36 @@ adds the `wait_required` / `terminal: false` fields for background spawns.
 The distinction matters: agents that parse `to_wire()` without requesting it explicitly will
 receive `to_agent_wire()` instead.
 
+## SpawnActionOutput Text Format Contract
+
+`format_text()` branches on `FormatContext.verbosity` and spawn status:
+
+- **`verbosity == 0` + terminal status** (`succeeded`, `failed`, `cancelled`) + non-background:
+  uses `_format_terminal_text()`. Output: `{spawn_id} {status} ({duration}s)\n\n{report body or
+  "(no report)"}\n\nTranscript: meridian session log {spawn_id}`. Warning and error fields appear
+  before the report body.
+- **All other cases** (non-terminal, background, `--verbose`): uses the existing verbose format
+  (`_format_default_text()` / `_format_verbose_text()`).
+
+## SpawnDetailOutput format_text / format_wait_text
+
+`format_text()` now accepts `FormatContext`:
+- `verbosity == 0` → `_format_compact_text()`: `{spawn_id} {status} ({meta})\n\n{report body}`
+- `verbosity > 0` → `_format_verbose_text()`: full kv_block (unchanged).
+
+`SpawnWaitMultiOutput.format_text()` delegates to `format_wait_text()` for single-spawn waits,
+which uses verbosity-gated compact vs verbose.
+
+## Foreground Path Populates report
+
+`execute_spawn_blocking()` in `execute.py` reads `report.md` after spawn completion and
+passes `report=report_body` into `SpawnActionOutput`. Previously `report` was always `None` for
+foreground results. Text output uses that report for compact rendering; explicit JSON also exposes
+the primary result content structurally with report and transcript fields.
+
+Callers in default text mode now get the report inline without needing a separate `spawn show`
+call. Callers that need machine-readable output should request `--format json`.
+
 ## Lateral Links
 
 → [../../.context/CONTEXT.md](../../.context/CONTEXT.md) — ops/ layer overview, SpawnApplicationService, SEAM-1/2/3

--- a/src/meridian/lib/ops/spawn/execute.py
+++ b/src/meridian/lib/ops/spawn/execute.py
@@ -1,7 +1,6 @@
 """Spawn execution entry points: execute_spawn_blocking, execute_spawn_background."""
 
 import asyncio
-import json
 import os
 import subprocess
 import time
@@ -48,7 +47,7 @@ from .execute_init import (
 from .execute_runner import launch_prepared_spawn
 from .failure_policy import finalize_launch_failure_sync
 from .models import SpawnActionOutput, SpawnCreateInput
-from .query import read_spawn_row
+from .query import read_report, read_spawn_row
 
 logger = structlog.get_logger(__name__)
 _BACKGROUND_SUBMIT_MESSAGE = "Background spawn submitted."
@@ -402,8 +401,6 @@ def execute_spawn_blocking(
                 spawn_id=str(spawn.spawn_id),
                 exc_info=True,
             )
-        # Emit spawn ID immediately so the caller can reference it while blocking.
-        print(json.dumps({"spawn_id": str(spawn.spawn_id), "status": "running"}), flush=True)
         started = time.monotonic()
         stream_stdout_to_terminal = payload.stream
         event_observer = None
@@ -466,7 +463,12 @@ def execute_spawn_blocking(
 
     duration = time.monotonic() - started
     row = read_spawn_row(project_paths.project_root, str(spawn.spawn_id))
-    # Report is read on-demand via `spawn show`, not inlined here.
+    _, report_body = read_report(
+        project_paths.project_root,
+        str(spawn.spawn_id),
+        include_body=True,
+        runtime_root=context.runtime_root,
+    )
     status = "failed"
     if row is not None:
         status = row.status
@@ -505,9 +507,9 @@ def execute_spawn_blocking(
         reference_files=request.reference_files,
         template_vars=request.template_vars,
         context_from_resolved=context_from_resolved,
-        report=None,
+        report=report_body,
         exit_code=exit_code,
-        duration_secs=duration,
+        duration_secs=done_secs,
     )
 
 

--- a/src/meridian/lib/ops/spawn/models.py
+++ b/src/meridian/lib/ops/spawn/models.py
@@ -176,6 +176,11 @@ class SpawnActionOutput(BaseModel):
     def goal_contract_preview(self) -> str | None:
         return build_goal_contract_preview(self.goal)
 
+    def _transcript_command(self) -> str | None:
+        if self.command != "spawn.create" or self.spawn_id is None or self.background:
+            return None
+        return f"meridian session log {self.spawn_id}"
+
     def to_wire(self) -> dict[str, object]:
         """Project minimal external JSON shape. Omit nulls and input echo."""
         wire: dict[str, object] = {"status": self.status}
@@ -200,6 +205,9 @@ class SpawnActionOutput(BaseModel):
             wire["exit_code"] = self.exit_code
         if self.context_from_resolved:
             wire["context_from_resolved"] = list(self.context_from_resolved)
+        transcript_command = self._transcript_command()
+        if transcript_command is not None:
+            wire["transcript_command"] = transcript_command
         if self.status == "dry-run":
             if self.project_root is not None or self.runtime_root is not None:
                 wire["resolved_authority"] = {
@@ -281,7 +289,39 @@ class SpawnActionOutput(BaseModel):
         return self.to_wire()
 
     def format_text(self, ctx: FormatContext | None = None) -> str:
-        _ = ctx
+        effective_ctx = ctx or FormatContext()
+        if (
+            self.command == "spawn.create"
+            and self.status in {"succeeded", "failed", "cancelled"}
+            and not self.background
+            and effective_ctx.verbosity == 0
+        ):
+            return self._format_terminal_text()
+        return self._format_default_text()
+
+    def _format_terminal_text(self) -> str:
+        if self.spawn_id is None:
+            return self._format_default_text()
+        duration_suffix = ""
+        if self.duration_secs is not None:
+            duration_suffix = f" ({self.duration_secs:.1f}s)"
+        lines = [f"{self.spawn_id} {self.status}{duration_suffix}"]
+        if self.warning:
+            lines.append(f"Warning: {self.warning}")
+        if self.error:
+            lines.append(f"Error: {self.error}")
+        report_text = (self.report or "").strip()
+        if report_text:
+            lines.append("")
+            lines.append(report_text)
+        elif self.status == "succeeded":
+            lines.append("")
+            lines.append("(no report)")
+        lines.append("")
+        lines.append(f"Transcript: meridian session log {self.spawn_id}")
+        return "\n".join(lines)
+
+    def _format_default_text(self) -> str:
         lines: list[str] = []
         if self.message:
             lines.append(self.message)
@@ -329,6 +369,13 @@ class SpawnActionOutput(BaseModel):
             lines.append(shlex.join(self.cli_command))
         if self.exit_code is not None:
             lines.append(f"Exit code: {self.exit_code}")
+        transcript_command = self._transcript_command()
+        if transcript_command is not None:
+            report_text = (self.report or "").strip()
+            if report_text:
+                lines.append("")
+                lines.append(report_text)
+            lines.append(f"Transcript: {transcript_command}")
         return "\n".join(lines)
 
 
@@ -670,6 +717,9 @@ class SpawnDetailOutput(BaseModel):
             return None
         return f"Report for {self.spawn_id}\n{report_text}"
 
+    def transcript_command(self) -> str:
+        return f"meridian session log {self.spawn_id}"
+
     def to_cli_wire(self) -> dict[str, object]:
         """Project slim JSON shape for wire serialization. Omits internal fields."""
         wire: dict[str, object] = {
@@ -745,6 +795,47 @@ class SpawnDetailOutput(BaseModel):
         return self.to_cli_wire()
 
     def format_text(self, ctx: FormatContext | None = None) -> str:
+        effective_ctx = ctx or FormatContext()
+        return self._format_verbose_text(always_show_transcript=effective_ctx.verbosity > 0)
+
+    def format_wait_text(self, ctx: FormatContext | None = None) -> str:
+        effective_ctx = ctx or FormatContext()
+        if effective_ctx.verbosity > 0:
+            return self._format_verbose_text(always_show_transcript=True)
+        return self._format_compact_text()
+
+    def _format_compact_text(self) -> str:
+        status_str = self.status
+        if self.exit_code is not None and self.status == "failed":
+            status_str += f" (exit {self.exit_code})"
+
+        meta_parts: list[str] = []
+        if self.duration_secs is not None:
+            meta_parts.append(f"{self.duration_secs:.1f}s")
+        meta_suffix = f" ({', '.join(meta_parts)})" if meta_parts else ""
+
+        lines = [f"{self.spawn_id} {status_str}{meta_suffix}"]
+        if self.failure_reason:
+            failure_value = self.failure_reason
+            if failure_value == "orphan_finalization":
+                failure_value = (
+                    "orphan_finalization (harness likely completed; "
+                    "report.md may still contain useful content)"
+                )
+            lines.append(f"Failure: {failure_value}")
+
+        report_text = self._normalized_report_body()
+        if report_text is not None:
+            lines.append("")
+            lines.append(report_text)
+            lines.append("")
+        else:
+            lines.append("")
+        lines.append(f"Transcript: {self.transcript_command()}")
+
+        return "\n".join(lines)
+
+    def _format_verbose_text(self, *, always_show_transcript: bool = False) -> str:
         """Key-value detail view for text output mode. Omits None/empty fields."""
         from meridian.lib.core.formatting import kv_block
 
@@ -833,8 +924,9 @@ class SpawnDetailOutput(BaseModel):
             ),
             (
                 "Transcript",
-                f"meridian session log {self.spawn_id}"
-                if self.harness_session_id and self.harness_session_id.strip()
+                self.transcript_command()
+                if always_show_transcript
+                or (self.harness_session_id is not None and self.harness_session_id.strip())
                 else None,
             ),
         ]
@@ -939,12 +1031,13 @@ class SpawnWaitMultiOutput(BaseModel):
 
     def format_text(self, ctx: FormatContext | None = None) -> str:
         """Render waited spawns, expanding report content when available."""
+        effective_ctx = ctx or FormatContext()
         if self.checkpoint:
             return self._format_checkpoint_text()
         if not self.spawns:
             return ""
         if len(self.spawns) == 1:
-            return self.spawns[0].format_text(ctx)
+            return self.spawns[0].format_wait_text(effective_ctx)
 
         from meridian.lib.core.formatting import tabular
 
@@ -1019,8 +1112,18 @@ class SpawnWaitMultiOutput(BaseModel):
             wire["status"] = self.status
         if self.exit_code is not None:
             wire["exit_code"] = self.exit_code
-        # Sparse spawn details
-        wire["spawns"] = [spawn.to_cli_wire() for spawn in self.spawns]
+        if len(self.spawns) == 1:
+            single = self.spawns[0]
+            wire["transcript_command"] = single.transcript_command()
+            if single.report_body is not None:
+                wire["report_body"] = single.report_body
+        # Sparse spawn details.
+        spawn_wires: list[dict[str, object]] = []
+        for spawn in self.spawns:
+            spawn_wire = spawn.to_cli_wire()
+            spawn_wire["transcript_command"] = spawn.transcript_command()
+            spawn_wires.append(spawn_wire)
+        wire["spawns"] = spawn_wires
         return wire
 
     def to_cli_output(

--- a/tests/integration/cli/test_cli_spawn.py
+++ b/tests/integration/cli/test_cli_spawn.py
@@ -8,9 +8,12 @@ import pytest
 from meridian.lib.ops.spawn.models import (
     SpawnActionOutput,
     SpawnCreateInput,
+    SpawnDetailOutput,
     SpawnForkInput,
     SpawnListEntry,
     SpawnListOutput,
+    SpawnWaitInput,
+    SpawnWaitMultiOutput,
 )
 
 cli_main = importlib.import_module("meridian.cli.main")
@@ -24,6 +27,31 @@ class _FakeStdin(io.StringIO):
 
     def isatty(self) -> bool:
         return self._is_tty
+
+
+def _wait_detail(
+    *,
+    spawn_id: str = "p123",
+    report_body: str | None = "done report",
+) -> SpawnDetailOutput:
+    return SpawnDetailOutput(
+        spawn_id=spawn_id,
+        status="succeeded",
+        model="gpt-5.4",
+        harness="codex",
+        started_at="2026-05-15T00:00:00Z",
+        finished_at="2026-05-15T00:00:04Z",
+        duration_secs=4.1,
+        exit_code=0,
+        failure_reason=None,
+        input_tokens=120,
+        output_tokens=80,
+        cost_usd=0.0127,
+        cost_is_estimate=True,
+        report_path="/tmp/report.md",
+        report_summary=report_body,
+        report_body=report_body,
+    )
 
 
 def test_spawn_prompt_file_dash_reads_stdin_through_main(
@@ -300,6 +328,127 @@ def test_spawn_background_explicit_json_preserves_rich_wire_and_events(
     assert '"t":"meridian.spawn.start"' in captured.err
 
 
+def test_spawn_background_human_text_submission_stays_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MERIDIAN_DEPTH", "1")
+    monkeypatch.setattr(spawn_cli.sys, "stdin", _FakeStdin("", is_tty=True))
+
+    def _fake_spawn_create_sync(
+        payload: SpawnCreateInput,
+        *,
+        sink: Any | None = None,
+        prepared: Any | None = None,
+    ) -> SpawnActionOutput:
+        _ = (sink, prepared)
+        assert payload.background is True
+        return SpawnActionOutput(
+            command="spawn.create",
+            status="running",
+            spawn_id="p789",
+            message="Background spawn submitted.",
+            background=True,
+            model="gpt-5.4",
+            harness_id="codex",
+        )
+
+    monkeypatch.setattr(spawn_cli, "spawn_create_sync", _fake_spawn_create_sync)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["--human", "spawn", "-p", "build", "--bg"])
+
+    assert exc_info.value.code == 0
+    rendered = capsys.readouterr().out
+    assert rendered.startswith("Background spawn submitted.\nSpawn id: p789")
+    assert "After spawning all subagents, you MUST run:" in rendered
+    assert "Or wait for this spawn only: meridian spawn wait p789" in rendered
+    assert "Transcript: meridian session log p789" not in rendered
+
+
+def test_spawn_background_metadata_text_submission_stays_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MERIDIAN_DEPTH", "1")
+    monkeypatch.setattr(spawn_cli.sys, "stdin", _FakeStdin("", is_tty=True))
+    captured: dict[str, object] = {}
+
+    def _fake_spawn_create_sync(
+        payload: SpawnCreateInput,
+        *,
+        sink: Any | None = None,
+        prepared: Any | None = None,
+    ) -> SpawnActionOutput:
+        _ = (sink, prepared)
+        captured["verbose"] = payload.verbose
+        assert payload.background is True
+        return SpawnActionOutput(
+            command="spawn.create",
+            status="running",
+            spawn_id="p790",
+            message="Background spawn submitted.",
+            background=True,
+            model="gpt-5.4",
+            harness_id="codex",
+        )
+
+    monkeypatch.setattr(spawn_cli, "spawn_create_sync", _fake_spawn_create_sync)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["--human", "spawn", "-p", "build", "--bg", "--metadata"])
+
+    assert exc_info.value.code == 0
+    assert captured["verbose"] is False
+    rendered = capsys.readouterr().out
+    assert rendered.startswith("Background spawn submitted.\nSpawn id: p790")
+    assert "After spawning all subagents, you MUST run:" in rendered
+    assert "Or wait for this spawn only: meridian spawn wait p790" in rendered
+    assert "Transcript: meridian session log p790" not in rendered
+    assert "Report:" not in rendered
+    assert "Input tokens:" not in rendered
+
+
+def test_spawn_background_metadata_agent_mode_keeps_json_wire(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MERIDIAN_DEPTH", "1")
+    monkeypatch.setattr(spawn_cli.sys, "stdin", _FakeStdin("", is_tty=True))
+    captured: dict[str, object] = {}
+
+    def _fake_spawn_create_sync(
+        payload: SpawnCreateInput,
+        *,
+        sink: Any | None = None,
+        prepared: Any | None = None,
+    ) -> SpawnActionOutput:
+        _ = (sink, prepared)
+        captured["verbose"] = payload.verbose
+        assert payload.background is True
+        return SpawnActionOutput(
+            command="spawn.create",
+            status="running",
+            spawn_id="p791",
+            warning="heads up",
+            background=True,
+        )
+
+    monkeypatch.setattr(spawn_cli, "spawn_create_sync", _fake_spawn_create_sync)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["spawn", "-p", "build", "--bg", "--metadata"])
+
+    assert exc_info.value.code == 0
+    assert captured["verbose"] is False
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "running"
+    assert payload["spawn_id"] == "p791"
+    assert payload["wait_required"] is True
+    assert payload["wait_command"] == "meridian spawn wait"
+    assert "transcript_command" not in payload
+
+
 def test_spawn_children_agent_mode_uses_children_text_view(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -328,6 +477,908 @@ def test_spawn_children_agent_mode_uses_children_text_view(
     rendered = capsys.readouterr().out
     assert "reviewer" in rendered
     assert "review child" in rendered
+
+
+def test_spawn_wait_defaults_report_body_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MERIDIAN_DEPTH", "1")
+    captured: dict[str, object] = {}
+
+    def _fake_spawn_wait_sync(
+        payload: SpawnWaitInput,
+        *,
+        sink: Any | None = None,
+        prepared: Any | None = None,
+    ) -> SpawnWaitMultiOutput:
+        _ = (sink, prepared)
+        captured["include_report_body"] = payload.include_report_body
+        return SpawnWaitMultiOutput(
+            spawns=(),
+            total_runs=0,
+            succeeded_runs=0,
+            failed_runs=0,
+            cancelled_runs=0,
+            any_failed=False,
+        )
+
+    monkeypatch.setattr(spawn_cli, "spawn_wait_sync", _fake_spawn_wait_sync)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["spawn", "wait"])
+
+    assert exc_info.value.code == 0
+    assert captured["include_report_body"] is True
+
+
+def test_spawn_wait_no_report_disables_report_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MERIDIAN_DEPTH", "1")
+    captured: dict[str, object] = {}
+
+    def _fake_spawn_wait_sync(
+        payload: SpawnWaitInput,
+        *,
+        sink: Any | None = None,
+        prepared: Any | None = None,
+    ) -> SpawnWaitMultiOutput:
+        _ = (sink, prepared)
+        captured["include_report_body"] = payload.include_report_body
+        return SpawnWaitMultiOutput(
+            spawns=(),
+            total_runs=0,
+            succeeded_runs=0,
+            failed_runs=0,
+            cancelled_runs=0,
+            any_failed=False,
+        )
+
+    monkeypatch.setattr(spawn_cli, "spawn_wait_sync", _fake_spawn_wait_sync)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["spawn", "wait", "--no-report"])
+
+    assert exc_info.value.code == 0
+    assert captured["include_report_body"] is False
+
+
+def test_spawn_wait_single_agent_mode_default_text_is_compact_with_report(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MERIDIAN_DEPTH", "1")
+
+    def _fake_spawn_wait_sync(
+        payload: SpawnWaitInput,
+        *,
+        sink: Any | None = None,
+        prepared: Any | None = None,
+    ) -> SpawnWaitMultiOutput:
+        _ = (payload, sink, prepared)
+        detail = _wait_detail(report_body="final report body")
+        return SpawnWaitMultiOutput(
+            spawns=(detail,),
+            total_runs=1,
+            succeeded_runs=1,
+            failed_runs=0,
+            cancelled_runs=0,
+            any_failed=False,
+            spawn_id=detail.spawn_id,
+            status=detail.status,
+            exit_code=detail.exit_code,
+        )
+
+    monkeypatch.setattr(spawn_cli, "spawn_wait_sync", _fake_spawn_wait_sync)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["spawn", "wait", "p123"])
+
+    assert exc_info.value.code == 0
+    rendered = capsys.readouterr().out
+    assert rendered.startswith("p123 succeeded (4.1s)\n\nfinal report body\n")
+    assert "Transcript: meridian session log p123" in rendered
+    assert "Spawn: p123" not in rendered
+
+
+def test_spawn_wait_single_default_text_with_missing_report_still_shows_transcript(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MERIDIAN_DEPTH", "1")
+
+    def _fake_spawn_wait_sync(
+        payload: SpawnWaitInput,
+        *,
+        sink: Any | None = None,
+        prepared: Any | None = None,
+    ) -> SpawnWaitMultiOutput:
+        _ = (payload, sink, prepared)
+        detail = _wait_detail(report_body=None)
+        return SpawnWaitMultiOutput(
+            spawns=(detail,),
+            total_runs=1,
+            succeeded_runs=1,
+            failed_runs=0,
+            cancelled_runs=0,
+            any_failed=False,
+            spawn_id=detail.spawn_id,
+            status=detail.status,
+            exit_code=detail.exit_code,
+        )
+
+    monkeypatch.setattr(spawn_cli, "spawn_wait_sync", _fake_spawn_wait_sync)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["--human", "spawn", "wait", "p123", "--no-report"])
+
+    assert exc_info.value.code == 0
+    rendered = capsys.readouterr().out
+    assert rendered.startswith("p123 succeeded (4.1s)\n\n")
+    assert "final report body" not in rendered
+    assert "Transcript: meridian session log p123" in rendered
+
+
+def test_spawn_wait_single_verbose_text_shows_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MERIDIAN_DEPTH", "1")
+
+    def _fake_spawn_wait_sync(
+        payload: SpawnWaitInput,
+        *,
+        sink: Any | None = None,
+        prepared: Any | None = None,
+    ) -> SpawnWaitMultiOutput:
+        _ = (payload, sink, prepared)
+        detail = _wait_detail(report_body="verbose report body")
+        return SpawnWaitMultiOutput(
+            spawns=(detail,),
+            total_runs=1,
+            succeeded_runs=1,
+            failed_runs=0,
+            cancelled_runs=0,
+            any_failed=False,
+            spawn_id=detail.spawn_id,
+            status=detail.status,
+            exit_code=detail.exit_code,
+        )
+
+    monkeypatch.setattr(spawn_cli, "spawn_wait_sync", _fake_spawn_wait_sync)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["--human", "spawn", "wait", "p123", "--verbose"])
+
+    assert exc_info.value.code == 0
+    rendered = capsys.readouterr().out
+    assert "Spawn: p123" in rendered
+    assert "Model: gpt-5.4 (codex)" in rendered
+    assert "verbose report body" in rendered
+    assert "Transcript: meridian session log p123" in rendered
+
+
+def test_spawn_wait_single_metadata_text_shows_metadata_without_verbose(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MERIDIAN_DEPTH", "1")
+
+    def _fake_spawn_wait_sync(
+        payload: SpawnWaitInput,
+        *,
+        sink: Any | None = None,
+        prepared: Any | None = None,
+    ) -> SpawnWaitMultiOutput:
+        _ = (sink, prepared)
+        assert payload.verbose is False
+        detail = _wait_detail(report_body="metadata report body")
+        return SpawnWaitMultiOutput(
+            spawns=(detail,),
+            total_runs=1,
+            succeeded_runs=1,
+            failed_runs=0,
+            cancelled_runs=0,
+            any_failed=False,
+            spawn_id=detail.spawn_id,
+            status=detail.status,
+            exit_code=detail.exit_code,
+        )
+
+    monkeypatch.setattr(spawn_cli, "spawn_wait_sync", _fake_spawn_wait_sync)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["--human", "spawn", "wait", "p123", "--metadata"])
+
+    assert exc_info.value.code == 0
+    rendered = capsys.readouterr().out
+    assert "Spawn: p123" in rendered
+    assert "Model: gpt-5.4 (codex)" in rendered
+    assert "Status: succeeded (exit 0)" in rendered
+    assert "Duration: 4.1s" in rendered
+    assert "Input tokens: 120" in rendered
+    assert "Output tokens: 80" in rendered
+    assert "Cost: ~$0.0127" in rendered
+    assert "Report: /tmp/report.md" in rendered
+    assert "metadata report body" in rendered
+    assert "Transcript: meridian session log p123" in rendered
+
+
+def test_spawn_wait_single_metadata_no_report_keeps_metadata_and_transcript(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MERIDIAN_DEPTH", "1")
+    captured: dict[str, object] = {}
+
+    def _fake_spawn_wait_sync(
+        payload: SpawnWaitInput,
+        *,
+        sink: Any | None = None,
+        prepared: Any | None = None,
+    ) -> SpawnWaitMultiOutput:
+        _ = (sink, prepared)
+        captured["include_report_body"] = payload.include_report_body
+        captured["verbose"] = payload.verbose
+        detail = _wait_detail(report_body=None)
+        return SpawnWaitMultiOutput(
+            spawns=(detail,),
+            total_runs=1,
+            succeeded_runs=1,
+            failed_runs=0,
+            cancelled_runs=0,
+            any_failed=False,
+            spawn_id=detail.spawn_id,
+            status=detail.status,
+            exit_code=detail.exit_code,
+        )
+
+    monkeypatch.setattr(spawn_cli, "spawn_wait_sync", _fake_spawn_wait_sync)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["--human", "spawn", "wait", "p123", "--metadata", "--no-report"])
+
+    assert exc_info.value.code == 0
+    assert captured == {"include_report_body": False, "verbose": False}
+    rendered = capsys.readouterr().out
+    assert "Spawn: p123" in rendered
+    assert "Input tokens: 120" in rendered
+    assert "Output tokens: 80" in rendered
+    assert "Cost: ~$0.0127" in rendered
+    assert "metadata report body" not in rendered
+    assert "Transcript: meridian session log p123" in rendered
+
+
+def test_spawn_wait_multi_text_stays_table_plus_reports(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MERIDIAN_DEPTH", "1")
+
+    def _fake_spawn_wait_sync(
+        payload: SpawnWaitInput,
+        *,
+        sink: Any | None = None,
+        prepared: Any | None = None,
+    ) -> SpawnWaitMultiOutput:
+        _ = (payload, sink, prepared)
+        return SpawnWaitMultiOutput(
+            spawns=(
+                _wait_detail(spawn_id="p101", report_body="first report"),
+                _wait_detail(spawn_id="p102", report_body="second report"),
+            ),
+            total_runs=2,
+            succeeded_runs=2,
+            failed_runs=0,
+            cancelled_runs=0,
+            any_failed=False,
+        )
+
+    monkeypatch.setattr(spawn_cli, "spawn_wait_sync", _fake_spawn_wait_sync)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["--human", "spawn", "wait", "p101", "p102"])
+
+    assert exc_info.value.code == 0
+    rendered = capsys.readouterr().out
+    assert rendered.startswith("spawn_id")
+    assert "p101" in rendered
+    assert "p102" in rendered
+    assert "Report for p101\nfirst report" in rendered
+    assert "Report for p102\nsecond report" in rendered
+    assert "Transcript: meridian session log" not in rendered
+
+
+def test_spawn_foreground_agent_mode_default_text_is_compact_report(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MERIDIAN_DEPTH", "1")
+    monkeypatch.setattr(spawn_cli.sys, "stdin", _FakeStdin("", is_tty=True))
+
+    def _fake_spawn_create_sync(
+        payload: SpawnCreateInput,
+        *,
+        sink: Any | None = None,
+        prepared: Any | None = None,
+    ) -> SpawnActionOutput:
+        _ = (payload, sink, prepared)
+        return SpawnActionOutput(
+            command="spawn.create",
+            status="succeeded",
+            spawn_id="p999",
+            model="gpt-5.4",
+            harness_id="codex",
+            report="foreground report",
+            duration_secs=2.3,
+            exit_code=0,
+        )
+
+    monkeypatch.setattr(spawn_cli, "spawn_create_sync", _fake_spawn_create_sync)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["spawn", "-p", "ship it"])
+
+    assert exc_info.value.code == 0
+    rendered = capsys.readouterr().out
+    assert rendered.startswith("p999 succeeded (2.3s)\n\nforeground report\n")
+    assert "Transcript: meridian session log p999" in rendered
+    assert "Spawn id: p999" not in rendered
+
+
+def test_spawn_foreground_explicit_text_is_compact_report(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MERIDIAN_DEPTH", "1")
+    monkeypatch.setattr(spawn_cli.sys, "stdin", _FakeStdin("", is_tty=True))
+
+    def _fake_spawn_create_sync(
+        payload: SpawnCreateInput,
+        *,
+        sink: Any | None = None,
+        prepared: Any | None = None,
+    ) -> SpawnActionOutput:
+        _ = (payload, sink, prepared)
+        return SpawnActionOutput(
+            command="spawn.create",
+            status="succeeded",
+            spawn_id="p997",
+            report="explicit text report",
+            duration_secs=1.8,
+            exit_code=0,
+        )
+
+    monkeypatch.setattr(spawn_cli, "spawn_create_sync", _fake_spawn_create_sync)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["--format", "text", "spawn", "-p", "ship it"])
+
+    assert exc_info.value.code == 0
+    rendered = capsys.readouterr().out
+    assert rendered == (
+        "p997 succeeded (1.8s)\n\n"
+        "explicit text report\n\n"
+        "Transcript: meridian session log p997\n"
+    )
+
+
+def test_spawn_foreground_default_text_no_report_still_shows_transcript(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MERIDIAN_DEPTH", "1")
+    monkeypatch.setattr(spawn_cli.sys, "stdin", _FakeStdin("", is_tty=True))
+
+    def _fake_spawn_create_sync(
+        payload: SpawnCreateInput,
+        *,
+        sink: Any | None = None,
+        prepared: Any | None = None,
+    ) -> SpawnActionOutput:
+        _ = (payload, sink, prepared)
+        return SpawnActionOutput(
+            command="spawn.create",
+            status="succeeded",
+            spawn_id="p999",
+            model="gpt-5.4",
+            harness_id="codex",
+            report=None,
+            duration_secs=2.3,
+            exit_code=0,
+        )
+
+    monkeypatch.setattr(spawn_cli, "spawn_create_sync", _fake_spawn_create_sync)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["--human", "spawn", "-p", "ship it"])
+
+    assert exc_info.value.code == 0
+    rendered = capsys.readouterr().out
+    assert "(no report)" in rendered
+    assert "Transcript: meridian session log p999" in rendered
+
+
+def test_spawn_foreground_metadata_text_shows_metadata_without_verbose(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MERIDIAN_DEPTH", "1")
+    monkeypatch.setattr(spawn_cli.sys, "stdin", _FakeStdin("", is_tty=True))
+    captured: dict[str, object] = {}
+
+    def _fake_spawn_create_sync(
+        payload: SpawnCreateInput,
+        *,
+        sink: Any | None = None,
+        prepared: Any | None = None,
+    ) -> SpawnActionOutput:
+        _ = (sink, prepared)
+        captured["verbose"] = payload.verbose
+        return SpawnActionOutput(
+            command="spawn.create",
+            status="succeeded",
+            spawn_id="p999",
+            model="gpt-5.4",
+            harness_id="codex",
+            report="foreground report",
+            duration_secs=2.3,
+            exit_code=0,
+        )
+
+    def _fake_spawn_show_sync(
+        payload: Any,
+        *,
+        sink: Any | None = None,
+        prepared: Any | None = None,
+    ) -> SpawnDetailOutput:
+        _ = (sink, prepared)
+        captured["spawn_id"] = payload.spawn_id
+        captured["include_report_body"] = payload.include_report_body
+        return _wait_detail(spawn_id="p999", report_body="metadata foreground report")
+
+    monkeypatch.setattr(spawn_cli, "spawn_create_sync", _fake_spawn_create_sync)
+    monkeypatch.setattr(spawn_cli, "spawn_show_sync", _fake_spawn_show_sync)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["--human", "spawn", "-p", "ship it", "--metadata"])
+
+    assert exc_info.value.code == 0
+    assert captured == {"verbose": False, "spawn_id": "p999", "include_report_body": True}
+    rendered = capsys.readouterr().out
+    assert "Spawn: p999" in rendered
+    assert "Model: gpt-5.4 (codex)" in rendered
+    assert "Status: succeeded (exit 0)" in rendered
+    assert "Duration: 4.1s" in rendered
+    assert "Input tokens: 120" in rendered
+    assert "Output tokens: 80" in rendered
+    assert "Cost: ~$0.0127" in rendered
+    assert "Report: /tmp/report.md" in rendered
+    assert "metadata foreground report" in rendered
+    assert "Transcript: meridian session log p999" in rendered
+
+
+def test_spawn_foreground_metadata_falls_back_without_spawn_show(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MERIDIAN_DEPTH", "1")
+    monkeypatch.setattr(spawn_cli.sys, "stdin", _FakeStdin("", is_tty=True))
+
+    def _fake_spawn_create_sync(
+        payload: SpawnCreateInput,
+        *,
+        sink: Any | None = None,
+        prepared: Any | None = None,
+    ) -> SpawnActionOutput:
+        _ = (payload, sink, prepared)
+        return SpawnActionOutput(
+            command="spawn.create",
+            status="succeeded",
+            spawn_id="p996",
+            model="gpt-5.4",
+            harness_id="codex",
+            report="fallback report",
+            duration_secs=2.3,
+            exit_code=0,
+        )
+
+    def _fail_spawn_show_sync(*_args: Any, **_kwargs: Any) -> SpawnDetailOutput:
+        raise KeyError("missing spawn")
+
+    monkeypatch.setattr(spawn_cli, "spawn_create_sync", _fake_spawn_create_sync)
+    monkeypatch.setattr(spawn_cli, "spawn_show_sync", _fail_spawn_show_sync)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["--human", "spawn", "-p", "ship it", "--metadata"])
+
+    assert exc_info.value.code == 0
+    rendered = capsys.readouterr().out
+    assert "Spawn id: p996" in rendered
+    assert "Model: gpt-5.4 (codex)" in rendered
+    assert "Exit code: 0" in rendered
+    assert "fallback report" in rendered
+    assert "Transcript: meridian session log p996" in rendered
+
+
+def test_spawn_foreground_verbose_text_shows_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MERIDIAN_DEPTH", "1")
+    monkeypatch.setattr(spawn_cli.sys, "stdin", _FakeStdin("", is_tty=True))
+
+    def _fake_spawn_create_sync(
+        payload: SpawnCreateInput,
+        *,
+        sink: Any | None = None,
+        prepared: Any | None = None,
+    ) -> SpawnActionOutput:
+        _ = (payload, sink, prepared)
+        return SpawnActionOutput(
+            command="spawn.create",
+            status="succeeded",
+            spawn_id="p999",
+            model="gpt-5.4",
+            harness_id="codex",
+            report="foreground report",
+            duration_secs=2.3,
+            exit_code=0,
+        )
+
+    monkeypatch.setattr(spawn_cli, "spawn_create_sync", _fake_spawn_create_sync)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["--human", "spawn", "-p", "ship it", "--verbose"])
+
+    assert exc_info.value.code == 0
+    rendered = capsys.readouterr().out
+    assert "Spawn id: p999" in rendered
+    assert "Model: gpt-5.4 (codex)" in rendered
+    assert "Exit code: 0" in rendered
+    assert "foreground report" in rendered
+    assert "Transcript: meridian session log p999" in rendered
+
+
+def test_spawn_explicit_json_includes_report_and_transcript_command(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MERIDIAN_DEPTH", "1")
+    monkeypatch.setattr(spawn_cli.sys, "stdin", _FakeStdin("", is_tty=True))
+
+    def _fake_spawn_create_sync(
+        payload: SpawnCreateInput,
+        *,
+        sink: Any | None = None,
+        prepared: Any | None = None,
+    ) -> SpawnActionOutput:
+        _ = (payload, sink, prepared)
+        return SpawnActionOutput(
+            command="spawn.create",
+            status="succeeded",
+            spawn_id="p999",
+            model="gpt-5.4",
+            harness_id="codex",
+            report="foreground report",
+            duration_secs=2.3,
+            exit_code=0,
+        )
+
+    monkeypatch.setattr(spawn_cli, "spawn_create_sync", _fake_spawn_create_sync)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["--format", "json", "spawn", "-p", "ship it"])
+
+    assert exc_info.value.code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "succeeded"
+    assert payload["spawn_id"] == "p999"
+    assert payload["report"] == "foreground report"
+    assert payload["transcript_command"] == "meridian session log p999"
+
+
+def test_spawn_explicit_json_metadata_stays_json(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MERIDIAN_DEPTH", "1")
+    monkeypatch.setattr(spawn_cli.sys, "stdin", _FakeStdin("", is_tty=True))
+    captured: dict[str, object] = {}
+
+    def _fake_spawn_create_sync(
+        payload: SpawnCreateInput,
+        *,
+        sink: Any | None = None,
+        prepared: Any | None = None,
+    ) -> SpawnActionOutput:
+        _ = (sink, prepared)
+        captured["verbose"] = payload.verbose
+        return SpawnActionOutput(
+            command="spawn.create",
+            status="succeeded",
+            spawn_id="p995",
+            report="foreground report",
+            duration_secs=2.3,
+            exit_code=0,
+        )
+
+    monkeypatch.setattr(spawn_cli, "spawn_create_sync", _fake_spawn_create_sync)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["--format", "json", "spawn", "-p", "ship it", "--metadata"])
+
+    assert exc_info.value.code == 0
+    assert captured["verbose"] is False
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "succeeded"
+    assert payload["spawn_id"] == "p995"
+    assert payload["report"] == "foreground report"
+    assert payload["transcript_command"] == "meridian session log p995"
+
+
+def test_spawn_wait_explicit_json_includes_report_and_transcript_command(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MERIDIAN_DEPTH", "1")
+
+    def _fake_spawn_wait_sync(
+        payload: SpawnWaitInput,
+        *,
+        sink: Any | None = None,
+        prepared: Any | None = None,
+    ) -> SpawnWaitMultiOutput:
+        _ = (payload, sink, prepared)
+        detail = _wait_detail(report_body="final report body")
+        return SpawnWaitMultiOutput(
+            spawns=(detail,),
+            total_runs=1,
+            succeeded_runs=1,
+            failed_runs=0,
+            cancelled_runs=0,
+            any_failed=False,
+            spawn_id=detail.spawn_id,
+            status=detail.status,
+            exit_code=detail.exit_code,
+        )
+
+    monkeypatch.setattr(spawn_cli, "spawn_wait_sync", _fake_spawn_wait_sync)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["--format", "json", "spawn", "wait", "p123"])
+
+    assert exc_info.value.code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["spawn_id"] == "p123"
+    assert payload["status"] == "succeeded"
+    assert payload["report_body"] == "final report body"
+    assert payload["transcript_command"] == "meridian session log p123"
+    assert payload["spawns"][0]["report_body"] == "final report body"
+    assert payload["spawns"][0]["transcript_command"] == "meridian session log p123"
+
+
+def test_spawn_wait_explicit_text_is_compact_report(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MERIDIAN_DEPTH", "1")
+
+    def _fake_spawn_wait_sync(
+        payload: SpawnWaitInput,
+        *,
+        sink: Any | None = None,
+        prepared: Any | None = None,
+    ) -> SpawnWaitMultiOutput:
+        _ = (payload, sink, prepared)
+        detail = _wait_detail(report_body="explicit wait text")
+        return SpawnWaitMultiOutput(
+            spawns=(detail,),
+            total_runs=1,
+            succeeded_runs=1,
+            failed_runs=0,
+            cancelled_runs=0,
+            any_failed=False,
+            spawn_id=detail.spawn_id,
+            status=detail.status,
+            exit_code=detail.exit_code,
+        )
+
+    monkeypatch.setattr(spawn_cli, "spawn_wait_sync", _fake_spawn_wait_sync)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["--format", "text", "spawn", "wait", "p123"])
+
+    assert exc_info.value.code == 0
+    rendered = capsys.readouterr().out
+    assert rendered == (
+        "p123 succeeded (4.1s)\n\n"
+        "explicit wait text\n\n"
+        "Transcript: meridian session log p123\n"
+    )
+
+
+def test_spawn_wait_explicit_json_no_report_keeps_transcript_without_body(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MERIDIAN_DEPTH", "1")
+    captured: dict[str, object] = {}
+
+    def _fake_spawn_wait_sync(
+        payload: SpawnWaitInput,
+        *,
+        sink: Any | None = None,
+        prepared: Any | None = None,
+    ) -> SpawnWaitMultiOutput:
+        _ = (sink, prepared)
+        captured["include_report_body"] = payload.include_report_body
+        detail = _wait_detail(report_body=None)
+        return SpawnWaitMultiOutput(
+            spawns=(detail,),
+            total_runs=1,
+            succeeded_runs=1,
+            failed_runs=0,
+            cancelled_runs=0,
+            any_failed=False,
+            spawn_id=detail.spawn_id,
+            status=detail.status,
+            exit_code=detail.exit_code,
+        )
+
+    monkeypatch.setattr(spawn_cli, "spawn_wait_sync", _fake_spawn_wait_sync)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["--format", "json", "spawn", "wait", "p123", "--no-report"])
+
+    assert exc_info.value.code == 0
+    assert captured["include_report_body"] is False
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["spawn_id"] == "p123"
+    assert payload["transcript_command"] == "meridian session log p123"
+    assert "report_body" not in payload
+    assert "report_body" not in payload["spawns"][0]
+
+
+def test_spawn_wait_explicit_json_metadata_stays_json(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MERIDIAN_DEPTH", "1")
+    captured: dict[str, object] = {}
+
+    def _fake_spawn_wait_sync(
+        payload: SpawnWaitInput,
+        *,
+        sink: Any | None = None,
+        prepared: Any | None = None,
+    ) -> SpawnWaitMultiOutput:
+        _ = (sink, prepared)
+        captured["verbose"] = payload.verbose
+        detail = _wait_detail(report_body="json metadata wait")
+        return SpawnWaitMultiOutput(
+            spawns=(detail,),
+            total_runs=1,
+            succeeded_runs=1,
+            failed_runs=0,
+            cancelled_runs=0,
+            any_failed=False,
+            spawn_id=detail.spawn_id,
+            status=detail.status,
+            exit_code=detail.exit_code,
+        )
+
+    monkeypatch.setattr(spawn_cli, "spawn_wait_sync", _fake_spawn_wait_sync)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["--format", "json", "spawn", "wait", "p123", "--metadata"])
+
+    assert exc_info.value.code == 0
+    assert captured["verbose"] is False
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["spawn_id"] == "p123"
+    assert payload["report_body"] == "json metadata wait"
+    assert payload["transcript_command"] == "meridian session log p123"
+
+
+def test_spawn_wait_explicit_json_multi_has_per_spawn_reports_without_single_top_level(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MERIDIAN_DEPTH", "1")
+
+    def _fake_spawn_wait_sync(
+        payload: SpawnWaitInput,
+        *,
+        sink: Any | None = None,
+        prepared: Any | None = None,
+    ) -> SpawnWaitMultiOutput:
+        _ = (payload, sink, prepared)
+        return SpawnWaitMultiOutput(
+            spawns=(
+                _wait_detail(spawn_id="p101", report_body="first report"),
+                _wait_detail(spawn_id="p102", report_body="second report"),
+            ),
+            total_runs=2,
+            succeeded_runs=2,
+            failed_runs=0,
+            cancelled_runs=0,
+            any_failed=False,
+        )
+
+    monkeypatch.setattr(spawn_cli, "spawn_wait_sync", _fake_spawn_wait_sync)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["--format", "json", "spawn", "wait", "p101", "p102"])
+
+    assert exc_info.value.code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["total_runs"] == 2
+    assert "report_body" not in payload
+    assert "transcript_command" not in payload
+    assert payload["spawns"][0]["report_body"] == "first report"
+    assert payload["spawns"][0]["transcript_command"] == "meridian session log p101"
+    assert payload["spawns"][1]["report_body"] == "second report"
+    assert payload["spawns"][1]["transcript_command"] == "meridian session log p102"
+
+
+def test_spawn_show_human_text_remains_detail_view(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MERIDIAN_DEPTH", "1")
+
+    def _fake_spawn_show_sync(
+        payload: Any,
+        *,
+        sink: Any | None = None,
+        prepared: Any | None = None,
+    ) -> SpawnDetailOutput:
+        _ = (payload, sink, prepared)
+        return _wait_detail(spawn_id="p123", report_body="show report body")
+
+    monkeypatch.setattr(spawn_cli, "spawn_show_sync", _fake_spawn_show_sync)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["--human", "spawn", "show", "p123"])
+
+    assert exc_info.value.code == 0
+    rendered = capsys.readouterr().out
+    assert rendered.startswith("Spawn: p123")
+    assert "Model: gpt-5.4 (codex)" in rendered
+    assert "Report: /tmp/report.md" in rendered
+    assert "show report body" in rendered
+    assert not rendered.startswith("p123 succeeded")
+
+
+def test_spawn_show_explicit_json_remains_detail_view(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MERIDIAN_DEPTH", "1")
+
+    def _fake_spawn_show_sync(
+        payload: Any,
+        *,
+        sink: Any | None = None,
+        prepared: Any | None = None,
+    ) -> SpawnDetailOutput:
+        _ = (payload, sink, prepared)
+        return _wait_detail(spawn_id="p123", report_body="show report body")
+
+    monkeypatch.setattr(spawn_cli, "spawn_show_sync", _fake_spawn_show_sync)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["--format", "json", "spawn", "show", "p123"])
+
+    assert exc_info.value.code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["spawn_id"] == "p123"
+    assert payload["model"] == "gpt-5.4"
+    assert payload["harness"] == "codex"
+    assert payload["report_path"] == "/tmp/report.md"
+    assert payload["report_body"] == "show report body"
+    assert "transcript_command" not in payload
 
 
 def test_spawn_bare_fork_uses_meridian_spawn_id_from_environment(

--- a/tests/integration/ops/test_spawn_execute_report_output.py
+++ b/tests/integration/ops/test_spawn_execute_report_output.py
@@ -1,0 +1,80 @@
+"""Foreground spawn execution output/report boundary tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+import meridian.lib.ops.spawn.execute as execute_module
+from meridian.lib.config.settings import load_config
+from meridian.lib.launch.request import SpawnRequest
+from meridian.lib.ops.runtime import (
+    build_runtime_from_root_and_config,
+    resolve_runtime_authority_for_write,
+)
+from meridian.lib.ops.spawn.models import SpawnCreateInput
+from meridian.lib.state import spawn_store
+
+if TYPE_CHECKING:
+    import pytest
+
+# qa-validated: spawn-return-report
+
+
+def test_execute_spawn_blocking_reads_report_and_does_not_print_running_preamble(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    monkeypatch.setenv("MERIDIAN_HOME", (tmp_path / "home").as_posix())
+    authority = resolve_runtime_authority_for_write(project_root)
+    assert authority.runtime_root is not None
+    config = load_config(project_root, authority=authority)
+    runtime = build_runtime_from_root_and_config(
+        project_root,
+        config,
+        authority=authority,
+    )
+
+    async def _fake_launch_prepared_spawn(**kwargs: object) -> int:
+        spawn = cast("Any", kwargs["spawn"])
+        runtime_root = Path(cast("Path", kwargs["runtime_root"]))
+        spawn_id = str(spawn.spawn_id)
+        report_path = runtime_root / "spawns" / spawn_id / "report.md"
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text("fake report body\n", encoding="utf-8")
+        spawn_store.finalize_spawn(
+            runtime_root,
+            spawn_id,
+            "succeeded",
+            0,
+            origin="runner",
+            duration_secs=1.25,
+        )
+        return 0
+
+    monkeypatch.setattr(execute_module, "launch_prepared_spawn", _fake_launch_prepared_spawn)
+
+    result = execute_module.execute_spawn_blocking(
+        payload=SpawnCreateInput(prompt="run"),
+        request=SpawnRequest(
+            prompt="run",
+            model="gpt-5.4",
+            harness="codex",
+            agent="coder",
+        ),
+        runtime=runtime,
+    )
+
+    captured = capsys.readouterr()
+    assert '{"spawn_id":' not in captured.out
+    assert '"status": "running"' not in captured.out
+    assert result.status == "succeeded"
+    assert result.exit_code == 0
+    assert result.report == "fake report body"
+    assert result.duration_secs == 1.25
+    assert result.format_text().endswith(
+        "fake report body\n\nTranscript: meridian session log " + str(result.spawn_id)
+    )

--- a/tests/smoke/spawn-return-report.md
+++ b/tests/smoke/spawn-return-report.md
@@ -1,0 +1,74 @@
+# Spawn Return Report
+
+Manual smoke checklist for foreground spawn and single-spawn wait output.
+
+## Validation: spawn-return-report
+
+Use an isolated scratch project and a cheap model/agent. Replace `pNNN` with the
+spawn id printed by each command.
+
+```bash
+export MERIDIAN_HOME="$(mktemp -d)"
+scratch="$(mktemp -d)"
+cd "$scratch"
+meridian init
+```
+
+1. Foreground default:
+   ```bash
+   meridian spawn -a meridian-subagent -m gpt-5.4-mini -p 'Reply with exactly OK'
+   ```
+   Expect compact text: one status line, report body, then
+   `Transcript: meridian session log <spawn_id>`. No token/cost/path block.
+
+2. Foreground metadata:
+   ```bash
+   meridian spawn -a meridian-subagent -m gpt-5.4-mini -p 'Reply with exactly OK' --metadata
+   ```
+   Expect report body plus inline accounting fields such as model, duration,
+   tokens/cost when available, report path, and transcript command.
+
+3. Foreground JSON:
+   ```bash
+   meridian --format json spawn -a meridian-subagent -m gpt-5.4-mini -p 'Reply with exactly OK'
+   ```
+   Expect valid JSON on stdout with `report` and `transcript_command`. No
+   running-status preamble before the JSON object.
+
+4. Agent-mode foreground default:
+   ```bash
+   MERIDIAN_DEPTH=1 meridian spawn -a meridian-subagent -m gpt-5.4-mini -p 'Reply with exactly OK'
+   ```
+   Expect compact text, not JSON.
+
+5. Agent-mode background preservation:
+   ```bash
+   MERIDIAN_DEPTH=1 meridian spawn -a meridian-subagent -m gpt-5.4-mini -p 'Reply with exactly OK' --bg
+   ```
+   Expect JSON wait-note wire output with `wait_required: true`; no compact
+   report view and no transcript pointer in the submission response.
+
+6. Wait default:
+   ```bash
+   meridian spawn wait pNNN
+   ```
+   Expect compact text with report body and transcript command.
+
+7. Wait no-report:
+   ```bash
+   meridian spawn wait pNNN --no-report
+   ```
+   Expect status and transcript command; report body omitted.
+
+8. Wait JSON:
+   ```bash
+   meridian --format json spawn wait pNNN
+   ```
+   Expect JSON with `report_body` and `transcript_command`.
+
+9. Multi-wait text, if two completed ids are available:
+   ```bash
+   meridian spawn wait pNNN pMMM
+   ```
+   Expect table plus `Report for <id>` sections; not the single-spawn compact
+   status format.

--- a/tests/unit/ops/test_spawn_models.py
+++ b/tests/unit/ops/test_spawn_models.py
@@ -1,0 +1,188 @@
+"""Unit tests for spawn output model formatting and wire contracts."""
+
+from __future__ import annotations
+
+from meridian.lib.ops.spawn.models import (
+    SpawnActionOutput,
+    SpawnDetailOutput,
+    SpawnWaitMultiOutput,
+)
+
+# qa-validated: spawn-return-report
+
+
+def _make_spawn_detail(
+    *,
+    spawn_id: str = "p1",
+    status: str = "succeeded",
+    duration_secs: float | None = None,
+    exit_code: int | None = None,
+    failure_reason: str | None = None,
+    report_body: str | None = "done report",
+) -> SpawnDetailOutput:
+    return SpawnDetailOutput(
+        spawn_id=spawn_id,
+        status=status,
+        model="gpt-5.4",
+        harness="codex",
+        started_at="2026-05-15T00:00:00Z",
+        finished_at="2026-05-15T00:00:04Z",
+        duration_secs=duration_secs,
+        exit_code=exit_code,
+        failure_reason=failure_reason,
+        input_tokens=None,
+        output_tokens=None,
+        cost_usd=None,
+        report_path="/tmp/report.md",
+        report_summary=report_body,
+        report_body=report_body,
+    )
+
+
+def test_spawn_action_terminal_success_compact_text_exact() -> None:
+    output = SpawnActionOutput(
+        command="spawn.create",
+        status="succeeded",
+        spawn_id="p1",
+        report="body",
+        duration_secs=1.2,
+        exit_code=0,
+    )
+
+    text = output.format_text()
+    assert text == "p1 succeeded (1.2s)\n\nbody\n\nTranscript: meridian session log p1"
+    assert "Spawn id:" not in text
+    assert "Model:" not in text
+    assert "Exit code:" not in text
+
+
+def test_spawn_action_terminal_success_no_report_keeps_transcript() -> None:
+    output = SpawnActionOutput(command="spawn.create", status="succeeded", spawn_id="p2")
+
+    assert output.format_text() == (
+        "p2 succeeded\n\n(no report)\n\nTranscript: meridian session log p2"
+    )
+
+
+def test_spawn_action_terminal_failed_includes_error_report_and_transcript() -> None:
+    output = SpawnActionOutput(
+        command="spawn.create",
+        status="failed",
+        spawn_id="p3",
+        error="execution_crash",
+        report="partial",
+        exit_code=1,
+    )
+
+    text = output.format_text()
+    assert (
+        text
+        == "p3 failed\nError: execution_crash\n\npartial\n\nTranscript: meridian session log p3"
+    )
+    assert text.index("Error: execution_crash") < text.index("partial")
+
+
+def test_spawn_action_terminal_cancelled_without_report_keeps_transcript() -> None:
+    output = SpawnActionOutput(command="spawn.create", status="cancelled", spawn_id="p4")
+
+    text = output.format_text()
+    assert text == "p4 cancelled\n\nTranscript: meridian session log p4"
+    assert "(no report)" not in text
+
+
+def test_spawn_action_non_create_keeps_default_text() -> None:
+    output = SpawnActionOutput(command="spawn.cancel", status="succeeded", spawn_id="p123")
+
+    assert output.format_text() == "Spawn succeeded.\nSpawn id: p123"
+
+
+def test_spawn_detail_wait_failed_orphan_compact_text_exact() -> None:
+    detail = _make_spawn_detail(
+        status="failed",
+        duration_secs=2.5,
+        exit_code=1,
+        failure_reason="orphan_finalization",
+        report_body="partial",
+    )
+
+    assert detail.format_wait_text() == (
+        "p1 failed (exit 1) (2.5s)\n"
+        "Failure: orphan_finalization (harness likely completed; "
+        "report.md may still contain useful content)\n"
+        "\n"
+        "partial\n"
+        "\n"
+        "Transcript: meridian session log p1"
+    )
+
+
+def test_spawn_detail_wait_no_report_still_has_transcript() -> None:
+    detail = _make_spawn_detail(report_body=None)
+
+    text = detail.format_wait_text()
+    assert text == "p1 succeeded\n\nTranscript: meridian session log p1"
+    assert "(no report)" not in text
+
+
+def test_spawn_wait_multi_json_single_and_multi_projection() -> None:
+    single = SpawnWaitMultiOutput(
+        spawns=(_make_spawn_detail(spawn_id="p1", report_body="single report"),),
+        total_runs=1,
+        succeeded_runs=1,
+        failed_runs=0,
+        cancelled_runs=0,
+        any_failed=False,
+        spawn_id="p1",
+        status="succeeded",
+        exit_code=0,
+    )
+    single_wire = single.to_cli_wire()
+    assert single_wire["report_body"] == "single report"
+    assert single_wire["transcript_command"] == "meridian session log p1"
+    assert single_wire["spawns"][0]["report_body"] == "single report"
+    assert single_wire["spawns"][0]["transcript_command"] == "meridian session log p1"
+
+    multi = SpawnWaitMultiOutput(
+        spawns=(
+            _make_spawn_detail(spawn_id="p1", report_body="first report"),
+            _make_spawn_detail(spawn_id="p2", report_body="second report"),
+        ),
+        total_runs=2,
+        succeeded_runs=2,
+        failed_runs=0,
+        cancelled_runs=0,
+        any_failed=False,
+    )
+    multi_wire = multi.to_cli_wire()
+    assert "report_body" not in multi_wire
+    assert "transcript_command" not in multi_wire
+    assert multi_wire["spawns"][0]["transcript_command"] == "meridian session log p1"
+    assert multi_wire["spawns"][1]["transcript_command"] == "meridian session log p2"
+    assert multi_wire["spawns"][0]["report_body"] == "first report"
+    assert multi_wire["spawns"][1]["report_body"] == "second report"
+
+
+def test_spawn_action_wire_background_does_not_add_transcript_command() -> None:
+    output = SpawnActionOutput(
+        command="spawn.create",
+        status="running",
+        spawn_id="pbg",
+        background=True,
+    )
+
+    wire = output.to_wire()
+    assert wire["status"] == "running"
+    assert wire["spawn_id"] == "pbg"
+    assert wire["terminal"] is False
+    assert wire["wait_required"] is True
+    assert wire["wait_command"] == "meridian spawn wait"
+    assert wire["note"].startswith("Background spawn submitted.")
+    assert "transcript_command" not in wire
+
+    agent_wire = output.to_agent_wire()
+    assert agent_wire["status"] == "running"
+    assert agent_wire["spawn_id"] == "pbg"
+    assert agent_wire["terminal"] is False
+    assert agent_wire["wait_required"] is True
+    assert agent_wire["wait_command"] == "meridian spawn wait"
+    assert "transcript_command" not in agent_wire


### PR DESCRIPTION
## Summary

- Make foreground `meridian spawn` and single-spawn `meridian spawn wait` report-first by default: compact status, report body, and transcript command.
- Switch agent-mode defaults for foreground spawn/wait to compact text while preserving background spawn submission as JSON.
- Add structured JSON parity for explicit `--format json`, including report and transcript fields.
- Add `--metadata` for inline accounting/details while keeping `spawn show` as canonical full inspection.
- Document the output contract and add unit/integration/smoke coverage.

## Why

Spawn output previously led with metadata or omitted the actual agent response. That made agent handoffs and human review harder; users had to run `spawn show` or inspect transcript paths manually to see what the spawned agent actually said.

## Validation

Pre-push hook passed:

- `uv run ruff check .`
- `uv run pyright`
- `uv run pytest -x -q` — 1196 passed, 2 skipped
- `uv build --no-sources`

Additional QA lead validation also passed focused output-mode suites and `git diff --check`.
