### PR TITLE
Fix flaky Pi RPC malformed lifecycle test

### DIFF
--- a/tests/unit/harness/test_pi_integration.py
+++ b/tests/unit/harness/test_pi_integration.py
@@ -820,16 +820,28 @@ async def test_pi_rpc_connection_malformed_canonical_event_fails_closed_through_
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     shim = bin_dir / "pi"
+    # Spawned Pi RPC sessions must stay alive long enough to receive Meridian's
+    # initial prompt. Emitting the malformed sidecar event before reading stdin
+    # races connection startup instead of exercising manager fail-closed logic.
     shim.write_text(
         "#!/bin/sh\n"
         "if [ \"$1\" = \"--version\" ]; then echo 'pi 1.2.3'; exit 0; fi\n"
         f"if [ \"$1\" = \"--help\" ]; then echo '{_PI_HELP_SURFACE}'; exit 0; fi\n"
-        "printf '%s\\n' '{\"type\":\"session\",\"id\":\"ses-malformed\"}'\n"
-        "printf '%s\\n' '{\"type\":\"message_update\",\"delta\":\"before malformed\"}'\n"
-        "printf '%s\\n' '{\"type\":\"meridian.subspawn.start\",\"schema_version\":2}' >> "
+        "while IFS= read -r line; do\n"
+        "  case \"$line\" in\n"
+        "    *'\"type\":\"prompt\"'*)\n"
+        "      printf '%s\\n' '{\"type\":\"session\",\"id\":\"ses-malformed\"}'\n"
+        "      printf '%s\\n' '{\"type\":\"message_update\",\"delta\":\"before malformed\"}'\n"
+        "      printf '%s\\n' "
+        "'{\"type\":\"meridian.subspawn.start\",\"schema_version\":2}' >> "
         f"\"${_PI_LIFECYCLE_EVENT_FILE_ENV}\"\n"
-        "printf '%s\\n' "
-        "'{\"type\":\"agent_end\",\"messages\":[{\"role\":\"assistant\",\"stopReason\":\"stop\"}]}'\n",
+        "      printf '%s\\n' "
+        "'{\"type\":\"agent_end\",\"messages\":[{\"role\":\"assistant\",\"stopReason\":\"stop\"}]}'\n"
+        "      exit 0\n"
+        "      ;;\n"
+        "    *'\"type\":\"abort\"'*) exit 0 ;;\n"
+        "  esac\n"
+        "done\n",
         encoding="utf-8",
     )
     shim.chmod(0o755)


### PR DESCRIPTION
## Summary
- make the malformed Pi lifecycle manager test wait for the spawned RPC initial prompt before emitting events
- preserve the fail-closed assertion for malformed canonical sidecar events
- document why the shim must not exit before stdin is writable

## Diagnosis
The flaky shim printed session/message/lifecycle/agent_end events and exited without reading stdin. `PiRpcConnection.start()` spawns the process and immediately sends the initial prompt; on CI the shim could finish first, setting `process.returncode`, so `_send_rpc_message()` correctly raised `ConnectionNotReady` before manager fail-closed handling ran. Real spawned Pi RPC sessions are expected to stay alive and accept the initial prompt, so this was a test fixture race rather than a production contract change.

## Verification
- `uv run pytest-llm -q tests/unit/harness/test_pi_integration.py::test_pi_rpc_connection_malformed_canonical_event_fails_closed_through_manager`
- 100-iteration stress loop before final comment move: passed
- 50-iteration final stress loop: passed
- `uv run pytest-llm -q tests/unit/harness/test_pi_integration.py tests/unit/streaming/test_pi_quiescence.py`
- `bash scripts/preflight.sh` (1387 passed, 11 skipped)
- pre-push preflight via `git push` (1387 passed, 11 skipped)
