### PR TITLE
Persist spawn launch policy snapshots for exact continue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ Two orchestrators split the dev lifecycle: **dev-orchestrator** handles interact
 
 Use `meridian spawn` (not `uv run meridian spawn`) to hand off tasks to subagents. `uv run meridian` runs from local source, so other agents editing meridian's own code in the same repo can leave it in a half-written state — use it only for smoke-testing local dev changes. The installed `meridian` binary is stable and isolated from in-progress source edits.
 
-**Model aliases are the interface.** When the user specifies a model name (e.g. `gptmini`, `codex`, `opus`), pass it directly to `-m` as-is — never translate, guess, or expand the alias to an underlying model ID. Meridian resolves aliases at spawn time. If you need to know what an alias maps to, run `meridian mars models list` first. Do not invent model identifiers.
+**Model aliases are the interface.** When the user specifies a model name (e.g. `gptmini`, `codex`, `opus`), pass it directly to `-m` as-is — never translate, guess, or expand the alias to an underlying model ID. Meridian resolves aliases at spawn time. If you need to know what an alias maps to in the current project, run `meridian mars models resolve <alias> --json`. Use `meridian mars models list --live` only when you need bulk runnable/availability evidence. Do not invent model identifiers.
 
 **Use cheap models for trivial spawn/model smoke tests.** When testing harness plumbing, alias resolution, or spawn mechanics with a throwaway prompt (e.g. `Reply with exactly OK`), reach for `haiku`, `gpt-5.4-mini`, or a cheap OpenCode model. Reserve expensive models (Claude Sonnet/Opus, GPT-5) for tasks that need their reasoning.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - Spawn rows now persist `launch_policy_snapshot`; older `state.json` files without the field still read cleanly.
 - Launch preparation now snapshots resolved agent description/body, skill paths, and policy provenance fields into the persisted launch-policy snapshot.
+- Launch preparation now snapshots resolved loaded skill payloads into the persisted launch-policy snapshot so replay keeps skill content/name/path stable.
 
 ### Changed
 - `spawn --continue` now replays the source launch policy snapshot and rejects policy-changing overrides.
-- Spawn launch-policy compilation now reuses persisted snapshots when present instead of re-running live launch-bundle/config/profile resolution.
+- Spawn launch-policy compilation now reuses persisted snapshots when present instead of re-running live launch-bundle/config/profile/skill resolution.
 - Primary Claude launches now project profile-resolved `approval:auto` to `--permission-mode acceptEdits` without requiring a CLI `--approval` override.
 
 ## [0.2.7] - 2026-05-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Launch preparation now snapshots resolved loaded skill payloads into the persisted launch-policy snapshot so replay keeps skill content/name/path stable.
 
 ### Changed
+- Bump bundled `mars-agents` to 0.7.3 and document static `models list` vs live `models list --live` semantics.
 - `spawn --continue` now replays the source launch policy snapshot and rejects policy-changing overrides.
 - Spawn launch-policy compilation now reuses persisted snapshots when present instead of re-running live launch-bundle/config/profile/skill resolution.
 - Primary Claude launches now project profile-resolved `approval:auto` to `--permission-mode acceptEdits` without requiring a CLI `--approval` override.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Spawn rows now persist `launch_policy_snapshot`; older `state.json` files without the field still read cleanly.
+
+### Changed
+- `spawn --continue` now replays the source launch policy snapshot and rejects policy-changing overrides.
+
 ## [0.2.7] - 2026-05-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - Spawn rows now persist `launch_policy_snapshot`; older `state.json` files without the field still read cleanly.
+- Launch preparation now snapshots resolved agent description/body, skill paths, and policy provenance fields into the persisted launch-policy snapshot.
 
 ### Changed
 - `spawn --continue` now replays the source launch policy snapshot and rejects policy-changing overrides.
+- Spawn launch-policy compilation now reuses persisted snapshots when present instead of re-running live launch-bundle/config/profile resolution.
+- Primary Claude launches now project profile-resolved `approval:auto` to `--permission-mode acceptEdits` without requiring a CLI `--approval` override.
 
 ## [0.2.7] - 2026-05-25
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -107,9 +107,11 @@ Run:
 meridian doctor
 meridian mars sync
 meridian mars models list
+meridian mars models list --live
 ```
 
 Notes:
-- `meridian mars models list` may require provider API keys.
+- `meridian mars models list` is a lightweight static catalog check.
+- `meridian mars models list --live` checks runnable harness routes and may require provider credentials or installed harness CLIs.
 - `meridian mars sync` should complete without package resolution errors.
 - Report any failed checks and propose next concrete fix steps.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -469,9 +469,16 @@ When `source = "git"`, Meridian clones the remote into a local cache and resolve
 
 ## Model Catalog
 
-`meridian mars models list` shows resolved model aliases. Use `--all` to include
-all alias candidates, `--unavailable` to include unavailable routes, or
-`--catalog` for the raw models.dev cache.
+`meridian mars models list` shows the static alias/catalog inventory for the
+current project. Use `--all` to include all alias candidates or `--catalog` for
+the raw models.dev cache.
+
+Use `meridian mars models list --live` when you need routed availability,
+selected harnesses, and runnable paths. In live mode, `--unavailable` includes
+unavailable routes.
+
+Use `meridian mars models resolve ALIAS --json` for the authoritative mapping a
+spawn will use in the current project and local config.
 
 Builtin aliases (`opus`, `sonnet`, `haiku`, `codex`, `gpt`, `gemini`) auto-resolve to the latest model per family. The default list filters aggressively:
 
@@ -482,7 +489,10 @@ Builtin aliases (`opus`, `sonnet`, `haiku`, `codex`, `gpt`, `gemini`) auto-resol
 
 Use `meridian mars models refresh` to force a cache refresh from the models.dev catalog.
 
-Cursor models appear as `runnable` when the `cursor` binary is installed and the harness probe succeeds. If `cursor` is not on `PATH`, cursor models show as `unavailable`. Run `meridian doctor` to check harness status.
+In `models list --live` output, Cursor models appear as `runnable` when the
+`cursor` binary is installed and the harness probe succeeds. If `cursor` is not
+on `PATH`, Cursor routes show as `unavailable`. Run `meridian doctor` to check
+harness status.
 
 ## Cursor Harness
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,7 +13,7 @@ Meridian is a coordination layer — it needs at least one harness installed to 
 
 **Claude Code** is the most mature primary-session harness. Codex also supports managed primary TUI passthrough, including hidden instruction routing and managed session tracking. See [codex-tui-passthrough.md](codex-tui-passthrough.md).
 
-**Cursor** runs as a subprocess harness via `cursor agent`. Models are checked at spawn time — run `meridian mars models list` to confirm which cursor models show as available on your installation.
+**Cursor** runs as a subprocess harness via `cursor agent`. Models are checked at spawn time — run `meridian mars models list --live` to confirm which cursor models are runnable on your installation.
 
 **Platform**: macOS, Linux, Windows, WSL.
 
@@ -114,7 +114,8 @@ This links the mars-compiled output into the target harness directory so skills 
 
 ```bash
 meridian config show   # confirm resolved config
-meridian mars models list   # confirm available models
+meridian mars models list   # confirm model catalog inventory
+meridian mars models list --live   # confirm runnable models
 meridian doctor        # check harness connectivity
 ```
 

--- a/docs/harness-integration.md
+++ b/docs/harness-integration.md
@@ -718,7 +718,7 @@ For Mars to fully support a harness, the following are needed:
    `harness: pi` and `model: sonnet` and have resolution produce the correct
    Pi model string.
 
-4. **`meridian mars models list`**: Should show which models are available
+4. **`meridian mars models list --live`**: Should show which models are runnable
    through the Pi harness.
 
 **Current Pi status**: None of the above is implemented. Pi-compatible model

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -39,11 +39,13 @@ Then confirm with `meridian doctor`.
 
 ## Model routes to wrong harness
 
-Harness routing is determined by model prefix patterns. Check what's resolved:
+Harness routing is determined by model aliases, effective config, and runtime
+harness evidence. Check what resolves:
 
 ```bash
-meridian mars models list # see available models and their harnesses
-meridian config show      # see harness defaults and overrides
+meridian mars models resolve MODEL --json # inspect model/harness resolution
+meridian mars models list --live          # see runnable models and harnesses
+meridian config show                      # see harness defaults and overrides
 ```
 
 To force a specific harness for a spawn, use `--harness`:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "cyclopts>=3.0",
   "fastapi>=0.115",
   "markdown-it-py>=4.0",
-  "mars-agents==0.7.1",
+  "mars-agents==0.7.3",
   "mcp>=1.0",
   "pathspec>=1.1.0",
   "psutil>=7.2.2",

--- a/src/meridian/cli/startup/catalog.py
+++ b/src/meridian/cli/startup/catalog.py
@@ -206,7 +206,7 @@ _COMMAND_DESCRIPTORS: tuple[CommandDescriptor, ...] = (
         StateRequirement.NONE,
         TelemetryMode.NONE,
         "text",
-        "List available models.",
+        "List model catalog inventory.",
         redirect=RedirectPolicy(
             target="meridian mars models list", message="Redirecting to meridian mars models list"
         ),

--- a/src/meridian/cli/startup/help.py
+++ b/src/meridian/cli/startup/help.py
@@ -36,7 +36,7 @@ Primary launch/resume:
 Quick start:
   meridian spawn -m MODEL --prompt-file /tmp/task.md --bg   Launch a subagent
   meridian spawn wait                        Wait for all pending spawns
-  meridian mars models list                  See available models
+  meridian mars models list                  See model catalog inventory
 
 Commands:
   spawn    Create and manage subagent runs

--- a/src/meridian/lib/catalog/model_aliases.py
+++ b/src/meridian/lib/catalog/model_aliases.py
@@ -595,8 +595,9 @@ def _mars_merged_to_entries(merged: dict[str, object]) -> list[AliasEntry]:
                     default_autocompact_pct=_coerce_optional_int(default_autocompact_pct),
                 )
             )
-        # Auto-resolve aliases without the cache can't be resolved here
-        # — they need mars models list which runs auto-resolve against the cache
+        # Auto-resolve aliases without the cache cannot be resolved from the merged file.
+        # Use `mars models resolve <alias> --json` for authoritative per-alias routing
+        # or `mars models list --live` for bulk live availability/runnable data.
 
     return entries
 
@@ -608,11 +609,13 @@ def load_mars_aliases(
 ) -> list[AliasEntry]:
     """Load model aliases from mars.
 
-    Prefers ``mars models list --json`` for the full resolved view
-    (includes consumer overrides + auto-resolution).  Falls back to
-    reading ``.mars/models-merged.json`` if the mars binary isn't available.
+    Prefers ``mars models list --json`` for the static project alias inventory.
+    Falls back to reading ``.mars/models-merged.json`` if the mars binary isn't
+    available. Use ``mars models resolve <alias> --json`` for authoritative
+    per-alias routing and ``mars models list --live`` for availability/runnable
+    data.
     """
-    # Try mars CLI first — it returns fully resolved aliases
+    # Try mars CLI first — it returns the static project alias inventory.
     mars_list = cached_mars_models_list(project_root, cache=cache)
     if mars_list is not None:
         entries = _mars_list_to_entries(mars_list)

--- a/src/meridian/lib/core/launch_policy_snapshot.py
+++ b/src/meridian/lib/core/launch_policy_snapshot.py
@@ -1,5 +1,42 @@
-"""Compatibility import for the persisted spawn launch-policy snapshot model."""
+"""Durable launch-policy snapshot DTO persisted with spawn state."""
 
-from meridian.lib.state.spawn.model import LaunchPolicySnapshot
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from meridian.lib.core.domain import SkillContent
+from meridian.lib.core.execution_policy import ResolvedExecutionPolicy
+from meridian.lib.tools import ToolsField
+
+
+class LaunchPolicySnapshot(BaseModel):
+    """Durable JSON-safe resolved launch contract persisted with a spawn row."""
+
+    model_config = ConfigDict(frozen=True)
+
+    schema_version: int = 1
+    model: str
+    harness: str
+    agent: str | None = None
+    agent_path: str | None = None
+    agent_description: str = ""
+    agent_profile_body: str = ""
+    skills: tuple[str, ...] = ()
+    skill_paths: tuple[str, ...] = ()
+    loaded_skills: tuple[SkillContent, ...] = ()
+    extra_args: tuple[str, ...] = ()
+    execution_policy: ResolvedExecutionPolicy = Field(default_factory=ResolvedExecutionPolicy)
+    tools: ToolsField | None = None
+    mcp_tools: tuple[str, ...] = ()
+    terminal_surface_mode: str | None = None
+    matched_policy_rule: str | None = None
+    model_selection_requested_token: str | None = None
+    model_selection_selected_token: str | None = None
+    model_selection_canonical_id: str | None = None
+    model_selection_harness_provenance: str | None = None
+    model_selection_harness_model_id: str | None = None
+    field_provenance: dict[str, str] = Field(default_factory=dict)
+    fallback_chain: tuple[dict[str, object], ...] = ()
+
 
 __all__ = ["LaunchPolicySnapshot"]

--- a/src/meridian/lib/core/launch_policy_snapshot.py
+++ b/src/meridian/lib/core/launch_policy_snapshot.py
@@ -1,0 +1,5 @@
+"""Compatibility import for the persisted spawn launch-policy snapshot model."""
+
+from meridian.lib.state.spawn.model import LaunchPolicySnapshot
+
+__all__ = ["LaunchPolicySnapshot"]

--- a/src/meridian/lib/core/lifecycle.py
+++ b/src/meridian/lib/core/lifecycle.py
@@ -16,9 +16,10 @@ Design decisions in effect:
 
 Import note
 -----------
-Shared spawn domain models live in ``meridian.lib.state.spawn.model`` so this
-service imports shared types without depending on store-owned models. Store access
-stays lazy so package-level compatibility re-exports do not reintroduce cycles.
+Shared spawn record types live in ``meridian.lib.state.spawn.model`` and
+launch-policy snapshot lives in ``meridian.lib.core.launch_policy_snapshot``.
+Store access stays lazy so package-level compatibility re-exports do not
+reintroduce cycles.
 """
 
 from __future__ import annotations
@@ -54,12 +55,12 @@ if TYPE_CHECKING:
 
     from meridian.lib.core.clock import Clock
     from meridian.lib.core.domain import SpawnStatus, TokenUsage
+    from meridian.lib.core.launch_policy_snapshot import LaunchPolicySnapshot
     from meridian.lib.hooks.dispatch import HookDispatcher
     from meridian.lib.launch.types import PrimarySessionMetadata
     from meridian.lib.platform.process_scope.base import ProcessScopeSnapshot
     from meridian.lib.state.spawn.model import (
         LaunchMode,
-        LaunchPolicySnapshot,
         SpawnOrigin,
         SpawnRecord,
     )

--- a/src/meridian/lib/core/lifecycle.py
+++ b/src/meridian/lib/core/lifecycle.py
@@ -57,7 +57,12 @@ if TYPE_CHECKING:
     from meridian.lib.hooks.dispatch import HookDispatcher
     from meridian.lib.launch.types import PrimarySessionMetadata
     from meridian.lib.platform.process_scope.base import ProcessScopeSnapshot
-    from meridian.lib.state.spawn.model import LaunchMode, SpawnOrigin, SpawnRecord
+    from meridian.lib.state.spawn.model import (
+        LaunchMode,
+        LaunchPolicySnapshot,
+        SpawnOrigin,
+        SpawnRecord,
+    )
     from meridian.lib.state.spawn_store import FinalizeOutcome
 
 logger = structlog.get_logger(__name__)
@@ -245,6 +250,7 @@ class SpawnLifecycleService:
         launch_mode: LaunchMode | None = None,
         worker_pid: int | None = None,
         runner_pid: int | None = None,
+        launch_policy_snapshot: LaunchPolicySnapshot | None = None,
         status: SpawnStatus = "running",
         started_at: str | None = None,
         clock: Clock | None = None,
@@ -276,6 +282,7 @@ class SpawnLifecycleService:
                 launch_mode=launch_mode,
                 worker_pid=worker_pid,
                 runner_pid=runner_pid,
+                launch_policy_snapshot=launch_policy_snapshot,
                 status=status,
                 started_at=started_at,
                 clock=clock,

--- a/src/meridian/lib/core/spawn_service.py
+++ b/src/meridian/lib/core/spawn_service.py
@@ -355,6 +355,7 @@ class SpawnApplicationService:
             desc=payload.desc,
             work_id=effective_work_id,
             goal=getattr(resolved_request, "goal", None),
+            launch_policy_snapshot=resolved_request.launch_policy_snapshot,
         )
 
         # SEAM-ID.1: Persist the already-reserved ID via lifecycle service only
@@ -386,6 +387,7 @@ class SpawnApplicationService:
                 execution_cwd=launch_ctx.binding.child_cwd.as_posix(),
                 launch_mode=payload.launch_mode,
                 runner_pid=payload.runner_pid,
+                launch_policy_snapshot=resolved_request.launch_policy_snapshot,
                 status=payload.initial_status,
             )
         )

--- a/src/meridian/lib/core/spawn_start.py
+++ b/src/meridian/lib/core/spawn_start.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from meridian.lib.core.launch_policy_snapshot import LaunchPolicySnapshot
+
 
 @dataclass(frozen=True)
 class SpawnStartMetadata:
@@ -12,3 +14,4 @@ class SpawnStartMetadata:
     desc: str | None = None
     work_id: str | None = None
     goal: str | None = None
+    launch_policy_snapshot: LaunchPolicySnapshot | None = None

--- a/src/meridian/lib/launch/context.py
+++ b/src/meridian/lib/launch/context.py
@@ -23,6 +23,7 @@ from meridian.lib.config.settings import MeridianConfig, load_config
 from meridian.lib.config.workspace import get_projectable_roots
 from meridian.lib.context.resolver import resolve_context_paths
 from meridian.lib.core.child_env import validate_child_env_keys
+from meridian.lib.core.domain import SkillContent
 from meridian.lib.core.overrides import RuntimeOverrides
 from meridian.lib.core.resolved_context import ResolvedContext
 from meridian.lib.core.types import HarnessId, ModelId, SpawnId
@@ -525,6 +526,7 @@ def build_launch_policy_snapshot(
     request: SpawnRequest,
     *,
     model_selection: ModelSelectionContext | None = None,
+    loaded_skills: tuple[SkillContent, ...] = (),
 ) -> LaunchPolicySnapshot:
     """Build a durable launch-policy snapshot from a resolved request."""
 
@@ -532,6 +534,8 @@ def build_launch_policy_snapshot(
     harness = (request.harness or "").strip()
     if not harness:
         raise ValueError("Resolved request is missing harness for launch policy snapshot.")
+    resolved_skill_names = tuple(skill.name for skill in loaded_skills) or request.skills
+    resolved_skill_paths = tuple(skill.path for skill in loaded_skills) or request.skill_paths
     return LaunchPolicySnapshot(
         model=model,
         harness=harness,
@@ -541,8 +545,9 @@ def build_launch_policy_snapshot(
             request.agent_metadata.get("session_agent_description") or ""
         ).strip(),
         agent_profile_body=request.agent_metadata.get("session_agent_profile_body") or "",
-        skills=request.skills,
-        skill_paths=request.skill_paths,
+        skills=resolved_skill_names,
+        skill_paths=resolved_skill_paths,
+        loaded_skills=loaded_skills,
         execution_policy=request.execution_policy,
         tools=request.tools,
         mcp_tools=request.mcp_tools,
@@ -1411,6 +1416,7 @@ def prepare_launch_surface(
             or build_launch_policy_snapshot(
                 resolved_request,
                 model_selection=model_selection,
+                loaded_skills=resolved_skills.loaded_skills,
             )
         }
     )

--- a/src/meridian/lib/launch/context.py
+++ b/src/meridian/lib/launch/context.py
@@ -521,13 +521,15 @@ def _request_prompt_payload(prompt_payload: PreparedPromptPayload) -> RequestPro
     )
 
 
-def build_launch_policy_snapshot(request: SpawnRequest) -> LaunchPolicySnapshot:
+def build_launch_policy_snapshot(
+    request: SpawnRequest,
+    *,
+    model_selection: ModelSelectionContext | None = None,
+) -> LaunchPolicySnapshot:
     """Build a durable launch-policy snapshot from a resolved request."""
 
     model = (request.model or "").strip()
     harness = (request.harness or "").strip()
-    if not model:
-        raise ValueError("Resolved request is missing model for launch policy snapshot.")
     if not harness:
         raise ValueError("Resolved request is missing harness for launch policy snapshot.")
     return LaunchPolicySnapshot(
@@ -547,11 +549,15 @@ def build_launch_policy_snapshot(request: SpawnRequest) -> LaunchPolicySnapshot:
         extra_args=request.extra_args,
         model_selection_requested_token=request.model_selection_requested_token,
         model_selection_selected_token=(
-            request.model_selection_requested_token or (request.model or "").strip() or None
+            model_selection.selected_model_token
+            if model_selection is not None
+            else request.model_selection_requested_token or (request.model or "").strip() or None
         ),
         model_selection_canonical_id=request.model_selection_canonical_id,
         model_selection_harness_provenance=request.model_selection_harness_provenance,
-        model_selection_harness_model_id=None,
+        model_selection_harness_model_id=(
+            model_selection.harness_model_id if model_selection is not None else None
+        ),
         matched_policy_rule=request.matched_policy_rule,
         fallback_chain=request.fallback_chain,
         terminal_surface_mode=request.terminal_surface_mode,
@@ -1399,6 +1405,15 @@ def prepare_launch_surface(
             **model_selection_update,
         }
     )
+    resolved_request = resolved_request.model_copy(
+        update={
+            "launch_policy_snapshot": request.launch_policy_snapshot
+            or build_launch_policy_snapshot(
+                resolved_request,
+                model_selection=model_selection,
+            )
+        }
+    )
     return PreparedLaunchSurface(
         request=resolved_request,
         harness=harness,
@@ -1442,7 +1457,13 @@ def _build_direct_surface(
     )
 
     return PreparedLaunchSurface(
-        request=request,
+        request=(
+            request
+            if request.launch_policy_snapshot is not None
+            else request.model_copy(
+                update={"launch_policy_snapshot": build_launch_policy_snapshot(request)}
+            )
+        ),
         harness=harness,
         composition_warnings=composition_warnings,
         content=PreparedLaunchContent(

--- a/src/meridian/lib/launch/context.py
+++ b/src/meridian/lib/launch/context.py
@@ -1455,15 +1455,16 @@ def _build_direct_surface(
         reference_anchor=reference_anchor.expanduser().resolve(),
         kb_dir=resolve_kb_dir(resolved_project_root),
     )
+    resolved_request = (
+        request
+        if request.launch_policy_snapshot is not None
+        else request.model_copy(
+            update={"launch_policy_snapshot": build_launch_policy_snapshot(request)}
+        )
+    )
 
     return PreparedLaunchSurface(
-        request=(
-            request
-            if request.launch_policy_snapshot is not None
-            else request.model_copy(
-                update={"launch_policy_snapshot": build_launch_policy_snapshot(request)}
-            )
-        ),
+        request=resolved_request,
         harness=harness,
         composition_warnings=composition_warnings,
         content=PreparedLaunchContent(
@@ -1486,7 +1487,7 @@ def _build_direct_surface(
         has_profile_for_nested_deny=False,
         model_selection=None,
         alias_catalog=None,
-        launch_request=request,
+        launch_request=resolved_request,
     )
 
 

--- a/src/meridian/lib/launch/context.py
+++ b/src/meridian/lib/launch/context.py
@@ -23,7 +23,6 @@ from meridian.lib.config.settings import MeridianConfig, load_config
 from meridian.lib.config.workspace import get_projectable_roots
 from meridian.lib.context.resolver import resolve_context_paths
 from meridian.lib.core.child_env import validate_child_env_keys
-from meridian.lib.core.domain import SkillContent
 from meridian.lib.core.overrides import RuntimeOverrides
 from meridian.lib.core.resolved_context import ResolvedContext
 from meridian.lib.core.types import HarnessId, ModelId, SpawnId
@@ -85,6 +84,7 @@ from .policies import (
     SurfacePolicyInput,
     resolve_launch_policy,
 )
+from .policy_snapshot import build_launch_policy_snapshot
 from .prompt import (
     build_goal_instruction,
     build_launch_context_documents,
@@ -104,7 +104,6 @@ from .reference import (
 from .request import (
     LaunchArgvIntent,
     LaunchCompositionSurface,
-    LaunchPolicySnapshot,
     LaunchRuntime,
     RequestPromptPayload,
     SpawnRequest,
@@ -519,53 +518,6 @@ def _request_prompt_payload(prompt_payload: PreparedPromptPayload) -> RequestPro
         adhoc_agent_payload=prompt_payload.adhoc_agent_payload,
         appended_system_prompt=prompt_payload.appended_system_prompt,
         user_turn_content=prompt_payload.user_turn_content,
-    )
-
-
-def build_launch_policy_snapshot(
-    request: SpawnRequest,
-    *,
-    model_selection: ModelSelectionContext | None = None,
-    loaded_skills: tuple[SkillContent, ...] = (),
-) -> LaunchPolicySnapshot:
-    """Build a durable launch-policy snapshot from a resolved request."""
-
-    model = (request.model or "").strip()
-    harness = (request.harness or "").strip()
-    if not harness:
-        raise ValueError("Resolved request is missing harness for launch policy snapshot.")
-    resolved_skill_names = tuple(skill.name for skill in loaded_skills) or request.skills
-    resolved_skill_paths = tuple(skill.path for skill in loaded_skills) or request.skill_paths
-    return LaunchPolicySnapshot(
-        model=model,
-        harness=harness,
-        agent=(request.agent or "").strip() or None,
-        agent_path=(request.agent_metadata.get("session_agent_path") or "").strip() or None,
-        agent_description=(
-            request.agent_metadata.get("session_agent_description") or ""
-        ).strip(),
-        agent_profile_body=request.agent_metadata.get("session_agent_profile_body") or "",
-        skills=resolved_skill_names,
-        skill_paths=resolved_skill_paths,
-        loaded_skills=loaded_skills,
-        execution_policy=request.execution_policy,
-        tools=request.tools,
-        mcp_tools=request.mcp_tools,
-        extra_args=request.extra_args,
-        model_selection_requested_token=request.model_selection_requested_token,
-        model_selection_selected_token=(
-            model_selection.selected_model_token
-            if model_selection is not None
-            else request.model_selection_requested_token or (request.model or "").strip() or None
-        ),
-        model_selection_canonical_id=request.model_selection_canonical_id,
-        model_selection_harness_provenance=request.model_selection_harness_provenance,
-        model_selection_harness_model_id=(
-            model_selection.harness_model_id if model_selection is not None else None
-        ),
-        matched_policy_rule=request.matched_policy_rule,
-        fallback_chain=request.fallback_chain,
-        terminal_surface_mode=request.terminal_surface_mode,
     )
 
 

--- a/src/meridian/lib/launch/context.py
+++ b/src/meridian/lib/launch/context.py
@@ -103,6 +103,7 @@ from .reference import (
 from .request import (
     LaunchArgvIntent,
     LaunchCompositionSurface,
+    LaunchPolicySnapshot,
     LaunchRuntime,
     RequestPromptPayload,
     SpawnRequest,
@@ -520,6 +521,43 @@ def _request_prompt_payload(prompt_payload: PreparedPromptPayload) -> RequestPro
     )
 
 
+def build_launch_policy_snapshot(request: SpawnRequest) -> LaunchPolicySnapshot:
+    """Build a durable launch-policy snapshot from a resolved request."""
+
+    model = (request.model or "").strip()
+    harness = (request.harness or "").strip()
+    if not model:
+        raise ValueError("Resolved request is missing model for launch policy snapshot.")
+    if not harness:
+        raise ValueError("Resolved request is missing harness for launch policy snapshot.")
+    return LaunchPolicySnapshot(
+        model=model,
+        harness=harness,
+        agent=(request.agent or "").strip() or None,
+        agent_path=(request.agent_metadata.get("session_agent_path") or "").strip() or None,
+        agent_description=(
+            request.agent_metadata.get("session_agent_description") or ""
+        ).strip(),
+        agent_profile_body=request.agent_metadata.get("session_agent_profile_body") or "",
+        skills=request.skills,
+        skill_paths=request.skill_paths,
+        execution_policy=request.execution_policy,
+        tools=request.tools,
+        mcp_tools=request.mcp_tools,
+        extra_args=request.extra_args,
+        model_selection_requested_token=request.model_selection_requested_token,
+        model_selection_selected_token=(
+            request.model_selection_requested_token or (request.model or "").strip() or None
+        ),
+        model_selection_canonical_id=request.model_selection_canonical_id,
+        model_selection_harness_provenance=request.model_selection_harness_provenance,
+        model_selection_harness_model_id=None,
+        matched_policy_rule=request.matched_policy_rule,
+        fallback_chain=request.fallback_chain,
+        terminal_surface_mode=request.terminal_surface_mode,
+    )
+
+
 def materialize_launch_artifacts(
     *,
     harness: SubprocessHarness,
@@ -913,6 +951,7 @@ def compile_prepared_policy_surface(
             harness_registry=harness_registry,
             skills_readonly=dry_run,
             requested_skills=request.skills,
+            policy_snapshot=request.launch_policy_snapshot,
         )
     )
 
@@ -1222,6 +1261,7 @@ def prepare_launch_surface(
     active_work_dir = prepared_policy.active_work_dir
     policies = prepared_policy.resolved_policy
     profile = policies.profile
+    using_policy_snapshot = request.launch_policy_snapshot is not None
     has_profile = profile is not None
     execution_policy = policies.execution_policy
     model_selection = policies.model_selection
@@ -1292,6 +1332,10 @@ def prepare_launch_surface(
     session_agent_path = resolve_profile_path(profile)
     if resolved_agent_name is not None:
         agent_metadata["session_agent"] = resolved_agent_name
+    if profile is not None and profile.description.strip():
+        agent_metadata["session_agent_description"] = profile.description.strip()
+    if profile is not None and profile.body.strip():
+        agent_metadata["session_agent_profile_body"] = profile.body
     if session_agent_path:
         agent_metadata["session_agent_path"] = session_agent_path
     adhoc_agent_payload = ""
@@ -1314,7 +1358,9 @@ def prepare_launch_surface(
         agent_inventory_prompt=content.agent_inventory_prompt,
         context_prompt=content.context_prompt,
     )
-    profile_tools_for_nested_deny = policies.resolved_tools if profile is not None else None
+    profile_tools_for_nested_deny = (
+        policies.resolved_tools if (profile is not None or using_policy_snapshot) else None
+    )
 
     resolved_request = request.model_copy(
         update={
@@ -1326,10 +1372,16 @@ def prepare_launch_surface(
             "skills": resolved_skills.skill_names,
             "extra_args": final_passthrough_args,
             "mcp_tools": (
-                policies.resolved_mcp_tools if profile is not None else request.mcp_tools
+                policies.resolved_mcp_tools
+                if (profile is not None or using_policy_snapshot)
+                else request.mcp_tools
             ),
             "execution_policy": execution_policy,
-            "tools": policies.resolved_tools if profile is not None else request.tools,
+            "tools": (
+                policies.resolved_tools
+                if (profile is not None or using_policy_snapshot)
+                else request.tools
+            ),
             "session": request.session.model_copy(
                 update={
                     "requested_harness_session_id": continuation.harness_session_id,
@@ -1357,7 +1409,7 @@ def prepare_launch_surface(
             seed_session_args=seed_session_args,
         ),
         profile_tools_for_nested_deny=profile_tools_for_nested_deny,
-        has_profile_for_nested_deny=has_profile,
+        has_profile_for_nested_deny=has_profile or using_policy_snapshot,
         model_selection=model_selection,
         alias_catalog=policies.alias_catalog,
         launch_request=request,
@@ -1839,6 +1891,7 @@ __all__ = [
     "bind_launch_context",
     "build_child_runtime_env_overrides",
     "build_launch_context",
+    "build_launch_policy_snapshot",
     "compile_prepared_policy_surface",
     "materialize_launch_artifacts",
     "merge_env_overrides",

--- a/src/meridian/lib/launch/policies.py
+++ b/src/meridian/lib/launch/policies.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from pathlib import Path
 
 from meridian.lib.catalog.agent import AgentProfile
 from meridian.lib.catalog.catalog_session import CatalogSession
@@ -32,6 +31,10 @@ from .launch_types import (
     ResolvedExecutionPolicy,
     ResolvedLaunchRouting,
     TerminalSurfaceMode,
+)
+from .policy_snapshot import (
+    ReplayedModelSelection,
+    replay_launch_policy_snapshot,
 )
 from .request import LaunchCompositionSurface, LaunchPolicySnapshot
 from .resolve import (
@@ -533,91 +536,45 @@ def _resolve_policy_from_snapshot(
 ) -> ResolvedLaunchPolicy:
     """Resolve launch policy from a persisted launch-policy snapshot."""
 
-    project_root = surface.catalog.project_root
-    snapshot_model = snapshot.model.strip()
-    snapshot_harness = snapshot.harness.strip()
-    if not snapshot_model:
-        raise ValueError("Launch policy snapshot is missing model.")
-    if not snapshot_harness:
-        raise ValueError("Launch policy snapshot is missing harness.")
-    harness_id = HarnessId(snapshot_harness)
-    adapter = surface.harness_registry.get_subprocess_harness(harness_id)
-
-    snapshot_agent = (snapshot.agent or "").strip() or None
-    profile = None
-    snapshot_skill_names = (
-        tuple(skill.name for skill in snapshot.loaded_skills)
-        if snapshot.loaded_skills
-        else dedupe_skill_names(snapshot.skills)
-    )
-    if snapshot_agent is not None:
-        profile_path = (
-            Path(snapshot.agent_path).expanduser().resolve()
-            if snapshot.agent_path is not None and snapshot.agent_path.strip()
-            else (project_root / ".mars" / "agents" / f"{snapshot_agent}.md").resolve()
-        )
-        profile = AgentProfile(
-            name=snapshot_agent,
-            description=snapshot.agent_description,
-            skills=snapshot_skill_names,
-            body=snapshot.agent_profile_body,
-            path=profile_path,
-            raw_content=snapshot.agent_profile_body,
-        )
-
-    if snapshot.loaded_skills:
-        resolved_skills = ResolvedSkills(
-            skill_names=snapshot_skill_names,
-            loaded_skills=snapshot.loaded_skills,
-            missing_skills=(),
-        )
-    else:
-        resolved_skills = resolve_skills_from_profile(
-            profile_skills=dedupe_skill_names(snapshot.skills),
-            project_root=project_root,
-            readonly=surface.skills_readonly,
-            harness_id=harness_id.value,
-            selected_model_token=snapshot.model_selection_requested_token or snapshot_model,
-            canonical_model_id=snapshot.model_selection_canonical_id or snapshot_model,
-        )
-    model_selection = ModelSelectionContext(
-        requested_token=snapshot.model_selection_requested_token or snapshot_model,
-        selected_model_token=snapshot.model_selection_selected_token
-        or snapshot.model_selection_requested_token
-        or snapshot_model,
-        canonical_model_id=snapshot.model_selection_canonical_id or snapshot_model,
-        harness_provenance=snapshot.model_selection_harness_provenance or "snapshot",
-        harness_model_id=snapshot.model_selection_harness_model_id,
-    )
-    terminal_surface_mode = _resolve_terminal_surface_mode(harness_id=harness_id)
-    if snapshot.terminal_surface_mode is not None:
-        try:
-            terminal_surface_mode = TerminalSurfaceMode(snapshot.terminal_surface_mode)
-        except ValueError:
-            _LOGGER.warning(
-                "Ignoring unsupported snapshot terminal_surface_mode '%s'.",
-                snapshot.terminal_surface_mode,
-            )
-    return ResolvedLaunchPolicy(
-        profile=profile,
-        model=snapshot_model,
-        harness=harness_id,
-        adapter=adapter,
-        resolved_skills=resolved_skills,
-        routing=ResolvedLaunchRouting(
-            model=model_selection.selected_model_token,
-            harness=harness_id,
-            agent=snapshot_agent,
-        ),
-        execution_policy=snapshot.execution_policy,
-        resolved_tools=snapshot.tools,
-        resolved_mcp_tools=snapshot.mcp_tools,
-        terminal_surface_mode=terminal_surface_mode,
-        matched_policy_rule=snapshot.matched_policy_rule,
-        model_selection=model_selection,
-        fallback_chain=snapshot.fallback_chain,
-        warnings=(),
+    replayed = replay_launch_policy_snapshot(
+        snapshot=snapshot,
+        project_root=surface.catalog.project_root,
+        harness_registry=surface.harness_registry,
+        skills_readonly=surface.skills_readonly,
         alias_catalog=surface.catalog.alias_map(),
+        resolve_terminal_surface_mode=_resolve_terminal_surface_mode,
+        logger=_LOGGER,
+    )
+    return ResolvedLaunchPolicy(
+        profile=replayed.profile,
+        model=replayed.model,
+        harness=replayed.harness,
+        adapter=replayed.adapter,
+        resolved_skills=replayed.resolved_skills,
+        routing=replayed.routing,
+        execution_policy=replayed.execution_policy,
+        resolved_tools=replayed.resolved_tools,
+        resolved_mcp_tools=replayed.resolved_mcp_tools,
+        terminal_surface_mode=replayed.terminal_surface_mode,
+        matched_policy_rule=replayed.matched_policy_rule,
+        model_selection=_model_selection_from_replayed_snapshot(replayed.model_selection),
+        fallback_chain=replayed.fallback_chain,
+        warnings=(),
+        alias_catalog=replayed.alias_catalog,
+    )
+
+
+def _model_selection_from_replayed_snapshot(
+    replayed: ReplayedModelSelection | None,
+) -> ModelSelectionContext | None:
+    if replayed is None:
+        return None
+    return ModelSelectionContext(
+        requested_token=replayed.requested_token,
+        selected_model_token=replayed.selected_model_token,
+        canonical_model_id=replayed.canonical_model_id,
+        harness_provenance=replayed.harness_provenance,
+        harness_model_id=replayed.harness_model_id,
     )
 
 

--- a/src/meridian/lib/launch/policies.py
+++ b/src/meridian/lib/launch/policies.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
+from pathlib import Path
 
 from meridian.lib.catalog.agent import AgentProfile
 from meridian.lib.catalog.catalog_session import CatalogSession
@@ -32,7 +33,7 @@ from .launch_types import (
     ResolvedLaunchRouting,
     TerminalSurfaceMode,
 )
-from .request import LaunchCompositionSurface
+from .request import LaunchCompositionSurface, LaunchPolicySnapshot
 from .resolve import (
     ResolvedSkills,
     dedupe_skill_names,
@@ -70,6 +71,7 @@ class SurfacePolicyInput:
     harness_registry: HarnessRegistry
     skills_readonly: bool = True
     requested_skills: tuple[str, ...] = ()
+    policy_snapshot: LaunchPolicySnapshot | None = None
     supported_execution_policy_fields: frozenset[ExecutionPolicyField] = (
         _DEFAULT_EXECUTION_POLICY_FIELDS
     )
@@ -524,12 +526,98 @@ def _resolve_policy_from_bundle(surface: SurfacePolicyInput) -> ResolvedLaunchPo
     )
 
 
+def _resolve_policy_from_snapshot(
+    *,
+    surface: SurfacePolicyInput,
+    snapshot: LaunchPolicySnapshot,
+) -> ResolvedLaunchPolicy:
+    """Resolve launch policy from a persisted launch-policy snapshot."""
+
+    project_root = surface.catalog.project_root
+    snapshot_model = snapshot.model.strip()
+    snapshot_harness = snapshot.harness.strip()
+    if not snapshot_model:
+        raise ValueError("Launch policy snapshot is missing model.")
+    if not snapshot_harness:
+        raise ValueError("Launch policy snapshot is missing harness.")
+    harness_id = HarnessId(snapshot_harness)
+    adapter = surface.harness_registry.get_subprocess_harness(harness_id)
+
+    snapshot_agent = (snapshot.agent or "").strip() or None
+    profile = None
+    if snapshot_agent is not None:
+        profile_path = (
+            Path(snapshot.agent_path).expanduser().resolve()
+            if snapshot.agent_path is not None and snapshot.agent_path.strip()
+            else (project_root / ".mars" / "agents" / f"{snapshot_agent}.md").resolve()
+        )
+        profile = AgentProfile(
+            name=snapshot_agent,
+            description=snapshot.agent_description,
+            skills=dedupe_skill_names(snapshot.skills),
+            body=snapshot.agent_profile_body,
+            path=profile_path,
+            raw_content=snapshot.agent_profile_body,
+        )
+
+    resolved_skills = resolve_skills_from_profile(
+        profile_skills=dedupe_skill_names(snapshot.skills),
+        project_root=project_root,
+        readonly=surface.skills_readonly,
+        harness_id=harness_id.value,
+        selected_model_token=snapshot.model_selection_requested_token or snapshot_model,
+        canonical_model_id=snapshot.model_selection_canonical_id or snapshot_model,
+    )
+    model_selection = ModelSelectionContext(
+        requested_token=snapshot.model_selection_requested_token or snapshot_model,
+        selected_model_token=snapshot.model_selection_selected_token
+        or snapshot.model_selection_requested_token
+        or snapshot_model,
+        canonical_model_id=snapshot.model_selection_canonical_id or snapshot_model,
+        harness_provenance=snapshot.model_selection_harness_provenance or "snapshot",
+        harness_model_id=snapshot.model_selection_harness_model_id,
+    )
+    terminal_surface_mode = _resolve_terminal_surface_mode(harness_id=harness_id)
+    if snapshot.terminal_surface_mode is not None:
+        try:
+            terminal_surface_mode = TerminalSurfaceMode(snapshot.terminal_surface_mode)
+        except ValueError:
+            _LOGGER.warning(
+                "Ignoring unsupported snapshot terminal_surface_mode '%s'.",
+                snapshot.terminal_surface_mode,
+            )
+    return ResolvedLaunchPolicy(
+        profile=profile,
+        model=snapshot_model,
+        harness=harness_id,
+        adapter=adapter,
+        resolved_skills=resolved_skills,
+        routing=ResolvedLaunchRouting(
+            model=model_selection.selected_model_token,
+            harness=harness_id,
+            agent=snapshot_agent,
+        ),
+        execution_policy=snapshot.execution_policy,
+        resolved_tools=snapshot.tools,
+        resolved_mcp_tools=snapshot.mcp_tools,
+        terminal_surface_mode=terminal_surface_mode,
+        matched_policy_rule=snapshot.matched_policy_rule,
+        model_selection=model_selection,
+        fallback_chain=snapshot.fallback_chain,
+        warnings=(),
+        alias_catalog=surface.catalog.alias_map(),
+    )
+
+
 def resolve_launch_policy(surface: SurfacePolicyInput) -> ResolvedLaunchPolicy:
     """Resolve the shared launch policy boundary for one launch-like surface.
 
     PRIMARY and SPAWN_PREPARE both use the mars launch-bundle path.  DIRECT is
     handled separately (no policy resolution needed — already-resolved inputs).
     """
+
+    if surface.policy_snapshot is not None:
+        return _resolve_policy_from_snapshot(surface=surface, snapshot=surface.policy_snapshot)
 
     if surface.surface in {
         LaunchCompositionSurface.PRIMARY,

--- a/src/meridian/lib/launch/policies.py
+++ b/src/meridian/lib/launch/policies.py
@@ -545,6 +545,11 @@ def _resolve_policy_from_snapshot(
 
     snapshot_agent = (snapshot.agent or "").strip() or None
     profile = None
+    snapshot_skill_names = (
+        tuple(skill.name for skill in snapshot.loaded_skills)
+        if snapshot.loaded_skills
+        else dedupe_skill_names(snapshot.skills)
+    )
     if snapshot_agent is not None:
         profile_path = (
             Path(snapshot.agent_path).expanduser().resolve()
@@ -554,20 +559,27 @@ def _resolve_policy_from_snapshot(
         profile = AgentProfile(
             name=snapshot_agent,
             description=snapshot.agent_description,
-            skills=dedupe_skill_names(snapshot.skills),
+            skills=snapshot_skill_names,
             body=snapshot.agent_profile_body,
             path=profile_path,
             raw_content=snapshot.agent_profile_body,
         )
 
-    resolved_skills = resolve_skills_from_profile(
-        profile_skills=dedupe_skill_names(snapshot.skills),
-        project_root=project_root,
-        readonly=surface.skills_readonly,
-        harness_id=harness_id.value,
-        selected_model_token=snapshot.model_selection_requested_token or snapshot_model,
-        canonical_model_id=snapshot.model_selection_canonical_id or snapshot_model,
-    )
+    if snapshot.loaded_skills:
+        resolved_skills = ResolvedSkills(
+            skill_names=snapshot_skill_names,
+            loaded_skills=snapshot.loaded_skills,
+            missing_skills=(),
+        )
+    else:
+        resolved_skills = resolve_skills_from_profile(
+            profile_skills=dedupe_skill_names(snapshot.skills),
+            project_root=project_root,
+            readonly=surface.skills_readonly,
+            harness_id=harness_id.value,
+            selected_model_token=snapshot.model_selection_requested_token or snapshot_model,
+            canonical_model_id=snapshot.model_selection_canonical_id or snapshot_model,
+        )
     model_selection = ModelSelectionContext(
         requested_token=snapshot.model_selection_requested_token or snapshot_model,
         selected_model_token=snapshot.model_selection_selected_token

--- a/src/meridian/lib/launch/policy_snapshot.py
+++ b/src/meridian/lib/launch/policy_snapshot.py
@@ -1,0 +1,276 @@
+"""Launch-policy snapshot build and replay helpers."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from meridian.lib.catalog.agent import AgentProfile
+from meridian.lib.catalog.model_aliases import AliasEntry
+from meridian.lib.core.domain import SkillContent
+from meridian.lib.core.execution_policy import ResolvedExecutionPolicy
+from meridian.lib.core.launch_policy_snapshot import LaunchPolicySnapshot
+from meridian.lib.core.types import HarnessId
+from meridian.lib.harness.adapter import SubprocessHarness
+from meridian.lib.harness.registry import HarnessRegistry
+from meridian.lib.launch.launch_types import ResolvedLaunchRouting, TerminalSurfaceMode
+from meridian.lib.tools import ToolsField
+
+from .request import SpawnRequest
+from .resolve import ResolvedSkills, dedupe_skill_names, resolve_skills_from_profile
+
+
+class SnapshotModelSelection(Protocol):
+    """Shape needed to serialize model-selection metadata into snapshots."""
+
+    @property
+    def selected_model_token(self) -> str: ...
+
+    @property
+    def harness_model_id(self) -> str | None: ...
+
+
+@dataclass(frozen=True)
+class ReplayedModelSelection:
+    """Model-selection context reconstructed from a persisted snapshot."""
+
+    requested_token: str
+    selected_model_token: str
+    canonical_model_id: str
+    harness_provenance: str
+    harness_model_id: str | None = None
+
+
+@dataclass(frozen=True)
+class ReplayedLaunchPolicySnapshot:
+    """Resolved policy fields reconstructed directly from a snapshot."""
+
+    profile: AgentProfile | None
+    model: str
+    harness: HarnessId
+    adapter: SubprocessHarness
+    resolved_skills: ResolvedSkills
+    routing: ResolvedLaunchRouting
+    execution_policy: ResolvedExecutionPolicy
+    resolved_tools: ToolsField | None = None
+    resolved_mcp_tools: tuple[str, ...] = ()
+    terminal_surface_mode: TerminalSurfaceMode = TerminalSurfaceMode.PTY_MEDIATED
+    matched_policy_rule: str | None = None
+    model_selection: ReplayedModelSelection | None = None
+    fallback_chain: tuple[dict[str, object], ...] = ()
+    alias_catalog: dict[str, AliasEntry] | None = None
+
+
+def build_launch_policy_snapshot(
+    request: SpawnRequest,
+    *,
+    model_selection: SnapshotModelSelection | None = None,
+    loaded_skills: tuple[SkillContent, ...] = (),
+) -> LaunchPolicySnapshot:
+    """Build a durable launch-policy snapshot from a resolved request."""
+
+    model = (request.model or "").strip()
+    harness = (request.harness or "").strip()
+    if not harness:
+        raise ValueError("Resolved request is missing harness for launch policy snapshot.")
+    resolved_skill_names = tuple(skill.name for skill in loaded_skills) or request.skills
+    resolved_skill_paths = tuple(skill.path for skill in loaded_skills) or request.skill_paths
+    return LaunchPolicySnapshot(
+        model=model,
+        harness=harness,
+        agent=(request.agent or "").strip() or None,
+        agent_path=(request.agent_metadata.get("session_agent_path") or "").strip() or None,
+        agent_description=(
+            request.agent_metadata.get("session_agent_description") or ""
+        ).strip(),
+        agent_profile_body=request.agent_metadata.get("session_agent_profile_body") or "",
+        skills=resolved_skill_names,
+        skill_paths=resolved_skill_paths,
+        loaded_skills=loaded_skills,
+        execution_policy=request.execution_policy,
+        tools=request.tools,
+        mcp_tools=request.mcp_tools,
+        extra_args=request.extra_args,
+        model_selection_requested_token=request.model_selection_requested_token,
+        model_selection_selected_token=(
+            model_selection.selected_model_token
+            if model_selection is not None
+            else request.model_selection_requested_token or (request.model or "").strip() or None
+        ),
+        model_selection_canonical_id=request.model_selection_canonical_id,
+        model_selection_harness_provenance=request.model_selection_harness_provenance,
+        model_selection_harness_model_id=(
+            model_selection.harness_model_id if model_selection is not None else None
+        ),
+        matched_policy_rule=request.matched_policy_rule,
+        fallback_chain=request.fallback_chain,
+        terminal_surface_mode=(
+            request.terminal_surface_mode.value
+            if request.terminal_surface_mode is not None
+            else None
+        ),
+    )
+
+
+def replay_launch_policy_snapshot(
+    *,
+    snapshot: LaunchPolicySnapshot,
+    project_root: Path,
+    harness_registry: HarnessRegistry,
+    skills_readonly: bool,
+    alias_catalog: dict[str, AliasEntry],
+    resolve_terminal_surface_mode: Callable[..., TerminalSurfaceMode],
+    logger: logging.Logger | None = None,
+) -> ReplayedLaunchPolicySnapshot:
+    """Resolve policy fields directly from persisted snapshot data."""
+
+    snapshot_model = snapshot.model.strip()
+    snapshot_harness = snapshot.harness.strip()
+    if not snapshot_model:
+        raise ValueError("Launch policy snapshot is missing model.")
+    if not snapshot_harness:
+        raise ValueError("Launch policy snapshot is missing harness.")
+
+    harness_id = HarnessId(snapshot_harness)
+    adapter = harness_registry.get_subprocess_harness(harness_id)
+    snapshot_agent = (snapshot.agent or "").strip() or None
+    snapshot_skill_names = (
+        tuple(skill.name for skill in snapshot.loaded_skills)
+        if snapshot.loaded_skills
+        else dedupe_skill_names(snapshot.skills)
+    )
+
+    profile = _snapshot_profile(
+        snapshot=snapshot,
+        project_root=project_root,
+        snapshot_agent=snapshot_agent,
+        snapshot_skill_names=snapshot_skill_names,
+    )
+    resolved_skills = _snapshot_skills(
+        snapshot=snapshot,
+        project_root=project_root,
+        skills_readonly=skills_readonly,
+        snapshot_model=snapshot_model,
+        harness_id=harness_id,
+        snapshot_skill_names=snapshot_skill_names,
+    )
+    model_selection = ReplayedModelSelection(
+        requested_token=snapshot.model_selection_requested_token or snapshot_model,
+        selected_model_token=snapshot.model_selection_selected_token
+        or snapshot.model_selection_requested_token
+        or snapshot_model,
+        canonical_model_id=snapshot.model_selection_canonical_id or snapshot_model,
+        harness_provenance=snapshot.model_selection_harness_provenance or "snapshot",
+        harness_model_id=snapshot.model_selection_harness_model_id,
+    )
+    terminal_surface_mode = _resolve_snapshot_terminal_mode(
+        snapshot=snapshot,
+        harness_id=harness_id,
+        resolve_terminal_surface_mode=resolve_terminal_surface_mode,
+        logger=logger,
+    )
+    return ReplayedLaunchPolicySnapshot(
+        profile=profile,
+        model=snapshot_model,
+        harness=harness_id,
+        adapter=adapter,
+        resolved_skills=resolved_skills,
+        routing=ResolvedLaunchRouting(
+            model=model_selection.selected_model_token,
+            harness=harness_id,
+            agent=snapshot_agent,
+        ),
+        execution_policy=snapshot.execution_policy,
+        resolved_tools=snapshot.tools,
+        resolved_mcp_tools=snapshot.mcp_tools,
+        terminal_surface_mode=terminal_surface_mode,
+        matched_policy_rule=snapshot.matched_policy_rule,
+        model_selection=model_selection,
+        fallback_chain=snapshot.fallback_chain,
+        alias_catalog=alias_catalog,
+    )
+
+
+def _snapshot_profile(
+    *,
+    snapshot: LaunchPolicySnapshot,
+    project_root: Path,
+    snapshot_agent: str | None,
+    snapshot_skill_names: tuple[str, ...],
+) -> AgentProfile | None:
+    if snapshot_agent is None:
+        return None
+
+    profile_path = (
+        Path(snapshot.agent_path).expanduser().resolve()
+        if snapshot.agent_path is not None and snapshot.agent_path.strip()
+        else (project_root / ".mars" / "agents" / f"{snapshot_agent}.md").resolve()
+    )
+    return AgentProfile(
+        name=snapshot_agent,
+        description=snapshot.agent_description,
+        skills=snapshot_skill_names,
+        body=snapshot.agent_profile_body,
+        path=profile_path,
+        raw_content=snapshot.agent_profile_body,
+    )
+
+
+def _snapshot_skills(
+    *,
+    snapshot: LaunchPolicySnapshot,
+    project_root: Path,
+    skills_readonly: bool,
+    snapshot_model: str,
+    harness_id: HarnessId,
+    snapshot_skill_names: tuple[str, ...],
+) -> ResolvedSkills:
+    if snapshot.loaded_skills:
+        return ResolvedSkills(
+            skill_names=snapshot_skill_names,
+            loaded_skills=snapshot.loaded_skills,
+            missing_skills=(),
+        )
+
+    return resolve_skills_from_profile(
+        profile_skills=dedupe_skill_names(snapshot.skills),
+        project_root=project_root,
+        readonly=skills_readonly,
+        harness_id=harness_id.value,
+        selected_model_token=snapshot.model_selection_requested_token or snapshot_model,
+        canonical_model_id=snapshot.model_selection_canonical_id or snapshot_model,
+    )
+
+
+def _resolve_snapshot_terminal_mode(
+    *,
+    snapshot: LaunchPolicySnapshot,
+    harness_id: HarnessId,
+    resolve_terminal_surface_mode: Callable[..., TerminalSurfaceMode],
+    logger: logging.Logger | None,
+) -> TerminalSurfaceMode:
+    terminal_surface_mode = resolve_terminal_surface_mode(harness_id=harness_id)
+    if snapshot.terminal_surface_mode is None:
+        return terminal_surface_mode
+
+    try:
+        return TerminalSurfaceMode(snapshot.terminal_surface_mode)
+    except ValueError:
+        if logger is not None:
+            logger.warning(
+                "Ignoring unsupported snapshot terminal_surface_mode '%s'.",
+                snapshot.terminal_surface_mode,
+            )
+        return terminal_surface_mode
+
+
+__all__ = [
+    "ReplayedLaunchPolicySnapshot",
+    "ReplayedModelSelection",
+    "SnapshotModelSelection",
+    "build_launch_policy_snapshot",
+    "replay_launch_policy_snapshot",
+]

--- a/src/meridian/lib/launch/request.py
+++ b/src/meridian/lib/launch/request.py
@@ -5,6 +5,7 @@ from enum import StrEnum
 from pydantic import BaseModel, ConfigDict, Field
 
 from meridian.lib.core.execution_policy import ResolvedExecutionPolicy
+from meridian.lib.core.launch_policy_snapshot import LaunchPolicySnapshot
 from meridian.lib.core.overrides import RuntimeOverrides
 from meridian.lib.launch.composition import PromptDocument
 from meridian.lib.launch.launch_types import TerminalSurfaceMode
@@ -110,6 +111,7 @@ class SpawnRequest(BaseModel):
     warning: str | None = None
     agent_metadata: dict[str, str] = Field(default_factory=_empty_agent_metadata)
     prompt_payload: RequestPromptPayload = Field(default_factory=RequestPromptPayload)
+    launch_policy_snapshot: LaunchPolicySnapshot | None = None
 
     # Resolved metadata (computed at prepare time; NOT used by executors for composition)
     skill_paths: tuple[str, ...] = ()
@@ -205,6 +207,7 @@ __all__ = [
     "ExecutionBudget",
     "LaunchArgvIntent",
     "LaunchCompositionSurface",
+    "LaunchPolicySnapshot",
     "LaunchRuntime",
     "RequestPromptPayload",
     "RetryPolicy",

--- a/src/meridian/lib/ops/spawn/api.py
+++ b/src/meridian/lib/ops/spawn/api.py
@@ -14,6 +14,7 @@ from meridian.lib.bootstrap.services import (
 from meridian.lib.config.settings import MeridianConfig, load_config
 from meridian.lib.core.context import RuntimeContext
 from meridian.lib.core.depth import max_depth_reached
+from meridian.lib.core.launch_policy_snapshot import LaunchPolicySnapshot
 from meridian.lib.core.sink import NullSink, OutputSink
 from meridian.lib.core.spawn_lifecycle import ACTIVE_SPAWN_STATUSES, is_active_spawn_status
 from meridian.lib.core.spawn_service import CancelOutcome
@@ -64,6 +65,7 @@ from .models import (
     SpawnCreateInput,
     SpawnDetailOutput,
     SpawnForkInput,
+    SpawnLaunchOptionUpdates,
     SpawnListEntry,
     SpawnListInput,
     SpawnListOutput,
@@ -1626,6 +1628,98 @@ def _reject_continue_policy_overrides(payload: SpawnContinueInput) -> None:
         )
 
 
+def _continue_launch_options(
+    *,
+    payload: SpawnContinueInput,
+    source_snapshot: LaunchPolicySnapshot | None,
+    source_harness: str | None,
+) -> SpawnLaunchOptionUpdates:
+    launch_options = payload.launch_option_updates()
+    if source_snapshot is None:
+        launch_options["harness"] = source_harness
+        return launch_options
+
+    launch_options.update(
+        {
+            "approval": source_snapshot.execution_policy.approval,
+            "autocompact": source_snapshot.execution_policy.autocompact,
+            "autocompact_pct": source_snapshot.execution_policy.autocompact_pct,
+            "effort": source_snapshot.execution_policy.effort,
+            "sandbox": source_snapshot.execution_policy.sandbox,
+            "harness": source_snapshot.harness,
+            "passthrough_args": source_snapshot.extra_args,
+        }
+    )
+    return launch_options
+
+
+def _build_continue_create_input(
+    *,
+    payload: SpawnContinueInput,
+    source_spawn: SpawnRecord,
+    source_spawn_id: str,
+    resolved_reference: ResolvedSessionReference,
+    source_harness: str | None,
+    source_snapshot: LaunchPolicySnapshot | None,
+) -> SpawnCreateInput:
+    launch_options = _continue_launch_options(
+        payload=payload,
+        source_snapshot=source_snapshot,
+        source_harness=source_harness,
+    )
+    resolved_goal = payload.goal if payload.goal is not None else source_spawn.goal
+    derived_prompt = _prompt_for_follow_up(source_spawn, source_spawn_id, payload.prompt)
+    return SpawnCreateInput(
+        prompt=derived_prompt,
+        model=(
+            source_snapshot.model
+            if source_snapshot is not None
+            else _model_for_follow_up(source_spawn, payload.model)
+        ),
+        files=payload.files,
+        template_vars=payload.template_vars,
+        agent=source_snapshot.agent if source_snapshot is not None else payload.agent,
+        skills=source_snapshot.skills if source_snapshot is not None else payload.skills,
+        goal=resolved_goal,
+        desc=payload.desc,
+        work=source_spawn.work_id or "",
+        worktree=None,
+        repo=None,
+        launch_policy_snapshot=source_snapshot,
+        session=SessionRequest(
+            requested_harness_session_id=resolved_reference.harness_session_id,
+            continue_harness=resolved_reference.harness,
+            continue_source_tracked=resolved_reference.tracked,
+            continue_source_ref=source_spawn_id,
+            continue_fork=payload.fork,
+            continue_chat_id=resolved_reference.source_chat_id,
+            forked_from_chat_id=resolved_reference.source_chat_id if payload.fork else None,
+            source_control_root=resolved_reference.source_control_root,
+            source_execution_cwd=resolved_reference.source_execution_cwd,
+            source_claude_config_dir=resolved_reference.source_claude_config_dir,
+            source_pi_session_dir=resolved_reference.source_pi_session_dir,
+        ),
+        **launch_options,
+    )
+
+
+def _resolve_continue_target_harness(
+    *,
+    create_input: SpawnCreateInput,
+    source_snapshot: LaunchPolicySnapshot | None,
+    source_harness: str | None,
+    project_root: Path,
+) -> str:
+    if source_snapshot is not None:
+        return source_snapshot.harness
+    if source_harness is not None:
+        return source_harness
+    return _resolve_effective_fork_target_harness(
+        create_input,
+        resolved_project_root=project_root,
+    )
+
+
 def _with_command(result: SpawnActionOutput, command: str) -> SpawnActionOutput:
     return result.model_copy(update={"command": command})
 
@@ -1825,63 +1919,19 @@ def spawn_continue_sync(
             f"source spawn uses '{source_harness}'."
         )
 
-    derived_prompt = _prompt_for_follow_up(source_spawn, resolved_spawn_id, payload.prompt)
-    resolved_goal = payload.goal if payload.goal is not None else source_spawn.goal
-    launch_options = payload.launch_option_updates()
-    if source_snapshot is not None:
-        launch_options.update(
-            {
-                "approval": source_snapshot.execution_policy.approval,
-                "autocompact": source_snapshot.execution_policy.autocompact,
-                "autocompact_pct": source_snapshot.execution_policy.autocompact_pct,
-                "effort": source_snapshot.execution_policy.effort,
-                "sandbox": source_snapshot.execution_policy.sandbox,
-                "harness": source_snapshot.harness,
-                "passthrough_args": source_snapshot.extra_args,
-            }
-        )
-    else:
-        launch_options["harness"] = source_harness
-    create_input = SpawnCreateInput(
-        prompt=derived_prompt,
-        model=(
-            source_snapshot.model
-            if source_snapshot is not None
-            else _model_for_follow_up(source_spawn, payload.model)
-        ),
-        files=payload.files,
-        template_vars=payload.template_vars,
-        agent=source_snapshot.agent if source_snapshot is not None else payload.agent,
-        skills=source_snapshot.skills if source_snapshot is not None else payload.skills,
-        goal=resolved_goal,
-        desc=payload.desc,
-        work=source_spawn.work_id or "",
-        worktree=None,
-        repo=None,
-        launch_policy_snapshot=source_snapshot,
-        session=SessionRequest(
-            requested_harness_session_id=resolved_reference.harness_session_id,
-            continue_harness=resolved_reference.harness,
-            continue_source_tracked=resolved_reference.tracked,
-            continue_source_ref=resolved_spawn_id,
-            continue_fork=payload.fork,
-            continue_chat_id=resolved_reference.source_chat_id,
-            forked_from_chat_id=resolved_reference.source_chat_id if payload.fork else None,
-            source_control_root=resolved_reference.source_control_root,
-            source_execution_cwd=resolved_reference.source_execution_cwd,
-            source_claude_config_dir=resolved_reference.source_claude_config_dir,
-            source_pi_session_dir=resolved_reference.source_pi_session_dir,
-        ),
-        **launch_options,
+    create_input = _build_continue_create_input(
+        payload=payload,
+        source_spawn=source_spawn,
+        source_spawn_id=resolved_spawn_id,
+        resolved_reference=resolved_reference,
+        source_harness=source_harness,
+        source_snapshot=source_snapshot,
     )
-    target_harness = (
-        source_snapshot.harness
-        if source_snapshot is not None
-        else source_harness
-        or _resolve_effective_fork_target_harness(
-            create_input,
-            resolved_project_root=project_root,
-        )
+    target_harness = _resolve_continue_target_harness(
+        create_input=create_input,
+        source_snapshot=source_snapshot,
+        source_harness=source_harness,
+        project_root=project_root,
     )
     if source_harness is not None and source_harness != target_harness:
         raise ValueError(

--- a/src/meridian/lib/ops/spawn/api.py
+++ b/src/meridian/lib/ops/spawn/api.py
@@ -1612,6 +1612,12 @@ def _reject_continue_policy_overrides(payload: SpawnContinueInput) -> None:
         rejected.append("--autocompact-pct")
     if payload.passthrough_args:
         rejected.append("--")
+    if payload.work.strip():
+        rejected.append("--work")
+    if payload.worktree is not None:
+        rejected.append("--worktree/--no-worktree")
+    if payload.repo is not None and payload.repo.strip():
+        rejected.append("--repo")
     if rejected:
         flags = ", ".join(rejected)
         raise ValueError(
@@ -1849,9 +1855,9 @@ def spawn_continue_sync(
         skills=source_snapshot.skills if source_snapshot is not None else payload.skills,
         goal=resolved_goal,
         desc=payload.desc,
-        work=payload.work,
-        worktree=payload.worktree,
-        repo=payload.repo,
+        work=source_spawn.work_id or "",
+        worktree=None,
+        repo=None,
         launch_policy_snapshot=source_snapshot,
         session=SessionRequest(
             requested_harness_session_id=resolved_reference.harness_session_id,

--- a/src/meridian/lib/ops/spawn/api.py
+++ b/src/meridian/lib/ops/spawn/api.py
@@ -1841,7 +1841,7 @@ def spawn_continue_sync(
             }
         )
     else:
-        launch_options["harness"] = requested_harness
+        launch_options["harness"] = source_harness
     create_input = SpawnCreateInput(
         prompt=derived_prompt,
         model=(
@@ -1877,7 +1877,8 @@ def spawn_continue_sync(
     target_harness = (
         source_snapshot.harness
         if source_snapshot is not None
-        else _resolve_effective_fork_target_harness(
+        else source_harness
+        or _resolve_effective_fork_target_harness(
             create_input,
             resolved_project_root=project_root,
         )

--- a/src/meridian/lib/ops/spawn/api.py
+++ b/src/meridian/lib/ops/spawn/api.py
@@ -1588,6 +1588,38 @@ def _model_for_follow_up(source_spawn: SpawnRecord, override_model: str) -> str:
     return (source_spawn.model or "").strip()
 
 
+def _reject_continue_policy_overrides(payload: SpawnContinueInput) -> None:
+    """Reject launch-contract changes for exact continuation."""
+
+    rejected: list[str] = []
+    if payload.model.strip():
+        rejected.append("--model")
+    if payload.agent is not None and payload.agent.strip():
+        rejected.append("--agent")
+    if payload.skills:
+        rejected.append("--skills")
+    if (payload.harness or "").strip():
+        rejected.append("--harness")
+    if payload.approval is not None:
+        rejected.append("--approval")
+    if payload.sandbox is not None:
+        rejected.append("--sandbox")
+    if payload.effort is not None:
+        rejected.append("--effort")
+    if payload.autocompact is not None:
+        rejected.append("--autocompact")
+    if payload.autocompact_pct is not None:
+        rejected.append("--autocompact-pct")
+    if payload.passthrough_args:
+        rejected.append("--")
+    if rejected:
+        flags = ", ".join(rejected)
+        raise ValueError(
+            f"Cannot use policy-changing option(s) with spawn --continue: {flags}. "
+            "Use --fork-fresh to change launch identity or policy."
+        )
+
+
 def _with_command(result: SpawnActionOutput, command: str) -> SpawnActionOutput:
     return result.model_copy(update={"command": command})
 
@@ -1772,6 +1804,9 @@ def spawn_continue_sync(
             f"Spawn '{resolved_spawn_id}' has no recorded session — cannot continue/fork."
         )
 
+    _reject_continue_policy_overrides(payload)
+    source_snapshot = source_spawn.launch_policy_snapshot
+
     requested_harness = (payload.harness or "").strip() or None
     source_harness = (resolved_reference.harness or "").strip() or None
     if (
@@ -1787,19 +1822,37 @@ def spawn_continue_sync(
     derived_prompt = _prompt_for_follow_up(source_spawn, resolved_spawn_id, payload.prompt)
     resolved_goal = payload.goal if payload.goal is not None else source_spawn.goal
     launch_options = payload.launch_option_updates()
-    launch_options["harness"] = requested_harness
+    if source_snapshot is not None:
+        launch_options.update(
+            {
+                "approval": source_snapshot.execution_policy.approval,
+                "autocompact": source_snapshot.execution_policy.autocompact,
+                "autocompact_pct": source_snapshot.execution_policy.autocompact_pct,
+                "effort": source_snapshot.execution_policy.effort,
+                "sandbox": source_snapshot.execution_policy.sandbox,
+                "harness": source_snapshot.harness,
+                "passthrough_args": source_snapshot.extra_args,
+            }
+        )
+    else:
+        launch_options["harness"] = requested_harness
     create_input = SpawnCreateInput(
         prompt=derived_prompt,
-        model=_model_for_follow_up(source_spawn, payload.model),
+        model=(
+            source_snapshot.model
+            if source_snapshot is not None
+            else _model_for_follow_up(source_spawn, payload.model)
+        ),
         files=payload.files,
         template_vars=payload.template_vars,
-        agent=payload.agent,
-        skills=payload.skills,
+        agent=source_snapshot.agent if source_snapshot is not None else payload.agent,
+        skills=source_snapshot.skills if source_snapshot is not None else payload.skills,
         goal=resolved_goal,
         desc=payload.desc,
         work=payload.work,
         worktree=payload.worktree,
         repo=payload.repo,
+        launch_policy_snapshot=source_snapshot,
         session=SessionRequest(
             requested_harness_session_id=resolved_reference.harness_session_id,
             continue_harness=resolved_reference.harness,
@@ -1815,9 +1868,13 @@ def spawn_continue_sync(
         ),
         **launch_options,
     )
-    target_harness = _resolve_effective_fork_target_harness(
-        create_input,
-        resolved_project_root=project_root,
+    target_harness = (
+        source_snapshot.harness
+        if source_snapshot is not None
+        else _resolve_effective_fork_target_harness(
+            create_input,
+            resolved_project_root=project_root,
+        )
     )
     if source_harness is not None and source_harness != target_harness:
         raise ValueError(

--- a/src/meridian/lib/ops/spawn/execute.py
+++ b/src/meridian/lib/ops/spawn/execute.py
@@ -166,6 +166,7 @@ def execute_spawn_background(
         control_root=execution_contract.control_root.as_posix(),
         task_cwd=initial_task_cwd,
         execution_cwd=initial_execution_cwd,
+        launch_policy_snapshot=request.launch_policy_snapshot,
         ctx=resolved_context,
     )
     spawn_id_text = str(context.spawn.spawn_id)
@@ -424,6 +425,7 @@ def execute_spawn_blocking(
         control_root=execution_contract.control_root.as_posix(),
         task_cwd=initial_task_cwd,
         execution_cwd=initial_execution_cwd,
+        launch_policy_snapshot=request.launch_policy_snapshot,
         ctx=resolved_context,
     )
     spawn = context.spawn

--- a/src/meridian/lib/ops/spawn/execute_init.py
+++ b/src/meridian/lib/ops/spawn/execute_init.py
@@ -13,6 +13,7 @@ from meridian.lib.config.project_paths import ProjectConfigPaths, resolve_projec
 from meridian.lib.core.context import RuntimeContext
 from meridian.lib.core.depth import current_meridian_depth, max_depth_reached
 from meridian.lib.core.domain import Spawn, SpawnStatus
+from meridian.lib.core.launch_policy_snapshot import LaunchPolicySnapshot
 from meridian.lib.core.resolved_context import ResolvedContext
 from meridian.lib.core.sink import OutputSink
 from meridian.lib.core.types import ModelId, SpawnId
@@ -159,6 +160,7 @@ def _init_spawn(
     status: SpawnStatus = "running",
     launch_mode: LaunchMode | None = None,
     runner_pid: int | None = None,
+    launch_policy_snapshot: LaunchPolicySnapshot | None = None,
     control_root: str | None = None,
     task_cwd: str | None = None,
     execution_cwd: str | None = None,
@@ -208,6 +210,7 @@ def _init_spawn(
         execution_cwd=execution_cwd,
         launch_mode=launch_mode,
         runner_pid=runner_pid,
+        launch_policy_snapshot=launch_policy_snapshot or request.launch_policy_snapshot,
         status=status,
     )
     spawn = Spawn(

--- a/src/meridian/lib/ops/spawn/models.py
+++ b/src/meridian/lib/ops/spawn/models.py
@@ -6,6 +6,7 @@ from typing import NotRequired, TypedDict
 from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator, model_serializer
 
 from meridian.lib.core.domain import SpawnStatus
+from meridian.lib.core.launch_policy_snapshot import LaunchPolicySnapshot
 from meridian.lib.core.spawn_lifecycle import is_active_spawn_status
 from meridian.lib.core.util import FormatContext
 from meridian.lib.launch.request import SessionRequest
@@ -125,6 +126,7 @@ class SpawnCreateInput(SpawnLaunchOptions):
     worktree: bool | None = None
     repo: str | None = None
     session: SessionRequest = SessionRequest()
+    launch_policy_snapshot: LaunchPolicySnapshot | None = None
 
     @field_validator("goal", mode="before")
     @classmethod

--- a/src/meridian/lib/ops/spawn/prepare.py
+++ b/src/meridian/lib/ops/spawn/prepare.py
@@ -6,7 +6,7 @@ from meridian.lib.core.execution_policy import ResolvedExecutionPolicy
 from meridian.lib.core.overrides import RuntimeOverrides
 from meridian.lib.diagnostics import capture_library_diagnostics
 from meridian.lib.harness.registry import get_default_harness_registry
-from meridian.lib.launch.context import build_launch_context, build_launch_policy_snapshot
+from meridian.lib.launch.context import build_launch_context
 from meridian.lib.launch.cwd import LaunchDirectoryContext, TaskCwdResolution, resolve_task_cwd
 from meridian.lib.launch.reference import parse_template_assignments, validate_reference_paths
 from meridian.lib.launch.request import (
@@ -188,9 +188,6 @@ def build_create_payload(
         return preview_context.resolved_request.model_copy(
             update={
                 "cli_command": preview_context.binding.argv,
-                "launch_policy_snapshot": build_launch_policy_snapshot(
-                    preview_context.resolved_request
-                ),
             }
         )
 

--- a/src/meridian/lib/ops/spawn/prepare.py
+++ b/src/meridian/lib/ops/spawn/prepare.py
@@ -1,5 +1,7 @@
 """Spawn create-input validation and payload preparation helpers."""
 
+from pathlib import Path
+
 from meridian.lib.config.settings import load_config
 from meridian.lib.core.context import RuntimeContext
 from meridian.lib.core.execution_policy import ResolvedExecutionPolicy
@@ -86,8 +88,19 @@ def build_create_payload(
             except Exception:
                 ambient_work_id = None
         project_state_dir = resolve_project_paths(project_root).root_dir
+        continued_source_execution_cwd = (
+            (payload.session.source_execution_cwd or "").strip() or None
+            if payload.session.continue_source_tracked
+            else None
+        )
         if forced_task_cwd_resolution is not None:
             task_cwd_resolution = forced_task_cwd_resolution
+        elif continued_source_execution_cwd is not None:
+            task_cwd_resolution = TaskCwdResolution(
+                task_cwd=Path(continued_source_execution_cwd),
+                source="continued-source",
+                work_item=explicit_work_id,
+            )
         else:
             task_cwd_resolution = resolve_task_cwd(
                 project_root,

--- a/src/meridian/lib/ops/spawn/prepare.py
+++ b/src/meridian/lib/ops/spawn/prepare.py
@@ -6,7 +6,7 @@ from meridian.lib.core.execution_policy import ResolvedExecutionPolicy
 from meridian.lib.core.overrides import RuntimeOverrides
 from meridian.lib.diagnostics import capture_library_diagnostics
 from meridian.lib.harness.registry import get_default_harness_registry
-from meridian.lib.launch.context import build_launch_context
+from meridian.lib.launch.context import build_launch_context, build_launch_policy_snapshot
 from meridian.lib.launch.cwd import LaunchDirectoryContext, TaskCwdResolution, resolve_task_cwd
 from meridian.lib.launch.reference import parse_template_assignments, validate_reference_paths
 from meridian.lib.launch.request import (
@@ -159,6 +159,7 @@ def build_create_payload(
             reference_anchor=directory_context.reference_anchor.as_posix(),
             task_cwd_source=directory_context.task_cwd_source,
             task_cwd_work_item=directory_context.work_item,
+            launch_policy_snapshot=payload.launch_policy_snapshot,
         )
 
         preview_context = build_launch_context(
@@ -185,7 +186,12 @@ def build_create_payload(
             dry_run=True,
         )
         return preview_context.resolved_request.model_copy(
-            update={"cli_command": preview_context.binding.argv}
+            update={
+                "cli_command": preview_context.binding.argv,
+                "launch_policy_snapshot": build_launch_policy_snapshot(
+                    preview_context.resolved_request
+                ),
+            }
         )
 
 

--- a/src/meridian/lib/state/spawn/model.py
+++ b/src/meridian/lib/state/spawn/model.py
@@ -12,7 +12,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from meridian.lib.core.domain import SpawnStatus
+from meridian.lib.core.domain import SkillContent, SpawnStatus
 from meridian.lib.core.execution_policy import ResolvedExecutionPolicy
 from meridian.lib.launch.launch_types import TerminalSurfaceMode
 from meridian.lib.tools import ToolsField
@@ -50,6 +50,7 @@ class LaunchPolicySnapshot(BaseModel):
     agent_profile_body: str = ""
     skills: tuple[str, ...] = ()
     skill_paths: tuple[str, ...] = ()
+    loaded_skills: tuple[SkillContent, ...] = ()
     extra_args: tuple[str, ...] = ()
     execution_policy: ResolvedExecutionPolicy = Field(default_factory=ResolvedExecutionPolicy)
     tools: ToolsField | None = None

--- a/src/meridian/lib/state/spawn/model.py
+++ b/src/meridian/lib/state/spawn/model.py
@@ -10,9 +10,12 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from meridian.lib.core.domain import SpawnStatus
+from meridian.lib.core.execution_policy import ResolvedExecutionPolicy
+from meridian.lib.launch.launch_types import TerminalSurfaceMode
+from meridian.lib.tools import ToolsField
 
 LaunchMode = Literal["background", "foreground", "app"]
 BACKGROUND_LAUNCH_MODE: LaunchMode = "background"
@@ -31,6 +34,35 @@ _AUTHORITATIVE_ORIGIN_VALUES: tuple[SpawnOrigin, ...] = (
     "cancel",
 )
 AUTHORITATIVE_ORIGINS: frozenset[SpawnOrigin] = frozenset(_AUTHORITATIVE_ORIGIN_VALUES)
+
+
+class LaunchPolicySnapshot(BaseModel):
+    """Durable JSON-safe resolved launch contract persisted with a spawn row."""
+
+    model_config = ConfigDict(frozen=True)
+
+    schema_version: int = 1
+    model: str
+    harness: str
+    agent: str | None = None
+    agent_path: str | None = None
+    agent_description: str = ""
+    agent_profile_body: str = ""
+    skills: tuple[str, ...] = ()
+    skill_paths: tuple[str, ...] = ()
+    extra_args: tuple[str, ...] = ()
+    execution_policy: ResolvedExecutionPolicy = Field(default_factory=ResolvedExecutionPolicy)
+    tools: ToolsField | None = None
+    mcp_tools: tuple[str, ...] = ()
+    terminal_surface_mode: TerminalSurfaceMode | None = None
+    matched_policy_rule: str | None = None
+    model_selection_requested_token: str | None = None
+    model_selection_selected_token: str | None = None
+    model_selection_canonical_id: str | None = None
+    model_selection_harness_provenance: str | None = None
+    model_selection_harness_model_id: str | None = None
+    field_provenance: dict[str, str] = Field(default_factory=dict)
+    fallback_chain: tuple[dict[str, object], ...] = ()
 
 
 class SpawnRecord(BaseModel):
@@ -82,6 +114,7 @@ class SpawnRecord(BaseModel):
     error: str | None
     terminal_origin: SpawnOrigin | None
     process_scopes: tuple[dict[str, object], ...] | None = None
+    launch_policy_snapshot: LaunchPolicySnapshot | None = None
 
 
 __all__ = [
@@ -92,6 +125,7 @@ __all__ = [
     "_AUTHORITATIVE_ORIGIN_VALUES",
     "_LAUNCH_MODE_VALUES",
     "LaunchMode",
+    "LaunchPolicySnapshot",
     "SpawnOrigin",
     "SpawnRecord",
     "TerminalSpawnStatus",

--- a/src/meridian/lib/state/spawn/model.py
+++ b/src/meridian/lib/state/spawn/model.py
@@ -10,12 +10,10 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict
 
-from meridian.lib.core.domain import SkillContent, SpawnStatus
-from meridian.lib.core.execution_policy import ResolvedExecutionPolicy
-from meridian.lib.launch.launch_types import TerminalSurfaceMode
-from meridian.lib.tools import ToolsField
+from meridian.lib.core.domain import SpawnStatus
+from meridian.lib.core.launch_policy_snapshot import LaunchPolicySnapshot
 
 LaunchMode = Literal["background", "foreground", "app"]
 BACKGROUND_LAUNCH_MODE: LaunchMode = "background"
@@ -34,36 +32,6 @@ _AUTHORITATIVE_ORIGIN_VALUES: tuple[SpawnOrigin, ...] = (
     "cancel",
 )
 AUTHORITATIVE_ORIGINS: frozenset[SpawnOrigin] = frozenset(_AUTHORITATIVE_ORIGIN_VALUES)
-
-
-class LaunchPolicySnapshot(BaseModel):
-    """Durable JSON-safe resolved launch contract persisted with a spawn row."""
-
-    model_config = ConfigDict(frozen=True)
-
-    schema_version: int = 1
-    model: str
-    harness: str
-    agent: str | None = None
-    agent_path: str | None = None
-    agent_description: str = ""
-    agent_profile_body: str = ""
-    skills: tuple[str, ...] = ()
-    skill_paths: tuple[str, ...] = ()
-    loaded_skills: tuple[SkillContent, ...] = ()
-    extra_args: tuple[str, ...] = ()
-    execution_policy: ResolvedExecutionPolicy = Field(default_factory=ResolvedExecutionPolicy)
-    tools: ToolsField | None = None
-    mcp_tools: tuple[str, ...] = ()
-    terminal_surface_mode: TerminalSurfaceMode | None = None
-    matched_policy_rule: str | None = None
-    model_selection_requested_token: str | None = None
-    model_selection_selected_token: str | None = None
-    model_selection_canonical_id: str | None = None
-    model_selection_harness_provenance: str | None = None
-    model_selection_harness_model_id: str | None = None
-    field_provenance: dict[str, str] = Field(default_factory=dict)
-    fallback_chain: tuple[dict[str, object], ...] = ()
 
 
 class SpawnRecord(BaseModel):

--- a/src/meridian/lib/state/spawn/repository.py
+++ b/src/meridian/lib/state/spawn/repository.py
@@ -13,10 +13,11 @@ from typing import TYPE_CHECKING, Literal, cast
 
 from pydantic import BaseModel, ConfigDict
 
+from meridian.lib.core.launch_policy_snapshot import LaunchPolicySnapshot
 from meridian.lib.core.spawn_lifecycle import TERMINAL_SPAWN_STATUSES
 from meridian.lib.platform.locking import lock_file
 from meridian.lib.state.atomic import atomic_write_text
-from meridian.lib.state.spawn.model import LaunchPolicySnapshot, SpawnRecord
+from meridian.lib.state.spawn.model import SpawnRecord
 
 if TYPE_CHECKING:
     from meridian.lib.core.domain import SpawnStatus

--- a/src/meridian/lib/state/spawn/repository.py
+++ b/src/meridian/lib/state/spawn/repository.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel, ConfigDict
 from meridian.lib.core.spawn_lifecycle import TERMINAL_SPAWN_STATUSES
 from meridian.lib.platform.locking import lock_file
 from meridian.lib.state.atomic import atomic_write_text
-from meridian.lib.state.spawn.model import SpawnRecord
+from meridian.lib.state.spawn.model import LaunchPolicySnapshot, SpawnRecord
 
 if TYPE_CHECKING:
     from meridian.lib.core.domain import SpawnStatus
@@ -78,6 +78,7 @@ class StoredSpawnState(BaseModel):
     error: str | None = None
     terminal_origin: str | None = None
     prompt_length: int | None = None
+    launch_policy_snapshot: LaunchPolicySnapshot | None = None
 
 
 def _spawn_dir(spawns_dir: Path, spawn_id: str) -> Path:
@@ -148,6 +149,7 @@ def record_to_stored_state(
         error=record.error,
         terminal_origin=record.terminal_origin,
         prompt_length=len(record.prompt) if record.prompt is not None else None,
+        launch_policy_snapshot=record.launch_policy_snapshot,
     )
 
 
@@ -201,6 +203,7 @@ def stored_state_to_record(
         cost_is_estimate=stored.cost_is_estimate,
         error=stored.error,
         terminal_origin=cast("SpawnOrigin | None", stored.terminal_origin),
+        launch_policy_snapshot=stored.launch_policy_snapshot,
     )
 
 

--- a/src/meridian/lib/state/spawn_store.py
+++ b/src/meridian/lib/state/spawn_store.py
@@ -17,6 +17,9 @@ from pydantic import BaseModel, ConfigDict
 
 from meridian.lib.core.clock import Clock, RealClock
 from meridian.lib.core.domain import SpawnStatus, TokenUsage
+from meridian.lib.core.launch_policy_snapshot import (
+    LaunchPolicySnapshot as LaunchPolicySnapshot,
+)
 from meridian.lib.core.spawn_lifecycle import (
     ACTIVE_SPAWN_STATUSES as _ACTIVE_SPAWN_STATUSES,
 )
@@ -30,9 +33,6 @@ from meridian.lib.state.event_store import lock_file
 from meridian.lib.state.paths import RuntimePaths
 from meridian.lib.state.spawn.model import (
     LaunchMode as LaunchMode,
-)
-from meridian.lib.state.spawn.model import (
-    LaunchPolicySnapshot as LaunchPolicySnapshot,
 )
 from meridian.lib.state.spawn.model import (
     SpawnOrigin as SpawnOrigin,

--- a/src/meridian/lib/state/spawn_store.py
+++ b/src/meridian/lib/state/spawn_store.py
@@ -32,6 +32,9 @@ from meridian.lib.state.spawn.model import (
     LaunchMode as LaunchMode,
 )
 from meridian.lib.state.spawn.model import (
+    LaunchPolicySnapshot as LaunchPolicySnapshot,
+)
+from meridian.lib.state.spawn.model import (
     SpawnOrigin as SpawnOrigin,
 )
 from meridian.lib.state.spawn.model import (
@@ -135,13 +138,24 @@ def _resolve_start_metadata(
     desc: str | None,
     work_id: str | None,
     goal: str | None,
+    launch_policy_snapshot: LaunchPolicySnapshot | None,
 ) -> SpawnStartMetadata:
     if metadata is None:
-        return SpawnStartMetadata(desc=desc, work_id=work_id, goal=goal)
+        return SpawnStartMetadata(
+            desc=desc,
+            work_id=work_id,
+            goal=goal,
+            launch_policy_snapshot=launch_policy_snapshot,
+        )
     return SpawnStartMetadata(
         desc=metadata.desc if metadata.desc is not None else desc,
         work_id=metadata.work_id if metadata.work_id is not None else work_id,
         goal=metadata.goal if metadata.goal is not None else goal,
+        launch_policy_snapshot=(
+            metadata.launch_policy_snapshot
+            if metadata.launch_policy_snapshot is not None
+            else launch_policy_snapshot
+        ),
     )
 
 
@@ -239,6 +253,7 @@ def start_spawn(
     worker_pid: int | None = None,
     runner_pid: int | None = None,
     runner_created_at_epoch: float | None = None,
+    launch_policy_snapshot: LaunchPolicySnapshot | None = None,
     status: SpawnStatus = "running",
     started_at: str | None = None,
     clock: Clock | None = None,
@@ -253,6 +268,7 @@ def start_spawn(
         desc=desc,
         work_id=work_id,
         goal=goal,
+        launch_policy_snapshot=launch_policy_snapshot,
     )
     normalized_goal: str | None = None
     if start_metadata.goal is not None:
@@ -263,6 +279,10 @@ def start_spawn(
     resolved_runner_created_at_epoch = runner_created_at_epoch
     if resolved_runner_created_at_epoch is None:
         resolved_runner_created_at_epoch = _runner_created_at_epoch_for_pid(runner_pid)
+
+    resolved_launch_policy_snapshot = (
+        launch_policy_snapshot or start_metadata.launch_policy_snapshot
+    )
 
     with lock_file(paths.spawns_flock):
         if spawn_id is not None:
@@ -322,6 +342,7 @@ def start_spawn(
             cost_is_estimate=False,
             error=None,
             terminal_origin=None,
+            launch_policy_snapshot=resolved_launch_policy_snapshot,
         )
         spawn_dir = paths.spawns_dir / str(resolved_spawn_id)
         spawn_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/integration/launch/test_launch_resolution_spawn_prepare.py
+++ b/tests/integration/launch/test_launch_resolution_spawn_prepare.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from meridian.lib.core.execution_policy import ResolvedExecutionPolicy
 from meridian.lib.core.types import HarnessId
 from meridian.lib.harness.registry import get_default_harness_registry
 from meridian.lib.launch.context import build_launch_context
@@ -94,6 +95,47 @@ def test_spawn_prepare_opencode_keeps_all_references_inline(
     assert f"# Reference: {dir_ref.as_posix()}/" in preview.resolved_request.prompt
     assert "# Meridian Agents" not in preview.resolved_request.prompt
     assert "# Meridian Agents" in preview.projected_content.system_prompt
+
+
+def test_spawn_prepare_profile_resolved_claude_approval_auto_projects_accept_edits(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_minimal_mars_config(tmp_path)
+    stub_bundle_request_and_resolve(
+        monkeypatch,
+        model="claude-sonnet-4-6",
+        harness=HarnessId.CLAUDE,
+        execution_policy=ResolvedExecutionPolicy(approval="auto"),
+        provenance={
+            "model_source": "profile-default",
+            "harness_source": "provider",
+            "approval_source": "profile-default",
+        },
+    )
+    write_agent(tmp_path, name="coder", model="claude-sonnet-4-6")
+
+    preview = build_launch_context(
+        spawn_id="dry-run-claude-spawn-prepare-approval-auto",
+        request=SpawnRequest(
+            prompt="task prompt",
+            prompt_is_composed=False,
+            agent="coder",
+        ),
+        runtime=LaunchRuntime(
+            argv_intent=LaunchArgvIntent.REQUIRED,
+            composition_surface=LaunchCompositionSurface.SPAWN_PREPARE,
+            runtime_root=(tmp_path / ".meridian").as_posix(),
+            project_paths_project_root=tmp_path.as_posix(),
+            project_paths_execution_cwd=tmp_path.as_posix(),
+        ),
+        harness_registry=get_default_harness_registry(),
+        dry_run=True,
+    )
+
+    assert preview.resolved_request.execution_policy.approval == "auto"
+    assert "--permission-mode" in preview.binding.argv
+    assert "acceptEdits" in preview.binding.argv
 
 
 @pytest.mark.parametrize(
@@ -298,3 +340,39 @@ def test_spawn_prepare_claude_continue_session_keeps_skills_in_system_prompt(
     assert "continue the task" in projected.user_turn_content
     assert "# Skill:" not in projected.user_turn_content
     assert "# Meridian Agents" not in projected.user_turn_content
+
+
+def test_spawn_prepare_claude_projects_profile_auto_approval_without_cli_override(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_minimal_mars_config(tmp_path)
+    stub_bundle_request_and_resolve(
+        monkeypatch,
+        model="claude-sonnet-4-5",
+        harness=HarnessId.CLAUDE,
+        execution_policy=ResolvedExecutionPolicy(approval="auto"),
+    )
+
+    preview = build_launch_context(
+        spawn_id="dry-run-claude-spawn-prepare-approval-auto",
+        request=SpawnRequest(
+            prompt="task",
+            prompt_is_composed=False,
+            model="claude-sonnet-4-5",
+            harness="claude",
+        ),
+        runtime=LaunchRuntime(
+            argv_intent=LaunchArgvIntent.REQUIRED,
+            composition_surface=LaunchCompositionSurface.SPAWN_PREPARE,
+            runtime_root=(tmp_path / ".meridian").as_posix(),
+            project_paths_project_root=tmp_path.as_posix(),
+            project_paths_execution_cwd=tmp_path.as_posix(),
+        ),
+        harness_registry=get_default_harness_registry(),
+        dry_run=True,
+    )
+
+    argv = preview.binding.argv
+    assert "--permission-mode" in argv
+    assert "acceptEdits" in argv

--- a/tests/integration/launch/test_streaming_serve.py
+++ b/tests/integration/launch/test_streaming_serve.py
@@ -26,6 +26,7 @@ def _fake_launch_context(
             harness="codex",
             agent="coder",
             prompt=prompt,
+            launch_policy_snapshot=None,
             skills=(),
             skill_paths=(),
             session=SimpleNamespace(requested_harness_session_id=None),

--- a/tests/integration/ops/test_spawn_api_create.py
+++ b/tests/integration/ops/test_spawn_api_create.py
@@ -215,6 +215,11 @@ def test_spawn_create_dry_run_with_work_is_non_mutating(
     project_root.mkdir()
     (project_root / "mars.toml").write_text("", encoding="utf-8")
     monkeypatch.chdir(project_root)
+    stub_bundle_request_and_resolve(
+        monkeypatch,
+        model="gpt-5.4-mini",
+        harness=HarnessId.CODEX,
+    )
     project_state_dir = resolve_project_paths(project_root).root_dir
 
     assert work_store.get_work_item(project_state_dir, "new-work-item") is None

--- a/tests/integration/ops/test_spawn_api_create.py
+++ b/tests/integration/ops/test_spawn_api_create.py
@@ -41,6 +41,11 @@ def test_spawn_create_dry_run_resolves_project_root_from_nested_cwd(
     reference_file = project_root / "guide.md"
     reference_file.write_text("# Guide\n", encoding="utf-8")
     monkeypatch.chdir(nested)
+    stub_bundle_request_and_resolve(
+        monkeypatch,
+        model="gpt-5.4-mini",
+        harness=HarnessId.CODEX,
+    )
 
     result = spawn_api.spawn_create_sync(
         SpawnCreateInput(

--- a/tests/integration/ops/test_spawn_continue.py
+++ b/tests/integration/ops/test_spawn_continue.py
@@ -15,6 +15,7 @@ from meridian.lib.core.launch_policy_snapshot import LaunchPolicySnapshot
 from meridian.lib.ops.spawn.models import SpawnActionOutput, SpawnContinueInput, SpawnCreateInput
 from meridian.lib.state import spawn_store
 from meridian.lib.state.paths import resolve_project_runtime_root
+from tests.support.fixtures import write_skill
 
 
 def _state_root(project_root: Path) -> Path:
@@ -209,6 +210,7 @@ def test_spawn_continue_replays_source_launch_policy_snapshot(
     project_root = tmp_path / "repo"
     project_root.mkdir()
     runtime_root = _state_root(project_root)
+    write_skill(project_root, "testing-principles")
     snapshot = LaunchPolicySnapshot(
         model="claude-sonnet-4-6",
         harness="claude",
@@ -225,22 +227,33 @@ def test_spawn_continue_replays_source_launch_policy_snapshot(
         harness_session_id="session-28",
         launch_policy_snapshot=snapshot,
     )
-    captured: dict[str, SpawnCreateInput] = {}
+    monkeypatch.setenv("MERIDIAN_MODEL", "gpt-5.4")
+    monkeypatch.setenv("MERIDIAN_APPROVAL", "confirm")
+    monkeypatch.setenv("MERIDIAN_SANDBOX", "read-only")
 
-    def fake_spawn_create_sync(
-        create_input: SpawnCreateInput,
-        *args: object,
-        **kwargs: object,
+    def fail_bundle_resolution(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("snapshot replay should not re-resolve live policy")
+
+    monkeypatch.setattr(
+        "meridian.lib.launch.bundle_adapter.request_and_resolve",
+        fail_bundle_resolution,
+    )
+
+    captured: dict[str, object] = {}
+
+    def fake_execute_spawn_blocking(
+        *,
+        payload: SpawnCreateInput,
+        request: object,
+        runtime: object,
+        ctx: object = None,
     ) -> SpawnActionOutput:
-        captured["create_input"] = create_input
+        _ = (runtime, ctx)
+        captured["payload"] = payload
+        captured["request"] = request
         return SpawnActionOutput(command="spawn.create", status="running", spawn_id="p29")
 
-    monkeypatch.setattr(spawn_api, "spawn_create_sync", fake_spawn_create_sync)
-    monkeypatch.setattr(
-        spawn_api,
-        "_resolve_effective_fork_target_harness",
-        lambda _create_input, *, resolved_project_root=None: "codex",
-    )
+    monkeypatch.setattr(spawn_api, "execute_spawn_blocking", fake_execute_spawn_blocking)
 
     result = spawn_api.spawn_continue_sync(
         SpawnContinueInput(
@@ -251,12 +264,75 @@ def test_spawn_continue_replays_source_launch_policy_snapshot(
     )
 
     assert result.command == "spawn.continue"
-    create_input = captured["create_input"]
+    create_input = captured["request"]
+    continue_input = captured["payload"]
+    assert isinstance(continue_input, SpawnCreateInput)
+    assert continue_input.launch_policy_snapshot == snapshot
     assert create_input.launch_policy_snapshot == snapshot
     assert create_input.model == snapshot.model
     assert create_input.harness == snapshot.harness
     assert create_input.agent == snapshot.agent
     assert create_input.skills == snapshot.skills
-    assert create_input.approval == snapshot.execution_policy.approval
-    assert create_input.sandbox == snapshot.execution_policy.sandbox
-    assert create_input.passthrough_args == snapshot.extra_args
+    assert create_input.execution_policy.approval == snapshot.execution_policy.approval
+    assert create_input.execution_policy.sandbox == snapshot.execution_policy.sandbox
+    assert create_input.execution_policy.effort == snapshot.execution_policy.effort
+    assert create_input.extra_args == snapshot.extra_args
+
+
+def test_spawn_continue_uses_legacy_source_launch_policy_without_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    runtime_root = _state_root(project_root)
+    _seed_spawn(runtime_root, spawn_id="p30", harness_session_id="session-30")
+
+    monkeypatch.setenv("MERIDIAN_MODEL", "claude-sonnet-4-6")
+    monkeypatch.setenv("MERIDIAN_APPROVAL", "confirm")
+
+    def fail_live_harness_resolution(
+        _create_input: SpawnCreateInput,
+        *,
+        resolved_project_root: Path | None = None,
+    ) -> str:
+        _ = resolved_project_root
+        raise AssertionError("legacy continue should use the persisted source harness")
+
+    monkeypatch.setattr(
+        spawn_api,
+        "_resolve_effective_fork_target_harness",
+        fail_live_harness_resolution,
+    )
+
+    captured: dict[str, object] = {}
+
+    def fake_execute_spawn_blocking(
+        *,
+        payload: SpawnCreateInput,
+        request: object,
+        runtime: object,
+        ctx: object = None,
+    ) -> SpawnActionOutput:
+        _ = (runtime, ctx)
+        captured["payload"] = payload
+        captured["request"] = request
+        return SpawnActionOutput(command="spawn.create", status="running", spawn_id="p31")
+
+    monkeypatch.setattr(spawn_api, "execute_spawn_blocking", fake_execute_spawn_blocking)
+
+    result = spawn_api.spawn_continue_sync(
+        SpawnContinueInput(
+            spawn_id="p30",
+            prompt="follow-up prompt",
+            project_root=project_root.as_posix(),
+        )
+    )
+
+    assert result.command == "spawn.continue"
+    create_input = captured["request"]
+    continue_input = captured["payload"]
+    assert isinstance(continue_input, SpawnCreateInput)
+    assert continue_input.launch_policy_snapshot is None
+    assert create_input.harness == "codex"
+    assert create_input.model == "gpt-5.3-codex"

--- a/tests/integration/ops/test_spawn_continue.py
+++ b/tests/integration/ops/test_spawn_continue.py
@@ -147,6 +147,9 @@ def test_spawn_continue_rejects_model_override_before_legacy_fallback_resolution
         ({"autocompact": 5000}, "--autocompact"),
         ({"autocompact_pct": 35}, "--autocompact-pct"),
         ({"passthrough_args": ("--custom",)}, "--"),
+        ({"work": "other-work"}, "--work"),
+        ({"worktree": True}, "--worktree/--no-worktree"),
+        ({"repo": "../other"}, "--repo"),
     ],
 )
 def test_spawn_continue_rejects_policy_flags_without_snapshot(

--- a/tests/integration/ops/test_spawn_continue.py
+++ b/tests/integration/ops/test_spawn_continue.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 import meridian.lib.ops.spawn.api as spawn_api
+from meridian.lib.core.domain import SkillContent
 from meridian.lib.core.execution_policy import ResolvedExecutionPolicy
 from meridian.lib.core.launch_policy_snapshot import LaunchPolicySnapshot
 from meridian.lib.ops.spawn.models import SpawnActionOutput, SpawnContinueInput, SpawnCreateInput
@@ -216,6 +217,15 @@ def test_spawn_continue_replays_source_launch_policy_snapshot(
         harness="claude",
         agent="coder",
         skills=("testing-principles",),
+        loaded_skills=(
+            SkillContent(
+                name="testing-principles",
+                description="testing-principles skill",
+                path="/skills/testing-principles/SKILL.md",
+                content="# testing-principles\n\nBe consistent.\n",
+                skill_type="reference",
+            ),
+        ),
         execution_policy=ResolvedExecutionPolicy(approval="auto", sandbox="workspace-write"),
         tools={"write": "allow"},
         mcp_tools=("github",),
@@ -273,6 +283,7 @@ def test_spawn_continue_replays_source_launch_policy_snapshot(
     assert create_input.harness == snapshot.harness
     assert create_input.agent == snapshot.agent
     assert create_input.skills == snapshot.skills
+    assert create_input.launch_policy_snapshot.loaded_skills == snapshot.loaded_skills
     assert create_input.execution_policy.approval == snapshot.execution_policy.approval
     assert create_input.execution_policy.sandbox == snapshot.execution_policy.sandbox
     assert create_input.execution_policy.effort == snapshot.execution_policy.effort

--- a/tests/integration/ops/test_spawn_continue.py
+++ b/tests/integration/ops/test_spawn_continue.py
@@ -13,10 +13,12 @@ import meridian.lib.ops.spawn.api as spawn_api
 from meridian.lib.core.domain import SkillContent
 from meridian.lib.core.execution_policy import ResolvedExecutionPolicy
 from meridian.lib.core.launch_policy_snapshot import LaunchPolicySnapshot
+from meridian.lib.core.types import HarnessId
 from meridian.lib.ops.spawn.models import SpawnActionOutput, SpawnContinueInput, SpawnCreateInput
 from meridian.lib.state import spawn_store
 from meridian.lib.state.paths import resolve_project_runtime_root
 from tests.support.fixtures import write_skill
+from tests.support.launch import stub_bundle_request_and_resolve
 
 
 def _state_root(project_root: Path) -> Path:
@@ -301,6 +303,13 @@ def test_spawn_continue_uses_legacy_source_launch_policy_without_snapshot(
 
     monkeypatch.setenv("MERIDIAN_MODEL", "claude-sonnet-4-6")
     monkeypatch.setenv("MERIDIAN_APPROVAL", "confirm")
+    stub_bundle_request_and_resolve(
+        monkeypatch,
+        model="gpt-5.3-codex",
+        model_token="gpt-5.3-codex",
+        harness=HarnessId.CODEX,
+        harness_model="openai/gpt-5.3-codex",
+    )
 
     def fail_live_harness_resolution(
         _create_input: SpawnCreateInput,

--- a/tests/integration/ops/test_spawn_continue.py
+++ b/tests/integration/ops/test_spawn_continue.py
@@ -10,7 +10,9 @@ from pathlib import Path
 import pytest
 
 import meridian.lib.ops.spawn.api as spawn_api
-from meridian.lib.ops.spawn.models import SpawnContinueInput
+from meridian.lib.core.execution_policy import ResolvedExecutionPolicy
+from meridian.lib.core.launch_policy_snapshot import LaunchPolicySnapshot
+from meridian.lib.ops.spawn.models import SpawnActionOutput, SpawnContinueInput, SpawnCreateInput
 from meridian.lib.state import spawn_store
 from meridian.lib.state.paths import resolve_project_runtime_root
 
@@ -35,20 +37,30 @@ def _seed_spawn(
     prompt: str = "seed prompt",
     goal: str | None = None,
     execution_cwd: str | None = None,
+    launch_policy_snapshot: LaunchPolicySnapshot | None = None,
 ) -> None:
+    model = launch_policy_snapshot.model if launch_policy_snapshot is not None else "gpt-5.3-codex"
+    agent = (
+        (launch_policy_snapshot.agent or "coder")
+        if launch_policy_snapshot is not None
+        else "coder"
+    )
+    skills = launch_policy_snapshot.skills if launch_policy_snapshot is not None else ("skill-c",)
+    harness = launch_policy_snapshot.harness if launch_policy_snapshot is not None else "codex"
     spawn_store.start_spawn(
         runtime_root,
         spawn_id=spawn_id,
         chat_id="c-seed",
-        model="gpt-5.3-codex",
-        agent="coder",
-        skills=("skill-c",),
-        harness="codex",
+        model=model,
+        agent=agent,
+        skills=skills,
+        harness=harness,
         prompt=prompt,
         goal=goal,
         work_id="w-spawn",
         harness_session_id=harness_session_id,
         execution_cwd=execution_cwd,
+        launch_policy_snapshot=launch_policy_snapshot,
     )
 
 
@@ -92,13 +104,11 @@ def test_spawn_continue_errors_on_explicit_harness_conflict(
             )
         )
 
-    assert (
-        str(exc_info.value)
-        == "Cannot continue spawn 'p24' with harness 'claude'; source spawn uses 'codex'."
-    )
+    assert "--harness" in str(exc_info.value)
+    assert "--fork-fresh" in str(exc_info.value)
 
 
-def test_spawn_continue_rejects_cross_harness_from_resolved_model_policy(
+def test_spawn_continue_rejects_model_override_before_legacy_fallback_resolution(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -122,7 +132,128 @@ def test_spawn_continue_rejects_cross_harness_from_resolved_model_policy(
             )
         )
 
-    assert (
-        str(exc_info.value)
-        == "Cannot continue across harnesses: source is 'codex', target is 'claude'."
+    assert "--model" in str(exc_info.value)
+    assert "--fork-fresh" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    ("updates", "flag"),
+    [
+        ({"agent": "reviewer"}, "--agent"),
+        ({"skills": ("skill-override",)}, "--skills"),
+        ({"approval": "auto"}, "--approval"),
+        ({"sandbox": "workspace-write"}, "--sandbox"),
+        ({"effort": "high"}, "--effort"),
+        ({"autocompact": 5000}, "--autocompact"),
+        ({"autocompact_pct": 35}, "--autocompact-pct"),
+        ({"passthrough_args": ("--custom",)}, "--"),
+    ],
+)
+def test_spawn_continue_rejects_policy_flags_without_snapshot(
+    tmp_path: Path,
+    updates: dict[str, object],
+    flag: str,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    runtime_root = _state_root(project_root)
+    _seed_spawn(runtime_root, spawn_id="p25", harness_session_id="session-25")
+
+    with pytest.raises(ValueError) as exc_info:
+        spawn_api.spawn_continue_sync(
+            SpawnContinueInput(
+                spawn_id="p25",
+                prompt="follow-up prompt",
+                project_root=project_root.as_posix(),
+                **updates,
+            )
+        )
+
+    message = str(exc_info.value)
+    assert flag in message
+    assert "--fork-fresh" in message
+
+
+def test_spawn_continue_rejects_policy_flags_when_snapshot_exists(tmp_path: Path) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    runtime_root = _state_root(project_root)
+    _seed_spawn(
+        runtime_root,
+        spawn_id="p27",
+        harness_session_id="session-27",
+        launch_policy_snapshot=LaunchPolicySnapshot(model="gpt-5.3-codex", harness="codex"),
     )
+
+    with pytest.raises(ValueError) as exc_info:
+        spawn_api.spawn_continue_sync(
+            SpawnContinueInput(
+                spawn_id="p27",
+                prompt="follow-up prompt",
+                model="claude-sonnet-4-6",
+                project_root=project_root.as_posix(),
+            )
+        )
+
+    assert "--model" in str(exc_info.value)
+    assert "--fork-fresh" in str(exc_info.value)
+
+
+def test_spawn_continue_replays_source_launch_policy_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    runtime_root = _state_root(project_root)
+    snapshot = LaunchPolicySnapshot(
+        model="claude-sonnet-4-6",
+        harness="claude",
+        agent="coder",
+        skills=("testing-principles",),
+        execution_policy=ResolvedExecutionPolicy(approval="auto", sandbox="workspace-write"),
+        tools={"write": "allow"},
+        mcp_tools=("github",),
+        extra_args=("--permission-mode", "acceptEdits"),
+    )
+    _seed_spawn(
+        runtime_root,
+        spawn_id="p28",
+        harness_session_id="session-28",
+        launch_policy_snapshot=snapshot,
+    )
+    captured: dict[str, SpawnCreateInput] = {}
+
+    def fake_spawn_create_sync(
+        create_input: SpawnCreateInput,
+        *args: object,
+        **kwargs: object,
+    ) -> SpawnActionOutput:
+        captured["create_input"] = create_input
+        return SpawnActionOutput(command="spawn.create", status="running", spawn_id="p29")
+
+    monkeypatch.setattr(spawn_api, "spawn_create_sync", fake_spawn_create_sync)
+    monkeypatch.setattr(
+        spawn_api,
+        "_resolve_effective_fork_target_harness",
+        lambda _create_input, *, resolved_project_root=None: "codex",
+    )
+
+    result = spawn_api.spawn_continue_sync(
+        SpawnContinueInput(
+            spawn_id="p28",
+            prompt="follow-up prompt",
+            project_root=project_root.as_posix(),
+        )
+    )
+
+    assert result.command == "spawn.continue"
+    create_input = captured["create_input"]
+    assert create_input.launch_policy_snapshot == snapshot
+    assert create_input.model == snapshot.model
+    assert create_input.harness == snapshot.harness
+    assert create_input.agent == snapshot.agent
+    assert create_input.skills == snapshot.skills
+    assert create_input.approval == snapshot.execution_policy.approval
+    assert create_input.sandbox == snapshot.execution_policy.sandbox
+    assert create_input.passthrough_args == snapshot.extra_args

--- a/tests/integration/state/test_spawn_store_crud.py
+++ b/tests/integration/state/test_spawn_store_crud.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import pytest
 
+from meridian.lib.core.domain import SkillContent
 from meridian.lib.core.execution_policy import ResolvedExecutionPolicy
 from meridian.lib.core.launch_policy_snapshot import LaunchPolicySnapshot
 from meridian.lib.core.spawn_start import SpawnStartMetadata
@@ -76,6 +77,8 @@ def test_start_and_update_project_fields_round_trip(tmp_path: Path) -> None:
     assert row is not None
     assert row.launch_mode == "foreground"
     assert row.runner_pid == 2222
+
+
 def test_start_spawn_persists_control_root_and_task_cwd(tmp_path: Path) -> None:
     runtime_root = _state_root(tmp_path)
     control_root = (tmp_path / "control-root").resolve()
@@ -136,6 +139,15 @@ def test_start_spawn_persists_launch_policy_snapshot(tmp_path: Path) -> None:
         harness="claude",
         agent="coder",
         skills=("testing-principles",),
+        loaded_skills=(
+            SkillContent(
+                name="testing-principles",
+                description="testing-principles skill",
+                path="/skills/testing-principles/SKILL.md",
+                content="# testing-principles\n\nBe consistent.\n",
+                skill_type="reference",
+            ),
+        ),
         execution_policy=ResolvedExecutionPolicy(
             approval="auto",
             sandbox="workspace-write",
@@ -174,6 +186,15 @@ def test_start_spawn_embeds_launch_policy_snapshot_in_state_json(tmp_path: Path)
     snapshot = LaunchPolicySnapshot(
         model="claude-sonnet-4-6",
         harness="claude",
+        loaded_skills=(
+            SkillContent(
+                name="testing-principles",
+                description="testing-principles skill",
+                path="/skills/testing-principles/SKILL.md",
+                content="# testing-principles\n\nBe consistent.\n",
+                skill_type="reference",
+            ),
+        ),
         execution_policy=ResolvedExecutionPolicy(approval="auto", sandbox="workspace-write"),
         extra_args=("--permission-mode", "acceptEdits"),
     )
@@ -240,6 +261,8 @@ def test_start_spawn_rejects_empty_goal(tmp_path: Path) -> None:
         )
 
     assert list_spawns(runtime_root) == []
+
+
 def test_list_spawns_filters_v2_rows_and_keeps_listings_promptless(tmp_path: Path) -> None:
     runtime_root = _state_root(tmp_path)
     p1 = _start_test_spawn(runtime_root)
@@ -261,6 +284,8 @@ def test_list_spawns_filters_v2_rows_and_keeps_listings_promptless(tmp_path: Pat
     assert [spawn.id for spawn in filtered] == [p2]
     assert filtered[0].prompt is None
     assert filtered[0].desc == "desc-2"
+
+
 def test_spawn_queries_read_v2_state_and_prompt(tmp_path: Path) -> None:
     runtime_root = _state_root(tmp_path)
     p1 = _start_test_spawn(runtime_root)
@@ -308,6 +333,8 @@ def test_next_and_reserved_spawn_ids_ignore_opaque_dirs_and_honor_highest_seed(
     assert reserve_spawn_id(runtime_root) == "p21"
     assert next_spawn_id(runtime_root) == "p22"
     assert (runtime_root / "spawn-id-counter").read_text(encoding="utf-8").strip() == "21"
+
+
 def test_exited_event_is_non_terminal_and_projects_last_attempt_exit(tmp_path: Path) -> None:
     runtime_root = _state_root(tmp_path)
     spawn_id = _start_test_spawn(runtime_root)

--- a/tests/integration/state/test_spawn_store_crud.py
+++ b/tests/integration/state/test_spawn_store_crud.py
@@ -9,11 +9,16 @@ test_spawn_store_finalize.py.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
 
+from meridian.lib.core.execution_policy import ResolvedExecutionPolicy
+from meridian.lib.core.launch_policy_snapshot import LaunchPolicySnapshot
 from meridian.lib.core.spawn_start import SpawnStartMetadata
+from meridian.lib.state.paths import RuntimePaths
+from meridian.lib.state.spawn.repository import read_state
 from meridian.lib.state.spawn_store import (
     finalize_spawn,
     get_spawn,
@@ -122,6 +127,69 @@ def test_start_spawn_persists_goal_from_start_metadata(tmp_path: Path) -> None:
     assert row.desc == "goal test"
     assert row.work_id == "w-goal"
     assert row.goal == "keep scope tight"
+
+
+def test_start_spawn_persists_launch_policy_snapshot(tmp_path: Path) -> None:
+    runtime_root = _state_root(tmp_path)
+    snapshot = LaunchPolicySnapshot(
+        model="claude-sonnet-4-6",
+        harness="claude",
+        agent="coder",
+        skills=("testing-principles",),
+        execution_policy=ResolvedExecutionPolicy(
+            approval="auto",
+            sandbox="workspace-write",
+            effort="high",
+        ),
+        tools={"write": "allow"},
+        mcp_tools=("github",),
+        extra_args=("--append-system-prompt", "stable"),
+        terminal_surface_mode="pty_mediated",
+        matched_policy_rule="profile-default",
+        model_selection_requested_token="sonnet",
+        model_selection_canonical_id="claude-sonnet-4-6",
+        model_selection_harness_provenance="alias-default",
+        fallback_chain=({"source": "snapshot"},),
+    )
+
+    spawn_id = str(
+        start_spawn(
+            runtime_root,
+            chat_id="c1",
+            model="claude-sonnet-4-6",
+            agent="coder",
+            harness="claude",
+            prompt="hello",
+            launch_policy_snapshot=snapshot,
+        )
+    )
+
+    row = get_spawn(runtime_root, spawn_id)
+    assert row is not None
+    assert row.launch_policy_snapshot == snapshot
+
+
+def test_spawn_state_without_launch_policy_snapshot_remains_readable(tmp_path: Path) -> None:
+    runtime_root = _state_root(tmp_path)
+    spawn_id = str(
+        start_spawn(
+            runtime_root,
+            chat_id="c1",
+            model="gpt-5.4",
+            agent="coder",
+            harness="codex",
+            prompt="hello",
+        )
+    )
+    paths = RuntimePaths.from_root_dir(runtime_root)
+    state_path = paths.spawns_dir / spawn_id / "state.json"
+    payload = json.loads(state_path.read_text(encoding="utf-8"))
+    payload.pop("launch_policy_snapshot", None)
+    state_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    row = read_state(paths.spawns_dir, spawn_id)
+    assert row is not None
+    assert row.launch_policy_snapshot is None
 
 
 def test_start_spawn_rejects_empty_goal(tmp_path: Path) -> None:

--- a/tests/integration/state/test_spawn_store_crud.py
+++ b/tests/integration/state/test_spawn_store_crud.py
@@ -169,6 +169,39 @@ def test_start_spawn_persists_launch_policy_snapshot(tmp_path: Path) -> None:
     assert row.launch_policy_snapshot == snapshot
 
 
+def test_start_spawn_embeds_launch_policy_snapshot_in_state_json(tmp_path: Path) -> None:
+    runtime_root = _state_root(tmp_path)
+    snapshot = LaunchPolicySnapshot(
+        model="claude-sonnet-4-6",
+        harness="claude",
+        execution_policy=ResolvedExecutionPolicy(approval="auto", sandbox="workspace-write"),
+        extra_args=("--permission-mode", "acceptEdits"),
+    )
+
+    spawn_id = str(
+        start_spawn(
+            runtime_root,
+            chat_id="c1",
+            model="claude-sonnet-4-6",
+            agent="coder",
+            harness="claude",
+            prompt="hello",
+            launch_policy_snapshot=snapshot,
+        )
+    )
+
+    spawn_dir = runtime_root / "spawns" / spawn_id
+    state_path = spawn_dir / "state.json"
+    payload = json.loads(state_path.read_text(encoding="utf-8"))
+
+    assert payload["launch_policy_snapshot"] == snapshot.model_dump(mode="json")
+    assert not any(
+        "launch_policy_snapshot" in path.name
+        for path in spawn_dir.iterdir()
+        if path.name != "state.json"
+    )
+
+
 def test_spawn_state_without_launch_policy_snapshot_remains_readable(tmp_path: Path) -> None:
     runtime_root = _state_root(tmp_path)
     spawn_id = str(

--- a/tests/unit/launch/test_launch_context_build.py
+++ b/tests/unit/launch/test_launch_context_build.py
@@ -261,8 +261,32 @@ def test_primary_bundle_auto_approval_projects_claude_accept_edits(
     )
 
     assert runtime_ctx.resolved_request.execution_policy.approval == "auto"
+    assert runtime_ctx.resolved_request.launch_policy_snapshot is not None
+    assert (
+        runtime_ctx.resolved_request.launch_policy_snapshot.model_selection_harness_model_id
+        == "claude-sonnet-4-6"
+    )
     assert "--permission-mode" in runtime_ctx.binding.argv
     assert "acceptEdits" in runtime_ctx.binding.argv
+
+
+def test_direct_launch_context_synthesizes_policy_snapshot(tmp_path: Path) -> None:
+    runtime_ctx = build_launch_context(
+        spawn_id="p-direct-snapshot",
+        request=SpawnRequest(
+            model="gpt-5.4",
+            harness=HarnessId.CODEX.value,
+            prompt="direct prompt",
+        ),
+        runtime=_build_launch_runtime(tmp_path=tmp_path),
+        harness_registry=get_default_harness_registry(),
+        dry_run=True,
+    )
+
+    snapshot = runtime_ctx.resolved_request.launch_policy_snapshot
+    assert snapshot is not None
+    assert snapshot.model == "gpt-5.4"
+    assert snapshot.harness == HarnessId.CODEX.value
 
 
 def test_spawn_prepare_reuses_policy_snapshot_over_live_env(

--- a/tests/unit/launch/test_launch_context_build.py
+++ b/tests/unit/launch/test_launch_context_build.py
@@ -285,6 +285,7 @@ def test_direct_launch_context_synthesizes_policy_snapshot(tmp_path: Path) -> No
 
     snapshot = runtime_ctx.resolved_request.launch_policy_snapshot
     assert snapshot is not None
+    assert runtime_ctx.request.launch_policy_snapshot == snapshot
     assert snapshot.model == "gpt-5.4"
     assert snapshot.harness == HarnessId.CODEX.value
 

--- a/tests/unit/launch/test_launch_context_build.py
+++ b/tests/unit/launch/test_launch_context_build.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from meridian.lib.core.execution_policy import ResolvedExecutionPolicy
+from meridian.lib.core.launch_policy_snapshot import LaunchPolicySnapshot
 from meridian.lib.core.types import HarnessId
 from meridian.lib.harness.registry import get_default_harness_registry
 from meridian.lib.launch.composition import PromptDocument
@@ -227,3 +229,81 @@ def test_build_launch_context_spawn_prepare_injects_goal_completion_contract(
     )
     assert "# Spawn Goal" in projected_goal_contract
     assert "<goal>\nfinish launch composition wiring\n</goal>" in projected_goal_contract
+
+
+def test_primary_bundle_auto_approval_projects_claude_accept_edits(
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _write_minimal_mars_config(tmp_path)
+    stub_bundle_request_and_resolve(
+        monkeypatch,
+        model="claude-sonnet-4-6",
+        harness=HarnessId.CLAUDE,
+        execution_policy=ResolvedExecutionPolicy(approval="auto"),
+    )
+    request = SpawnRequest(
+        model="claude-sonnet-4-6",
+        harness=HarnessId.CLAUDE.value,
+        prompt="# Meridian Session",
+    )
+    runtime = _build_launch_runtime(
+        tmp_path=tmp_path,
+        composition_surface=LaunchCompositionSurface.PRIMARY,
+    )
+
+    runtime_ctx = build_launch_context(
+        spawn_id="p-primary-auto-approval",
+        request=request,
+        runtime=runtime,
+        harness_registry=get_default_harness_registry(),
+        dry_run=True,
+    )
+
+    assert runtime_ctx.resolved_request.execution_policy.approval == "auto"
+    assert "--permission-mode" in runtime_ctx.binding.argv
+    assert "acceptEdits" in runtime_ctx.binding.argv
+
+
+def test_spawn_prepare_reuses_policy_snapshot_over_live_env(
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _write_minimal_mars_config(tmp_path)
+    snapshot = LaunchPolicySnapshot(
+        model="claude-sonnet-4-6",
+        harness=HarnessId.CLAUDE.value,
+        execution_policy=ResolvedExecutionPolicy(approval="auto", sandbox="workspace-write"),
+    )
+    monkeypatch.setenv("MERIDIAN_MODEL", "gpt-5.4")
+    monkeypatch.setenv("MERIDIAN_APPROVAL", "confirm")
+
+    def fail_bundle(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("snapshot replay should not call launch-bundle")
+
+    monkeypatch.setattr("meridian.lib.launch.bundle_adapter.request_and_resolve", fail_bundle)
+    request = SpawnRequest(
+        model="gpt-5.4",
+        harness=HarnessId.CODEX.value,
+        prompt="snapshot replay prompt",
+        prompt_is_composed=False,
+        launch_policy_snapshot=snapshot,
+    )
+    runtime = _build_launch_runtime(
+        tmp_path=tmp_path,
+        composition_surface=LaunchCompositionSurface.SPAWN_PREPARE,
+    )
+
+    runtime_ctx = build_launch_context(
+        spawn_id="p-snapshot-replay",
+        request=request,
+        runtime=runtime,
+        harness_registry=get_default_harness_registry(),
+        dry_run=True,
+    )
+
+    assert runtime_ctx.resolved_request.model == snapshot.model
+    assert runtime_ctx.resolved_request.harness == snapshot.harness
+    assert runtime_ctx.resolved_request.execution_policy.approval == "auto"
+    assert "--permission-mode" in runtime_ctx.binding.argv
+    assert "acceptEdits" in runtime_ctx.binding.argv

--- a/tests/unit/launch/test_launch_context_build.py
+++ b/tests/unit/launch/test_launch_context_build.py
@@ -317,12 +317,12 @@ def test_primary_launch_policy_snapshot_persists_loaded_skills(
     snapshot = runtime_ctx.resolved_request.launch_policy_snapshot
     assert snapshot is not None
     assert snapshot.skills == ("testing-principles",)
-    assert snapshot.skill_paths == (skill_path.resolve().as_posix(),)
+    assert snapshot.skill_paths == (str(skill_path.resolve()),)
     assert snapshot.loaded_skills == (
         SkillContent(
             name="testing-principles",
             description="testing-principles skill",
-            path=skill_path.resolve().as_posix(),
+            path=str(skill_path.resolve()),
             content=skill_path.read_text(encoding="utf-8"),
             skill_type="reference",
         ),

--- a/tests/unit/launch/test_launch_context_build.py
+++ b/tests/unit/launch/test_launch_context_build.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from meridian.lib.core.domain import SkillContent
 from meridian.lib.core.execution_policy import ResolvedExecutionPolicy
 from meridian.lib.core.launch_policy_snapshot import LaunchPolicySnapshot
 from meridian.lib.core.types import HarnessId
@@ -20,6 +21,7 @@ from meridian.lib.launch.request import (
     LaunchRuntime,
     SpawnRequest,
 )
+from tests.support.fixtures import write_agent, write_skill
 from tests.support.launch import stub_bundle_request_and_resolve
 
 if TYPE_CHECKING:
@@ -268,6 +270,63 @@ def test_primary_bundle_auto_approval_projects_claude_accept_edits(
     )
     assert "--permission-mode" in runtime_ctx.binding.argv
     assert "acceptEdits" in runtime_ctx.binding.argv
+
+
+def test_primary_launch_policy_snapshot_persists_loaded_skills(
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _write_minimal_mars_config(tmp_path)
+    skill_path = write_skill(
+        tmp_path,
+        "testing-principles",
+        body="# testing-principles\n\nBe consistent.\n",
+        description="testing-principles skill",
+    )
+    write_agent(
+        tmp_path,
+        name="coder",
+        model="gpt-5.4",
+        skills=("testing-principles",),
+        harness=HarnessId.CODEX.value,
+    )
+    stub_bundle_request_and_resolve(
+        monkeypatch,
+        model="gpt-5.4",
+        harness=HarnessId.CODEX,
+    )
+    request = SpawnRequest(
+        model="gpt-5.4",
+        harness=HarnessId.CODEX.value,
+        agent="coder",
+        prompt="# Meridian Session",
+    )
+    runtime = _build_launch_runtime(
+        tmp_path=tmp_path,
+        composition_surface=LaunchCompositionSurface.PRIMARY,
+    )
+
+    runtime_ctx = build_launch_context(
+        spawn_id="p-primary-snapshot-skills",
+        request=request,
+        runtime=runtime,
+        harness_registry=get_default_harness_registry(),
+        dry_run=True,
+    )
+
+    snapshot = runtime_ctx.resolved_request.launch_policy_snapshot
+    assert snapshot is not None
+    assert snapshot.skills == ("testing-principles",)
+    assert snapshot.skill_paths == (skill_path.resolve().as_posix(),)
+    assert snapshot.loaded_skills == (
+        SkillContent(
+            name="testing-principles",
+            description="testing-principles skill",
+            path=skill_path.resolve().as_posix(),
+            content=skill_path.read_text(encoding="utf-8"),
+            skill_type="reference",
+        ),
+    )
 
 
 def test_direct_launch_context_synthesizes_policy_snapshot(tmp_path: Path) -> None:

--- a/tests/unit/launch/test_policies.py
+++ b/tests/unit/launch/test_policies.py
@@ -687,5 +687,5 @@ def test_snapshot_replay_uses_persisted_loaded_skills_after_live_catalog_changes
     assert replayed_policy.resolved_skills.skill_names == ("testing-principles",)
     assert replayed_policy.resolved_skills.loaded_skills == original_skills
     assert replayed_policy.resolved_skills.loaded_skills[0].name == "testing-principles"
-    assert replayed_policy.resolved_skills.loaded_skills[0].path == skill_path.as_posix()
+    assert replayed_policy.resolved_skills.loaded_skills[0].path == str(skill_path)
     assert replayed_policy.resolved_skills.loaded_skills[0].content == original_skills[0].content

--- a/tests/unit/launch/test_policies.py
+++ b/tests/unit/launch/test_policies.py
@@ -11,6 +11,7 @@ from meridian.lib.core.types import HarnessId, ModelId
 from meridian.lib.harness.registry import get_default_harness_registry
 from meridian.lib.launch import bundle_adapter
 from meridian.lib.launch.compiler import ModelPolicyRule, ProvenanceLevel
+from meridian.lib.launch.context import build_launch_policy_snapshot
 from meridian.lib.launch.launch_types import ResolvedExecutionPolicy
 from meridian.lib.launch.policies import (
     SurfacePolicyInput,
@@ -18,7 +19,8 @@ from meridian.lib.launch.policies import (
     resolve_launch_policy,
     resolve_policy_fields,
 )
-from meridian.lib.launch.request import LaunchCompositionSurface
+from meridian.lib.launch.request import LaunchCompositionSurface, SpawnRequest
+from tests.support.fixtures import write_agent, write_skill
 from tests.support.launch import FakeBundleResult
 
 
@@ -593,3 +595,97 @@ def test_spawn_prepare_passes_profile_and_requested_skills_to_bundle(
     )
 
     assert captured["skills"] == ("alpha", "beta", "gamma")
+
+
+def test_snapshot_replay_uses_persisted_loaded_skills_after_live_catalog_changes(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    skill_path = write_skill(
+        tmp_path,
+        "testing-principles",
+        body="# testing-principles\n\nBe consistent.\n",
+        description="testing-principles skill",
+    )
+    write_agent(
+        tmp_path,
+        name="coder",
+        model="gpt-5.4",
+        skills=("testing-principles",),
+        harness=HarnessId.CODEX.value,
+    )
+
+    monkeypatch.setattr(
+        bundle_adapter,
+        "request_and_resolve",
+        lambda request, *, harness_registry: FakeBundleResult(
+            model="gpt-5.4",
+            model_token="gpt5.4",
+            harness=HarnessId.CODEX,
+            harness_model="gpt-5.4",
+            execution_policy=ResolvedExecutionPolicy(approval="auto"),
+            provenance={"harness_source": "provider"},
+        ),
+    )
+    monkeypatch.setattr(CatalogSession, "alias_map", lambda self: {})
+
+    initial_policy = resolve_launch_policy(
+        SurfacePolicyInput(
+            surface=LaunchCompositionSurface.SPAWN_PREPARE,
+            catalog=CatalogSession(tmp_path),
+            layers=(RuntimeOverrides(agent="coder"), RuntimeOverrides()),
+            config_overrides=RuntimeOverrides.from_spawn_config(MeridianConfig()),
+            config=MeridianConfig(),
+            harness_registry=get_default_harness_registry(),
+        )
+    )
+
+    original_skills = initial_policy.resolved_skills.loaded_skills
+    assert original_skills
+    snapshot = build_launch_policy_snapshot(
+        SpawnRequest(
+            model=initial_policy.model,
+            harness=initial_policy.harness.value,
+            agent=initial_policy.profile.name if initial_policy.profile is not None else None,
+            skills=initial_policy.resolved_skills.skill_names,
+            execution_policy=initial_policy.execution_policy,
+            prompt="snapshot replay prompt",
+            extra_args=(),
+        ),
+        model_selection=initial_policy.model_selection,
+        loaded_skills=original_skills,
+    )
+
+    skill_path.unlink()
+
+    monkeypatch.setattr(
+        "meridian.lib.launch.policies.resolve_skills_from_profile",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("snapshot replay should not re-resolve live skill catalog")
+        ),
+    )
+    monkeypatch.setattr(
+        bundle_adapter,
+        "request_and_resolve",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("snapshot replay should not call launch-bundle")
+        ),
+    )
+
+    replayed_policy = resolve_launch_policy(
+        SurfacePolicyInput(
+            surface=LaunchCompositionSurface.SPAWN_PREPARE,
+            catalog=CatalogSession(tmp_path),
+            layers=(RuntimeOverrides(), RuntimeOverrides()),
+            config_overrides=RuntimeOverrides.from_spawn_config(MeridianConfig()),
+            config=MeridianConfig(),
+            harness_registry=get_default_harness_registry(),
+            policy_snapshot=snapshot,
+        )
+    )
+
+    assert replayed_policy.resolved_skills.skill_names == ("testing-principles",)
+    assert replayed_policy.resolved_skills.loaded_skills == original_skills
+    assert replayed_policy.resolved_skills.loaded_skills[0].name == "testing-principles"
+    assert replayed_policy.resolved_skills.loaded_skills[0].path == skill_path.as_posix()
+    assert replayed_policy.resolved_skills.loaded_skills[0].content == original_skills[0].content

--- a/tests/unit/ops/test_reference_control_root.py
+++ b/tests/unit/ops/test_reference_control_root.py
@@ -175,13 +175,11 @@ def test_spawn_continue_uses_persisted_source_control_root(
         SpawnContinueInput(
             spawn_id=spawn_id,
             prompt="Continue",
-            worktree=True,
             project_root=current_control_root.as_posix(),
         )
     )
 
     assert captured["session"].source_control_root == persisted_control_root.as_posix()
-    assert captured["create_input"].worktree is True
 
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -666,15 +666,15 @@ wheels = [
 
 [[package]]
 name = "mars-agents"
-version = "0.7.1"
+version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/00/8e/4a7882c87503747ca3e3657e145e37c893af317d6e0bd0c0e46e5a509f2d/mars_agents-0.7.1.tar.gz", hash = "sha256:147c74059f7607d2c0b709cea877469f36e6465ab63e7963400215db11c2e13e", size = 568932, upload-time = "2026-05-24T13:19:23.29Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/f4/249946e11d932662a66636e4687362175bb31eae5ac8071e964e1db7e846/mars_agents-0.7.3.tar.gz", hash = "sha256:b0d2940f219366213fd564c30635f6e951c330e3703035a551bf9e57245d1668", size = 585905, upload-time = "2026-05-26T03:22:18.584Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/2b/5ba656df28156570910a580f3d5ba11eda1549310e882f1b522dd2bbb387/mars_agents-0.7.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e7443e748b8d4d229fad464c11b898e5eb62cf2a89e164cd8c36c54405169e16", size = 3205682, upload-time = "2026-05-24T13:19:13.021Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/67/b0b08559023eceef8114911f9130ffc89d30c649e420546d81e9e659bdfc/mars_agents-0.7.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:18b7c88826dcc6b5c7e66100cbe5b920d06a7ee30b623ebc2028252e664a86e3", size = 3067997, upload-time = "2026-05-24T13:19:15.402Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/9e/1e943501ad80142d427b81bbcf2c7a0ac8837c8c947e219ff19ca38fbc8b/mars_agents-0.7.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5b5fb6d37db41c5cef4753d744d3536fc5ee6211b70b82832221e26ef5044a11", size = 3119410, upload-time = "2026-05-24T13:19:17.358Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/1a/3edd92ec3f09744aac5acbcd974214639d1c935010bcf6c100abedf74893/mars_agents-0.7.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:75ad32a841ea957bbbed981e4f519253b0b58b53141e6f17e5230a697b76c8e3", size = 3327640, upload-time = "2026-05-24T13:19:19.133Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/2c/e10dc74db0fd27e77ddb82baae2577c78bb9fe3c8fdaf696cc8447bebb84/mars_agents-0.7.1-py3-none-win_amd64.whl", hash = "sha256:92e98fc68c29c0eb5fc48220b6d16447c552a3ed2ee04b59888f3677885ff781", size = 3234914, upload-time = "2026-05-24T13:19:21.166Z" },
+    { url = "https://files.pythonhosted.org/packages/71/d2/5e0b254494a49f73962690760aa186d1c3ab7fa0b8c3cec54240f9041cfd/mars_agents-0.7.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:a82fabe19d68dd5d974632496195fe18e14a4dfd290b6eba32fdf74744a52d84", size = 3265530, upload-time = "2026-05-26T03:22:09.02Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1e/b5d7f3ba46e99c7b23ae605d302555521c5a54d375f69141cff78567585b/mars_agents-0.7.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:df53d6a95322bfe8971a994c1b358950b3696df0f55683b6153e6800f164cde8", size = 3132435, upload-time = "2026-05-26T03:22:11.098Z" },
+    { url = "https://files.pythonhosted.org/packages/64/1e/489d320c4041d22d177b088b1b08c35975ab93050534e3a7635753a80673/mars_agents-0.7.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:56a4c062494ba62f749734281f92acfb6ba5e7e8529d04b31cb8a26f5e74fb31", size = 3180572, upload-time = "2026-05-26T03:22:12.959Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/eb/996cf442fece1271f3de9ac004f08a73061c4b95f6cbc65a40ac40e79efb/mars_agents-0.7.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e9a2a3cc35dd22eadf476fff5da89b81d8445f5e34934e0d2725c0e66905cd3f", size = 3389262, upload-time = "2026-05-26T03:22:14.93Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/86/c4e4e6e5f8f4df5c181e1895afbd01a6c740a7af824c9ef4f6520560b124/mars_agents-0.7.3-py3-none-win_amd64.whl", hash = "sha256:53d29d07c8182a94709d10f32d008037f8635b58484b76e51c6894e3671a57ed", size = 3305196, upload-time = "2026-05-26T03:22:16.802Z" },
 ]
 
 [[package]]
@@ -764,7 +764,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'app'", specifier = ">=0.28" },
     { name = "jinja2", marker = "extra == 'templates'", specifier = ">=3.1" },
     { name = "markdown-it-py", specifier = ">=4.0" },
-    { name = "mars-agents", specifier = "==0.7.1" },
+    { name = "mars-agents", specifier = "==0.7.3" },
     { name = "mcp", specifier = ">=1.0" },
     { name = "pathspec", specifier = ">=1.1.0" },
     { name = "psutil", specifier = ">=7.2.2" },


### PR DESCRIPTION
## Why

`meridian spawn --continue <id>` re-resolved live launch policy instead of replaying the source spawn contract, which could drop approval/sandbox/tool permissions and break resumed writes.

## Goal

Persist the resolved launch policy at spawn creation and use it for exact continuation while preserving readable fallback behavior for old rows.

## Summary

- Added embedded `launch_policy_snapshot` state with resolved model/harness/agent/skills, loaded skill payloads, execution policy, tools, model-selection provenance, and terminal surface metadata.
- Built snapshots in the launch layer after policy resolution and threaded them through spawn start/state persistence.
- Replayed snapshots on `spawn --continue` without live policy re-resolution; legacy no-snapshot rows still continue through fallback.
- Rejected policy-changing flags with exact continuation and kept `--fork-fresh` as the identity-changing path.
- Covered Claude `approval:auto` projection to `--permission-mode acceptEdits`.

## Resulting Behavior

Continuing a spawn resumes the prior harness session under the persisted source launch contract, including approval/sandbox/tool policy and resolved skills, even if live env/profile/config defaults changed. Policy-changing continue flags now fail with guidance to use `--fork-fresh`.

## Work Item

spawn-continue-launch-policy-snapshot

## Verification

- `uv run ruff check .`
- `uv run pytest-llm tests/integration/ops/test_spawn_api_create.py::test_spawn_create_dry_run_resolves_project_root_from_nested_cwd tests/integration/launch/test_streaming_serve.py::test_streaming_serve_debug_keeps_projected_connection_config tests/unit/ops/test_reference_control_root.py tests/unit/launch/test_launch_context_build.py tests/unit/launch/test_policies.py tests/integration/state/test_spawn_store_crud.py tests/integration/ops/test_spawn_continue.py tests/integration/launch/test_launch_resolution_spawn_prepare.py` — 67 passed
- `uv run --extra dev python -m pyright` — 0 errors, 1 existing warning in `src/meridian/lib/launch/compiler.py`
- Pre-push hook: `ruff`, `pyright`, full pytest, and `uv build --no-sources` — 1131 passed, 11 skipped; build succeeded
- Smoke tester p2735: CLI dry-run/rejection probes passed for snapshot replay and Claude `acceptEdits` projection

## Knowledge Updates

No durable KB/docs updates needed; behavior is covered by changelog and tests.

## Spawn Trace

- p2713 coder — closed QA test gaps and legacy fallback coverage
- p2727/p2729 coder — persisted loaded skill payloads and fixed focused test failures
- p2733 reviewer — final blocking review after skill fix
- p2734 qa-lead — final QA audit and stale test cleanup
- p2735 smoke-tester — final smoke verification
- p2745/p2748 coder — fixed pre-push test fakes

## Release Label Guide

Set `release:patch`.

## Post-Merge Automation

After merge to `main`, CI owns version bump, changelog promotion, and tag creation.

## Cleanup

After merge, run:

```bash
scripts/prune-worktrees.sh
```