### PR TITLE
v0.2.0: Mars launch bundle schema v2, Pi harness, model-optional passthrough

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -397,6 +397,18 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+      - name: Set up Node.js
+        if: steps.release_intent.outputs.should_release == 'true' && steps.release_guard.outputs.already_released != 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Build Pi extensions
+        if: steps.release_intent.outputs.should_release == 'true' && steps.release_guard.outputs.already_released != 'true'
+        run: |
+          corepack enable
+          cd src/meridian/pi_runtime && pnpm install --frozen-lockfile && pnpm run build:extensions
+
       - name: Run shared preflight
         if: steps.release_intent.outputs.should_release == 'true' && steps.release_guard.outputs.already_released != 'true'
         run: scripts/preflight.sh full

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Fixed
-- Meridian now accepts Mars 0.5.0 launch-bundle schema v2, so spawns do not fail when Mars returns schema version 2.
+- Meridian now accepts Mars launch-bundle schema v2 and requires mars-agents >= 0.6.0.
 
 ## [0.1.14-rc.5] - 2026-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Meridian now accepts Mars 0.5.0 launch-bundle schema v2, so spawns do not fail when Mars returns schema version 2.
+
 ## [0.1.14-rc.5] - 2026-05-22
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "cyclopts>=3.0",
   "fastapi>=0.115",
   "markdown-it-py>=4.0",
-  "mars-agents==0.5.0",
+  "mars-agents==0.6.1",
   "mcp>=1.0",
   "pathspec>=1.1.0",
   "psutil>=7.2.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ build-backend = "hatchling.build"
 path = "src/meridian/__init__.py"
 
 [tool.hatch.build]
-artifacts = ["src/meridian/web_dist/*"]
+artifacts = ["src/meridian/web_dist/*", "src/meridian/pi_runtime/dist/extensions/*"]
 
 [tool.hatch.build.targets.sdist]
 include = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "cyclopts>=3.0",
   "fastapi>=0.115",
   "markdown-it-py>=4.0",
-  "mars-agents==0.4.8rc7",
+  "mars-agents==0.5.0",
   "mcp>=1.0",
   "pathspec>=1.1.0",
   "psutil>=7.2.2",

--- a/src/meridian/lib/harness/projections/project_claude.py
+++ b/src/meridian/lib/harness/projections/project_claude.py
@@ -139,9 +139,6 @@ def _log_collision_if_needed(
         "Claude projection known managed flag %s also present in extra_args; "
         "user tail value wins by last-wins semantics"
     )
-    if managed_flag == "--append-system-prompt":
-        logger.warning(message, managed_flag)
-        return
     logger.debug(message, managed_flag)
 
 

--- a/src/meridian/lib/harness/projections/project_claude.py
+++ b/src/meridian/lib/harness/projections/project_claude.py
@@ -139,6 +139,9 @@ def _log_collision_if_needed(
         "Claude projection known managed flag %s also present in extra_args; "
         "user tail value wins by last-wins semantics"
     )
+    if managed_flag == "--append-system-prompt":
+        logger.warning(message, managed_flag)
+        return
     logger.debug(message, managed_flag)
 
 

--- a/src/meridian/lib/launch/bundle_adapter.py
+++ b/src/meridian/lib/launch/bundle_adapter.py
@@ -6,7 +6,7 @@ import json
 import shutil
 import subprocess
 import sys
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
@@ -28,10 +28,6 @@ if TYPE_CHECKING:
 
 _MARS_BUNDLE_MIN_VERSION = "0.5.0"
 _SUPPORTED_BUNDLE_SCHEMA_VERSION = 2
-
-
-def _empty_object_dict() -> dict[str, object]:
-    return {}
 
 
 @dataclass(frozen=True)
@@ -73,11 +69,6 @@ class _BundleResult:
     tools_mcp: tuple[str, ...]
     skills_loaded: tuple[str, ...]
     skills_missing: tuple[str, ...]
-    selection_kind: str = ""
-    match_evidence: str = ""
-    harness_model_source: str = ""
-    harness_model_confidence: str = ""
-    route_trace: dict[str, object] = field(default_factory=_empty_object_dict)
 
 
 def _resolve_mars_binary() -> str | None:
@@ -286,7 +277,8 @@ def _parse_bundle_payload(
     if version != _SUPPORTED_BUNDLE_SCHEMA_VERSION:
         raise RuntimeError(
             "Mars launch-bundle schema version "
-            f"{version} is unsupported. Expected {_SUPPORTED_BUNDLE_SCHEMA_VERSION}."
+            f"{version} is unsupported. Expected {_SUPPORTED_BUNDLE_SCHEMA_VERSION}. "
+            f"Meridian requires mars >= {_MARS_BUNDLE_MIN_VERSION}."
         )
 
     routing = _required_object_field(payload, "routing")
@@ -296,16 +288,6 @@ def _parse_bundle_payload(
     model_token = _normalize_str(routing.get("model_token")) or model
     harness = _parse_harness_id(routing.get("harness"), harness_registry=harness_registry)
     harness_model = _normalize_str(routing.get("harness_model")) or None
-    selection_kind = _normalize_str(routing.get("selection_kind"))
-    match_evidence = _normalize_str(routing.get("match_evidence"))
-    harness_model_source = _normalize_str(routing.get("harness_model_source"))
-    harness_model_confidence = _normalize_str(routing.get("harness_model_confidence"))
-    route_trace_raw = routing.get("route_trace")
-    route_trace = (
-        cast("dict[str, object]", route_trace_raw)
-        if isinstance(route_trace_raw, dict)
-        else {}
-    )
 
     execution_policy_payload = _required_object_field(payload, "execution_policy")
     execution_policy = ResolvedExecutionPolicy.model_validate(
@@ -341,11 +323,6 @@ def _parse_bundle_payload(
         tools_mcp=_as_str_tuple(tools.get("mcp")),
         skills_loaded=_as_str_tuple(skills_metadata.get("loaded")),
         skills_missing=_as_str_tuple(skills_metadata.get("missing")),
-        selection_kind=selection_kind,
-        match_evidence=match_evidence,
-        harness_model_source=harness_model_source,
-        harness_model_confidence=harness_model_confidence,
-        route_trace=route_trace,
     )
 
 

--- a/src/meridian/lib/launch/bundle_adapter.py
+++ b/src/meridian/lib/launch/bundle_adapter.py
@@ -6,7 +6,7 @@ import json
 import shutil
 import subprocess
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
@@ -26,8 +26,12 @@ if TYPE_CHECKING:
     from meridian.lib.launch.policies import ModelSelectionContext, ResolvedLaunchPolicy
     from meridian.lib.launch.resolve import ResolvedSkills
 
-_MARS_BUNDLE_MIN_VERSION = "0.4.8rc3"
-_SUPPORTED_BUNDLE_SCHEMA_VERSION = 1
+_MARS_BUNDLE_MIN_VERSION = "0.5.0"
+_SUPPORTED_BUNDLE_SCHEMA_VERSION = 2
+
+
+def _empty_object_dict() -> dict[str, object]:
+    return {}
 
 
 @dataclass(frozen=True)
@@ -69,6 +73,11 @@ class _BundleResult:
     tools_mcp: tuple[str, ...]
     skills_loaded: tuple[str, ...]
     skills_missing: tuple[str, ...]
+    selection_kind: str = ""
+    match_evidence: str = ""
+    harness_model_source: str = ""
+    harness_model_confidence: str = ""
+    route_trace: dict[str, object] = field(default_factory=_empty_object_dict)
 
 
 def _resolve_mars_binary() -> str | None:
@@ -287,6 +296,16 @@ def _parse_bundle_payload(
     model_token = _normalize_str(routing.get("model_token")) or model
     harness = _parse_harness_id(routing.get("harness"), harness_registry=harness_registry)
     harness_model = _normalize_str(routing.get("harness_model")) or None
+    selection_kind = _normalize_str(routing.get("selection_kind"))
+    match_evidence = _normalize_str(routing.get("match_evidence"))
+    harness_model_source = _normalize_str(routing.get("harness_model_source"))
+    harness_model_confidence = _normalize_str(routing.get("harness_model_confidence"))
+    route_trace_raw = routing.get("route_trace")
+    route_trace = (
+        cast("dict[str, object]", route_trace_raw)
+        if isinstance(route_trace_raw, dict)
+        else {}
+    )
 
     execution_policy_payload = _required_object_field(payload, "execution_policy")
     execution_policy = ResolvedExecutionPolicy.model_validate(
@@ -322,6 +341,11 @@ def _parse_bundle_payload(
         tools_mcp=_as_str_tuple(tools.get("mcp")),
         skills_loaded=_as_str_tuple(skills_metadata.get("loaded")),
         skills_missing=_as_str_tuple(skills_metadata.get("missing")),
+        selection_kind=selection_kind,
+        match_evidence=match_evidence,
+        harness_model_source=harness_model_source,
+        harness_model_confidence=harness_model_confidence,
+        route_trace=route_trace,
     )
 
 

--- a/src/meridian/lib/launch/bundle_adapter.py
+++ b/src/meridian/lib/launch/bundle_adapter.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from meridian.lib.launch.policies import ModelSelectionContext, ResolvedLaunchPolicy
     from meridian.lib.launch.resolve import ResolvedSkills
 
-_MARS_BUNDLE_MIN_VERSION = "0.5.0"
+_MARS_BUNDLE_MIN_VERSION = "0.6.1"
 _SUPPORTED_BUNDLE_SCHEMA_VERSION = 2
 
 

--- a/src/meridian/lib/launch/bundle_adapter.py
+++ b/src/meridian/lib/launch/bundle_adapter.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
@@ -26,7 +27,14 @@ if TYPE_CHECKING:
     from meridian.lib.launch.policies import ModelSelectionContext, ResolvedLaunchPolicy
     from meridian.lib.launch.resolve import ResolvedSkills
 
-_MARS_BUNDLE_MIN_VERSION = "0.6.1"
+def _resolve_mars_min_version() -> str:
+    try:
+        return version("mars-agents")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+_MARS_BUNDLE_MIN_VERSION = _resolve_mars_min_version()
 _SUPPORTED_BUNDLE_SCHEMA_VERSION = 2
 
 

--- a/src/meridian/lib/launch/bundle_adapter.py
+++ b/src/meridian/lib/launch/bundle_adapter.py
@@ -283,8 +283,6 @@ def _parse_bundle_payload(
 
     routing = _required_object_field(payload, "routing")
     model = _normalize_str(routing.get("model"))
-    if not model:
-        raise _bundle_schema_error("routing.model is empty")
     model_token = _normalize_str(routing.get("model_token")) or model
     harness = _parse_harness_id(routing.get("harness"), harness_registry=harness_registry)
     harness_model = _normalize_str(routing.get("harness_model")) or None

--- a/src/meridian/lib/launch/policies.py
+++ b/src/meridian/lib/launch/policies.py
@@ -482,7 +482,7 @@ def _resolve_policy_from_bundle(surface: SurfacePolicyInput) -> ResolvedLaunchPo
         selected_model_token=selected_model_token,
         canonical_model_id=resolved_model,
     )
-    if bundle_result.harness_model is None:
+    if bundle_result.harness_model is None and resolved_model:
         if default_harness is not None and resolved_harness != default_harness:
             policy_warnings.append(
                 CompositionWarning(

--- a/src/meridian/lib/launch/streaming_runner.py
+++ b/src/meridian/lib/launch/streaming_runner.py
@@ -954,7 +954,7 @@ async def execute_with_streaming(
                 )
                 conclusion.absorb_attempt(attempt)
                 if attempt.start_error is not None:
-                    logger.warning(
+                    logger.info(
                         "Failed to execute streaming spawn attempt.",
                         spawn_id=str(run.spawn_id),
                         harness_id=str(harness.id),
@@ -1152,7 +1152,7 @@ async def execute_with_streaming(
 
                     conclusion.retries_attempted += 1
                     conclusion.exit_code = 1
-                    logger.warning(
+                    logger.info(
                         "Retrying after guardrail failure.",
                         spawn_id=str(run.spawn_id),
                         harness_id=str(harness.id),
@@ -1200,7 +1200,7 @@ async def execute_with_streaming(
                     break
 
                 conclusion.retries_attempted += 1
-                logger.warning(
+                logger.info(
                     "Retrying failed run attempt.",
                     spawn_id=str(run.spawn_id),
                     harness_id=str(harness.id),

--- a/tests/unit/launch/test_bundle_adapter.py
+++ b/tests/unit/launch/test_bundle_adapter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 from pathlib import Path, PureWindowsPath
 from typing import cast
@@ -9,7 +10,13 @@ import pytest
 
 from meridian.lib.core.types import HarnessId
 from meridian.lib.harness.registry import get_default_harness_registry
-from meridian.lib.launch.bundle_adapter import BundleRequest, request_and_resolve
+from meridian.lib.launch.bundle_adapter import (
+    _MARS_BUNDLE_MIN_VERSION,
+    BundleRequest,
+    request_and_resolve,
+)
+
+_ESCAPED_MIN_VERSION = re.escape(_MARS_BUNDLE_MIN_VERSION)
 
 
 def _completed(
@@ -198,7 +205,7 @@ def test_request_and_resolve_uses_native_windows_root_path(monkeypatch: pytest.M
 def test_request_and_resolve_reports_missing_mars_binary(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("meridian.lib.launch.bundle_adapter._resolve_mars_binary", lambda: None)
 
-    with pytest.raises(RuntimeError, match=r"mars >= 0\.6\.1"):
+    with pytest.raises(RuntimeError, match=rf"mars >= {_ESCAPED_MIN_VERSION}"):
         request_and_resolve(
             BundleRequest(agent=None, project_root=Path("/tmp/project")),
             harness_registry=get_default_harness_registry(),
@@ -217,7 +224,7 @@ def test_request_and_resolve_reports_unsupported_launch_bundle_command(
         ),
     )
 
-    with pytest.raises(RuntimeError, match=r"mars >= 0\.6\.1"):
+    with pytest.raises(RuntimeError, match=rf"mars >= {_ESCAPED_MIN_VERSION}"):
         request_and_resolve(
             BundleRequest(agent=None, project_root=Path("/tmp/project")),
             harness_registry=get_default_harness_registry(),

--- a/tests/unit/launch/test_bundle_adapter.py
+++ b/tests/unit/launch/test_bundle_adapter.py
@@ -28,12 +28,17 @@ def _completed(
 
 def _valid_bundle_payload() -> dict[str, object]:
     return {
-        "version": 1,
+        "version": 2,
         "routing": {
             "model": "gpt-5.5",
             "model_token": "gpt55",
             "harness": "opencode",
             "harness_model": "openai/gpt-5.5",
+            "selection_kind": "policy",
+            "match_evidence": "alias-and-policy",
+            "harness_model_source": "registry",
+            "harness_model_confidence": "high",
+            "route_trace": {"path": ["alias", "policy"]},
         },
         "execution_policy": {
             "effort": "high",
@@ -176,7 +181,7 @@ def test_request_and_resolve_uses_native_windows_root_path(monkeypatch: pytest.M
 def test_request_and_resolve_reports_missing_mars_binary(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("meridian.lib.launch.bundle_adapter._resolve_mars_binary", lambda: None)
 
-    with pytest.raises(RuntimeError, match=r"mars >= 0\.4\.8rc3"):
+    with pytest.raises(RuntimeError, match=r"mars >= 0\.5\.0"):
         request_and_resolve(
             BundleRequest(agent=None, project_root=Path("/tmp/project")),
             harness_registry=get_default_harness_registry(),
@@ -195,7 +200,7 @@ def test_request_and_resolve_reports_unsupported_launch_bundle_command(
         ),
     )
 
-    with pytest.raises(RuntimeError, match=r"mars >= 0\.4\.8rc3"):
+    with pytest.raises(RuntimeError, match=r"mars >= 0\.5\.0"):
         request_and_resolve(
             BundleRequest(agent=None, project_root=Path("/tmp/project")),
             harness_registry=get_default_harness_registry(),
@@ -231,17 +236,58 @@ def test_request_and_resolve_reports_unsupported_schema_version(
 ) -> None:
     monkeypatch.setattr("meridian.lib.launch.bundle_adapter._resolve_mars_binary", lambda: "mars")
     payload = _valid_bundle_payload()
-    payload["version"] = 2
+    payload["version"] = 3
     monkeypatch.setattr(
         "subprocess.run",
         lambda *args, **kwargs: _completed(stdout=json.dumps(payload)),
     )
 
-    with pytest.raises(RuntimeError, match="schema version 2 is unsupported"):
+    with pytest.raises(RuntimeError, match="schema version 3 is unsupported"):
         request_and_resolve(
             BundleRequest(agent=None, project_root=Path("/tmp/project")),
             harness_registry=get_default_harness_registry(),
         )
+
+
+def test_request_and_resolve_extracts_schema_v2_routing_diagnostics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("meridian.lib.launch.bundle_adapter._resolve_mars_binary", lambda: "mars")
+    payload = _valid_bundle_payload()
+    payload["routing"] = {
+        "model": "gpt-5.5",
+        "model_token": "gpt55",
+        "harness": "opencode",
+        "harness_model": "openai/gpt-5.5",
+        "selection_kind": "policy",
+        "match_evidence": "rule-42",
+        "harness_model_source": "policy",
+        "harness_model_confidence": "medium",
+        "route_trace": {
+            "rule_id": "rule-42",
+            "steps": ["alias-lookup", "policy-match"],
+            "extra": {"reason": "exact-match"},
+        },
+    }
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *args, **kwargs: _completed(stdout=json.dumps(payload)),
+    )
+
+    bundle = request_and_resolve(
+        BundleRequest(agent=None, project_root=Path("/tmp/project")),
+        harness_registry=get_default_harness_registry(),
+    )
+
+    assert bundle.selection_kind == "policy"
+    assert bundle.match_evidence == "rule-42"
+    assert bundle.harness_model_source == "policy"
+    assert bundle.harness_model_confidence == "medium"
+    assert bundle.route_trace == {
+        "rule_id": "rule-42",
+        "steps": ["alias-lookup", "policy-match"],
+        "extra": {"reason": "exact-match"},
+    }
 
 
 def test_request_and_resolve_reports_missing_routing_model(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/launch/test_bundle_adapter.py
+++ b/tests/unit/launch/test_bundle_adapter.py
@@ -258,12 +258,16 @@ def test_request_and_resolve_reports_unsupported_schema_version(
         _resolve_with_payload(monkeypatch, payload)
 
 
-def test_request_and_resolve_reports_missing_routing_model(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_request_and_resolve_accepts_empty_model_for_harness_passthrough(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     payload = _valid_bundle_payload()
-    payload["routing"] = {"harness": "opencode"}
+    payload["routing"] = {"model": "", "harness": "opencode"}
 
-    with pytest.raises(RuntimeError, match=r"routing\.model is empty"):
-        _resolve_with_payload(monkeypatch, payload)
+    bundle = _resolve_with_payload(monkeypatch, payload)
+    assert bundle.model == ""
+    assert bundle.model_token == ""
+    assert bundle.harness is HarnessId.OPENCODE
 
 
 def test_request_and_resolve_reports_missing_routing_harness(

--- a/tests/unit/launch/test_bundle_adapter.py
+++ b/tests/unit/launch/test_bundle_adapter.py
@@ -231,18 +231,20 @@ def test_request_and_resolve_reports_non_object_json_payload(
         )
 
 
+@pytest.mark.parametrize("schema_version", [1, 3])
 def test_request_and_resolve_reports_unsupported_schema_version(
     monkeypatch: pytest.MonkeyPatch,
+    schema_version: int,
 ) -> None:
     monkeypatch.setattr("meridian.lib.launch.bundle_adapter._resolve_mars_binary", lambda: "mars")
     payload = _valid_bundle_payload()
-    payload["version"] = 3
+    payload["version"] = schema_version
     monkeypatch.setattr(
         "subprocess.run",
         lambda *args, **kwargs: _completed(stdout=json.dumps(payload)),
     )
 
-    with pytest.raises(RuntimeError, match="schema version 3 is unsupported"):
+    with pytest.raises(RuntimeError, match=f"schema version {schema_version} is unsupported"):
         request_and_resolve(
             BundleRequest(agent=None, project_root=Path("/tmp/project")),
             harness_registry=get_default_harness_registry(),

--- a/tests/unit/launch/test_bundle_adapter.py
+++ b/tests/unit/launch/test_bundle_adapter.py
@@ -290,6 +290,30 @@ def test_request_and_resolve_extracts_schema_v2_routing_diagnostics(
     }
 
 
+def test_request_and_resolve_schema_v2_route_trace_falls_back_to_empty_dict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("meridian.lib.launch.bundle_adapter._resolve_mars_binary", lambda: "mars")
+    payload = _valid_bundle_payload()
+    payload["routing"] = {
+        "model": "gpt-5.5",
+        "model_token": "gpt55",
+        "harness": "opencode",
+        "route_trace": ["alias-lookup", "policy-match"],
+    }
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *args, **kwargs: _completed(stdout=json.dumps(payload)),
+    )
+
+    bundle = request_and_resolve(
+        BundleRequest(agent=None, project_root=Path("/tmp/project")),
+        harness_registry=get_default_harness_registry(),
+    )
+
+    assert bundle.route_trace == {}
+
+
 def test_request_and_resolve_reports_missing_routing_model(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("meridian.lib.launch.bundle_adapter._resolve_mars_binary", lambda: "mars")
     payload = _valid_bundle_payload()

--- a/tests/unit/launch/test_bundle_adapter.py
+++ b/tests/unit/launch/test_bundle_adapter.py
@@ -198,7 +198,7 @@ def test_request_and_resolve_uses_native_windows_root_path(monkeypatch: pytest.M
 def test_request_and_resolve_reports_missing_mars_binary(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("meridian.lib.launch.bundle_adapter._resolve_mars_binary", lambda: None)
 
-    with pytest.raises(RuntimeError, match=r"mars >= 0\.5\.0"):
+    with pytest.raises(RuntimeError, match=r"mars >= 0\.6\.1"):
         request_and_resolve(
             BundleRequest(agent=None, project_root=Path("/tmp/project")),
             harness_registry=get_default_harness_registry(),
@@ -217,7 +217,7 @@ def test_request_and_resolve_reports_unsupported_launch_bundle_command(
         ),
     )
 
-    with pytest.raises(RuntimeError, match=r"mars >= 0\.5\.0"):
+    with pytest.raises(RuntimeError, match=r"mars >= 0\.6\.1"):
         request_and_resolve(
             BundleRequest(agent=None, project_root=Path("/tmp/project")),
             harness_registry=get_default_harness_registry(),
@@ -254,7 +254,7 @@ def test_request_and_resolve_reports_unsupported_schema_version(
     payload = _valid_bundle_payload()
     payload["version"] = 99
 
-    with pytest.raises(RuntimeError, match=r"schema version 99 is unsupported.*mars >= 0\.5\.0"):
+    with pytest.raises(RuntimeError, match=r"schema version 99 is unsupported.*mars >= 0\.6\.1"):
         _resolve_with_payload(monkeypatch, payload)
 
 

--- a/tests/unit/launch/test_bundle_adapter.py
+++ b/tests/unit/launch/test_bundle_adapter.py
@@ -34,11 +34,6 @@ def _valid_bundle_payload() -> dict[str, object]:
             "model_token": "gpt55",
             "harness": "opencode",
             "harness_model": "openai/gpt-5.5",
-            "selection_kind": "policy",
-            "match_evidence": "alias-and-policy",
-            "harness_model_source": "registry",
-            "harness_model_confidence": "high",
-            "route_trace": {"path": ["alias", "policy"]},
         },
         "execution_policy": {
             "effort": "high",
@@ -52,6 +47,28 @@ def _valid_bundle_payload() -> dict[str, object]:
         },
         "warnings": ["bundle warning"],
     }
+
+
+def _resolve_with_payload(
+    monkeypatch: pytest.MonkeyPatch,
+    payload: dict[str, object] | None = None,
+    *,
+    agent: str | None = None,
+    project_root: str | Path | None = None,
+):
+    monkeypatch.setattr("meridian.lib.launch.bundle_adapter._resolve_mars_binary", lambda: "mars")
+    resolved_payload = payload if payload is not None else _valid_bundle_payload()
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *args, **kwargs: _completed(stdout=json.dumps(resolved_payload)),
+    )
+    return request_and_resolve(
+        BundleRequest(
+            agent=agent,
+            project_root=Path(project_root) if project_root is not None else Path("/tmp/project"),
+        ),
+        harness_registry=get_default_harness_registry(),
+    )
 
 
 def test_request_and_resolve_builds_expected_mars_command(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -231,123 +248,32 @@ def test_request_and_resolve_reports_non_object_json_payload(
         )
 
 
-@pytest.mark.parametrize("schema_version", [1, 3])
 def test_request_and_resolve_reports_unsupported_schema_version(
     monkeypatch: pytest.MonkeyPatch,
-    schema_version: int,
 ) -> None:
-    monkeypatch.setattr("meridian.lib.launch.bundle_adapter._resolve_mars_binary", lambda: "mars")
     payload = _valid_bundle_payload()
-    payload["version"] = schema_version
-    monkeypatch.setattr(
-        "subprocess.run",
-        lambda *args, **kwargs: _completed(stdout=json.dumps(payload)),
-    )
+    payload["version"] = 99
 
-    with pytest.raises(RuntimeError, match=f"schema version {schema_version} is unsupported"):
-        request_and_resolve(
-            BundleRequest(agent=None, project_root=Path("/tmp/project")),
-            harness_registry=get_default_harness_registry(),
-        )
-
-
-def test_request_and_resolve_extracts_schema_v2_routing_diagnostics(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr("meridian.lib.launch.bundle_adapter._resolve_mars_binary", lambda: "mars")
-    payload = _valid_bundle_payload()
-    payload["routing"] = {
-        "model": "gpt-5.5",
-        "model_token": "gpt55",
-        "harness": "opencode",
-        "harness_model": "openai/gpt-5.5",
-        "selection_kind": "policy",
-        "match_evidence": "rule-42",
-        "harness_model_source": "policy",
-        "harness_model_confidence": "medium",
-        "route_trace": {
-            "rule_id": "rule-42",
-            "steps": ["alias-lookup", "policy-match"],
-            "extra": {"reason": "exact-match"},
-        },
-    }
-    monkeypatch.setattr(
-        "subprocess.run",
-        lambda *args, **kwargs: _completed(stdout=json.dumps(payload)),
-    )
-
-    bundle = request_and_resolve(
-        BundleRequest(agent=None, project_root=Path("/tmp/project")),
-        harness_registry=get_default_harness_registry(),
-    )
-
-    assert bundle.selection_kind == "policy"
-    assert bundle.match_evidence == "rule-42"
-    assert bundle.harness_model_source == "policy"
-    assert bundle.harness_model_confidence == "medium"
-    assert bundle.route_trace == {
-        "rule_id": "rule-42",
-        "steps": ["alias-lookup", "policy-match"],
-        "extra": {"reason": "exact-match"},
-    }
-
-
-def test_request_and_resolve_schema_v2_route_trace_falls_back_to_empty_dict(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr("meridian.lib.launch.bundle_adapter._resolve_mars_binary", lambda: "mars")
-    payload = _valid_bundle_payload()
-    payload["routing"] = {
-        "model": "gpt-5.5",
-        "model_token": "gpt55",
-        "harness": "opencode",
-        "route_trace": ["alias-lookup", "policy-match"],
-    }
-    monkeypatch.setattr(
-        "subprocess.run",
-        lambda *args, **kwargs: _completed(stdout=json.dumps(payload)),
-    )
-
-    bundle = request_and_resolve(
-        BundleRequest(agent=None, project_root=Path("/tmp/project")),
-        harness_registry=get_default_harness_registry(),
-    )
-
-    assert bundle.route_trace == {}
+    with pytest.raises(RuntimeError, match=r"schema version 99 is unsupported.*mars >= 0\.5\.0"):
+        _resolve_with_payload(monkeypatch, payload)
 
 
 def test_request_and_resolve_reports_missing_routing_model(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("meridian.lib.launch.bundle_adapter._resolve_mars_binary", lambda: "mars")
     payload = _valid_bundle_payload()
     payload["routing"] = {"harness": "opencode"}
-    monkeypatch.setattr(
-        "subprocess.run",
-        lambda *args, **kwargs: _completed(stdout=json.dumps(payload)),
-    )
 
     with pytest.raises(RuntimeError, match=r"routing\.model is empty"):
-        request_and_resolve(
-            BundleRequest(agent=None, project_root=Path("/tmp/project")),
-            harness_registry=get_default_harness_registry(),
-        )
+        _resolve_with_payload(monkeypatch, payload)
 
 
 def test_request_and_resolve_reports_missing_routing_harness(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr("meridian.lib.launch.bundle_adapter._resolve_mars_binary", lambda: "mars")
     payload = _valid_bundle_payload()
     payload["routing"] = {"model": "gpt-5.5"}
-    monkeypatch.setattr(
-        "subprocess.run",
-        lambda *args, **kwargs: _completed(stdout=json.dumps(payload)),
-    )
 
     with pytest.raises(RuntimeError, match=r"routing\.harness is empty"):
-        request_and_resolve(
-            BundleRequest(agent=None, project_root=Path("/tmp/project")),
-            harness_registry=get_default_harness_registry(),
-        )
+        _resolve_with_payload(monkeypatch, payload)
 
 
 @pytest.mark.parametrize(
@@ -363,41 +289,25 @@ def test_request_and_resolve_reports_invalid_nested_bundle_sections(
     field_value: object,
     message: str,
 ) -> None:
-    monkeypatch.setattr("meridian.lib.launch.bundle_adapter._resolve_mars_binary", lambda: "mars")
     payload = _valid_bundle_payload()
     payload[field_name] = field_value
-    monkeypatch.setattr(
-        "subprocess.run",
-        lambda *args, **kwargs: _completed(stdout=json.dumps(payload)),
-    )
 
     with pytest.raises(RuntimeError, match=message):
-        request_and_resolve(
-            BundleRequest(agent=None, project_root=Path("/tmp/project")),
-            harness_registry=get_default_harness_registry(),
-        )
+        _resolve_with_payload(monkeypatch, payload)
 
 
 def test_request_and_resolve_reports_unknown_routing_harness(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr("meridian.lib.launch.bundle_adapter._resolve_mars_binary", lambda: "mars")
     payload = _valid_bundle_payload()
     payload["routing"] = {
         "model": "gpt-5.5",
         "model_token": "gpt55",
         "harness": "definitely-not-a-harness",
     }
-    monkeypatch.setattr(
-        "subprocess.run",
-        lambda *args, **kwargs: _completed(stdout=json.dumps(payload)),
-    )
 
     with pytest.raises(ValueError, match="unsupported routing\\.harness"):
-        request_and_resolve(
-            BundleRequest(agent=None, project_root=Path("/tmp/project")),
-            harness_registry=get_default_harness_registry(),
-        )
+        _resolve_with_payload(monkeypatch, payload)
 
 
 def test_request_and_resolve_reports_subprocess_file_not_found(

--- a/uv.lock
+++ b/uv.lock
@@ -666,15 +666,15 @@ wheels = [
 
 [[package]]
 name = "mars-agents"
-version = "0.4.8rc7"
+version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1c/97/55948a51675fc1b23f0544c6e9e4cef7741875228ec9c81a84918cae9b3d/mars_agents-0.4.8rc7.tar.gz", hash = "sha256:a95dadcb861c16dd58f8fcbdf0ac280dbb1a832989f37727bdb7d11a14812781", size = 516899, upload-time = "2026-05-21T07:16:50.231Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/07/a8212a171efcbdaaf47c983bc46592468438e9f53bfb4aa543b6b510846a/mars_agents-0.5.0.tar.gz", hash = "sha256:cb72153120f17babed58161c94d52251dfc762ec233a6b9d2f177561a00a3f94", size = 541084, upload-time = "2026-05-22T16:29:09.033Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/47/098d42d67086654090f24807eb7493fb1948c9739c4038c3fdff09999867/mars_agents-0.4.8rc7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:c4323d45aca69fa1386f5f0d50b26914bcd3d235d0c0787537af2a4c05432d4b", size = 3082960, upload-time = "2026-05-21T07:16:40.24Z" },
-    { url = "https://files.pythonhosted.org/packages/95/9d/70a237ed0ed93a87636ac13f828b017a83d85479b2e6ac4929061f3e2ae3/mars_agents-0.4.8rc7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:8d1ac15c0ab95786a49deecd974579fbd75a856bf8964ebdfc6ea1c5eeb7cf31", size = 2947090, upload-time = "2026-05-21T07:16:42.294Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/14/066bfa339ff7d000a9a3d9c95e5edc39d5693a007732789bd32a5ed788bd/mars_agents-0.4.8rc7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b2a7437adcaaa5a6f41177a3450729920bc6224650156ad3e12efc94f255b208", size = 3008788, upload-time = "2026-05-21T07:16:44.636Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/e0/2d493dd73c2a41b4e571cb4862fbbd3cdbbc3721387f65c8456b00fad10a/mars_agents-0.4.8rc7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7fa72aa76259da5453a8923f68f0150f36bad401fe83b3297302219edf2eb97", size = 3198783, upload-time = "2026-05-21T07:16:46.343Z" },
-    { url = "https://files.pythonhosted.org/packages/48/06/e7f0128a88faa4cf7516d5efa7774a07ee5cfafc667181a47151258f30a2/mars_agents-0.4.8rc7-py3-none-win_amd64.whl", hash = "sha256:33321cc42abaf10cf329771b6f42919b9128e331b283ed3ac941fb987d1c0405", size = 3109789, upload-time = "2026-05-21T07:16:48.089Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/0f/bcf21fdfb6f8f4c8d980a8a1ccc4e16665286d5b9e90e01706a43675a86c/mars_agents-0.5.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:2001c72dceab776eb39539bd7b31768bece1940540ab8cd1bcaf9dd999d78d67", size = 3142507, upload-time = "2026-05-22T16:28:59.544Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3b/f366cce547227d5369b061df8fc540d1721e4d44996523e64c2017347b5a/mars_agents-0.5.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6e5c6e52f821cf08287c793c1ca9d289724bde1137b21afa4b0816f96bfb60c5", size = 3014005, upload-time = "2026-05-22T16:29:01.226Z" },
+    { url = "https://files.pythonhosted.org/packages/29/cc/725f64f013c3d73f5c15b15bcd4ef0c1ec746f18d26aaef31851715911f6/mars_agents-0.5.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a4b7b4dcd1aeb87df5219d5bf4e912c738fb5bd26fb62c636cb03d3e6e36bb88", size = 3051894, upload-time = "2026-05-22T16:29:02.916Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/ed/f397cb3e8773518b0012bd2ad06d6b408f2339b770bfcf159ca4b20dd804/mars_agents-0.5.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:640c22db442eae5643d62ae15e3ce0908f090b7bd5b663adf53cbc7380407b81", size = 3262135, upload-time = "2026-05-22T16:29:04.671Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a0/689511e306fbfc935059109b4b4f33963b481ab8c2f40762f952d8627e53/mars_agents-0.5.0-py3-none-win_amd64.whl", hash = "sha256:332d9cf75f3711c0525eae9355bd7288f54225ba7cdb75332cf78eea1b56e4ba", size = 3178608, upload-time = "2026-05-22T16:29:07.192Z" },
 ]
 
 [[package]]
@@ -763,7 +763,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'app'", specifier = ">=0.28" },
     { name = "jinja2", marker = "extra == 'templates'", specifier = ">=3.1" },
     { name = "markdown-it-py", specifier = ">=4.0" },
-    { name = "mars-agents", specifier = "==0.4.8rc7" },
+    { name = "mars-agents", specifier = "==0.5.0" },
     { name = "mcp", specifier = ">=1.0" },
     { name = "pathspec", specifier = ">=1.1.0" },
     { name = "psutil", specifier = ">=7.2.2" },

--- a/uv.lock
+++ b/uv.lock
@@ -666,15 +666,15 @@ wheels = [
 
 [[package]]
 name = "mars-agents"
-version = "0.5.0"
+version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/87/07/a8212a171efcbdaaf47c983bc46592468438e9f53bfb4aa543b6b510846a/mars_agents-0.5.0.tar.gz", hash = "sha256:cb72153120f17babed58161c94d52251dfc762ec233a6b9d2f177561a00a3f94", size = 541084, upload-time = "2026-05-22T16:29:09.033Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/8f/5bec6c63d9dfe20be1345c4f76fa0a32fc5aabc344e935e5f05d4d9e5a67/mars_agents-0.6.1.tar.gz", hash = "sha256:450b134ec816df58aefd9e3f7040f731514c98966b780d3a1261b51752b40249", size = 542465, upload-time = "2026-05-22T20:45:53.145Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/0f/bcf21fdfb6f8f4c8d980a8a1ccc4e16665286d5b9e90e01706a43675a86c/mars_agents-0.5.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:2001c72dceab776eb39539bd7b31768bece1940540ab8cd1bcaf9dd999d78d67", size = 3142507, upload-time = "2026-05-22T16:28:59.544Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/3b/f366cce547227d5369b061df8fc540d1721e4d44996523e64c2017347b5a/mars_agents-0.5.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6e5c6e52f821cf08287c793c1ca9d289724bde1137b21afa4b0816f96bfb60c5", size = 3014005, upload-time = "2026-05-22T16:29:01.226Z" },
-    { url = "https://files.pythonhosted.org/packages/29/cc/725f64f013c3d73f5c15b15bcd4ef0c1ec746f18d26aaef31851715911f6/mars_agents-0.5.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a4b7b4dcd1aeb87df5219d5bf4e912c738fb5bd26fb62c636cb03d3e6e36bb88", size = 3051894, upload-time = "2026-05-22T16:29:02.916Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/ed/f397cb3e8773518b0012bd2ad06d6b408f2339b770bfcf159ca4b20dd804/mars_agents-0.5.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:640c22db442eae5643d62ae15e3ce0908f090b7bd5b663adf53cbc7380407b81", size = 3262135, upload-time = "2026-05-22T16:29:04.671Z" },
-    { url = "https://files.pythonhosted.org/packages/87/a0/689511e306fbfc935059109b4b4f33963b481ab8c2f40762f952d8627e53/mars_agents-0.5.0-py3-none-win_amd64.whl", hash = "sha256:332d9cf75f3711c0525eae9355bd7288f54225ba7cdb75332cf78eea1b56e4ba", size = 3178608, upload-time = "2026-05-22T16:29:07.192Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/01/10adacd024bfd0108f33f654192a9bb9c92cd4d31d07e764b4e0dae69c86/mars_agents-0.6.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:8de061183d1622264409f18854672da49003bae277ff0f0ca157c86bfd197488", size = 3148317, upload-time = "2026-05-22T20:45:43.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/30/b0e47fc7ef0032e39f7e36a026c840a663cd6fa95edbc7ae283e86905716/mars_agents-0.6.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:0467d5e4cca62a0eb16b547dd1899c025b1afcaf8b23871381ed6ab2d7d2390a", size = 3011766, upload-time = "2026-05-22T20:45:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/35/972f59025920215228fd0051d2e23bb42a1a4e8d96a5f447d0f3b2f08101/mars_agents-0.6.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da713a40d20c52da05eb6dbb912c86fe3841041966c0af67c0eca2fe131b8193", size = 3052211, upload-time = "2026-05-22T20:45:47.823Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/a2/492e1568926f55844fcaf9ebc10da51f61fc6760d353eda4e12908998bfe/mars_agents-0.6.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de87a0751d9dc68b78ec2accb49ee2a21a44ca3da569f1dc67de6a06b317b8c3", size = 3267895, upload-time = "2026-05-22T20:45:49.783Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/0e/4884533ae95a4a4ba6b9ac9e327a696cd8649550acdc0de3f9f9f8659cc8/mars_agents-0.6.1-py3-none-win_amd64.whl", hash = "sha256:4fe2eb9fbf8738ce69c569cacf9c776809e132fef6b666c55a46bd8120ebb24c", size = 3185602, upload-time = "2026-05-22T20:45:51.43Z" },
 ]
 
 [[package]]
@@ -763,7 +763,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'app'", specifier = ">=0.28" },
     { name = "jinja2", marker = "extra == 'templates'", specifier = ">=3.1" },
     { name = "markdown-it-py", specifier = ">=4.0" },
-    { name = "mars-agents", specifier = "==0.5.0" },
+    { name = "mars-agents", specifier = "==0.6.1" },
     { name = "mcp", specifier = ">=1.0" },
     { name = "pathspec", specifier = ">=1.1.0" },
     { name = "psutil", specifier = ">=7.2.2" },


### PR DESCRIPTION
## Summary

This PR bundles all changes from `v0.1.14-rc.1` through `rc.5` plus the schema-v2 branch into a single minor release. The major themes:

### Mars launch bundle schema v2
- Spawn-prepare and primary launch policy now route model/harness/execution-policy through `mars build launch-bundle` adapter instead of local compiler resolution
- Schema v2 accepted, v1 and unknown versions rejected with upgrade hint
- `mars-agents` pinned to `0.6.1`
- `_MARS_BUNDLE_MIN_VERSION` derived from installed package metadata (no hardcoded version drift)
- Dead diagnostic fields removed from `_BundleResult` (5 fields, -110 lines net)

### Model-optional harness passthrough
- Empty `routing.model` from mars accepted — harness picks its default model instead of erroring
- Missing-runnable-path warning skipped when model is empty (no model to warn about)
- All harness projections (Claude, OpenCode, Codex, Pi) verified to skip `--model` flag on empty model

### Pi harness integration (rc.1–rc.4)
- Full Pi subprocess harness: `HarnessId.PI`, `meridian pi` shortcut, adapter, projection, extractor
- Pi runtime TypeScript extensions: `managed-bash` and `meridian-lifecycle`
- RPC-only spawned launch with managed extension projection and quiescence-aware drain
- Primary native Pi TUI with lifecycle extension, no RPC
- Cross-platform support: Windows path escaping, `file://` URLs for ESM loading, cross-platform child cleanup

### Spawn task cwd anchors (rc.4–rc.5)
- Authority root separated from task cwd: authority stays project/config/catalog/KB root, task cwd drives file work
- Relative `-f` paths resolve from task cwd/reference anchor
- `--work` is hard task-cwd selection boundary with stale worktree hard-error
- `meridian work set-worktree` / `clear-worktree` for explicit worktree assignment
- Task cwd outside authority root projected to harness workspace

### AgentProfile simplification (rc.4)
- AgentProfile shrunk to identity + content; mars parses profile routing/tools/execution-policy
- Removed: `AgentOverlayConfig`, `[agents]` block in `meridian.toml`, `MERIDIAN_HARNESS` env var, `[defaults]` routing keys
- Model listing consumes Mars model visibility output directly (no Meridian-side heuristics)

### Packaging & release
- Pi extension artifacts now included in wheel (`hatch artifacts`) — fixes `meridian pi` on installed packages
- Release workflow builds Pi extensions before preflight (`Node.js + pnpm + build:extensions`)
- Release workflow supports `release:minor` and `release:major` PR labels
- Warning hygiene: intermediate spawn retry warnings demoted to info, `--append-system-prompt` collision restored at warning level

### Test suite
- ~240 implementation-pinning tests deleted across rc.1–rc.5
- Spawn/launch integration tests now fake the bundle adapter boundary
- Suite runs parallel by default (`-n auto`, ~50s vs ~210s)

## Test plan
- [x] `uv run pytest` — 1009 passed, 2 skipped
- [x] `uv run ruff check .` — clean
- [x] `uv run pyright` — 0 errors
- [x] Pi extensions verified in built wheel
- [x] `meridian opencode` launches clean on empty-model passthrough
- [x] Rebased on main, preflight clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)