### PR TITLE
Add spawn status output tiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Added `meridian spawn status` as a `spawn show` companion with shared flags and report-body-off default.
+
+### Changed
+- `spawn show`/`spawn status` text output now defaults to a moderate status tier, with full internal diagnostics behind `--verbose`.
+- Auto-extracted spawn reports now persist with `# Report` heading instead of `# Auto-extracted Report`.
+
 ## [0.2.8] - 2026-05-27
 
 ### Added

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -18,6 +18,7 @@ Full command surface. Use `--help` on any command for flags and options.
 | `meridian spawn list --primary` | Show only primary spawns (top-level sessions) |
 | `meridian spawn wait ID` | Block until a spawn completes; report body included by default, `--no-report` to suppress |
 | `meridian spawn show ID` | Read a spawn's report and status |
+| `meridian spawn status ID` | Read spawn status summary (report body off by default; add `--report` to include) |
 | `meridian spawn --continue ID -p "more"` | Resume a prior spawn with new input |
 | `meridian spawn --fork [REF] -p "next"` | Start a new spawn by forking while preserving launch identity (agent/model/skills) |
 | `meridian spawn --fork-fresh [REF] -p "next"` | Start a new spawn by forking and allowing launch identity changes (`-m`, `-a`, `--skills`) |
@@ -75,12 +76,17 @@ timestamps, paths, model) is hidden by default.
 | `--format json` | Structured JSON with report body and transcript command fields |
 | `--bg` | Spawn ID + wait instructions (unchanged) |
 
+`spawn show` and `spawn status` default to a moderate tier: status/model/duration plus actionable failure context.
+Use `--verbose` to include internal diagnostics (tokens, lifecycle fields, backend metadata, and other internals).
+
 Progressive disclosure:
 
 ```bash
 meridian spawn -a reviewer -p "task"              # compact: status + report
 meridian spawn -a reviewer -p "task" --metadata   # adds model/cost/tokens/path inline
-meridian spawn show p123                           # full detailed record (unchanged)
+meridian spawn show p123                           # moderate summary + report body
+meridian spawn status p123                         # moderate summary without report body
+meridian spawn show p123 --verbose                 # internal diagnostics view
 meridian session log p123                          # recent transcript entries (last 5, chronological, safe content previews)
 meridian session log p123 --full                   # full selected segment, including entry 0 prologue/handoff slot
 meridian session log p123 --segment current --from 0 --limit 1  # read just segment prologue/handoff slot

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -94,9 +94,10 @@ meridian session log p123 --global --from 0 --limit 1           # read first ent
 meridian session log p123 --full --no-truncate     # full selected segment with full message content
 ```
 
-`spawn show` includes primary-session metadata when available from `primary_meta.json`:
-`kind`, `activity`, `managed_backend`, `backend_pid`, `tui_pid`, `backend_port`,
-`harness_session_id`, and `session_config_dir`.
+Primary-session metadata from `primary_meta.json` (`kind`, `activity`,
+`managed_backend`, `backend_pid`, `tui_pid`, `backend_port`,
+`harness_session_id`, `session_config_dir`) is available in
+`spawn show --verbose` and structured JSON output, not default moderate text.
 
 `spawn cancel-all` scopes cancellation to the calling spawn's subtree when invoked
 from inside a nested spawn (e.g., from an orchestrator agent). This prevents

--- a/docs/harness-integration.md
+++ b/docs/harness-integration.md
@@ -782,7 +782,7 @@ trivial `agent_end` event to stdout.
 - [ ] `meridian pi -m <cheap-model> "Reply with exactly OK"` exits 0
 - [ ] `meridian spawn --harness pi -m <cheap-model> "Reply with exactly OK"`
   exits 0 and reports status `succeeded`
-- [ ] `meridian spawn show <spawn-id>` shows report, usage, session ID
+- [ ] `meridian spawn show <spawn-id> --verbose` shows report, usage, session ID
 - [ ] Resume works: `meridian pi --continue <session-id> "continue"`
 - [ ] Fork works: `meridian pi --fork <session-id> "fork"`
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -156,7 +156,8 @@ meridian doctor
 After reconciliation, inspect the spawn:
 
 ```bash
-meridian spawn show ID          # check status, report, and error field
+meridian spawn show ID          # check status, report, and actionable failure context
+meridian spawn show ID --verbose # include internal diagnostics (error field, lifecycle internals)
 ```
 
 If `report.md` exists and looks complete, the work product is likely usable even though the spawn is marked `failed`. Relaunch only if the work wasn't done.

--- a/src/meridian/cli/spawn.py
+++ b/src/meridian/cli/spawn.py
@@ -35,6 +35,7 @@ from meridian.lib.ops.spawn.api import (
     SpawnListInput,
     SpawnShowInput,
     SpawnStatsInput,
+    SpawnStatusInput,
     SpawnWaitInput,
     SpawnWrittenFilesInput,
     spawn_cancel_all_sync,
@@ -47,6 +48,7 @@ from meridian.lib.ops.spawn.api import (
     spawn_list_sync,
     spawn_show_sync,
     spawn_stats_sync,
+    spawn_status_sync,
     spawn_wait_sync,
 )
 from meridian.lib.ops.spawn.models import SpawnLaunchOptionUpdates, normalize_goal
@@ -685,8 +687,12 @@ def _spawn_show(
     _spawn_show_like(
         emit,
         spawn_ids=spawn_ids,
-        report=report,
         verbose=verbose,
+        build_input=lambda spawn_id: SpawnShowInput(
+            spawn_id=spawn_id,
+            include_report_body=report,
+        ),
+        handler=spawn_show_sync,
     )
 
 
@@ -711,8 +717,12 @@ def _spawn_status(
     _spawn_show_like(
         emit,
         spawn_ids=spawn_ids,
-        report=report,
         verbose=verbose,
+        build_input=lambda spawn_id: SpawnStatusInput(
+            spawn_id=spawn_id,
+            include_report_body=report,
+        ),
+        handler=spawn_status_sync,
     )
 
 
@@ -720,18 +730,17 @@ def _spawn_show_like(
     emit: Any,
     *,
     spawn_ids: tuple[str, ...],
-    report: bool,
     verbose: bool,
+    build_input: Callable[[str], SpawnShowInput | SpawnStatusInput],
+    handler: Callable[..., Any],
 ) -> None:
     sink = _current_output_sink()
+    prepared = _prepare_spawn_runtime_read()
     results = tuple(
-        spawn_show_sync(
-            SpawnShowInput(
-                spawn_id=spawn_id,
-                include_report_body=report,
-            ),
+        handler(
+            build_input(spawn_id),
             sink=sink,
-            prepared=_prepare_spawn_runtime_read(),
+            prepared=prepared,
         )
         for spawn_id in spawn_ids
     )

--- a/src/meridian/cli/spawn.py
+++ b/src/meridian/cli/spawn.py
@@ -667,6 +667,10 @@ def _spawn_show(
         tuple[str, ...],
         Parameter(name="spawn_id", help="One or more spawn IDs to show."),
     ],
+    verbose: Annotated[
+        bool,
+        Parameter(name="--verbose", help="Include internal spawn diagnostics.", show=True),
+    ] = False,
     report: Annotated[
         bool,
         Parameter(
@@ -677,6 +681,47 @@ def _spawn_show(
             ),
         ),
     ] = True,
+) -> None:
+    _spawn_show_like(
+        emit,
+        spawn_ids=spawn_ids,
+        report=report,
+        verbose=verbose,
+    )
+
+
+def _spawn_status(
+    emit: Any,
+    spawn_ids: Annotated[
+        tuple[str, ...],
+        Parameter(name="spawn_id", help="One or more spawn IDs to show."),
+    ],
+    verbose: Annotated[
+        bool,
+        Parameter(name="--verbose", help="Include internal spawn diagnostics.", show=True),
+    ] = False,
+    report: Annotated[
+        bool,
+        Parameter(
+            name="--report",
+            help="Include report body in output (default: disabled).",
+        ),
+    ] = False,
+) -> None:
+    _spawn_show_like(
+        emit,
+        spawn_ids=spawn_ids,
+        report=report,
+        verbose=verbose,
+    )
+
+
+def _spawn_show_like(
+    emit: Any,
+    *,
+    spawn_ids: tuple[str, ...],
+    report: bool,
+    verbose: bool,
 ) -> None:
     sink = _current_output_sink()
     results = tuple(
@@ -691,15 +736,20 @@ def _spawn_show(
         for spawn_id in spawn_ids
     )
 
+    output_format = _get_global_options().output.format
     if len(results) == 1:
-        emit(results[0])
+        if output_format != "json" and verbose:
+            emit(results[0].format_text(FormatContext(verbosity=1)))
+        else:
+            emit(results[0])
         return
 
-    if _get_global_options().output.format == "json":
+    if output_format == "json":
         emit(list(results))
         return
 
-    emit("\n\n".join(result.format_text() for result in results))
+    fmt_ctx = FormatContext(verbosity=1) if verbose else None
+    emit("\n\n".join(result.format_text(fmt_ctx) for result in results))
 
 
 def _spawn_stats(
@@ -929,6 +979,7 @@ def register_spawn_commands(app: App, emit: Emitter) -> tuple[set[str], dict[str
         "meridian.spawn.list": lambda: partial(_spawn_list, emit),
         "meridian.spawn.stats": lambda: partial(_spawn_stats, emit),
         "meridian.spawn.show": lambda: partial(_spawn_show, emit),
+        "meridian.spawn.status": lambda: partial(_spawn_status, emit),
         "meridian.spawn.cancel": lambda: partial(_spawn_cancel, emit),
         "meridian.spawn.cancelAll": lambda: partial(_spawn_cancel_all, emit),
         "meridian.spawn.wait": lambda: partial(_spawn_wait, emit),

--- a/src/meridian/cli/startup/catalog.py
+++ b/src/meridian/cli/startup/catalog.py
@@ -315,6 +315,12 @@ _COMMAND_DESCRIPTORS: tuple[CommandDescriptor, ...] = (
         extension_ref="meridian.spawn.show",
     ),
     _read_runtime(
+        ("spawn", "status"),
+        "Show spawn status details without report body by default.",
+        default_output_mode="json",
+        extension_ref="meridian.spawn.status",
+    ),
+    _read_runtime(
         ("spawn", "wait"),
         "Wait for spawns.",
         default_output_mode="text",

--- a/src/meridian/lib/launch/extract.py
+++ b/src/meridian/lib/launch/extract.py
@@ -67,7 +67,7 @@ def _persist_report(
     target = log_dir / REPORT_FILENAME
     report_key = ArtifactKey(f"{spawn_id}/{REPORT_FILENAME}")
     if extracted.source == "assistant_message":
-        wrapped = f"# Auto-extracted Report\n\n{redacted_content.strip()}\n"
+        wrapped = f"# Report\n\n{redacted_content.strip()}\n"
         atomic_write_text(target, wrapped)
         artifacts.put(report_key, wrapped.encode("utf-8"))
         return target

--- a/src/meridian/lib/ops/commands.py
+++ b/src/meridian/lib/ops/commands.py
@@ -538,6 +538,22 @@ _OP_SPECS: tuple[ExtensionCommandSpec, ...] = (
     ),
     ExtensionCommandSpec.from_op(
         extension_id="meridian.spawn",
+        command_id="status",
+        summary=(
+            "Show spawn status, duration, model, and report path. "
+            "Use --report to include report text."
+        ),
+        handler=spawn_show,
+        sync_handler=spawn_show_sync,
+        input_type=SpawnShowInput,
+        output_type=SpawnDetailOutput,
+        cli_group="spawn",
+        cli_name="status",
+        agent_default_format="text",
+        surfaces=frozenset({ExtensionSurface.CLI}),
+    ),
+    ExtensionCommandSpec.from_op(
+        extension_id="meridian.spawn",
         command_id="stats",
         summary="Show total runs, success/fail counts, cost, and duration.",
         handler=spawn_stats,

--- a/src/meridian/lib/ops/commands.py
+++ b/src/meridian/lib/ops/commands.py
@@ -109,6 +109,7 @@ from meridian.lib.ops.spawn.api import (
     SpawnShowInput,
     SpawnStatsInput,
     SpawnStatsOutput,
+    SpawnStatusInput,
     SpawnWaitInput,
     SpawnWaitMultiOutput,
     SpawnWrittenFilesInput,
@@ -129,6 +130,8 @@ from meridian.lib.ops.spawn.api import (
     spawn_show_sync,
     spawn_stats,
     spawn_stats_sync,
+    spawn_status,
+    spawn_status_sync,
     spawn_wait,
     spawn_wait_sync,
 )
@@ -543,9 +546,9 @@ _OP_SPECS: tuple[ExtensionCommandSpec, ...] = (
             "Show spawn status, duration, model, and report path. "
             "Use --report to include report text."
         ),
-        handler=spawn_show,
-        sync_handler=spawn_show_sync,
-        input_type=SpawnShowInput,
+        handler=spawn_status,
+        sync_handler=spawn_status_sync,
+        input_type=SpawnStatusInput,
         output_type=SpawnDetailOutput,
         cli_group="spawn",
         cli_name="status",

--- a/src/meridian/lib/ops/spawn/.context/CONTEXT.md
+++ b/src/meridian/lib/ops/spawn/.context/CONTEXT.md
@@ -130,11 +130,17 @@ receive `to_agent_wire()` instead.
 ## SpawnDetailOutput format_text / format_wait_text
 
 `format_text()` now accepts `FormatContext`:
-- `verbosity == 0` → `_format_compact_text()`: `{spawn_id} {status} ({meta})\n\n{report body}`
-- `verbosity > 0` → `_format_verbose_text()`: full kv_block (unchanged).
+- `verbosity == 0` → `_format_moderate_text()`: labeled fields (`Spawn`, `Status`, `Model`,
+  `Duration`, `Work`, `Report`) plus report body when included.
+- `verbosity > 0` → `_format_verbose_text()`: full kv_block with internal status diagnostics
+  (for example primary activity/backend metadata and Pi cleanup fields).
 
 `SpawnWaitMultiOutput.format_text()` delegates to `format_wait_text()` for single-spawn waits,
 which uses verbosity-gated compact vs verbose.
+
+`meridian.spawn.status` now has a manifest-level default of `include_report_body=False`
+(`SpawnStatusInput`), while `meridian.spawn.show` keeps `include_report_body=True`
+(`SpawnShowInput`). CLI defaults were already aligned (`status` report-off, `show` report-on).
 
 ## Foreground Path Populates report
 

--- a/src/meridian/lib/ops/spawn/__init__.py
+++ b/src/meridian/lib/ops/spawn/__init__.py
@@ -13,6 +13,7 @@ from .api import (
     SpawnShowInput,
     SpawnStatsInput,
     SpawnStatsOutput,
+    SpawnStatusInput,
     SpawnWaitInput,
     SpawnWaitMultiOutput,
     spawn_cancel,
@@ -29,6 +30,8 @@ from .api import (
     spawn_show_sync,
     spawn_stats,
     spawn_stats_sync,
+    spawn_status,
+    spawn_status_sync,
     spawn_wait,
     spawn_wait_sync,
 )
@@ -46,6 +49,7 @@ __all__ = [
     "SpawnShowInput",
     "SpawnStatsInput",
     "SpawnStatsOutput",
+    "SpawnStatusInput",
     "SpawnWaitInput",
     "SpawnWaitMultiOutput",
     "spawn_cancel",
@@ -62,6 +66,8 @@ __all__ = [
     "spawn_show_sync",
     "spawn_stats",
     "spawn_stats_sync",
+    "spawn_status",
+    "spawn_status_sync",
     "spawn_wait",
     "spawn_wait_sync",
 ]

--- a/src/meridian/lib/ops/spawn/api.py
+++ b/src/meridian/lib/ops/spawn/api.py
@@ -73,6 +73,7 @@ from .models import (
     SpawnStatsChild,
     SpawnStatsInput,
     SpawnStatsOutput,
+    SpawnStatusInput,
     SpawnWaitInput,
     SpawnWaitMultiOutput,
     SpawnWrittenFilesInput,
@@ -868,6 +869,25 @@ def spawn_show_sync(
     )
 
 
+def spawn_status_sync(
+    payload: SpawnStatusInput,
+    ctx: RuntimeContext | None = None,
+    *,
+    sink: OutputSink | None = None,
+    prepared: RuntimeReadContext | None = None,
+) -> SpawnDetailOutput:
+    return spawn_show_sync(
+        SpawnShowInput(
+            spawn_id=payload.spawn_id,
+            include_report_body=payload.include_report_body,
+            project_root=payload.project_root,
+        ),
+        ctx=ctx,
+        sink=sink,
+        prepared=prepared,
+    )
+
+
 async def spawn_show(
     payload: SpawnShowInput,
     ctx: RuntimeContext | None = None,
@@ -876,6 +896,18 @@ async def spawn_show(
     prepared: RuntimeReadContext | None = None,
 ) -> SpawnDetailOutput:
     return await asyncio.to_thread(spawn_show_sync, payload, ctx=ctx, sink=sink, prepared=prepared)
+
+
+async def spawn_status(
+    payload: SpawnStatusInput,
+    ctx: RuntimeContext | None = None,
+    *,
+    sink: OutputSink | None = None,
+    prepared: RuntimeReadContext | None = None,
+) -> SpawnDetailOutput:
+    return await asyncio.to_thread(
+        spawn_status_sync, payload, ctx=ctx, sink=sink, prepared=prepared
+    )
 
 
 def spawn_files_sync(

--- a/src/meridian/lib/ops/spawn/models.py
+++ b/src/meridian/lib/ops/spawn/models.py
@@ -889,7 +889,9 @@ class SpawnDetailOutput(BaseModel):
 
     def format_text(self, ctx: FormatContext | None = None) -> str:
         effective_ctx = ctx or FormatContext()
-        return self._format_verbose_text(always_show_transcript=effective_ctx.verbosity > 0)
+        if effective_ctx.verbosity > 0:
+            return self._format_verbose_text(always_show_transcript=True)
+        return self._format_moderate_text()
 
     def format_wait_text(self, ctx: FormatContext | None = None) -> str:
         effective_ctx = ctx or FormatContext()
@@ -928,6 +930,33 @@ class SpawnDetailOutput(BaseModel):
             lines.append("")
         lines.append(f"Transcript: {self.transcript_command()}")
 
+        return "\n".join(lines)
+
+    def _format_moderate_text(self) -> str:
+        status_str = self.status
+        if self.exit_code is not None and self.status == "failed":
+            status_str += f" (exit {self.exit_code})"
+
+        lines = [f"Spawn: {self.spawn_id}"]
+        lines.append(f"Status: {status_str}")
+        lines.append(f"Model: {self.model} ({self.harness})")
+        if self.duration_secs is not None:
+            lines.append(f"Duration: {self.duration_secs:.1f}s")
+        work_value = (self.work_id or "").strip()
+        if work_value:
+            lines.append(f"Work: {work_value}")
+        if self._has_distinct_task_cwd():
+            lines.append(self._task_dir_line())
+        if self.report_path is not None:
+            lines.append(f"Report: {self.report_path}")
+
+        report_text = self._normalized_report_body()
+        if report_text is not None:
+            lines.append("")
+            lines.append(report_text)
+
+        lines.append("")
+        lines.append(f"Transcript: {self.transcript_command()}")
         return "\n".join(lines)
 
     def _format_verbose_text(self, *, always_show_transcript: bool = False) -> str:

--- a/src/meridian/lib/ops/spawn/models.py
+++ b/src/meridian/lib/ops/spawn/models.py
@@ -779,6 +779,26 @@ class SpawnDetailOutput(BaseModel):
             return None
         return report_text
 
+    def _status_for_compact_or_moderate(self) -> str:
+        status_str = self.status
+        if self.status == "finalizing":
+            return "finalizing (cleanup in progress)"
+        if self.exit_code is not None and self.status == "failed":
+            status_str += f" (exit {self.exit_code})"
+        return status_str
+
+    def _failure_line_for_compact_or_moderate(self) -> tuple[str, str] | None:
+        failure_value = self.failure_reason
+        if failure_value is None:
+            return None
+        if failure_value == "orphan_finalization":
+            failure_value = (
+                "orphan_finalization (harness likely completed; "
+                "report.md may still contain useful content)"
+            )
+        label = "Warning" if self.status == "succeeded" else "Failure"
+        return label, failure_value
+
     def _report_suffix(self) -> str:
         report_text = self._normalized_report_body()
         if report_text is None:
@@ -908,9 +928,7 @@ class SpawnDetailOutput(BaseModel):
         return self._format_compact_text()
 
     def _format_compact_text(self) -> str:
-        status_str = self.status
-        if self.exit_code is not None and self.status == "failed":
-            status_str += f" (exit {self.exit_code})"
+        status_str = self._status_for_compact_or_moderate()
 
         meta_parts: list[str] = []
         if self.duration_secs is not None:
@@ -918,14 +936,10 @@ class SpawnDetailOutput(BaseModel):
         meta_suffix = f" ({', '.join(meta_parts)})" if meta_parts else ""
 
         lines = [f"{self.spawn_id} {status_str}{meta_suffix}"]
-        if self.failure_reason:
-            failure_value = self.failure_reason
-            if failure_value == "orphan_finalization":
-                failure_value = (
-                    "orphan_finalization (harness likely completed; "
-                    "report.md may still contain useful content)"
-                )
-            lines.append(f"Failure: {failure_value}")
+        failure_line = self._failure_line_for_compact_or_moderate()
+        if failure_line is not None:
+            label, value = failure_line
+            lines.append(f"{label}: {value}")
         if self._has_distinct_task_cwd():
             lines.append(self._task_dir_line())
 
@@ -941,9 +955,7 @@ class SpawnDetailOutput(BaseModel):
         return "\n".join(lines)
 
     def _format_moderate_text(self) -> str:
-        status_str = self.status
-        if self.exit_code is not None and self.status == "failed":
-            status_str += f" (exit {self.exit_code})"
+        status_str = self._status_for_compact_or_moderate()
 
         lines = [f"Spawn: {self.spawn_id}"]
         lines.append(f"Status: {status_str}")
@@ -957,6 +969,10 @@ class SpawnDetailOutput(BaseModel):
             lines.append(self._task_dir_line())
         if self.report_path is not None:
             lines.append(f"Report: {self.report_path}")
+        failure_line = self._failure_line_for_compact_or_moderate()
+        if failure_line is not None:
+            label, value = failure_line
+            lines.append(f"{label}: {value}")
 
         report_text = self._normalized_report_body()
         if report_text is not None:

--- a/src/meridian/lib/ops/spawn/models.py
+++ b/src/meridian/lib/ops/spawn/models.py
@@ -676,6 +676,14 @@ class SpawnShowInput(BaseModel):
     project_root: str | None = None
 
 
+class SpawnStatusInput(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    spawn_id: str
+    include_report_body: bool = False
+    project_root: str | None = None
+
+
 class SpawnCancelInput(BaseModel):
     model_config = ConfigDict(frozen=True)
 
@@ -1292,6 +1300,7 @@ __all__ = [
     "SpawnShowInput",
     "SpawnStatsInput",
     "SpawnStatsOutput",
+    "SpawnStatusInput",
     "SpawnWaitInput",
     "SpawnWaitMultiOutput",
     "SpawnWrittenFilesInput",

--- a/tests/integration/cli/test_cli_spawn.py
+++ b/tests/integration/cli/test_cli_spawn.py
@@ -228,15 +228,19 @@ def test_spawn_show_and_status_report_defaults(
 
     with pytest.raises(SystemExit) as show_exit:
         cli_main.main(["spawn", "show", "p-show"])
+    with pytest.raises(SystemExit) as show_no_report_exit:
+        cli_main.main(["spawn", "show", "--no-report", "p-show-no-report"])
     with pytest.raises(SystemExit) as status_exit:
         cli_main.main(["spawn", "status", "p-status"])
     with pytest.raises(SystemExit) as status_report_exit:
         cli_main.main(["spawn", "status", "--report", "p-status-report"])
 
     assert show_exit.value.code == 0
+    assert show_no_report_exit.value.code == 0
     assert status_exit.value.code == 0
     assert status_report_exit.value.code == 0
     assert show_include_report["p-show"] is True
+    assert show_include_report["p-show-no-report"] is False
     assert "p-status" not in show_include_report
     assert "p-status-report" not in show_include_report
     assert status_include_report["p-status"] is False

--- a/tests/integration/cli/test_cli_spawn.py
+++ b/tests/integration/cli/test_cli_spawn.py
@@ -8,8 +8,10 @@ import pytest
 from meridian.lib.ops.spawn.models import (
     SpawnActionOutput,
     SpawnCreateInput,
+    SpawnDetailOutput,
     SpawnListEntry,
     SpawnListOutput,
+    SpawnShowInput,
 )
 
 cli_main = importlib.import_module("meridian.cli.main")
@@ -172,3 +174,89 @@ def test_spawn_children_agent_mode_uses_children_text_view(
     rendered = capsys.readouterr().out
     assert "reviewer" in rendered
     assert "review child" in rendered
+
+
+def _spawn_detail_output(report_body: str | None = "report body") -> SpawnDetailOutput:
+    return SpawnDetailOutput(
+        spawn_id="p500",
+        status="succeeded",
+        model="gpt-5.4",
+        harness="codex",
+        started_at="2026-05-15T00:00:00Z",
+        finished_at="2026-05-15T00:00:01Z",
+        duration_secs=1.0,
+        exit_code=0,
+        failure_reason=None,
+        input_tokens=None,
+        output_tokens=None,
+        cost_usd=None,
+        report_path="/tmp/report.md",
+        report_summary=report_body,
+        report_body=report_body,
+    )
+
+
+def test_spawn_show_and_status_report_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    include_report: dict[str, bool] = {}
+
+    def _fake_spawn_show_sync(
+        payload: SpawnShowInput,
+        *,
+        sink: object | None = None,
+        prepared: Any | None = None,
+    ) -> SpawnDetailOutput:
+        _ = (sink, prepared)
+        include_report[payload.spawn_id] = payload.include_report_body
+        return _spawn_detail_output("report body" if payload.include_report_body else None)
+
+    monkeypatch.setattr(spawn_cli, "spawn_show_sync", _fake_spawn_show_sync)
+
+    with pytest.raises(SystemExit) as show_exit:
+        cli_main.main(["spawn", "show", "p-show"])
+    with pytest.raises(SystemExit) as status_exit:
+        cli_main.main(["spawn", "status", "p-status"])
+    with pytest.raises(SystemExit) as status_report_exit:
+        cli_main.main(["spawn", "status", "--report", "p-status-report"])
+
+    assert show_exit.value.code == 0
+    assert status_exit.value.code == 0
+    assert status_report_exit.value.code == 0
+    assert include_report["p-show"] is True
+    assert include_report["p-status"] is False
+    assert include_report["p-status-report"] is True
+
+
+def test_spawn_status_verbose_renders_internal_fields(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        spawn_cli,
+        "spawn_show_sync",
+        lambda *_args, **_kwargs: SpawnDetailOutput(
+            spawn_id="p501",
+            status="succeeded",
+            model="gpt-5.4",
+            harness="codex",
+            started_at="2026-05-15T00:00:00Z",
+            finished_at="2026-05-15T00:00:01Z",
+            duration_secs=1.0,
+            exit_code=0,
+            failure_reason=None,
+            input_tokens=123,
+            output_tokens=456,
+            cost_usd=0.1,
+            report_path="/tmp/report.md",
+            report_summary=None,
+            report_body=None,
+        ),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["--human", "spawn", "status", "p501", "--verbose"])
+
+    assert exc_info.value.code == 0
+    rendered = capsys.readouterr().out
+    assert "Input tokens: 123" in rendered

--- a/tests/integration/cli/test_cli_spawn.py
+++ b/tests/integration/cli/test_cli_spawn.py
@@ -12,6 +12,7 @@ from meridian.lib.ops.spawn.models import (
     SpawnListEntry,
     SpawnListOutput,
     SpawnShowInput,
+    SpawnStatusInput,
 )
 
 cli_main = importlib.import_module("meridian.cli.main")
@@ -199,7 +200,8 @@ def _spawn_detail_output(report_body: str | None = "report body") -> SpawnDetail
 def test_spawn_show_and_status_report_defaults(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    include_report: dict[str, bool] = {}
+    show_include_report: dict[str, bool] = {}
+    status_include_report: dict[str, bool] = {}
 
     def _fake_spawn_show_sync(
         payload: SpawnShowInput,
@@ -208,10 +210,21 @@ def test_spawn_show_and_status_report_defaults(
         prepared: Any | None = None,
     ) -> SpawnDetailOutput:
         _ = (sink, prepared)
-        include_report[payload.spawn_id] = payload.include_report_body
+        show_include_report[payload.spawn_id] = payload.include_report_body
+        return _spawn_detail_output("report body" if payload.include_report_body else None)
+
+    def _fake_spawn_status_sync(
+        payload: SpawnStatusInput,
+        *,
+        sink: object | None = None,
+        prepared: Any | None = None,
+    ) -> SpawnDetailOutput:
+        _ = (sink, prepared)
+        status_include_report[payload.spawn_id] = payload.include_report_body
         return _spawn_detail_output("report body" if payload.include_report_body else None)
 
     monkeypatch.setattr(spawn_cli, "spawn_show_sync", _fake_spawn_show_sync)
+    monkeypatch.setattr(spawn_cli, "spawn_status_sync", _fake_spawn_status_sync)
 
     with pytest.raises(SystemExit) as show_exit:
         cli_main.main(["spawn", "show", "p-show"])
@@ -223,9 +236,11 @@ def test_spawn_show_and_status_report_defaults(
     assert show_exit.value.code == 0
     assert status_exit.value.code == 0
     assert status_report_exit.value.code == 0
-    assert include_report["p-show"] is True
-    assert include_report["p-status"] is False
-    assert include_report["p-status-report"] is True
+    assert show_include_report["p-show"] is True
+    assert "p-status" not in show_include_report
+    assert "p-status-report" not in show_include_report
+    assert status_include_report["p-status"] is False
+    assert status_include_report["p-status-report"] is True
 
 
 def test_spawn_status_verbose_renders_internal_fields(
@@ -234,7 +249,7 @@ def test_spawn_status_verbose_renders_internal_fields(
 ) -> None:
     monkeypatch.setattr(
         spawn_cli,
-        "spawn_show_sync",
+        "spawn_status_sync",
         lambda *_args, **_kwargs: SpawnDetailOutput(
             spawn_id="p501",
             status="succeeded",

--- a/tests/integration/launch/test_streaming_runner_watchdog.py
+++ b/tests/integration/launch/test_streaming_runner_watchdog.py
@@ -201,7 +201,7 @@ class _PiTimeoutThenTerminalConnection:
         assert project_root is not None
         spawn_dir = resolve_spawn_log_dir(project_root, self._spawn_id)
         spawn_dir.mkdir(parents=True, exist_ok=True)
-        (spawn_dir / "report.md").write_text("# Auto-extracted Report\n\nOK\n", encoding="utf-8")
+        (spawn_dir / "report.md").write_text("# Report\n\nOK\n", encoding="utf-8")
         yield HarnessEvent(
             event_type="session",
             harness_id="pi",

--- a/tests/integration/ops/test_spawn_api_query.py
+++ b/tests/integration/ops/test_spawn_api_query.py
@@ -13,6 +13,7 @@ import pytest
 
 import meridian.lib.ops.spawn.api as spawn_api
 from meridian.lib.bootstrap.services import prepare_for_runtime_write
+from meridian.lib.core.util import FormatContext
 from meridian.lib.launch.constants import PRIMARY_META_FILENAME
 from meridian.lib.ops.spawn.models import (
     SpawnActionOutput,
@@ -309,9 +310,11 @@ def test_spawn_show_and_list_render_primary_and_pi_diagnostics(tmp_path: Path) -
     assert pi_detail.pi_cleanup_reason == "abort_grace_expired"
 
     rendered = pi_detail.format_text()
-    assert "Pi phase: cleanup_stop_escalated" in rendered
-    assert "Pi cleanup status: escalated" in rendered
-    assert "Pi cleanup reason: abort_grace_expired" in rendered
+    assert "Pi phase: cleanup_stop_escalated" not in rendered
+    verbose_rendered = pi_detail.format_text(FormatContext(verbosity=1))
+    assert "Pi phase: cleanup_stop_escalated" in verbose_rendered
+    assert "Pi cleanup status: escalated" in verbose_rendered
+    assert "Pi cleanup reason: abort_grace_expired" in verbose_rendered
 
     wire = pi_detail.to_cli_wire()
     assert wire["pi_lifecycle_phase"] == "cleanup_stop_escalated"
@@ -342,7 +345,9 @@ def test_spawn_show_includes_persisted_goal_text_and_json(tmp_path: Path) -> Non
 
     assert detail.goal == "ship the migration"
     rendered = detail.format_text()
-    assert "Goal: ship the migration" in rendered
+    assert "Goal: ship the migration" not in rendered
+    verbose_rendered = detail.format_text(FormatContext(verbosity=1))
+    assert "Goal: ship the migration" in verbose_rendered
     wire = detail.to_cli_wire()
     assert wire["goal"] == "ship the migration"
 

--- a/tests/integration/ops/test_spawn_api_query.py
+++ b/tests/integration/ops/test_spawn_api_query.py
@@ -22,6 +22,7 @@ from meridian.lib.ops.spawn.models import (
     SpawnListInput,
     SpawnShowInput,
     SpawnStatsInput,
+    SpawnStatusInput,
 )
 from meridian.lib.state import spawn_store
 from meridian.lib.state.paths import resolve_project_runtime_root_for_write
@@ -219,6 +220,51 @@ def test_spawn_list_filters_by_profile_name(tmp_path: Path) -> None:
     )
 
     assert [entry.spawn_id for entry in output.spawns] == [str(reviewer_spawn_id)]
+
+
+def test_spawn_status_omits_report_body_until_requested(tmp_path: Path) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    runtime_root = _state_root(project_root)
+
+    spawn_id = spawn_store.start_spawn(
+        runtime_root,
+        spawn_id="p-report-toggle",
+        chat_id="c-report-toggle",
+        model="gpt-5.4",
+        agent="coder",
+        harness="codex",
+        prompt="hello",
+    )
+    report_path = runtime_root / "spawns" / str(spawn_id) / "report.md"
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text("report body\n", encoding="utf-8")
+    spawn_store.finalize_spawn(
+        runtime_root,
+        spawn_id,
+        "succeeded",
+        0,
+        origin="runner",
+    )
+
+    status_detail = spawn_api.spawn_status_sync(
+        SpawnStatusInput(project_root=project_root.as_posix(), spawn_id=str(spawn_id))
+    )
+    reported_status_detail = spawn_api.spawn_status_sync(
+        SpawnStatusInput(
+            project_root=project_root.as_posix(),
+            spawn_id=str(spawn_id),
+            include_report_body=True,
+        )
+    )
+    show_detail = spawn_api.spawn_show_sync(
+        SpawnShowInput(project_root=project_root.as_posix(), spawn_id=str(spawn_id))
+    )
+
+    assert status_detail.report_path == report_path.as_posix()
+    assert status_detail.report_body is None
+    assert reported_status_detail.report_body == "report body"
+    assert show_detail.report_body == "report body"
 
 
 def test_spawn_show_and_list_render_primary_and_pi_diagnostics(tmp_path: Path) -> None:

--- a/tests/integration/ops/test_spawn_read_reconcile.py
+++ b/tests/integration/ops/test_spawn_read_reconcile.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 import meridian.lib.ops.spawn.api as spawn_api
+from meridian.lib.core.util import FormatContext
 from meridian.lib.launch.constants import PI_LIFECYCLE_EVENTS_FILENAME
 from meridian.lib.ops.spawn import query as spawn_query
 from meridian.lib.ops.spawn.models import (
@@ -67,10 +68,12 @@ def test_spawn_show_sync_renders_finalizing_status_and_orphan_finalization_hint(
     assert output.last_attempt_exited_at == "2026-04-12T14:00:00Z"
     assert output.last_attempt_exit_code == 143
     rendered = output.format_text()
-    assert "Status: finalizing (cleanup in progress)" in rendered
-    assert "orphan_finalization" in rendered
-    assert "report.md may still contain useful content" in rendered
-    assert "awaiting finalization" not in rendered
+    assert "Status: finalizing" in rendered
+    verbose_rendered = output.format_text(FormatContext(verbosity=1))
+    assert "Status: finalizing (cleanup in progress)" in verbose_rendered
+    assert "orphan_finalization" in verbose_rendered
+    assert "report.md may still contain useful content" in verbose_rendered
+    assert "awaiting finalization" not in verbose_rendered
 
 
 def test_read_spawn_row_nested_stale_dead_runner_returns_synthetic_failed(

--- a/tests/smoke/pi-rpc-quiescence.md
+++ b/tests/smoke/pi-rpc-quiescence.md
@@ -259,11 +259,11 @@ Expect:
 
 ```bash
 uv run meridian spawn --harness pi -m <pi-model> --bg -p "Reply OK and run no commands."
-meridian spawn show <spawn-id>
+meridian spawn show <spawn-id> --verbose
 ```
 
 Expect:
-- Output includes `Pi phase:` while running or after completion
+- `meridian spawn show --verbose` output includes `Pi phase:` while running or after completion
 - A hang is diagnosable as one named phase, for example
   `waiting_for_first_pi_event_after_prompt`,
   `waiting_for_continuation_completion`, `pi_notification_timeout`,

--- a/tests/smoke/pi-rpc-quiescence.md
+++ b/tests/smoke/pi-rpc-quiescence.md
@@ -277,7 +277,7 @@ Run one successful primary launch and one successful spawned RPC launch with
 Expect:
 - Diagnostics identify whether runtime came from `PATH` or `MERIDIAN_PI_BINARY`
 - Auth/config remains Pi-owned; Meridian does not set a fake auth root
-- Spawned `spawn show` exposes a useful Pi phase during startup and cleanup
+- Spawned `spawn show --verbose` exposes a useful Pi phase during startup and cleanup
 
 ## S20-S22: Sidecar lifecycle ingestion and stderr isolation
 

--- a/tests/smoke/spawn-return-report.md
+++ b/tests/smoke/spawn-return-report.md
@@ -72,3 +72,19 @@ meridian init
    ```
    Expect table plus `Report for <id>` sections; not the single-spawn compact
    status format.
+
+10. Show/status progressive detail:
+    ```bash
+    meridian spawn show pNNN
+    meridian spawn show pNNN --no-report
+    meridian spawn status pNNN
+    meridian spawn status pNNN --report
+    meridian spawn status pNNN --verbose
+    ```
+    Expect `show` default text to include the moderate status/model/duration
+    summary, report path, report body, and transcript command. Expect
+    `show --no-report` and `status` to keep the summary/report path/transcript
+    while omitting the report body. Expect `status --report` to add the report
+    body. Expect `--verbose` to add internal diagnostics such as token/cost
+    fields or harness/session metadata when available; those internals should
+    not appear in the non-verbose `show`/`status` output.

--- a/tests/unit/launch/test_extract.py
+++ b/tests/unit/launch/test_extract.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+from meridian.lib.core.types import ArtifactKey, SpawnId
+from meridian.lib.launch.extract import _persist_report
+from meridian.lib.launch.report import ExtractedReport
+from meridian.lib.state.artifact_store import LocalStore
+
+
+def test_persist_report_wraps_assistant_extract_with_report_heading(tmp_path: Path) -> None:
+    artifacts = LocalStore(root_dir=tmp_path / "artifacts")
+    spawn_id = SpawnId("p-extract")
+    log_dir = tmp_path / "spawns" / str(spawn_id)
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    report_path = _persist_report(
+        artifacts=artifacts,
+        spawn_id=spawn_id,
+        log_dir=log_dir,
+        extracted=ExtractedReport(content="Done.", source="assistant_message"),
+        secrets=(),
+    )
+
+    assert report_path == log_dir / "report.md"
+    expected = "# Report\n\nDone.\n"
+    assert report_path.read_text(encoding="utf-8") == expected
+    assert artifacts.get(ArtifactKey(f"{spawn_id}/report.md")).decode("utf-8") == expected

--- a/tests/unit/ops/test_commands_manifest.py
+++ b/tests/unit/ops/test_commands_manifest.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from meridian.lib.extensions.types import ExtensionCommandSpec, ExtensionSurface
 from meridian.lib.ops.commands import get_all_op_specs
-from meridian.lib.ops.spawn.models import SpawnDetailOutput, SpawnShowInput
+from meridian.lib.ops.spawn.models import SpawnDetailOutput, SpawnStatusInput
 from meridian.lib.ops.work_lifecycle import (
     WorkClearWorktreeInput,
     WorkClearWorktreeOutput,
@@ -51,5 +51,7 @@ def test_spawn_status_command_is_registered_for_cli() -> None:
     assert status_spec.cli_group == "spawn"
     assert status_spec.cli_name == "status"
     assert status_spec.surfaces == frozenset({ExtensionSurface.CLI})
-    assert status_spec.args_schema is SpawnShowInput
+    assert status_spec.args_schema is SpawnStatusInput
     assert status_spec.result_schema is SpawnDetailOutput
+    parsed = status_spec.args_schema(spawn_id="p123")
+    assert parsed.include_report_body is False

--- a/tests/unit/ops/test_commands_manifest.py
+++ b/tests/unit/ops/test_commands_manifest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from meridian.lib.extensions.types import ExtensionCommandSpec, ExtensionSurface
 from meridian.lib.ops.commands import get_all_op_specs
+from meridian.lib.ops.spawn.models import SpawnDetailOutput, SpawnShowInput
 from meridian.lib.ops.work_lifecycle import (
     WorkClearWorktreeInput,
     WorkClearWorktreeOutput,
@@ -41,3 +42,14 @@ def test_work_set_and_clear_worktree_commands_are_registered() -> None:
     assert ensure_spec.surfaces == frozenset({ExtensionSurface.CLI, ExtensionSurface.HTTP})
     assert ensure_spec.args_schema is WorkWorktreeInput
     assert ensure_spec.result_schema is WorkWorktreeOutput
+
+
+def test_spawn_status_command_is_registered_for_cli() -> None:
+    specs = _spec_by_fqid()
+
+    status_spec = specs["meridian.spawn.status"]
+    assert status_spec.cli_group == "spawn"
+    assert status_spec.cli_name == "status"
+    assert status_spec.surfaces == frozenset({ExtensionSurface.CLI})
+    assert status_spec.args_schema is SpawnShowInput
+    assert status_spec.result_schema is SpawnDetailOutput

--- a/tests/unit/ops/test_spawn_models.py
+++ b/tests/unit/ops/test_spawn_models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from meridian.lib.core.util import FormatContext
 from meridian.lib.ops.spawn.models import (
     SpawnActionOutput,
     SpawnDetailOutput,
@@ -269,3 +270,81 @@ def test_spawn_detail_wait_includes_distinct_task_dir() -> None:
     ) in text
     assert wire["task_cwd"] == "/repo.worktrees/feature-x"
     assert "authority_root" not in wire
+
+
+def test_spawn_detail_default_text_uses_moderate_tier() -> None:
+    detail = _make_spawn_detail(
+        spawn_id="p10",
+        status="failed",
+        duration_secs=2.5,
+        exit_code=17,
+        work_id="feature-x",
+        authority_root="/repo/main",
+        task_cwd="/repo.worktrees/feature-x",
+        report_body="done report",
+    )
+
+    text = detail.format_text()
+    assert "Spawn: p10" in text
+    assert "Status: failed (exit 17)" in text
+    assert "Model: gpt-5.4 (codex)" in text
+    assert "Duration: 2.5s" in text
+    assert "Work: feature-x" in text
+    assert "Spawn is instructed to implement in this task dir: /repo.worktrees/feature-x" in text
+    assert "Report: /tmp/report.md" in text
+    assert "done report" in text
+    assert "Transcript: meridian session log p10" in text
+    assert "Pi phase:" not in text
+
+
+def test_spawn_detail_verbose_text_retains_internal_fields() -> None:
+    detail = SpawnDetailOutput(
+        spawn_id="p11",
+        status="failed",
+        model="gpt-5.4",
+        harness="codex",
+        kind="primary",
+        parent_id="p1",
+        work_id="feature-y",
+        authority_root="/repo/main",
+        task_cwd="/repo.worktrees/feature-y",
+        goal="ship it",
+        desc="desc",
+        started_at="2026-05-15T00:00:00Z",
+        finished_at="2026-05-15T00:00:04Z",
+        duration_secs=4.0,
+        exit_code=2,
+        failure_reason="runner_failed",
+        input_tokens=11,
+        output_tokens=12,
+        cache_read_input_tokens=13,
+        cache_creation_input_tokens=14,
+        reasoning_tokens=15,
+        cost_usd=0.1234,
+        cost_is_estimate=True,
+        report_path="/tmp/report.md",
+        report_summary="summary",
+        report_body="report body",
+        harness_session_id="hs-1",
+        pi_lifecycle_phase="cleanup_stop_escalated",
+        pi_cleanup_status="escalated",
+        pi_cleanup_phase="cleanup_stop_escalated",
+        pi_cleanup_reason="abort_grace_expired",
+        pi_cleanup_error="error",
+        last_message="last",
+        log_path="/tmp/log",
+        last_attempt_exited_at="2026-05-15T00:00:03Z",
+        last_attempt_exit_code=17,
+    )
+
+    text = detail.format_text(FormatContext(verbosity=1))
+    assert "Status: failed (exit 2)" in text
+    assert "Kind: primary" in text
+    assert "Parent: p1" in text
+    assert "Harness session: hs-1" in text
+    assert "Input tokens: 11" in text
+    assert "Cache read tokens: 13" in text
+    assert "Cost: ~$0.1234" in text
+    assert "Pi phase: cleanup_stop_escalated" in text
+    assert "Last attempt exited at: 2026-05-15T00:00:03Z" in text
+    assert "Transcript: meridian session log p11" in text

--- a/tests/unit/ops/test_spawn_models.py
+++ b/tests/unit/ops/test_spawn_models.py
@@ -284,6 +284,7 @@ def test_spawn_detail_default_text_uses_moderate_tier() -> None:
         status="failed",
         duration_secs=2.5,
         exit_code=17,
+        failure_reason="runner_failed",
         work_id="feature-x",
         authority_root="/repo/main",
         task_cwd="/repo.worktrees/feature-x",
@@ -298,9 +299,24 @@ def test_spawn_detail_default_text_uses_moderate_tier() -> None:
     assert "Work: feature-x" in text
     assert "Spawn is instructed to implement in this task dir: /repo.worktrees/feature-x" in text
     assert "Report: /tmp/report.md" in text
+    assert "Failure: runner_failed" in text
     assert "done report" in text
     assert "Transcript: meridian session log p10" in text
     assert "Pi phase:" not in text
+
+
+def test_spawn_detail_moderate_text_keeps_finalizing_and_orphan_context() -> None:
+    detail = _make_spawn_detail(
+        spawn_id="p12",
+        status="finalizing",
+        failure_reason="orphan_finalization",
+        report_body=None,
+    )
+
+    text = detail.format_text()
+    assert "Status: finalizing (cleanup in progress)" in text
+    assert "Failure: orphan_finalization (harness likely completed; " in text
+    assert "report.md may still contain useful content)" in text
 
 
 def test_spawn_detail_verbose_text_retains_internal_fields() -> None:

--- a/tests/unit/ops/test_spawn_models.py
+++ b/tests/unit/ops/test_spawn_models.py
@@ -6,7 +6,6 @@ from meridian.lib.core.util import FormatContext
 from meridian.lib.ops.spawn.models import (
     SpawnActionOutput,
     SpawnDetailOutput,
-    SpawnStatusInput,
     SpawnWaitMultiOutput,
 )
 
@@ -170,11 +169,6 @@ def test_spawn_wait_multi_json_single_and_multi_projection() -> None:
     assert multi_wire["spawns"][1]["report_body"] == "second report"
 
 
-def test_spawn_status_input_defaults_report_body_off() -> None:
-    parsed = SpawnStatusInput(spawn_id="p123")
-    assert parsed.include_report_body is False
-
-
 def test_spawn_action_wire_background_does_not_add_transcript_command() -> None:
     output = SpawnActionOutput(
         command="spawn.create",
@@ -289,6 +283,13 @@ def test_spawn_detail_default_text_uses_moderate_tier() -> None:
         authority_root="/repo/main",
         task_cwd="/repo.worktrees/feature-x",
         report_body="done report",
+    ).model_copy(
+        update={
+            "input_tokens": 123,
+            "cost_usd": 0.25,
+            "harness_session_id": "hs-10",
+            "pi_lifecycle_phase": "cleanup_stop_escalated",
+        }
     )
 
     text = detail.format_text()
@@ -302,6 +303,9 @@ def test_spawn_detail_default_text_uses_moderate_tier() -> None:
     assert "Failure: runner_failed" in text
     assert "done report" in text
     assert "Transcript: meridian session log p10" in text
+    assert "Input tokens:" not in text
+    assert "Cost:" not in text
+    assert "Harness session:" not in text
     assert "Pi phase:" not in text
 
 

--- a/tests/unit/ops/test_spawn_models.py
+++ b/tests/unit/ops/test_spawn_models.py
@@ -6,6 +6,7 @@ from meridian.lib.core.util import FormatContext
 from meridian.lib.ops.spawn.models import (
     SpawnActionOutput,
     SpawnDetailOutput,
+    SpawnStatusInput,
     SpawnWaitMultiOutput,
 )
 
@@ -167,6 +168,11 @@ def test_spawn_wait_multi_json_single_and_multi_projection() -> None:
     assert multi_wire["spawns"][1]["transcript_command"] == "meridian session log p2"
     assert multi_wire["spawns"][0]["report_body"] == "first report"
     assert multi_wire["spawns"][1]["report_body"] == "second report"
+
+
+def test_spawn_status_input_defaults_report_body_off() -> None:
+    parsed = SpawnStatusInput(spawn_id="p123")
+    assert parsed.include_report_body is False
 
 
 def test_spawn_action_wire_background_does_not_add_transcript_command() -> None:


### PR DESCRIPTION
## Why

`meridian spawn show` dumped operational status, report text, token/cost accounting, timestamps, harness/session internals, and cleanup diagnostics all at once. `meridian spawn status` was also being parsed as a prompt instead of a command.

## Goal

Provide progressive disclosure for spawn inspection: quick status by default, full diagnostics on request, and a real `spawn status` command.

## Summary

- Added `meridian spawn status` alongside `spawn show`.
- Kept show/status flags aligned while setting different report-body defaults (`show` on, `status` off).
- Split `SpawnDetailOutput` text into moderate default and verbose diagnostic tiers.
- Kept actionable failure/finalizing context in moderate output while moving internals behind `--verbose`.
- Added status-specific op/model wiring so CLI and extension/spec defaults match.
- Renamed auto-extracted report heading from `# Auto-extracted Report` to `# Report` for newly persisted reports.
- Updated command docs, smoke guide, changelog, and colocated context.

## Resulting Behavior

```bash
meridian spawn status p123              # status/model/duration/report path, no report body
meridian spawn status p123 --report     # same, with report body
meridian spawn show p123                # same moderate tier, report body included
meridian spawn show p123 --no-report    # moderate tier, report body omitted
meridian spawn show p123 --verbose      # internal diagnostics: tokens, cost, parent/session, lifecycle fields
```

JSON wire output and `spawn wait` compact formatting stay unchanged.

## Work Item

spawn-show-status-tiers

## Verification

- `uv run pytest-llm tests/integration/cli/test_cli_spawn.py tests/unit/ops/test_spawn_models.py tests/integration/ops/test_spawn_api_query.py tests/integration/ops/test_spawn_read_reconcile.py tests/integration/launch/test_streaming_runner_watchdog.py tests/unit/ops/test_commands_manifest.py tests/unit/launch/test_extract.py` — 48 passed
- `uv run ruff check .` — passed
- `uv run --extra dev python -m pyright` — 0 errors
- Pre-push hook: `uv run --extra dev ruff check .`, `uv run --extra dev python -m pyright`, `uv run --extra dev pytest -x -q`, `uv build --no-sources` — 1148 passed, 2 skipped, build passed
- Manual smoke:
  - `uv run meridian --human spawn status p2938`
  - `uv run meridian --human spawn show p2938 --no-report`
  - `uv run meridian --human spawn status p2938 --verbose --no-report`
  - `uv run meridian ext run meridian.spawn.status --args '{"spawn_id":"p2938"}' --format json` confirmed default `report_body: null`

## Knowledge Updates

- `CHANGELOG.md` updated under `[Unreleased]`.
- `docs/commands.md`, `docs/troubleshooting.md`, `docs/harness-integration.md` updated for show/status tiers.
- `tests/smoke/spawn-return-report.md` and `tests/smoke/pi-rpc-quiescence.md` updated.
- `src/meridian/lib/ops/spawn/.context/CONTEXT.md` updated with status/show report defaults and moderate/verbose behavior.

## Spawn Trace

- p2922 coder — initial implementation and focused tests
- p2923 reviewer — structural review
- p2924 reviewer — correctness review
- p2925 simplify-reviewer — simplification audit
- p2926 smoke-tester — initial end-to-end CLI smoke
- p2927 coder — manifest/spec status default fix and docs/smoke update
- p2928 coder — public spawn package exports
- p2929 reviewer — final structural review after fixes
- p2930 reviewer — final correctness review after fixes
- p2931 smoke-tester — final smoke verification
- p2932 coder — actionable failure context, CLI status handler alignment, docs update
- p2933 reviewer — final re-review
- p2934 smoke-tester — final smoke re-check
- p2935 coder — final docs clarification
- p2936 qa-lead — QA audit and test refinement

## Release Label Guide

Set one `release:*` label on this PR:

- `release:patch` — create the next patch release after merge
- `release:skip` — no release for this merge

No `release:*` label means no auto-release.

## Post-Merge Automation

After merge to `main`, CI (`.github/workflows/release-on-merge.yml`) will:

1. Read the PR release label
2. Skip when no `release:*` label is present or when `release:skip` is present
3. Compute the next patch version from existing `v*` tags
4. Update `src/meridian/__init__.py` + promote `CHANGELOG.md` `[Unreleased]`
5. Commit `Release X.Y.Z`, create/push `vX.Y.Z`
6. Run `.github/workflows/publish-pypi.yml` directly

## Cleanup

After merge, clean merged worktrees with:

```bash
scripts/prune-worktrees.sh
```
