### PR TITLE
[codex] clarify stale reaper cleanup warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- Reaper legacy-worker cleanup warning now says it cleaned up a stale spawn and identifies the affected spawn explicitly.
+
 ## [0.1.12] - 2026-05-17
 
 ### Fixed

--- a/src/meridian/lib/core/process_cleanup.py
+++ b/src/meridian/lib/core/process_cleanup.py
@@ -201,8 +201,10 @@ def _terminate_legacy_worker_pid(
         scope_id="legacy_worker",
     )
     logger.warning(
-        "Terminated legacy worker via degraded fallback.",
+        "Reaper cleaned up stale spawn via legacy worker fallback.",
         spawn_id=spawn_record.id,
+        affected_spawn_id=spawn_record.id,
+        cleanup_target="stale_spawn",
         scope_id=result.scope_id,
         root_pid=worker_pid,
         descendant_count=result.descendant_count,


### PR DESCRIPTION
## Summary

Clarify the legacy-worker reaper cleanup warning so the log subject is the stale spawn being reconciled, not the foreground command that happened to trigger read-path reconciliation.

## What changed

- Reworded the warning from `Terminated legacy worker via degraded fallback.` to `Reaper cleaned up stale spawn via legacy worker fallback.`
- Added structured fields: `affected_spawn_id` and `cleanup_target=stale_spawn`.
- Added an `[Unreleased]` changelog entry.

## Why

A read-path reaper cleanup can run during an unrelated command/session. The old wording foregrounded the termination mechanism and made the affected object ambiguous.

## Validation

- `uv run ruff check src/meridian/lib/core/process_cleanup.py tests/unit/core/test_process_cleanup_terminate.py`
- `uv run pytest-llm tests/unit/core/test_process_cleanup_terminate.py`
- `uv run pyright`
- Pre-push hook: `uv run ruff check .`, `uv run pyright`, `uv run pytest -x -q` (1208 passed, 2 skipped), `uv build --no-sources`