### PR TITLE
Fix duplicate builtin hook autosync names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Fixed
+- Unnamed duplicate builtin hooks now synthesize stable identity names, so multiple `git-autosync` remotes no longer override each other.
 - Git subprocess seams strip inherited repo-scoped `GIT_*` environment before invoking git. Worktree operations and `git-autosync` no longer risk retargeting commands into the parent checkout when launched from a git hook or git-managed process.
 
 ## [0.1.10] - 2026-05-16

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -18,11 +18,11 @@ meridian hooks list
 # Validate config before committing changes
 meridian hooks check
 
-# Manually trigger git-autosync
-meridian hooks run git-autosync
+# Manually trigger a named autosync hook
+meridian hooks run sync-notes
 
 # Trigger with a specific event context
-meridian hooks run git-autosync --event work.done
+meridian hooks run sync-notes --event work.done
 ```
 
 `hooks run` bypasses interval throttling. Use it to test hooks or force a sync outside the normal lifecycle.
@@ -51,6 +51,7 @@ Hooks live in any Meridian config file. Precedence is: `builtin < context < user
 # meridian.toml (project) or ~/.meridian/config.toml (user)
 
 [[hooks]]
+name    = "sync-notes"
 builtin = "git-autosync"
 remote  = "git@github.com:team/docs.git"
 
@@ -64,7 +65,7 @@ event   = "spawn.finalized"
 
 | Field | Type | Required | Default | Purpose |
 | ----- | ---- | -------- | ------- | ------- |
-| `name` | str | yes (unless `builtin`) | builtin name | Unique identifier; used by `hooks run NAME` |
+| `name` | str | yes (unless `builtin`) | builtin name or synthesized builtin identity | Unique identifier; used by `hooks run NAME` |
 | `builtin` | str | one of `builtin`/`command` | — | Use a builtin hook |
 | `command` | str | one of `builtin`/`command` | — | Shell command to run |
 | `event` | str | yes (unless builtin supplies defaults) | builtin default | Event that triggers the hook |
@@ -81,6 +82,8 @@ event   = "spawn.finalized"
 | `options.conflict_policy` | str | no | `"leave"` | `git-autosync` only: `"leave"` keeps rebase conflicts for review; `"abort"` restores old abort behavior |
 
 `command` and `builtin` are mutually exclusive.
+
+If you omit `name` for a builtin hook, Meridian may synthesize a stable name from the builtin identity (for example remote/options). That keeps distinct unnamed builtin rows from overriding each other. For predictable `hooks run NAME` usage, set `name` explicitly.
 
 ### Shell Behavior
 
@@ -151,6 +154,7 @@ the rebase on conflict.
 
 ```toml
 [[hooks]]
+name    = "sync-notes"
 builtin = "git-autosync"
 remote  = "git@github.com:team/notes.git"
 ```
@@ -160,6 +164,7 @@ To register only for specific events, set `event` explicitly:
 ```toml
 # Only sync when a work item completes
 [[hooks]]
+name    = "sync-notes"
 builtin = "git-autosync"
 remote  = "git@github.com:team/notes.git"
 event   = "work.done"
@@ -168,7 +173,7 @@ event   = "work.done"
 To run manually at any time:
 
 ```bash
-meridian hooks run git-autosync --event work.done
+meridian hooks run sync-notes --event work.done
 ```
 
 ## MCP

--- a/src/meridian/lib/hooks/config.py
+++ b/src/meridian/lib/hooks/config.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import re
 import tomllib
 from collections import OrderedDict
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, cast, get_args
@@ -33,11 +36,57 @@ if TYPE_CHECKING:
 HOOK_SOURCE_PRECEDENCE: tuple[str, ...] = ("builtin", "context", "user", "project", "local")
 _LOCAL_CONFIG_FILENAME = "meridian.local.toml"
 _INTERVAL_PATTERN = re.compile(r"^\d+[smhd]$")
+_HOOK_NAME_COMPONENT_PATTERN = re.compile(r"[^a-z0-9._-]+")
+_HOOK_NAME_REPEATED_DASH_PATTERN = re.compile(r"-+")
 _KNOWN_FAILURE_POLICIES = frozenset({"fail", "warn", "ignore"})
 _KNOWN_SPAWN_STATUSES = frozenset(get_args(SpawnStatus))
 
 # Backward-compatible alias; registry remains the single source of truth.
 BUILTIN_HOOK_DEFAULTS = BUILTIN_HOOK_REGISTRY
+
+
+def _slugify_hook_name_component(raw: str) -> str:
+    normalized = raw.strip().lower()
+    normalized = _HOOK_NAME_COMPONENT_PATTERN.sub("-", normalized)
+    normalized = _HOOK_NAME_REPEATED_DASH_PATTERN.sub("-", normalized)
+    normalized = normalized.strip("-.")
+    # Keep synthesized names readable while avoiding runaway path-like identifiers.
+    return normalized[:48].strip("-.")
+
+
+def _synthesize_builtin_hook_name(
+    *,
+    builtin: str,
+    remote: str | None,
+    options: Mapping[str, object],
+) -> str:
+    identity: dict[str, object] = dict(options)
+    if remote is not None:
+        identity["remote"] = remote
+
+    if not identity:
+        return builtin
+
+    payload = json.dumps(
+        identity,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        default=str,
+    )
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:10]
+
+    slug_source = ""
+    for candidate_key in ("remote", "path"):
+        candidate = identity.get(candidate_key)
+        if isinstance(candidate, str) and candidate.strip():
+            slug_source = candidate
+            break
+
+    slug = _slugify_hook_name_component(slug_source) if slug_source else ""
+    if slug:
+        return f"{builtin}:{slug}-{digest}"
+    return f"{builtin}:{digest}"
 
 
 @dataclass(frozen=True)
@@ -183,7 +232,11 @@ def _hook_from_row(
     name = cast("str | None", row.get("name"))
     if name is None:
         if builtin is not None:
-            name = builtin
+            name = _synthesize_builtin_hook_name(
+                builtin=builtin,
+                remote=remote,
+                options=options,
+            )
         else:
             raise ValueError(f"Invalid hook config '{row_source}': 'name' is required.")
 

--- a/tests/unit/hooks/test_config.py
+++ b/tests/unit/hooks/test_config.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from meridian.lib.hooks.builtin_registry import get_default_events
+from meridian.lib.hooks.config import _apply_name_overrides, _hooks_from_payload
+
+
+def test_unnamed_builtin_hooks_with_different_remotes_do_not_override_each_other() -> None:
+    docs_remote = "git@github.com:team/docs.git"
+    kb_remote = "git@github.com:team/kb.git"
+    hooks = _apply_name_overrides(
+        _hooks_from_payload(
+            {
+                "hooks": [
+                    {"builtin": "git-autosync", "remote": docs_remote},
+                    {"builtin": "git-autosync", "remote": kb_remote},
+                ]
+            },
+            source="project",
+        )
+    )
+
+    default_events = set(get_default_events("git-autosync"))
+    docs_hooks = tuple(hook for hook in hooks if hook.remote == docs_remote)
+    kb_hooks = tuple(hook for hook in hooks if hook.remote == kb_remote)
+    assert len(docs_hooks) == len(default_events)
+    assert len(kb_hooks) == len(default_events)
+    assert {hook.event for hook in docs_hooks} == default_events
+    assert {hook.event for hook in kb_hooks} == default_events
+
+    docs_names = {hook.name for hook in docs_hooks}
+    kb_names = {hook.name for hook in kb_hooks}
+    assert len(docs_names) == 1
+    assert len(kb_names) == 1
+    assert docs_names != kb_names
+    assert next(iter(docs_names)).startswith("git-autosync:")
+    assert next(iter(kb_names)).startswith("git-autosync:")
+
+
+def test_explicit_same_name_builtin_hooks_still_override_by_name_and_event() -> None:
+    hooks = _apply_name_overrides(
+        _hooks_from_payload(
+            {
+                "hooks": [
+                    {
+                        "name": "autosync-primary",
+                        "builtin": "git-autosync",
+                        "event": "work.done",
+                        "remote": "git@github.com:team/docs.git",
+                        "priority": 1,
+                    },
+                    {
+                        "name": "autosync-primary",
+                        "builtin": "git-autosync",
+                        "event": "work.done",
+                        "remote": "git@github.com:team/kb.git",
+                        "priority": 9,
+                    },
+                ]
+            },
+            source="project",
+        )
+    )
+
+    assert len(hooks) == 1
+    assert hooks[0].name == "autosync-primary"
+    assert hooks[0].event == "work.done"
+    assert hooks[0].remote == "git@github.com:team/kb.git"
+    assert hooks[0].priority == 9
+
+
+def test_duplicate_unnamed_builtin_hooks_with_same_remote_deterministically_override() -> None:
+    remote = "git@github.com:team/docs.git"
+    hooks = _apply_name_overrides(
+        _hooks_from_payload(
+            {
+                "hooks": [
+                    {"builtin": "git-autosync", "remote": remote, "priority": 1},
+                    {"builtin": "git-autosync", "remote": remote, "priority": 7},
+                ]
+            },
+            source="project",
+        )
+    )
+
+    default_events = set(get_default_events("git-autosync"))
+    assert len(hooks) == len(default_events)
+    assert {hook.event for hook in hooks} == default_events
+    assert {hook.priority for hook in hooks} == {7}
+    names = {hook.name for hook in hooks}
+    assert len(names) == 1
+    assert next(iter(names)).startswith("git-autosync:")


### PR DESCRIPTION
## Summary
- synthesize stable names for unnamed builtin hooks from remote/options identity
- preserve explicit hook name override behavior
- document synthesized names and add hook config regression tests

## Root cause
Multiple unnamed `git-autosync` hooks defaulted to the same `git-autosync` name, so override normalization collapsed work and KB autosync into one effective hook.

## Validation
- `uv run pytest tests/unit/hooks/test_config.py`
- `uv run ruff check src/meridian/lib/hooks/config.py tests/unit/hooks/test_config.py`
- pre-push hook: `uv run ruff check .`, `uv run pyright`, `uv run pytest -x -q`, `uv build --no-sources`
