### PR TITLE
Fix post-exit spawn reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Reaper reconciles active spawns with recorded process exit metadata after a short finalization grace, instead of waiting for the 120s heartbeat window. `spawn wait` no longer hangs on dead post-exit rows until stale-heartbeat cleanup.
+
 ## [0.1.11] - 2026-05-17
 
 ### Fixed

--- a/src/meridian/lib/state/reaper.py
+++ b/src/meridian/lib/state/reaper.py
@@ -35,6 +35,7 @@ logger = structlog.get_logger(__name__)
 
 _STARTUP_GRACE_SECS = 15
 _HEARTBEAT_WINDOW_SECS = 120
+_POST_EXIT_FINALIZATION_GRACE_SECS = 5
 _ACTIVITY_ARTIFACTS: tuple[str, ...] = (
     "heartbeat",
     HISTORY_FILENAME,
@@ -62,6 +63,7 @@ class Skip:
 @dataclass(frozen=True)
 class FinalizeFailed:
     error: str
+    exit_code: int = 1
 
 
 @dataclass(frozen=True)
@@ -69,7 +71,14 @@ class FinalizeSucceededFromReport:
     pass
 
 
-type ReconciliationDecision = Skip | FinalizeFailed | FinalizeSucceededFromReport
+@dataclass(frozen=True)
+class FinalizeSucceededFromExit:
+    exit_code: int
+
+
+type ReconciliationDecision = (
+    Skip | FinalizeFailed | FinalizeSucceededFromReport | FinalizeSucceededFromExit
+)
 
 
 def _started_at_epoch(started_at: str | None) -> float | None:
@@ -86,6 +95,12 @@ def _started_at_epoch(started_at: str | None) -> float | None:
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=UTC)
     return parsed.timestamp()
+
+
+def _exited_at_epoch(exited_at: str | None) -> float | None:
+    """Parse exited_at ISO string to epoch seconds."""
+
+    return _started_at_epoch(exited_at)
 
 
 def _read_completion_report(runtime_root: Path, spawn_id: str) -> str | None:
@@ -195,6 +210,14 @@ def _is_pre_worker_launch_boundary_ghost(
     return runner_pid == parent_observed_launcher_pid
 
 
+def _in_post_exit_finalization_grace(record: SpawnRecord, now: float) -> bool:
+    exited_epoch = _exited_at_epoch(record.exited_at)
+    return (
+        exited_epoch is not None
+        and now - exited_epoch < _POST_EXIT_FINALIZATION_GRACE_SECS
+    )
+
+
 def decide_generic_reconciliation(
     record: SpawnRecord,
     snapshot: ArtifactSnapshot,
@@ -206,6 +229,18 @@ def decide_generic_reconciliation(
         if snapshot.durable_report_completion:
             return FinalizeSucceededFromReport()
         return FinalizeFailed(error="orphan_finalization")
+
+    if record.process_exit_code is not None or record.exited_at is not None:
+        if _in_post_exit_finalization_grace(record, now):
+            return Skip(reason="post_exit_finalization_grace")
+        if snapshot.durable_report_completion:
+            return FinalizeSucceededFromReport()
+        if record.process_exit_code == 0:
+            return FinalizeSucceededFromExit(exit_code=0)
+        return FinalizeFailed(
+            error="orphan_run",
+            exit_code=record.process_exit_code if record.process_exit_code is not None else 1,
+        )
 
     if _is_pre_worker_launch_boundary_ghost(record, snapshot, now):
         if snapshot.durable_report_completion:
@@ -379,13 +414,14 @@ def _finalize_failed(
     error: str,
     snapshot: ArtifactSnapshot,
     now: float,
+    exit_code: int = 1,
 ) -> SpawnRecord:
     return _finalize_and_log(
         project_root,
         runtime_root,
         record,
         status="failed",
-        exit_code=1,
+        exit_code=exit_code,
         error=error,
         reason=error,
         snapshot=snapshot,
@@ -412,6 +448,27 @@ def _finalize_completed_report(
         exit_code=exit_code,
         error=error,
         reason="report_completed",
+        snapshot=snapshot,
+        now=now,
+    )
+
+
+def _finalize_completed_exit(
+    project_root: Path,
+    runtime_root: Path,
+    record: SpawnRecord,
+    decision: FinalizeSucceededFromExit,
+    snapshot: ArtifactSnapshot,
+    now: float,
+) -> SpawnRecord:
+    return _finalize_and_log(
+        project_root,
+        runtime_root,
+        record,
+        status="succeeded",
+        exit_code=decision.exit_code,
+        error=None,
+        reason="process_exited",
         snapshot=snapshot,
         now=now,
     )
@@ -447,6 +504,15 @@ def reconcile_active_spawn(
             project_root,
             runtime_root,
             record,
+            generic_snapshot,
+            now,
+        )
+    if isinstance(decision, FinalizeSucceededFromExit):
+        return _finalize_completed_exit(
+            project_root,
+            runtime_root,
+            record,
+            decision,
             generic_snapshot,
             now,
         )
@@ -505,6 +571,7 @@ def reconcile_active_spawn(
         decision.error,
         generic_snapshot,
         now,
+        exit_code=decision.exit_code,
     )
 
 

--- a/tests/integration/state/test_reaper_reconciliation.py
+++ b/tests/integration/state/test_reaper_reconciliation.py
@@ -424,3 +424,67 @@ def test_reconcile_active_spawn_dead_runner_recent_activity_skips_across_artifac
     latest = _get_spawn(runtime_root, spawn_id)
     assert latest.status == "running"
     assert latest.error is None
+
+
+def test_reconcile_active_spawn_post_exit_failure_bypasses_recent_activity_after_grace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime_root, spawn_id = _create_spawn(tmp_path, started_at=_OLD_STARTED_AT)
+
+    fixed_now = 1_000.0
+    monkeypatch.setattr("meridian.lib.state.reaper.time.time", lambda: fixed_now)
+    monkeypatch.setattr("tests.integration.state.conftest.time.time", lambda: fixed_now)
+    spawn_store.record_spawn_exited(
+        runtime_root,
+        spawn_id,
+        exit_code=3,
+        exited_at="1970-01-01T00:16:30Z",
+    )
+    _write_activity_artifact(runtime_root, spawn_id, "history.jsonl", age_secs=1)
+    record = _get_spawn(runtime_root, spawn_id)
+    monkeypatch.setattr(
+        "meridian.lib.state.reaper.is_process_alive",
+        lambda *_args, **_kwargs: False,
+    )
+
+    reconciled = _reconcile(tmp_path, runtime_root, record)
+
+    assert reconciled.status == "failed"
+    assert reconciled.exit_code == 3
+    assert reconciled.error == "orphan_run"
+    latest = _get_spawn(runtime_root, spawn_id)
+    assert latest.status == "failed"
+    assert latest.exit_code == 3
+    assert latest.error == "orphan_run"
+
+
+def test_reconcile_active_spawn_post_exit_zero_succeeds_after_grace_without_report(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime_root, spawn_id = _create_spawn(tmp_path, started_at=_OLD_STARTED_AT)
+
+    fixed_now = 1_000.0
+    monkeypatch.setattr("meridian.lib.state.reaper.time.time", lambda: fixed_now)
+    spawn_store.record_spawn_exited(
+        runtime_root,
+        spawn_id,
+        exit_code=0,
+        exited_at="1970-01-01T00:16:30Z",
+    )
+    record = _get_spawn(runtime_root, spawn_id)
+    monkeypatch.setattr(
+        "meridian.lib.state.reaper.is_process_alive",
+        lambda *_args, **_kwargs: False,
+    )
+
+    reconciled = _reconcile(tmp_path, runtime_root, record)
+
+    assert reconciled.status == "succeeded"
+    assert reconciled.exit_code == 0
+    assert reconciled.error is None
+    latest = _get_spawn(runtime_root, spawn_id)
+    assert latest.status == "succeeded"
+    assert latest.exit_code == 0
+    assert latest.error is None


### PR DESCRIPTION
## Summary

Fix stuck `spawn wait` when a background runner records process exit metadata but dies before terminal finalization.

## Root cause

The spawn row could persist as `status=running` while also carrying `process_exit_code` and `exited_at`. Reaper then treated recent heartbeat/history/stderr artifacts as active liveness evidence and deferred reconciliation until the 120s stale-heartbeat window elapsed.

## Change

- Treat `process_exit_code` / `exited_at` as authoritative process-exit evidence after a short finalization grace.
- Preserve non-zero process exit codes when reconciling failed post-exit rows.
- Allow exit code 0 without a report to reconcile as succeeded.
- Add regression coverage for post-exit reconciliation.

## Validation

- `uv run ruff check src/meridian/lib/state/reaper.py tests/integration/state/test_reaper_reconciliation.py`
- `uv run pytest-llm tests/integration/state/test_reaper_reconciliation.py -q`
- `uv run pyright src/meridian/lib/state/reaper.py tests/integration/state/test_reaper_reconciliation.py`
- Pre-push `scripts/preflight.sh` via hook:
  - `uv run ruff check .`
  - `uv run pyright`
  - `uv run pytest -x -q` → 1208 passed, 2 skipped
  - `uv build --no-sources`
