### PR TITLE
Improve session log readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 - `spawn show`/`spawn status` text output now defaults to a moderate status tier, with full internal diagnostics behind `--verbose`.
 - Auto-extracted spawn reports now persist with `# Report` heading instead of `# Auto-extracted Report`.
+- `session log` now defaults to a clean markdown-like transcript view (clean role headers, XML/tool chrome stripped, tool actions collapsed) with raw debug formatting behind `--raw`.
+- `session log` now keeps full raw entry/message content in model output and applies truncation only at render time (`--no-truncate` expands cleaned tool output inline).
+- Default `session log --tail` windows now emit `Previous:` navigation when earlier entries exist.
 
 ## [0.2.8] - 2026-05-27
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "cyclopts>=3.0",
   "fastapi>=0.115",
   "markdown-it-py>=4.0",
-  "mars-agents==0.7.3",
+  "mars-agents==0.7.4",
   "mcp>=1.0",
   "pathspec>=1.1.0",
   "psutil>=7.2.2",

--- a/src/meridian/cli/main.py
+++ b/src/meridian/cli/main.py
@@ -68,6 +68,7 @@ from meridian.cli.startup.policy import StartupClass, StateRequirement
 from meridian.cli.startup.policy import TelemetryMode as StartupTelemetryMode
 from meridian.lib.core.depth import is_nested_meridian_process, is_root_side_effect_process
 from meridian.lib.core.sink import OutputSink
+from meridian.lib.core.util import FormatContext
 from meridian.lib.telemetry import emit_telemetry
 
 if TYPE_CHECKING:
@@ -120,7 +121,7 @@ def current_output_sink() -> OutputSink:
     return sink
 
 
-def emit(payload: object) -> None:
+def emit(payload: object, *, format_ctx: FormatContext | None = None) -> None:
     """Write command output using current output format settings."""
 
     options = get_global_options()
@@ -133,9 +134,10 @@ def emit(payload: object) -> None:
                 agent_mode=agent_mode_enabled(),
             ),
             sink=sink,
+            format_ctx=format_ctx,
         )
     else:
-        emit_output(payload, sink=sink)
+        emit_output(payload, sink=sink, format_ctx=format_ctx)
     if flush_after:
         flush_sink(sink)
 

--- a/src/meridian/cli/output.py
+++ b/src/meridian/cli/output.py
@@ -84,11 +84,11 @@ def resolve_effective_format(
     return "text"
 
 
-def _render_text(value: Any) -> str:
+def _render_text(value: Any, format_ctx: FormatContext | None = None) -> str:
     # "text" mode: prefer format_text() if available, fall back to indented JSON
     # for types that have not yet implemented the protocol.
     if isinstance(value, TextFormattable):
-        return value.format_text(_DEFAULT_FORMAT_CTX)
+        return value.format_text(format_ctx or _DEFAULT_FORMAT_CTX)
     return json.dumps(_to_json_value(value), sort_keys=True, indent=2)
 
 
@@ -107,12 +107,18 @@ class TextSink:
         self._emit_events = emit_events
 
     def result(self, payload: Any) -> None:
+        self._render_result(payload, format_ctx=None)
+
+    def result_with_context(self, payload: Any, *, format_ctx: FormatContext) -> None:
+        self._render_result(payload, format_ctx=format_ctx)
+
+    def _render_result(self, payload: Any, *, format_ctx: FormatContext | None) -> None:
         if isinstance(payload, str):
             if payload == "":
                 return
             print(payload, file=self._stdout)
             return
-        rendered = _render_text(payload)
+        rendered = _render_text(payload, format_ctx)
         if rendered == "":
             return
         print(rendered, file=self._stdout)
@@ -215,7 +221,10 @@ def flush_sink(sink: OutputSink) -> None:
             return
 
 
-def emit(value: Any, *, sink: OutputSink) -> None:
+def emit(value: Any, *, sink: OutputSink, format_ctx: FormatContext | None = None) -> None:
     """Emit one payload via an explicit output sink."""
 
+    if format_ctx is not None and isinstance(sink, TextSink):
+        sink.result_with_context(value, format_ctx=format_ctx)
+        return
     sink.result(value)

--- a/src/meridian/cli/session_cmd.py
+++ b/src/meridian/cli/session_cmd.py
@@ -2,18 +2,21 @@
 
 from collections.abc import Callable
 from functools import partial
-from typing import Annotated, Any
+from typing import Annotated, Any, Protocol
 
 from cyclopts import App, Parameter
 
 from meridian.cli.ext_registration import register_extension_cli_group
+from meridian.lib.core.util import FormatContext
 from meridian.lib.extensions.registry import get_first_party_registry
 from meridian.lib.ops.session_export import SessionExportInput, session_export_sync
 from meridian.lib.ops.session_log import SessionLogInput, session_log_sync
 from meridian.lib.ops.session_repair import SessionRepairInput, repair_session_reference_sync
 from meridian.lib.ops.session_search import SessionSearchInput, session_search_sync
 
-Emitter = Callable[[Any], None]
+
+class Emitter(Protocol):
+    def __call__(self, payload: Any, *, format_ctx: FormatContext | None = None) -> None: ...
 
 
 def _session_log(
@@ -57,6 +60,13 @@ def _session_log(
         Parameter(
             name="--no-truncate",
             help="Show full entry/message content (default output truncates oversized content).",
+        ),
+    ] = False,
+    raw: Annotated[
+        bool,
+        Parameter(
+            name="--raw",
+            help="Render raw transcript content with metadata (no readability cleanup).",
         ),
     ] = False,
     tail: Annotated[
@@ -112,24 +122,26 @@ def _session_log(
         if len(tail) > 1:
             raise ValueError("--tail accepts at most one value.")
         resolved_tail = 5 if len(tail) == 0 else tail[0]
-    emit(
-        session_log_sync(
-            SessionLogInput(
-                ref=ref,
-                segment=segment,
-                global_scope=global_scope,
-                full=full,
-                truncate=not no_truncate,
-                tail=resolved_tail,
-                from_ordinal=from_ordinal,
-                before_ordinal=before_ordinal,
-                around_ordinal=around_ordinal,
-                limit=limit,
-                context=context,
-                file_path=file_path,
-            )
+    output = session_log_sync(
+        SessionLogInput(
+            ref=ref,
+            segment=segment,
+            global_scope=global_scope,
+            full=full,
+            truncate=not no_truncate,
+            tail=resolved_tail,
+            from_ordinal=from_ordinal,
+            before_ordinal=before_ordinal,
+            around_ordinal=around_ordinal,
+            limit=limit,
+            context=context,
+            file_path=file_path,
         )
     )
+    if raw:
+        emit(output, format_ctx=FormatContext(verbosity=1))
+        return
+    emit(output)
 
 
 def _session_export(
@@ -257,6 +269,7 @@ def register_session_commands(app: App, emit: Emitter) -> tuple[set[str], dict[s
                 "  meridian session log c123 --tail 20\n\n"
                 "  meridian session log c123 --full\n\n"
                 "  meridian session log c123 --full --no-truncate\n\n"
+                "  meridian session log c123 --raw\n\n"
                 "  meridian session log c123 --from 120 --limit 30\n\n"
                 "  meridian session log c123 --around 240 --context 8\n\n"
                 "  meridian session log c123 --global --around 240 --context 8\n\n"

--- a/src/meridian/lib/harness/.context/CONTEXT.md
+++ b/src/meridian/lib/harness/.context/CONTEXT.md
@@ -271,6 +271,66 @@ a sidecar JSONL file via `PI_LIFECYCLE_EVENT_FILE_ENV`. The Python connection la
 tails this file incrementally during the drain loop. If a lifecycle event does appear
 on stdout (e.g., from a misconfigured extension), it is silently dropped.
 
+## Session Read Path
+
+`transcript.py` is the cross-harness read path for session data. It is entirely
+independent of the spawn/write paths — it only reads JSONL event files that harnesses
+have already written.
+
+### ToolCall and _normalize_tool()
+
+`ToolCall` is the canonical harness-agnostic representation of a tool invocation:
+
+```python
+class ToolCall(NamedTuple):
+    name: str   # Canonical lowercase: bash, read, write, edit, grep, stdin, tool
+    body: str   # Meaningful payload: command string, file path, pattern, etc.
+```
+
+`_normalize_tool(name, body) → ToolCall` maps raw harness-specific tool names onto
+this canonical form. Downstream consumers (session log rendering) work from
+`ToolCall.name` and `ToolCall.body` without knowing which harness produced the event.
+
+Normalization table:
+
+| Raw harness name(s) | Canonical `name` | `body` |
+|---|---|---|
+| `bash` | `bash` | command string |
+| `exec_command`, `shell`, `terminal`, `run_command` | `bash` | extracts `cmd` field from Codex JSON body, falls back to raw body |
+| `write_stdin` | `stdin` | `""` (stdin interaction marker — no meaningful body) |
+| `read`, `write`, `edit`, `grep` | same (lowercase) | path / pattern / description |
+| anything else | lowercased name, or `"tool"` if empty | raw body |
+
+### TranscriptMessage
+
+`TranscriptMessage` carries a tool invocation when `tool_call` is set, and marks
+tool results with `is_tool_result=True`. Text-only messages leave both at their
+defaults (`None` / `False`). These fields are the typed surface callers use to
+distinguish conversation content from tool use — do not re-parse `content` to
+recover tool information when `tool_call` is available.
+
+### Providers
+
+Three providers handle different on-disk layouts. `transcript.py` selects the
+correct one based on path:
+
+| Provider | When selected | What it reads |
+|---|---|---|
+| `HistoryJsonlTranscriptProvider` | `path.name == HISTORY_FILENAME` | Crash-tolerant history via `iter_history_events()` |
+| `OpenCodeStorageTranscriptProvider` | OpenCode storage paths | OpenCode SQLite/JSONL layout |
+| `JsonlTranscriptProvider` | everything else | Raw JSONL, one event per line |
+
+Callers use `iter_transcript_events(path)` or `parse_transcript_file(path)` — they
+never select a provider directly.
+
+### TranscriptParseResult
+
+`segment_setups` holds the setup/handoff text for each compaction segment (one slot
+per segment, `None` if absent). `consumed_setup_event_indexes` identifies which raw
+event indexes were consumed by setup extraction — callers that iterate the raw event
+list alongside parsed segments use this to skip those events and avoid double-counting
+them in the message stream.
+
 ## Patterns
 
 ### Adding a Harness

--- a/src/meridian/lib/harness/AGENTS.md
+++ b/src/meridian/lib/harness/AGENTS.md
@@ -82,6 +82,13 @@ unique — always check `event.harness_id`. `turn/completed` is Codex; OpenCode 
 - `semantics.py` — `terminal_outcome()`, `activity_transition()`, `clears_signal()`.
   Cross-harness event classification.
 - `common.py` — shared extraction helpers used by adapters.
+- `transcript.py` — cross-harness session read path. `TranscriptMessage` (with
+  `tool_call: ToolCall | None` and `is_tool_result: bool`), `ToolCall` (canonical
+  harness-agnostic tool representation), and three providers
+  (`JsonlTranscriptProvider`, `HistoryJsonlTranscriptProvider`,
+  `OpenCodeStorageTranscriptProvider`). Independent of the spawn/write paths — reads
+  only. See [.context/CONTEXT.md](.context/CONTEXT.md#session-read-path) for the
+  normalization table and provider selection rules.
 
 ## Subpackages
 

--- a/src/meridian/lib/harness/transcript.py
+++ b/src/meridian/lib/harness/transcript.py
@@ -22,9 +22,18 @@ _TRANSCRIPT_TEXT_KEYS: tuple[str, ...] = (
 _MAX_PREVIEW = 120
 
 
+class ToolCall(NamedTuple):
+    """Normalized tool invocation — harness-agnostic."""
+
+    name: str  # Canonical lowercase name: bash, read, write, edit, grep, stdin, ...
+    body: str  # Extracted meaningful payload: command string, file path, pattern, etc.
+
+
 class TranscriptMessage(NamedTuple):
     role: str
     content: str
+    tool_call: ToolCall | None = None
+    is_tool_result: bool = False
 
 
 class TranscriptParseResult(NamedTuple):
@@ -89,18 +98,71 @@ def _preview(value: str, *, limit: int = _MAX_PREVIEW) -> str:
     return f"{compact[: limit - 3].rstrip()}..."
 
 
-def _tool_use_summary(block: dict[str, object]) -> str:
+# Harness tool names that map to shell execution.
+_EXEC_TOOL_NAMES: frozenset[str] = frozenset({
+    "exec_command", "shell", "terminal", "run_command",
+})
+
+# Harness tool names for stdin interaction.
+_STDIN_TOOL_NAMES: frozenset[str] = frozenset({"write_stdin"})
+
+# Keys that carry the "interesting" payload in a Claude-style tool input dict.
+_TOOL_BODY_KEYS: tuple[str, ...] = (
+    "file_path", "path", "command", "pattern", "description", "skill",
+)
+
+
+def _normalize_tool(name: str, body: str) -> ToolCall:
+    """Normalize a raw tool name + body into a canonical ToolCall."""
+    lowered = name.strip().lower()
+
+    # Shell-execution equivalents → bash
+    if lowered == "bash":
+        return ToolCall(name="bash", body=body)
+    if lowered in _EXEC_TOOL_NAMES:
+        # Codex JSON body: {"cmd":"..."} → extract cmd
+        extracted = _extract_json_field(body, "cmd")
+        return ToolCall(name="bash", body=extracted or body)
+
+    # Stdin interaction → stdin
+    if lowered in _STDIN_TOOL_NAMES:
+        return ToolCall(name="stdin", body="")
+
+    # Standard file/search tools → lowercase canonical
+    for verb in ("read", "write", "edit", "grep"):
+        if lowered == verb:
+            return ToolCall(name=verb, body=body)
+
+    return ToolCall(name=lowered or "tool", body=body)
+
+
+def _extract_json_field(body: str, field: str) -> str | None:
+    """Try to extract a string field from a JSON body."""
+    try:
+        parsed = json.loads(body)
+        if isinstance(parsed, dict):
+            value = parsed.get(field)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    except (json.JSONDecodeError, TypeError, ValueError):
+        pass
+    return None
+
+
+def _tool_use_summary(block: dict[str, object]) -> tuple[str, ToolCall]:
+    """Return (text_marker, normalized_tool_call) for a Claude tool_use block."""
     name = str(block.get("name", "tool")).strip() or "tool"
     tool_input = block.get("input")
     if not isinstance(tool_input, dict):
-        return f"[tool: {name}]"
+        return f"[tool: {name}]", _normalize_tool(name, "")
 
     input_payload = cast("dict[str, object]", tool_input)
-    for key in ("file_path", "path", "command", "pattern", "description", "skill"):
+    for key in _TOOL_BODY_KEYS:
         value = input_payload.get(key)
         if isinstance(value, str) and value.strip():
-            return f"[tool: {name} {_preview(value.strip())}]"
-    return f"[tool: {name}]"
+            body = value.strip()
+            return f"[tool: {name} {_preview(body)}]", _normalize_tool(name, body)
+    return f"[tool: {name}]", _normalize_tool(name, "")
 
 
 def _tool_result_summary(block: dict[str, object]) -> str:
@@ -145,10 +207,15 @@ def _extract_claude_content(role: str, content: object) -> list[TranscriptMessag
                 messages.append(TranscriptMessage(role=role, content=text))
             continue
         if role == "assistant" and block_type == "tool_use":
-            messages.append(TranscriptMessage(role=role, content=_tool_use_summary(block)))
+            marker, tool_call = _tool_use_summary(block)
+            messages.append(TranscriptMessage(
+                role=role, content=marker, tool_call=tool_call,
+            ))
             continue
         if role == "user" and block_type == "tool_result":
-            messages.append(TranscriptMessage(role=role, content=_tool_result_summary(block)))
+            messages.append(TranscriptMessage(
+                role=role, content=_tool_result_summary(block), is_tool_result=True,
+            ))
             continue
 
         text = text_from_value(block)
@@ -195,16 +262,21 @@ def _extract_codex_response_item(payload: dict[str, object]) -> list[TranscriptM
     if item_type == "function_call":
         name = str(payload.get("name", "tool")).strip() or "tool"
         arguments = text_from_value(payload.get("arguments"))
+        tool_call = _normalize_tool(name, arguments)
         rendered = f"[tool: {name}]"
         if arguments:
             rendered = f"[tool: {name} {_preview(arguments)}]"
-        return [TranscriptMessage(role="assistant", content=rendered)]
+        return [TranscriptMessage(role="assistant", content=rendered, tool_call=tool_call)]
 
     if item_type == "function_call_output":
         output = text_from_value(payload.get("output"))
         if output:
-            return [TranscriptMessage(role="user", content=f"[tool_result] {output}")]
-        return [TranscriptMessage(role="user", content="[tool_result]")]
+            return [TranscriptMessage(
+                role="user", content=f"[tool_result] {output}", is_tool_result=True,
+            )]
+        return [TranscriptMessage(
+            role="user", content="[tool_result]", is_tool_result=True,
+        )]
 
     return []
 
@@ -221,10 +293,17 @@ def _extract_codex_exec_item(item: dict[str, object]) -> list[TranscriptMessage]
         output = text_from_value(item.get("aggregated_output") or item.get("aggregatedOutput"))
         command = text_from_value(item.get("command"))
         if output:
-            return [TranscriptMessage(role="user", content=f"[tool_result] {output}")]
+            return [TranscriptMessage(
+                role="user", content=f"[tool_result] {output}", is_tool_result=True,
+            )]
         if command:
+            tool_call = ToolCall(name="bash", body=command)
             return [
-                TranscriptMessage(role="assistant", content=f"[tool: bash {_preview(command)}]")
+                TranscriptMessage(
+                    role="assistant",
+                    content=f"[tool: bash {_preview(command)}]",
+                    tool_call=tool_call,
+                )
             ]
 
     return []
@@ -275,7 +354,11 @@ class DefaultTranscriptEventParser(TranscriptEventParser):
             fallback_text = text_from_value(event.get("tool_use_result"))
             if role == "user" and fallback_text:
                 return (
-                    [TranscriptMessage(role="user", content=f"[tool_result] {fallback_text}")],
+                    [TranscriptMessage(
+                        role="user",
+                        content=f"[tool_result] {fallback_text}",
+                        is_tool_result=True,
+                    )],
                     is_boundary,
                 )
             return ([], is_boundary)
@@ -573,6 +656,7 @@ __all__ = [
     "HistoryJsonlTranscriptProvider",
     "JsonlTranscriptProvider",
     "OpenCodeStorageTranscriptProvider",
+    "ToolCall",
     "TranscriptEventParser",
     "TranscriptMessage",
     "TranscriptParseResult",

--- a/src/meridian/lib/ops/.context/CONTEXT.md
+++ b/src/meridian/lib/ops/.context/CONTEXT.md
@@ -172,6 +172,72 @@ if present, else delegates to `ensure_temporary_worktree()`. When `ensure=False`
 returns status-only response (no-op) if path already exists. When work_id is empty
 and no active work item, uses temporary worktree path.
 
+### session_log_render.py — Session Log Rendering
+
+Pure rendering module with no IO. Sits at the end of the session-read pipeline:
+
+```
+session_transcript.py  ← parses raw JSONL transcript
+      │
+session_log.py         ← windows entries, structures SessionLogOutput
+      │
+session_log_render.py  ← renders to string (clean/raw modes, tool collapsing)
+```
+
+Structured data flows through in full; truncation and collapsing happen at
+render time inside `render_session_log`, not before.
+
+**Content pipeline** within the module:
+
+`clean_content(text)` strips harness XML wrappers while preserving unknown tags.
+Handled tags: `<command-name/args/message>` blocks → `/command args`,
+`<bash-input>` → `$ cmd`, `<bash-stdout/stderr>` blocks → raw output (stderr
+prefixed with `stderr:`), `<local-command-stdout>` → ANSI-stripped text,
+`<system-reminder>` / `<usage>` / `<local-command-caveat>` → removed,
+`<system_notification>` → `[notification: status — summary]`,
+`<user_query>` / `<persisted-output>` → unwrapped content,
+`<tool_use_error>` → `[error: ...]`. ANSI escape sequences are stripped from
+`local-command-stdout` only — other content is passed through unchanged.
+
+`_truncate_preview(content)` limits to 80 lines / 8000 chars and appends
+`...[truncated: omitted N lines, M chars; rerun with --no-truncate]`.
+
+`render_entry(entry, *, clean, truncate) → (lines, collapsed)` formats one entry:
+- `clean=False` (raw / verbosity > 0): emits `--- N [segment S · messages M-M] [role] ---` header with raw content.
+- `clean=True` (default, verbosity ≤ 0): emits `---` separator and `**Role** [N]` markdown header. In truncate mode delegates to `_render_collapsed_tools()`; otherwise to `_render_expanded_tools()`.
+
+`render_session_log(...)` assembles the full output: header, per-entry blocks,
+navigation commands (`Previous:`, `Next:`), and hints. Appends
+`"Use --no-truncate to expand tool outputs"` when any entry collapsed tool output.
+
+**Tool collapsing** (`_render_collapsed_tools`): when `truncate=True`, tool
+invocations collapse to one-liners using the typed `ToolCall` from
+`SessionLogEntryMessage`:
+- Bash: `  $ cmd`
+- File tools (`read`, `write`, `edit`, `grep`): `  Read path`, `  Write path`, etc.
+- stdin: `  (stdin)`
+- Other: `  name: detail`
+
+Exit failures for bash are shown inline: `  (failed: exit N)`. Tool results are
+suppressed in collapsed mode — only failures surface. `_render_expanded_tools`
+shows full tool output indented with 2 spaces.
+
+**`ToolCall` threading**: `SessionLogEntryMessage.tool_call` and `.is_tool_result`
+are sourced from `AbsoluteTranscriptMessage` (threaded in `_entry_message_row()`
+in `session_log.py`), which in turn gets them from `harness/transcript.py`. The
+render layer works from these typed fields — it never re-parses content strings
+to detect tool boundaries.
+
+**Render mode selection**: `SessionLogOutput.format_text(ctx)` passes
+`ctx.verbosity` to `render_session_log`, which derives `clean = verbosity <= 0`.
+The verbosity level is the single control point — callers don't set `clean`
+directly.
+
+**Protocols**: `SessionLogRenderableMessage` and `SessionLogRenderableEntry` are
+structural `Protocol` types. `SessionLogEntryMessage` and `SessionLogEntry`
+satisfy them. The render functions accept the protocols, not the concrete models,
+keeping the render layer decoupled from the data layer.
+
 ## Contracts
 
 ### OperationRuntime

--- a/src/meridian/lib/ops/AGENTS.md
+++ b/src/meridian/lib/ops/AGENTS.md
@@ -39,8 +39,10 @@ spawn. The reaper also reads `MERIDIAN_DEPTH` and skips reaping when nested.
 
 ## Operation Categories
 
-**Session:** `session_transcript.py`, `session_log.py`, `session_render.py`,
-`session_search.py`, `session_target.py`, `session_export.py`, `session_repair.py`.
+**Session:** `session_transcript.py`, `session_log.py`, `session_log_render.py`
+(pure rendering — clean/raw modes, tool collapsing, content pipeline),
+`session_render.py`, `session_search.py`, `session_target.py`, `session_export.py`,
+`session_repair.py`.
 
 **Work and workspace:** `work_lifecycle.py`, `work_attachment.py`,
 `work_dashboard.py`, `workspace.py`, `worktree_lifecycle.py`, `worktree_ops.py`.

--- a/src/meridian/lib/ops/session_log.py
+++ b/src/meridian/lib/ops/session_log.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict
 
 from meridian.lib.core.context import RuntimeContext
 from meridian.lib.core.util import FormatContext
+from meridian.lib.harness.transcript import ToolCall
 from meridian.lib.ops.runtime import async_from_sync
 from meridian.lib.ops.session_log_render import render_session_log
 from meridian.lib.ops.session_render import (
@@ -52,6 +53,8 @@ class SessionLogEntryMessage(BaseModel):
     segment_message: int
     role: str
     content: str
+    tool_call: ToolCall | None = None
+    is_tool_result: bool = False
 
 
 class SessionLogEntry(BaseModel):
@@ -157,6 +160,8 @@ def _entry_message_row(message: AbsoluteTranscriptMessage) -> SessionLogEntryMes
         segment_message=message.segment_message_index,
         role=message.role,
         content=message.content,
+        tool_call=message.tool_call,
+        is_tool_result=message.is_tool_result,
     )
 
 

--- a/src/meridian/lib/ops/session_log.py
+++ b/src/meridian/lib/ops/session_log.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, ConfigDict
 from meridian.lib.core.context import RuntimeContext
 from meridian.lib.core.util import FormatContext
 from meridian.lib.ops.runtime import async_from_sync
+from meridian.lib.ops.session_log_render import render_session_log
 from meridian.lib.ops.session_render import (
     SessionWindow,
     showing_window,
@@ -25,9 +26,6 @@ from meridian.lib.ops.session_transcript import (
     build_session_log_command,
     read_session_transcript,
 )
-
-_CONTENT_PREVIEW_MAX_LINES = 80
-_CONTENT_PREVIEW_MAX_CHARS = 8000
 
 
 class SessionLogInput(BaseModel):
@@ -86,66 +84,31 @@ class SessionLogOutput(BaseModel):
     previous_segment_command: str | None = None
     next_segment_command: str | None = None
     hints: tuple[str, ...] = ()
+    truncate: bool = True
 
     @property
     def messages(self) -> tuple[SessionLogEntryMessage, ...]:
         return tuple(message for entry in self.entries for message in entry.messages)
 
     def format_text(self, ctx: FormatContext | None = None) -> str:
-        _ = ctx
-        source = self.source or ""
-        normalized_requested_ref = (self.requested_ref or "").strip()
-        if normalized_requested_ref and normalized_requested_ref != self.session_id:
-            session_label = (
-                f"{normalized_requested_ref} ({source}: {self.session_id})"
-                if source
-                else f"{normalized_requested_ref} ({self.session_id})"
-            )
-        else:
-            session_label = f"{self.session_id} ({source})" if source else self.session_id
-        entry_label = "entry" if self.total_entries == 1 else "entries"
-        lines = [
-            (
-                f"Session {session_label} — showing "
-                f"{self.showing} of {self.total_entries} {entry_label}"
-            )
-        ]
-        if self.segment_label is not None and self.segment_entries is not None:
-            lines.append(f"{self.segment_label}; {self.segment_entries} entries in segment")
-        for entry in self.entries:
-            lines.append("")
-            lines.append(
-                f"--- {entry.index} [segment {entry.segment} · "
-                f"messages {entry.segment_start_message}-{entry.segment_end_message}] "
-                f"[{entry.role}] ---"
-            )
-            if not entry.messages:
-                lines.append(entry.content)
-                continue
-            if len(entry.messages) == 1:
-                lines.append(entry.messages[0].content)
-                continue
-
-            for message in entry.messages:
-                lines.append("")
-                lines.append(f"[message {message.segment_message} · {message.role}]")
-                lines.append(message.content)
-        nav_lines: list[str] = []
-        if self.previous_command is not None:
-            nav_lines.append(f"Previous: {self.previous_command}")
-        if self.next_command is not None:
-            nav_lines.append(f"Next: {self.next_command}")
-        if self.previous_segment_command is not None:
-            nav_lines.append(f"Previous segment: {self.previous_segment_command}")
-        if self.next_segment_command is not None:
-            nav_lines.append(f"Next segment: {self.next_segment_command}")
-        if nav_lines:
-            lines.append("")
-            lines.extend(nav_lines)
-        if self.hints:
-            lines.append("")
-            lines.extend(self.hints)
-        return "\n".join(lines)
+        resolved_ctx = ctx or FormatContext()
+        return render_session_log(
+            session_id=self.session_id,
+            requested_ref=self.requested_ref,
+            source=self.source,
+            total_entries=self.total_entries,
+            segment_entries=self.segment_entries,
+            segment_label=self.segment_label,
+            showing=self.showing,
+            entries=self.entries,
+            previous_command=self.previous_command,
+            next_command=self.next_command,
+            previous_segment_command=self.previous_segment_command,
+            next_segment_command=self.next_segment_command,
+            hints=self.hints,
+            truncate=self.truncate,
+            verbosity=resolved_ctx.verbosity,
+        )
 
 
 def _window_hints(payload: SessionLogInput, *, uses_absolute_window: bool) -> tuple[str, ...]:
@@ -189,47 +152,11 @@ def _segment_label(*, selected_index: int, total_segments: int) -> str:
     return f"segment {selected_index}"
 
 
-def _truncate_preview(content: str) -> str:
-    if not content:
-        return content
-
-    line_parts = content.splitlines(keepends=True)
-    limited_by_lines = len(line_parts) > _CONTENT_PREVIEW_MAX_LINES
-    preview = (
-        "".join(line_parts[:_CONTENT_PREVIEW_MAX_LINES]) if limited_by_lines else content
-    )
-    if len(preview) > _CONTENT_PREVIEW_MAX_CHARS:
-        preview = preview[:_CONTENT_PREVIEW_MAX_CHARS]
-
-    omitted_chars = len(content) - len(preview)
-    if omitted_chars <= 0:
-        return content
-
-    omitted_lines = (
-        len(line_parts) - _CONTENT_PREVIEW_MAX_LINES if limited_by_lines else 0
-    )
-    line_label = "line" if omitted_lines == 1 else "lines"
-    char_label = "char" if omitted_chars == 1 else "chars"
-    marker = (
-        f"...[truncated: omitted {omitted_lines} {line_label}, "
-        f"{omitted_chars} {char_label}; rerun with --no-truncate]"
-    )
-    if not preview:
-        return marker
-    separator = "" if preview.endswith("\n") else "\n"
-    return f"{preview}{separator}{marker}"
-
-
-def _entry_message_row(
-    message: AbsoluteTranscriptMessage,
-    *,
-    truncate_content: bool,
-) -> SessionLogEntryMessage:
-    content = _truncate_preview(message.content) if truncate_content else message.content
+def _entry_message_row(message: AbsoluteTranscriptMessage) -> SessionLogEntryMessage:
     return SessionLogEntryMessage(
         segment_message=message.segment_message_index,
         role=message.role,
-        content=content,
+        content=message.content,
     )
 
 
@@ -237,19 +164,16 @@ def _entry_row_with_index(
     entry: AbsoluteTranscriptEntry,
     *,
     index: int,
-    truncate_content: bool,
 ) -> SessionLogEntry:
-    content = _truncate_preview(entry.content) if truncate_content else entry.content
     return SessionLogEntry(
         index=index,
         segment=entry.segment_index,
         segment_start_message=entry.start_segment_message_index,
         segment_end_message=entry.end_segment_message_index,
         role=entry.role,
-        content=content,
+        content=entry.content,
         messages=tuple(
-            _entry_message_row(message, truncate_content=truncate_content)
-            for message in entry.messages
+            _entry_message_row(message) for message in entry.messages
         ),
     )
 
@@ -410,6 +334,7 @@ def session_log_sync(
             segment_entries=selected_segment_entries,
         )
 
+    resolved_tail: int | None = None
     if not uses_window_selectors:
         interaction_entries = [
             entry for entry in address_space.entries if entry.kind == "interaction"
@@ -478,6 +403,15 @@ def session_log_sync(
                 from_ordinal=page.next_from,
                 limit=nav_limit,
             )
+    elif page.has_previous:
+        nav_limit = resolved_tail if resolved_tail is not None else 5
+        if page.previous_from is not None:
+            previous_command = build_session_log_command(
+                parsed.route,
+                segment_index=address_space.segment_index,
+                from_ordinal=page.previous_from,
+                limit=nav_limit,
+            )
 
     previous_segment_command, next_segment_command = _segment_boundary_commands(
         parsed_route=parsed.route,
@@ -492,7 +426,6 @@ def session_log_sync(
         _entry_row_with_index(
             item,
             index=address_space.ordinal_getter(item),
-            truncate_content=payload.truncate,
         )
         for item in page.entries
     )
@@ -519,6 +452,7 @@ def session_log_sync(
         previous_segment_command=previous_segment_command,
         next_segment_command=next_segment_command,
         hints=_window_hints(payload, uses_absolute_window=uses_window_selectors),
+        truncate=payload.truncate,
     )
 
 

--- a/src/meridian/lib/ops/session_log_render.py
+++ b/src/meridian/lib/ops/session_log_render.py
@@ -6,11 +6,12 @@ import re
 from collections.abc import Callable, Sequence
 from typing import Protocol
 
+from meridian.lib.harness.transcript import ToolCall
+
 _CONTENT_PREVIEW_MAX_LINES = 80
 _CONTENT_PREVIEW_MAX_CHARS = 8000
 _TOOL_RESULT_HINT = "Use --no-truncate to expand tool outputs"
-_TOOL_CALL_RE = re.compile(r"^\[tool:\s*(?P<name>[^\]\s]+)(?:\s+(?P<body>.*))?\]$", re.DOTALL)
-_TOOL_RESULT_PREFIX = "[tool_result]"
+_TOOL_RESULT_PREFIX = "[tool_result]"  # Text marker prefix for tool results
 _ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
 _COMMAND_BLOCK_RE = re.compile(
     r"(?:\s*<command-(?:name|args|message)>.*?</command-(?:name|args|message)>\s*)+",
@@ -40,6 +41,12 @@ class SessionLogRenderableMessage(Protocol):
 
     @property
     def content(self) -> str: ...
+
+    @property
+    def tool_call(self) -> ToolCall | None: ...
+
+    @property
+    def is_tool_result(self) -> bool: ...
 
 
 class SessionLogRenderableEntry(Protocol):
@@ -233,16 +240,8 @@ def _truncate_preview(content: str) -> str:
     return f"{preview}{separator}{marker}"
 
 
-def _tool_call_parts(content: str) -> tuple[str, str] | None:
-    match = _TOOL_CALL_RE.match(content.strip())
-    if match is None:
-        return None
-    name = match.group("name").strip()
-    body = (match.group("body") or "").strip()
-    return (name, body)
-
-
 def _tool_result_body(content: str) -> str | None:
+    """Extract tool result content from text marker (fallback for untyped messages)."""
     stripped = content.strip()
     if not stripped.startswith(_TOOL_RESULT_PREFIX):
         return None
@@ -311,29 +310,30 @@ def _indent_block(content: str, *, prefix: str = "  ") -> list[str]:
     return [f"{prefix}{line}" if line else prefix.rstrip() for line in content.splitlines()]
 
 
-def _tool_line(name: str, body: str) -> str:
-    normalized_name = name.strip() or "tool"
-    lowered = normalized_name.lower()
-    detail = " ".join(body.split())
-    if lowered == "bash":
-        command = detail or "bash"
-        return f"  $ {command}"
+def _tool_line(tool_call: ToolCall) -> str:
+    """Render a normalized tool call as a collapsed one-liner."""
+    name = tool_call.name
+    detail = " ".join(tool_call.body.split())
+
+    if name == "bash":
+        return f"  $ {detail or 'bash'}"
+
+    if name == "stdin":
+        return "  (stdin)"
 
     for verb in ("read", "write", "edit", "grep"):
-        if lowered == verb:
-            if detail:
-                return f"  {verb.title()} {detail}"
-            return f"  {verb.title()}"
+        if name == verb:
+            return f"  {verb.title()} {detail}" if detail else f"  {verb.title()}"
 
     if detail:
-        return f"  {normalized_name}: {detail}"
-    return f"  {normalized_name}"
+        return f"  {name}: {detail}"
+    return f"  {name}"
 
 
 def _tool_failed_reason(result_body: str) -> str | None:
     normalized = clean_content(result_body)
     exit_match = re.search(
-        r"(?:exit(?:ed)?(?:\s+status|\s+code)?|exit_code|\[exit_code\])\s*[:=]?\s*(\d+)",
+        r"(?:exit(?:ed)?(?:\s+(?:with\s+)?(?:status|code))?|exit_code|\[exit_code\])\s*[:=]?\s*(\d+)",
         normalized,
         flags=re.IGNORECASE,
     )
@@ -355,15 +355,15 @@ def _render_collapsed_tools(
     index = 0
     while index < len(messages):
         message = messages[index]
-        tool_call = _tool_call_parts(message.content)
-        if tool_call is not None:
-            name, body = tool_call
+
+        if message.tool_call is not None:
+            tc = message.tool_call
             result_body: str | None = None
-            if index + 1 < len(messages):
+            if index + 1 < len(messages) and messages[index + 1].is_tool_result:
                 result_body = _tool_result_body(messages[index + 1].content)
-            rendered.append(_tool_line(name, body))
+            rendered.append(_tool_line(tc))
             collapsed = True
-            if result_body is not None and name.strip().lower() == "bash":
+            if result_body is not None and tc.name == "bash":
                 failure = _tool_failed_reason(result_body)
                 if failure is not None:
                     if failure.startswith("exit"):
@@ -378,12 +378,15 @@ def _render_collapsed_tools(
             index += 1
             continue
 
-        result_body = _tool_result_body(message.content)
-        if result_body is not None:
+        if message.is_tool_result:
             collapsed = True
-            summary = clean_content(result_body).splitlines()
-            first_line = summary[0].strip() if summary else ""
-            rendered.append(f"  (tool output): {first_line or '(no output)'}")
+            result_body = _tool_result_body(message.content)
+            if result_body is not None:
+                summary = clean_content(result_body).splitlines()
+                first_line = summary[0].strip() if summary else ""
+                rendered.append(f"  (tool output): {first_line or '(no output)'}")
+            else:
+                rendered.append("  (tool output): (no output)")
             index += 1
             continue
 
@@ -401,11 +404,10 @@ def _render_expanded_tools(messages: Sequence[SessionLogRenderableMessage]) -> l
     index = 0
     while index < len(messages):
         message = messages[index]
-        tool_call = _tool_call_parts(message.content)
-        if tool_call is not None:
-            name, body = tool_call
-            rendered.append(_tool_line(name, body))
-            if index + 1 < len(messages):
+
+        if message.tool_call is not None:
+            rendered.append(_tool_line(message.tool_call))
+            if index + 1 < len(messages) and messages[index + 1].is_tool_result:
                 result_body = _tool_result_body(messages[index + 1].content)
                 if result_body is not None:
                     rendered.extend(_indent_block(clean_content(result_body)))
@@ -414,10 +416,11 @@ def _render_expanded_tools(messages: Sequence[SessionLogRenderableMessage]) -> l
             index += 1
             continue
 
-        result_body = _tool_result_body(message.content)
-        if result_body is not None:
+        if message.is_tool_result:
+            result_body = _tool_result_body(message.content)
             rendered.append("  (tool output)")
-            rendered.extend(_indent_block(clean_content(result_body)))
+            if result_body is not None:
+                rendered.extend(_indent_block(clean_content(result_body)))
             index += 1
             continue
 

--- a/src/meridian/lib/ops/session_log_render.py
+++ b/src/meridian/lib/ops/session_log_render.py
@@ -1,0 +1,554 @@
+"""Readable and raw renderers for session-log output."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Sequence
+from typing import Protocol
+
+_CONTENT_PREVIEW_MAX_LINES = 80
+_CONTENT_PREVIEW_MAX_CHARS = 8000
+_TOOL_RESULT_HINT = "Use --no-truncate to expand tool outputs"
+_TOOL_CALL_RE = re.compile(r"^\[tool:\s*(?P<name>[^\]\s]+)(?:\s+(?P<body>.*))?\]$", re.DOTALL)
+_TOOL_RESULT_PREFIX = "[tool_result]"
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+_COMMAND_BLOCK_RE = re.compile(
+    r"(?:\s*<command-(?:name|args|message)>.*?</command-(?:name|args|message)>\s*)+",
+    re.DOTALL,
+)
+_COMMAND_PART_RE = re.compile(
+    r"<command-(?P<name>name|args|message)>(?P<body>.*?)</command-(?P=name)>",
+    re.DOTALL,
+)
+_BASH_OUTPUT_BLOCK_RE = re.compile(
+    r"(?:\s*<bash-(?:stdout|stderr)>.*?</bash-(?:stdout|stderr)>\s*)+",
+    re.DOTALL,
+)
+_BASH_OUTPUT_PART_RE = re.compile(
+    r"<bash-(?P<name>stdout|stderr)>(?P<body>.*?)</bash-(?P=name)>",
+    re.DOTALL,
+)
+_NOTIFICATION_TAG_RE = re.compile(r"<(?P<name>status|summary)>(?P<body>.*?)</(?P=name)>", re.DOTALL)
+
+
+class SessionLogRenderableMessage(Protocol):
+    @property
+    def segment_message(self) -> int: ...
+
+    @property
+    def role(self) -> str: ...
+
+    @property
+    def content(self) -> str: ...
+
+
+class SessionLogRenderableEntry(Protocol):
+    @property
+    def index(self) -> int: ...
+
+    @property
+    def segment(self) -> int: ...
+
+    @property
+    def segment_start_message(self) -> int: ...
+
+    @property
+    def segment_end_message(self) -> int: ...
+
+    @property
+    def role(self) -> str: ...
+
+    @property
+    def content(self) -> str: ...
+
+    @property
+    def messages(self) -> Sequence[SessionLogRenderableMessage]: ...
+
+
+def _replace_tag(
+    text: str,
+    *,
+    name: str,
+    renderer: Callable[[str], str],
+) -> str:
+    pattern = re.compile(rf"<{name}>(.*?)</{name}>", re.DOTALL)
+
+    def _replacement(match: re.Match[str]) -> str:
+        return renderer(match.group(1))
+
+    return pattern.sub(_replacement, text)
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_ESCAPE_RE.sub("", text)
+
+
+def _normalize_command_name(name: str) -> str:
+    normalized = name.strip().lstrip("/")
+    return f"/{normalized}" if normalized else "/command"
+
+
+def _render_command_block(match: re.Match[str]) -> str:
+    parts: dict[str, str] = {}
+    for part in _COMMAND_PART_RE.finditer(match.group(0)):
+        parts[part.group("name")] = part.group("body")
+
+    raw_name = parts.get("name", "").strip()
+    if not raw_name:
+        fallback_parts = [parts.get("message", ""), parts.get("args", "")]
+        fallback = " ".join(" ".join(part.split()) for part in fallback_parts if part.strip())
+        return fallback
+
+    name = _normalize_command_name(raw_name)
+    args = " ".join(parts.get("args", "").split())
+    command = name
+    if args:
+        command = f"{command} {args}"
+    return command
+
+
+def _replace_command_blocks(text: str) -> str:
+    return _COMMAND_BLOCK_RE.sub(_render_command_block, text)
+
+
+def _render_bash_output_block(match: re.Match[str]) -> str:
+    outputs: list[str] = []
+    saw_stderr = False
+    saw_stdout = False
+
+    for part in _BASH_OUTPUT_PART_RE.finditer(match.group(0)):
+        tag_name = part.group("name")
+        body = part.group("body").strip()
+        if tag_name == "stdout":
+            saw_stdout = True
+            if body:
+                outputs.append(body)
+            continue
+        saw_stderr = True
+        if body:
+            outputs.append(f"stderr: {body}")
+
+    if outputs:
+        return "\n".join(outputs)
+    if saw_stdout and not saw_stderr:
+        return "(no output)"
+    return ""
+
+
+def _replace_bash_output_blocks(text: str) -> str:
+    def _replacement(match: re.Match[str]) -> str:
+        rendered = _render_bash_output_block(match)
+        if not rendered:
+            return ""
+        leading = match.group(0).split("<", 1)[0]
+        if "\n" in leading:
+            return f"\n{rendered}"
+        return rendered
+
+    return _BASH_OUTPUT_BLOCK_RE.sub(_replacement, text)
+
+
+def _render_system_notification(body: str) -> str:
+    details: dict[str, str] = {}
+    for match in _NOTIFICATION_TAG_RE.finditer(body):
+        details[match.group("name")] = " ".join(match.group("body").split())
+    status = details.get("status", "")
+    summary = details.get("summary", "")
+    if status and summary:
+        return f"[notification: {status} — {summary}]"
+    if summary:
+        return f"[notification: {summary}]"
+    if status:
+        return f"[notification: {status}]"
+    fallback = " ".join(body.split())
+    if not fallback:
+        return ""
+    return f"[notification: {fallback}]"
+
+
+def clean_content(text: str) -> str:
+    """Strip known harness wrappers while preserving unknown tags."""
+
+    if not text:
+        return text
+
+    cleaned = text.replace("\r\n", "\n")
+    cleaned = re.sub(r"</bash-input>\s*(?=<bash-(?:stdout|stderr)>)", "</bash-input>\n", cleaned)
+    cleaned = _replace_command_blocks(cleaned)
+    cleaned = _replace_tag(cleaned, name="local-command-caveat", renderer=lambda _inner: "")
+    cleaned = _replace_tag(cleaned, name="system-reminder", renderer=lambda _inner: "")
+    cleaned = _replace_tag(cleaned, name="usage", renderer=lambda _inner: "")
+    cleaned = _replace_tag(
+        cleaned,
+        name="local-command-stdout",
+        renderer=lambda inner: _strip_ansi(inner).strip(),
+    )
+    cleaned = _replace_tag(
+        cleaned,
+        name="bash-input",
+        renderer=lambda inner: f"$ {inner.strip()}" if inner.strip() else "$",
+    )
+    cleaned = _replace_bash_output_blocks(cleaned)
+    cleaned = _replace_tag(
+        cleaned,
+        name="system_notification",
+        renderer=_render_system_notification,
+    )
+    cleaned = _replace_tag(cleaned, name="user_query", renderer=lambda inner: inner.strip())
+    cleaned = _replace_tag(cleaned, name="persisted-output", renderer=lambda inner: inner.strip())
+    cleaned = _replace_tag(
+        cleaned,
+        name="tool_use_error",
+        renderer=lambda inner: f"[error: {' '.join(inner.split())}]" if inner.strip() else "",
+    )
+
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    return cleaned.strip()
+
+
+def _truncate_preview(content: str) -> str:
+    if not content:
+        return content
+
+    line_parts = content.splitlines(keepends=True)
+    limited_by_lines = len(line_parts) > _CONTENT_PREVIEW_MAX_LINES
+    preview = "".join(line_parts[:_CONTENT_PREVIEW_MAX_LINES]) if limited_by_lines else content
+    if len(preview) > _CONTENT_PREVIEW_MAX_CHARS:
+        preview = preview[:_CONTENT_PREVIEW_MAX_CHARS]
+
+    omitted_chars = len(content) - len(preview)
+    if omitted_chars <= 0:
+        return content
+
+    omitted_lines = len(line_parts) - _CONTENT_PREVIEW_MAX_LINES if limited_by_lines else 0
+    line_label = "line" if omitted_lines == 1 else "lines"
+    char_label = "char" if omitted_chars == 1 else "chars"
+    marker = (
+        f"...[truncated: omitted {omitted_lines} {line_label}, "
+        f"{omitted_chars} {char_label}; rerun with --no-truncate]"
+    )
+    if not preview:
+        return marker
+    separator = "" if preview.endswith("\n") else "\n"
+    return f"{preview}{separator}{marker}"
+
+
+def _tool_call_parts(content: str) -> tuple[str, str] | None:
+    match = _TOOL_CALL_RE.match(content.strip())
+    if match is None:
+        return None
+    name = match.group("name").strip()
+    body = (match.group("body") or "").strip()
+    return (name, body)
+
+
+def _tool_result_body(content: str) -> str | None:
+    stripped = content.strip()
+    if not stripped.startswith(_TOOL_RESULT_PREFIX):
+        return None
+    return stripped[len(_TOOL_RESULT_PREFIX) :].strip()
+
+
+def _role_label(role: str) -> str:
+    normalized = role.strip().lower()
+    if normalized == "user":
+        return "User"
+    if normalized == "assistant":
+        return "Assistant"
+    if normalized == "system":
+        return "System"
+    return normalized.title() or "Message"
+
+
+def _session_label(*, session_id: str, requested_ref: str | None) -> str:
+    requested = (requested_ref or "").strip()
+    if requested:
+        return requested
+    return session_id
+
+
+def _render_raw_header(
+    *,
+    session_id: str,
+    requested_ref: str | None,
+    source: str | None,
+    showing: str,
+    total_entries: int,
+) -> str:
+    resolved_source = source or ""
+    normalized_requested_ref = (requested_ref or "").strip()
+    if normalized_requested_ref and normalized_requested_ref != session_id:
+        session_label = (
+            f"{normalized_requested_ref} ({resolved_source}: {session_id})"
+            if resolved_source
+            else f"{normalized_requested_ref} ({session_id})"
+        )
+    else:
+        session_label = f"{session_id} ({resolved_source})" if resolved_source else session_id
+    entry_label = "entry" if total_entries == 1 else "entries"
+    return f"Session {session_label} — showing {showing} of {total_entries} {entry_label}"
+
+
+def _render_clean_header(
+    *,
+    session_id: str,
+    requested_ref: str | None,
+    total_entries: int,
+    segment_label: str | None,
+    showing: str,
+) -> tuple[str, str]:
+    entry_label = "entry" if total_entries == 1 else "entries"
+    segment_summary = segment_label or "all segments"
+    return (
+        f"# Session {_session_label(session_id=session_id, requested_ref=requested_ref)}",
+        f"{total_entries} {entry_label}, {segment_summary} · showing {showing}",
+    )
+
+
+def _indent_block(content: str, *, prefix: str = "  ") -> list[str]:
+    if not content:
+        return [f"{prefix}(no output)"]
+    return [f"{prefix}{line}" if line else prefix.rstrip() for line in content.splitlines()]
+
+
+def _tool_line(name: str, body: str) -> str:
+    normalized_name = name.strip() or "tool"
+    lowered = normalized_name.lower()
+    detail = " ".join(body.split())
+    if lowered == "bash":
+        command = detail or "bash"
+        return f"  $ {command}"
+
+    for verb in ("read", "write", "edit", "grep"):
+        if lowered == verb:
+            if detail:
+                return f"  {verb.title()} {detail}"
+            return f"  {verb.title()}"
+
+    if detail:
+        return f"  {normalized_name}: {detail}"
+    return f"  {normalized_name}"
+
+
+def _tool_failed_reason(result_body: str) -> str | None:
+    normalized = clean_content(result_body)
+    exit_match = re.search(
+        r"(?:exit(?:ed)?(?:\s+status|\s+code)?|exit_code|\[exit_code\])\s*[:=]?\s*(\d+)",
+        normalized,
+        flags=re.IGNORECASE,
+    )
+    if exit_match is not None:
+        exit_code = int(exit_match.group(1))
+        if exit_code != 0:
+            return f"exit {exit_code}"
+        return None
+    if re.search(r"\bfailed\b", normalized, flags=re.IGNORECASE):
+        return "failed"
+    return None
+
+
+def _render_collapsed_tools(
+    messages: Sequence[SessionLogRenderableMessage],
+) -> tuple[list[str], bool]:
+    rendered: list[str] = []
+    collapsed = False
+    index = 0
+    while index < len(messages):
+        message = messages[index]
+        tool_call = _tool_call_parts(message.content)
+        if tool_call is not None:
+            name, body = tool_call
+            result_body: str | None = None
+            if index + 1 < len(messages):
+                result_body = _tool_result_body(messages[index + 1].content)
+            rendered.append(_tool_line(name, body))
+            collapsed = True
+            if result_body is not None and name.strip().lower() == "bash":
+                failure = _tool_failed_reason(result_body)
+                if failure is not None:
+                    if failure.startswith("exit"):
+                        rendered.append(f"  (failed: {failure})")
+                    else:
+                        rendered.append("  (failed)")
+                index += 2
+                continue
+            if result_body is not None:
+                index += 2
+                continue
+            index += 1
+            continue
+
+        result_body = _tool_result_body(message.content)
+        if result_body is not None:
+            collapsed = True
+            summary = clean_content(result_body).splitlines()
+            first_line = summary[0].strip() if summary else ""
+            rendered.append(f"  (tool output): {first_line or '(no output)'}")
+            index += 1
+            continue
+
+        cleaned = clean_content(message.content)
+        if cleaned:
+            cleaned = _truncate_preview(cleaned)
+            rendered.append(cleaned)
+        index += 1
+
+    return rendered, collapsed
+
+
+def _render_expanded_tools(messages: Sequence[SessionLogRenderableMessage]) -> list[str]:
+    rendered: list[str] = []
+    index = 0
+    while index < len(messages):
+        message = messages[index]
+        tool_call = _tool_call_parts(message.content)
+        if tool_call is not None:
+            name, body = tool_call
+            rendered.append(_tool_line(name, body))
+            if index + 1 < len(messages):
+                result_body = _tool_result_body(messages[index + 1].content)
+                if result_body is not None:
+                    rendered.extend(_indent_block(clean_content(result_body)))
+                    index += 2
+                    continue
+            index += 1
+            continue
+
+        result_body = _tool_result_body(message.content)
+        if result_body is not None:
+            rendered.append("  (tool output)")
+            rendered.extend(_indent_block(clean_content(result_body)))
+            index += 1
+            continue
+
+        cleaned = clean_content(message.content)
+        if cleaned:
+            rendered.append(cleaned)
+        index += 1
+
+    return rendered
+
+
+def render_entry(
+    entry: SessionLogRenderableEntry,
+    *,
+    clean: bool,
+    truncate: bool,
+) -> tuple[list[str], bool]:
+    if not clean:
+        lines = [
+            f"--- {entry.index} [segment {entry.segment} · "
+            f"messages {entry.segment_start_message}-{entry.segment_end_message}] "
+            f"[{entry.role}] ---"
+        ]
+        if not entry.messages:
+            content = _truncate_preview(entry.content) if truncate else entry.content
+            lines.append(content)
+            return lines, False
+        if len(entry.messages) == 1:
+            content = entry.messages[0].content
+            lines.append(_truncate_preview(content) if truncate else content)
+            return lines, False
+
+        for message in entry.messages:
+            lines.append("")
+            lines.append(f"[message {message.segment_message} · {message.role}]")
+            content = _truncate_preview(message.content) if truncate else message.content
+            lines.append(content)
+        return lines, False
+
+    lines = ["---", "", f"**{_role_label(entry.role)}** [{entry.index}]", ""]
+    if not entry.messages:
+        content = clean_content(entry.content)
+        if truncate:
+            content = _truncate_preview(content)
+        if content:
+            lines.append(content)
+        return lines, False
+
+    collapsed = False
+    if truncate:
+        body_lines, collapsed = _render_collapsed_tools(entry.messages)
+    else:
+        body_lines = _render_expanded_tools(entry.messages)
+
+    for body_line in body_lines:
+        if body_line:
+            lines.append(body_line)
+    return lines, collapsed
+
+
+def render_session_log(
+    *,
+    session_id: str,
+    requested_ref: str | None,
+    source: str | None,
+    total_entries: int,
+    segment_entries: int | None,
+    segment_label: str | None,
+    showing: str,
+    entries: Sequence[SessionLogRenderableEntry],
+    previous_command: str | None,
+    next_command: str | None,
+    previous_segment_command: str | None,
+    next_segment_command: str | None,
+    hints: Sequence[str],
+    truncate: bool,
+    verbosity: int,
+) -> str:
+    clean = verbosity <= 0
+    lines: list[str] = []
+
+    if clean:
+        title, subtitle = _render_clean_header(
+            session_id=session_id,
+            requested_ref=requested_ref,
+            total_entries=total_entries,
+            segment_label=segment_label,
+            showing=showing,
+        )
+        lines.extend([title, "", subtitle])
+    else:
+        lines.append(
+            _render_raw_header(
+                session_id=session_id,
+                requested_ref=requested_ref,
+                source=source,
+                showing=showing,
+                total_entries=total_entries,
+            )
+        )
+        if segment_label is not None and segment_entries is not None:
+            lines.append(f"{segment_label}; {segment_entries} entries in segment")
+
+    collapsed_tool_output = False
+    for entry in entries:
+        lines.append("")
+        entry_lines, entry_collapsed = render_entry(entry, clean=clean, truncate=truncate)
+        collapsed_tool_output = collapsed_tool_output or entry_collapsed
+        lines.extend(entry_lines)
+
+    nav_lines: list[str] = []
+    if previous_command is not None:
+        nav_lines.append(f"Previous: {previous_command}")
+    if next_command is not None:
+        nav_lines.append(f"Next: {next_command}")
+    if previous_segment_command is not None:
+        nav_lines.append(f"Previous segment: {previous_segment_command}")
+    if next_segment_command is not None:
+        nav_lines.append(f"Next segment: {next_segment_command}")
+    if nav_lines:
+        lines.append("")
+        lines.extend(nav_lines)
+
+    rendered_hints = list(hints)
+    if clean and truncate and collapsed_tool_output and _TOOL_RESULT_HINT not in rendered_hints:
+        rendered_hints.append(_TOOL_RESULT_HINT)
+    if rendered_hints:
+        lines.append("")
+        lines.extend(rendered_hints)
+
+    return "\n".join(lines)
+
+
+__all__ = ["clean_content", "render_entry", "render_session_log"]

--- a/src/meridian/lib/ops/session_transcript.py
+++ b/src/meridian/lib/ops/session_transcript.py
@@ -6,7 +6,11 @@ from pathlib import Path
 from typing import Literal, NamedTuple
 
 from meridian.lib.core.command_strings import format_command_for_display
-from meridian.lib.harness.transcript import TranscriptMessage, parse_transcript_file_with_prologues
+from meridian.lib.harness.transcript import (
+    ToolCall,
+    TranscriptMessage,
+    parse_transcript_file_with_prologues,
+)
 from meridian.lib.ops.runtime import resolve_runtime_authority_for_read
 from meridian.lib.ops.session_target import SessionLogTarget, resolve_session_log_target
 
@@ -20,6 +24,8 @@ class AbsoluteTranscriptMessage(NamedTuple):
     segment_message_index: int
     role: str
     content: str
+    tool_call: ToolCall | None = None
+    is_tool_result: bool = False
 
 
 class AbsoluteTranscriptEntry(NamedTuple):
@@ -68,6 +74,8 @@ def flatten_transcript_segments(
                     segment_message_index=segment_message_index,
                     role=message.role,
                     content=message.content,
+                    tool_call=message.tool_call,
+                    is_tool_result=message.is_tool_result,
                 )
             )
             ordinal += 1

--- a/tests/smoke/session.md
+++ b/tests/smoke/session.md
@@ -38,6 +38,7 @@ uv run meridian session log --help
 - [ ] `--tail` appears in output
 - [ ] `--full` appears in output
 - [ ] `--no-truncate` appears in output
+- [ ] `--raw` appears in output
 - [ ] `--segment` appears in output
 - [ ] `--from` appears in output
 - [ ] `--around` appears in output
@@ -57,3 +58,42 @@ uv run meridian session repair --help
 ```
 - [ ] Exit 0
 - [ ] `repair` appears in output (case-insensitive)
+
+## Log readability — clean default, raw escape hatch, expanded tool output
+
+Create a deterministic transcript with XML chrome and a tool call/result pair:
+
+```bash
+cat > "$SCRATCH/session-log-readable.jsonl" <<'JSONL'
+{"type":"user","message":{"content":[{"type":"text","text":"<local-command-caveat>internal</local-command-caveat><bash-input>echo hi</bash-input><bash-stdout>hi</bash-stdout><system-reminder>noise</system-reminder>"}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"I'll run a command."}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"bash","input":{"command":"printf hi"}}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","content":"<bash-stdout>hi</bash-stdout>"}]}}
+JSONL
+```
+
+```bash
+uv run meridian session log --file "$SCRATCH/session-log-readable.jsonl" --full
+```
+- [ ] Exit 0
+- [ ] Output starts with a clean session header (`# Session`)
+- [ ] Role headers look like `**System**` / `**Mixed**`, not raw segment metadata
+- [ ] XML chrome is removed: no `<local-command-caveat>` or `<system-reminder>`
+- [ ] Command input is readable (`$ echo hi`)
+- [ ] Tool action is collapsed (`  $ printf hi`)
+- [ ] Raw `[tool_result]` is not shown
+- [ ] Footer hints mention `Use --no-truncate to expand tool outputs`
+
+```bash
+uv run meridian session log --file "$SCRATCH/session-log-readable.jsonl" --full --no-truncate
+```
+- [ ] Exit 0
+- [ ] Tool output expands inline (`  hi`)
+- [ ] `Use --no-truncate to expand tool outputs` is not shown
+
+```bash
+uv run meridian session log --file "$SCRATCH/session-log-readable.jsonl" --full --raw
+```
+- [ ] Exit 0
+- [ ] Raw entry headers include segment/message metadata (`--- 1 [segment`)
+- [ ] Raw transcript markers remain visible (`[tool_result]`, `<bash-stdout>hi</bash-stdout>`)

--- a/tests/unit/cli/test_output.py
+++ b/tests/unit/cli/test_output.py
@@ -1,0 +1,39 @@
+"""Unit tests for CLI output formatting behavior."""
+
+from __future__ import annotations
+
+from io import StringIO
+
+from meridian.cli.output import TextSink, emit
+from meridian.lib.core.util import FormatContext
+
+
+class _Formattable:
+    def __init__(self) -> None:
+        self.seen: list[FormatContext | None] = []
+
+    def format_text(self, ctx: FormatContext | None = None) -> str:
+        self.seen.append(ctx)
+        return "formatted"
+
+
+def test_emit_uses_explicit_format_context_for_text_sink() -> None:
+    stdout = StringIO()
+    sink = TextSink(stdout=stdout)
+    value = _Formattable()
+
+    emit(value, sink=sink, format_ctx=FormatContext(verbosity=1, width=120))
+
+    assert value.seen == [FormatContext(verbosity=1, width=120)]
+    assert stdout.getvalue().strip() == "formatted"
+
+
+def test_emit_uses_default_context_when_not_provided() -> None:
+    stdout = StringIO()
+    sink = TextSink(stdout=stdout)
+    value = _Formattable()
+
+    emit(value, sink=sink)
+
+    assert value.seen == [FormatContext()]
+    assert stdout.getvalue().strip() == "formatted"

--- a/tests/unit/cli/test_session_cmd.py
+++ b/tests/unit/cli/test_session_cmd.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from meridian.cli import session_cmd
+from meridian.lib.core.util import FormatContext
 from meridian.lib.ops.session_log import SessionLogInput
 
 
@@ -64,3 +65,21 @@ def test_session_log_global_maps_to_payload(monkeypatch) -> None:
     )
 
     assert captured[0].global_scope is True
+
+
+def test_session_log_raw_sets_verbose_format_context(monkeypatch) -> None:
+    captured: list[SessionLogInput] = []
+    captured_ctx: list[FormatContext | None] = []
+
+    def _fake_session_log_sync(payload: SessionLogInput) -> SessionLogInput:
+        captured.append(payload)
+        return payload
+
+    def _emit(_payload: object, *, format_ctx: FormatContext | None = None) -> None:
+        captured_ctx.append(format_ctx)
+
+    monkeypatch.setattr(session_cmd, "session_log_sync", _fake_session_log_sync)
+    session_cmd._session_log(_emit, ref="c1", raw=True)
+
+    assert captured[0].ref == "c1"
+    assert captured_ctx[0] == FormatContext(verbosity=1)

--- a/tests/unit/ops/test_session_log_navigation.py
+++ b/tests/unit/ops/test_session_log_navigation.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from meridian.lib.core.util import FormatContext
 from meridian.lib.ops.session_log import SessionLogInput, session_log_sync
 
 
@@ -113,6 +114,10 @@ def test_session_log_default_shows_recent_five_entries_in_current_segment(tmp_pa
     assert output.segment_entries == 9
     assert [entry.index for entry in output.entries] == [4, 5, 6, 7, 8]
     assert output.hints == ("Use --full to show the entire selected segment.",)
+    assert output.previous_command is not None
+    assert "--segment 0" in output.previous_command
+    assert "--from 1" in output.previous_command
+    assert "--limit 5" in output.previous_command
 
 
 def test_session_log_full_shows_entire_selected_segment(tmp_path: Path) -> None:
@@ -174,7 +179,7 @@ def test_session_log_header_preserves_requested_ref_when_resolved_id_differs() -
         ),
     )
 
-    assert output.format_text().splitlines()[0] == (
+    assert output.format_text(FormatContext(verbosity=1)).splitlines()[0] == (
         "Session p2490 (codex transcript: harness-session-123) — "
         "showing 1-1 of 1 entry"
     )
@@ -500,14 +505,14 @@ def test_session_log_boundary_hints_include_next_segment_at_bottom(tmp_path: Pat
 
 def test_session_log_truncates_oversized_content_by_default(tmp_path: Path) -> None:
     session_file = tmp_path / "session-large.jsonl"
-    _write_large_session_file(session_file)
+    large_text = _write_large_session_file(session_file)
 
     output = session_log_sync(SessionLogInput(file_path=session_file.as_posix(), full=True))
 
-    assistant_content = output.entries[2].messages[0].content
-    assert "truncated: omitted 40 lines" in assistant_content
-    assert "rerun with --no-truncate" in assistant_content
-    assert output.entries[2].content == assistant_content
+    assert output.entries[2].messages[0].content == large_text
+    rendered = output.format_text()
+    assert "truncated:" in rendered
+    assert "rerun with --no-truncate" in rendered
 
 
 def test_session_log_no_truncate_preserves_full_content(tmp_path: Path) -> None:
@@ -520,3 +525,4 @@ def test_session_log_no_truncate_preserves_full_content(tmp_path: Path) -> None:
 
     assert output.entries[2].messages[0].content == large_text
     assert output.entries[2].content == large_text
+    assert "truncated:" not in output.format_text()

--- a/tests/unit/ops/test_session_log_render.py
+++ b/tests/unit/ops/test_session_log_render.py
@@ -1,0 +1,258 @@
+"""Unit tests for readable session-log rendering."""
+
+from __future__ import annotations
+
+from meridian.lib.core.util import FormatContext
+from meridian.lib.ops.session_log import SessionLogEntry, SessionLogEntryMessage, SessionLogOutput
+from meridian.lib.ops.session_log_render import clean_content
+
+
+def _entry(
+    *,
+    index: int,
+    role: str,
+    messages: tuple[SessionLogEntryMessage, ...],
+) -> SessionLogEntry:
+    content = "\n\n".join(message.content for message in messages)
+    return SessionLogEntry(
+        index=index,
+        segment=0,
+        segment_start_message=1,
+        segment_end_message=max((message.segment_message for message in messages), default=0),
+        role=role,
+        content=content,
+        messages=messages,
+    )
+
+
+def _output(*, entries: tuple[SessionLogEntry, ...], truncate: bool = True) -> SessionLogOutput:
+    return SessionLogOutput(
+        session_id="c100",
+        requested_ref="c100",
+        source="codex transcript",
+        total_entries=len(entries),
+        total_segments=1,
+        segment_index=0,
+        segment_entries=len(entries),
+        segment_label="segment 0 (current)",
+        showing="1-1" if len(entries) == 1 else "1-2",
+        entries=entries,
+        truncate=truncate,
+    )
+
+
+def test_clean_content_strips_known_wrappers_and_keeps_unknown_tags() -> None:
+    content = (
+        "<local-command-caveat>meta</local-command-caveat>"
+        "<bash-input>echo hi</bash-input>\n"
+        "<local-command-stdout>\x1b[32mgreen\x1b[0m</local-command-stdout>\n"
+        "<system_notification><status>running</status><summary>syncing</summary>"
+        "</system_notification>\n"
+        "<custom-tag>keep me</custom-tag>"
+    )
+
+    cleaned = clean_content(content)
+
+    assert "local-command-caveat" not in cleaned
+    assert "$ echo hi" in cleaned
+    assert "green" in cleaned
+    assert "\x1b[" not in cleaned
+    assert "[notification: running — syncing]" in cleaned
+    assert "<custom-tag>keep me</custom-tag>" in cleaned
+
+
+def test_clean_content_collapses_command_triplet_in_any_order() -> None:
+    ordered = clean_content(
+        "<command-name>status</command-name>"
+        "<command-message>status details</command-message>"
+        "<command-args>--json --verbose</command-args>"
+    )
+    swapped = clean_content(
+        "<command-message>status details</command-message>"
+        "<command-name>status</command-name>"
+        "<command-args>--json --verbose</command-args>"
+    )
+    already_prefixed = clean_content(
+        "<command-name>/status</command-name>"
+        "<command-message>status details</command-message>"
+        "<command-args>--json</command-args>"
+    )
+
+    assert ordered == "/status --json --verbose"
+    assert swapped == "/status --json --verbose"
+    assert already_prefixed == "/status --json"
+
+
+def test_clean_content_renders_adjacent_bash_stdout_and_stderr_with_separator() -> None:
+    cleaned = clean_content("<bash-stdout>line one</bash-stdout><bash-stderr>boom</bash-stderr>")
+
+    assert cleaned == "line one\nstderr: boom"
+
+
+def test_clean_content_suppresses_no_output_marker_when_stderr_is_present() -> None:
+    cleaned = clean_content("<bash-stdout></bash-stdout><bash-stderr>boom</bash-stderr>")
+
+    assert cleaned == "stderr: boom"
+    assert "(no output)" not in cleaned
+
+
+def test_clean_content_separates_adjacent_bash_input_and_stderr_output() -> None:
+    cleaned = clean_content(
+        "<bash-input>run check</bash-input>"
+        "<bash-stdout></bash-stdout>"
+        "<bash-stderr>boom</bash-stderr>"
+    )
+
+    assert cleaned == "$ run check\nstderr: boom"
+
+
+def test_session_log_clean_mode_collapses_tool_output_and_adds_hint() -> None:
+    entry = _entry(
+        index=1,
+        role="mixed",
+        messages=(
+            SessionLogEntryMessage(
+                segment_message=1,
+                role="assistant",
+                content="I'll run a command.",
+            ),
+            SessionLogEntryMessage(
+                segment_message=2,
+                role="assistant",
+                content="[tool: bash echo hi]",
+            ),
+            SessionLogEntryMessage(
+                segment_message=3,
+                role="user",
+                content="[tool_result] <bash-stdout>hi</bash-stdout>",
+            ),
+        ),
+    )
+
+    rendered = _output(entries=(entry,)).format_text()
+
+    assert rendered.startswith("# Session c100")
+    assert "**Mixed** [1]" in rendered
+    assert "  $ echo hi" in rendered
+    assert "[tool_result]" not in rendered
+    assert "Use --no-truncate to expand tool outputs" in rendered
+
+
+def test_session_log_clean_mode_no_truncate_expands_tool_output() -> None:
+    entry = _entry(
+        index=1,
+        role="mixed",
+        messages=(
+            SessionLogEntryMessage(
+                segment_message=1,
+                role="assistant",
+                content="[tool: bash echo hi]",
+            ),
+            SessionLogEntryMessage(
+                segment_message=2,
+                role="user",
+                content="[tool_result] <bash-stdout>hi</bash-stdout>",
+            ),
+        ),
+    )
+
+    rendered = _output(entries=(entry,), truncate=False).format_text()
+
+    assert "  $ echo hi" in rendered
+    assert "  hi" in rendered
+    assert "Use --no-truncate to expand tool outputs" not in rendered
+
+
+def test_session_log_raw_mode_preserves_verbose_entry_layout() -> None:
+    entry = _entry(
+        index=4,
+        role="mixed",
+        messages=(
+            SessionLogEntryMessage(
+                segment_message=10,
+                role="assistant",
+                content="[tool: bash echo hi]",
+            ),
+            SessionLogEntryMessage(
+                segment_message=11,
+                role="user",
+                content="[tool_result] <bash-stdout>hi</bash-stdout>",
+            ),
+        ),
+    )
+
+    rendered = _output(entries=(entry,)).format_text(FormatContext(verbosity=1))
+
+    assert rendered.splitlines()[0] == "Session c100 (codex transcript) — showing 1-1 of 1 entry"
+    assert "--- 4 [segment 0 · messages 1-11] [mixed] ---" in rendered
+    assert "[message 10 · assistant]" in rendered
+    assert "[tool_result] <bash-stdout>hi</bash-stdout>" in rendered
+
+
+def test_session_log_clean_mode_truncates_non_tool_text_in_multi_message_entry() -> None:
+    long_text = "A" * 9001
+    entry = _entry(
+        index=1,
+        role="assistant",
+        messages=(
+            SessionLogEntryMessage(
+                segment_message=1,
+                role="assistant",
+                content=long_text,
+            ),
+            SessionLogEntryMessage(
+                segment_message=2,
+                role="assistant",
+                content="[tool: bash echo hi]",
+            ),
+            SessionLogEntryMessage(
+                segment_message=3,
+                role="user",
+                content="[tool_result] <bash-stdout>hi</bash-stdout>",
+            ),
+        ),
+    )
+
+    rendered = _output(entries=(entry,)).format_text()
+
+    assert "truncated:" in rendered
+    assert "rerun with --no-truncate" in rendered
+    assert "  $ echo hi" in rendered
+
+
+def test_session_log_clean_mode_single_message_orphan_tool_call_is_readable() -> None:
+    entry = _entry(
+        index=1,
+        role="assistant",
+        messages=(
+            SessionLogEntryMessage(
+                segment_message=1,
+                role="assistant",
+                content="[tool: read /tmp/file.txt]",
+            ),
+        ),
+    )
+
+    rendered = _output(entries=(entry,)).format_text()
+
+    assert "  Read /tmp/file.txt" in rendered
+    assert "[tool:" not in rendered
+
+
+def test_session_log_clean_mode_single_message_orphan_tool_result_is_readable() -> None:
+    entry = _entry(
+        index=1,
+        role="assistant",
+        messages=(
+            SessionLogEntryMessage(
+                segment_message=1,
+                role="assistant",
+                content="[tool_result] <bash-stdout>hi</bash-stdout>",
+            ),
+        ),
+    )
+
+    rendered = _output(entries=(entry,)).format_text()
+
+    assert "  (tool output): hi" in rendered
+    assert "[tool_result]" not in rendered

--- a/tests/unit/ops/test_session_log_render.py
+++ b/tests/unit/ops/test_session_log_render.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from meridian.lib.core.util import FormatContext
+from meridian.lib.harness.transcript import ToolCall
 from meridian.lib.ops.session_log import SessionLogEntry, SessionLogEntryMessage, SessionLogOutput
 from meridian.lib.ops.session_log_render import clean_content
 
@@ -41,186 +42,117 @@ def _output(*, entries: tuple[SessionLogEntry, ...], truncate: bool = True) -> S
     )
 
 
-def test_clean_content_strips_known_wrappers_and_keeps_unknown_tags() -> None:
-    content = (
+def _bash_call(msg_idx: int, command: str) -> SessionLogEntryMessage:
+    return SessionLogEntryMessage(
+        segment_message=msg_idx,
+        role="assistant",
+        content=f"[tool: bash {command}]",
+        tool_call=ToolCall(name="bash", body=command),
+    )
+
+
+def _tool_result(msg_idx: int, content: str) -> SessionLogEntryMessage:
+    return SessionLogEntryMessage(
+        segment_message=msg_idx,
+        role="user",
+        content=f"[tool_result] {content}",
+        is_tool_result=True,
+    )
+
+
+def test_clean_content_strips_known_wrappers() -> None:
+    cleaned = clean_content(
         "<local-command-caveat>meta</local-command-caveat>"
         "<bash-input>echo hi</bash-input>\n"
-        "<local-command-stdout>\x1b[32mgreen\x1b[0m</local-command-stdout>\n"
         "<system_notification><status>running</status><summary>syncing</summary>"
-        "</system_notification>\n"
-        "<custom-tag>keep me</custom-tag>"
+        "</system_notification>"
     )
-
-    cleaned = clean_content(content)
-
     assert "local-command-caveat" not in cleaned
     assert "$ echo hi" in cleaned
-    assert "green" in cleaned
-    assert "\x1b[" not in cleaned
     assert "[notification: running — syncing]" in cleaned
-    assert "<custom-tag>keep me</custom-tag>" in cleaned
 
 
-def test_clean_content_collapses_command_triplet_in_any_order() -> None:
-    ordered = clean_content(
-        "<command-name>status</command-name>"
-        "<command-message>status details</command-message>"
-        "<command-args>--json --verbose</command-args>"
-    )
-    swapped = clean_content(
-        "<command-message>status details</command-message>"
-        "<command-name>status</command-name>"
-        "<command-args>--json --verbose</command-args>"
-    )
-    already_prefixed = clean_content(
-        "<command-name>/status</command-name>"
-        "<command-message>status details</command-message>"
-        "<command-args>--json</command-args>"
-    )
-
-    assert ordered == "/status --json --verbose"
-    assert swapped == "/status --json --verbose"
-    assert already_prefixed == "/status --json"
-
-
-def test_clean_content_renders_adjacent_bash_stdout_and_stderr_with_separator() -> None:
-    cleaned = clean_content("<bash-stdout>line one</bash-stdout><bash-stderr>boom</bash-stderr>")
-
-    assert cleaned == "line one\nstderr: boom"
-
-
-def test_clean_content_suppresses_no_output_marker_when_stderr_is_present() -> None:
-    cleaned = clean_content("<bash-stdout></bash-stdout><bash-stderr>boom</bash-stderr>")
-
-    assert cleaned == "stderr: boom"
-    assert "(no output)" not in cleaned
-
-
-def test_clean_content_separates_adjacent_bash_input_and_stderr_output() -> None:
-    cleaned = clean_content(
-        "<bash-input>run check</bash-input>"
-        "<bash-stdout></bash-stdout>"
-        "<bash-stderr>boom</bash-stderr>"
-    )
-
-    assert cleaned == "$ run check\nstderr: boom"
-
-
-def test_session_log_clean_mode_collapses_tool_output_and_adds_hint() -> None:
+def test_clean_mode_collapses_tool_calls() -> None:
     entry = _entry(
         index=1,
         role="mixed",
         messages=(
-            SessionLogEntryMessage(
-                segment_message=1,
-                role="assistant",
-                content="I'll run a command.",
-            ),
-            SessionLogEntryMessage(
-                segment_message=2,
-                role="assistant",
-                content="[tool: bash echo hi]",
-            ),
-            SessionLogEntryMessage(
-                segment_message=3,
-                role="user",
-                content="[tool_result] <bash-stdout>hi</bash-stdout>",
-            ),
+            _bash_call(1, "echo hi"),
+            _tool_result(2, "<bash-stdout>hi</bash-stdout>"),
         ),
     )
-
     rendered = _output(entries=(entry,)).format_text()
-
-    assert rendered.startswith("# Session c100")
-    assert "**Mixed** [1]" in rendered
     assert "  $ echo hi" in rendered
     assert "[tool_result]" not in rendered
     assert "Use --no-truncate to expand tool outputs" in rendered
 
 
-def test_session_log_clean_mode_no_truncate_expands_tool_output() -> None:
+def test_no_truncate_expands_tool_output() -> None:
     entry = _entry(
         index=1,
         role="mixed",
         messages=(
-            SessionLogEntryMessage(
-                segment_message=1,
-                role="assistant",
-                content="[tool: bash echo hi]",
-            ),
-            SessionLogEntryMessage(
-                segment_message=2,
-                role="user",
-                content="[tool_result] <bash-stdout>hi</bash-stdout>",
-            ),
+            _bash_call(1, "echo hi"),
+            _tool_result(2, "<bash-stdout>hi</bash-stdout>"),
         ),
     )
-
     rendered = _output(entries=(entry,), truncate=False).format_text()
-
     assert "  $ echo hi" in rendered
     assert "  hi" in rendered
-    assert "Use --no-truncate to expand tool outputs" not in rendered
 
 
-def test_session_log_raw_mode_preserves_verbose_entry_layout() -> None:
+def test_raw_mode_preserves_verbose_layout() -> None:
     entry = _entry(
         index=4,
         role="mixed",
         messages=(
-            SessionLogEntryMessage(
-                segment_message=10,
-                role="assistant",
-                content="[tool: bash echo hi]",
-            ),
-            SessionLogEntryMessage(
-                segment_message=11,
-                role="user",
-                content="[tool_result] <bash-stdout>hi</bash-stdout>",
-            ),
+            _bash_call(10, "echo hi"),
+            _tool_result(11, "<bash-stdout>hi</bash-stdout>"),
         ),
     )
-
     rendered = _output(entries=(entry,)).format_text(FormatContext(verbosity=1))
-
-    assert rendered.splitlines()[0] == "Session c100 (codex transcript) — showing 1-1 of 1 entry"
-    assert "--- 4 [segment 0 · messages 1-11] [mixed] ---" in rendered
-    assert "[message 10 · assistant]" in rendered
-    assert "[tool_result] <bash-stdout>hi</bash-stdout>" in rendered
+    assert "--- 4 [segment 0" in rendered
+    assert "[tool_result]" in rendered
 
 
-def test_session_log_clean_mode_truncates_non_tool_text_in_multi_message_entry() -> None:
-    long_text = "A" * 9001
+def test_codex_exec_command_collapses_to_dollar_sign() -> None:
     entry = _entry(
         index=1,
-        role="assistant",
+        role="mixed",
         messages=(
             SessionLogEntryMessage(
                 segment_message=1,
                 role="assistant",
-                content=long_text,
+                content='[tool: exec_command {"cmd":"ruff check ."}]',
+                tool_call=ToolCall(name="bash", body="ruff check ."),
             ),
-            SessionLogEntryMessage(
-                segment_message=2,
-                role="assistant",
-                content="[tool: bash echo hi]",
-            ),
-            SessionLogEntryMessage(
-                segment_message=3,
-                role="user",
-                content="[tool_result] <bash-stdout>hi</bash-stdout>",
-            ),
+            _tool_result(2, "Process exited with code 0\nAll checks passed!"),
         ),
     )
-
     rendered = _output(entries=(entry,)).format_text()
-
-    assert "truncated:" in rendered
-    assert "rerun with --no-truncate" in rendered
-    assert "  $ echo hi" in rendered
+    assert "  $ ruff check ." in rendered
+    assert "exec_command" not in rendered
 
 
-def test_session_log_clean_mode_single_message_orphan_tool_call_is_readable() -> None:
+def test_codex_exec_command_failed() -> None:
+    entry = _entry(
+        index=1,
+        role="mixed",
+        messages=(
+            SessionLogEntryMessage(
+                segment_message=1,
+                role="assistant",
+                content='[tool: exec_command {"cmd":"ruff check ."}]',
+                tool_call=ToolCall(name="bash", body="ruff check ."),
+            ),
+            _tool_result(2, "Process exited with code 1\nsrc/bad.py:10 error"),
+        ),
+    )
+    rendered = _output(entries=(entry,)).format_text()
+    assert "(failed: exit 1)" in rendered
+
+
+def test_orphan_tool_call() -> None:
     entry = _entry(
         index=1,
         role="assistant",
@@ -229,17 +161,15 @@ def test_session_log_clean_mode_single_message_orphan_tool_call_is_readable() ->
                 segment_message=1,
                 role="assistant",
                 content="[tool: read /tmp/file.txt]",
+                tool_call=ToolCall(name="read", body="/tmp/file.txt"),
             ),
         ),
     )
-
     rendered = _output(entries=(entry,)).format_text()
-
     assert "  Read /tmp/file.txt" in rendered
-    assert "[tool:" not in rendered
 
 
-def test_session_log_clean_mode_single_message_orphan_tool_result_is_readable() -> None:
+def test_orphan_tool_result() -> None:
     entry = _entry(
         index=1,
         role="assistant",
@@ -248,11 +178,9 @@ def test_session_log_clean_mode_single_message_orphan_tool_result_is_readable() 
                 segment_message=1,
                 role="assistant",
                 content="[tool_result] <bash-stdout>hi</bash-stdout>",
+                is_tool_result=True,
             ),
         ),
     )
-
     rendered = _output(entries=(entry,)).format_text()
-
-    assert "  (tool output): hi" in rendered
-    assert "[tool_result]" not in rendered
+    assert "(tool output)" in rendered

--- a/uv.lock
+++ b/uv.lock
@@ -666,15 +666,15 @@ wheels = [
 
 [[package]]
 name = "mars-agents"
-version = "0.7.3"
+version = "0.7.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/99/f4/249946e11d932662a66636e4687362175bb31eae5ac8071e964e1db7e846/mars_agents-0.7.3.tar.gz", hash = "sha256:b0d2940f219366213fd564c30635f6e951c330e3703035a551bf9e57245d1668", size = 585905, upload-time = "2026-05-26T03:22:18.584Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/d7/26102d55f92c1016f6dda3f13f96b7d639520238fb3f00bcc00fc8727213/mars_agents-0.7.4.tar.gz", hash = "sha256:cea97eb3d24cfbb27152df30a6b0d26cd349be6366cfbe7df9b18fb62ec4ca7e", size = 581439, upload-time = "2026-05-27T04:43:29.263Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/d2/5e0b254494a49f73962690760aa186d1c3ab7fa0b8c3cec54240f9041cfd/mars_agents-0.7.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:a82fabe19d68dd5d974632496195fe18e14a4dfd290b6eba32fdf74744a52d84", size = 3265530, upload-time = "2026-05-26T03:22:09.02Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/1e/b5d7f3ba46e99c7b23ae605d302555521c5a54d375f69141cff78567585b/mars_agents-0.7.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:df53d6a95322bfe8971a994c1b358950b3696df0f55683b6153e6800f164cde8", size = 3132435, upload-time = "2026-05-26T03:22:11.098Z" },
-    { url = "https://files.pythonhosted.org/packages/64/1e/489d320c4041d22d177b088b1b08c35975ab93050534e3a7635753a80673/mars_agents-0.7.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:56a4c062494ba62f749734281f92acfb6ba5e7e8529d04b31cb8a26f5e74fb31", size = 3180572, upload-time = "2026-05-26T03:22:12.959Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/eb/996cf442fece1271f3de9ac004f08a73061c4b95f6cbc65a40ac40e79efb/mars_agents-0.7.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e9a2a3cc35dd22eadf476fff5da89b81d8445f5e34934e0d2725c0e66905cd3f", size = 3389262, upload-time = "2026-05-26T03:22:14.93Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/86/c4e4e6e5f8f4df5c181e1895afbd01a6c740a7af824c9ef4f6520560b124/mars_agents-0.7.3-py3-none-win_amd64.whl", hash = "sha256:53d29d07c8182a94709d10f32d008037f8635b58484b76e51c6894e3671a57ed", size = 3305196, upload-time = "2026-05-26T03:22:16.802Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/08/5947f1179345219f861d16c4d1e25c2848fa2fd6ddc022cb3d55414d00a8/mars_agents-0.7.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:1c5dae37db2789c33b1a1dae1ce1966f867b94e51ee4aff600a6dc9eb37d6502", size = 3271489, upload-time = "2026-05-27T04:43:20.637Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/2db79d203f327316da4556dbc1ced2dfaa5d09e47ee380065eb1eda717ae/mars_agents-0.7.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d9a2b1cac5808b071d301da77d9177541b09ddf9e576bf96c8fea6d7d164006e", size = 3127574, upload-time = "2026-05-27T04:43:22.484Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/f1/29ddfcff8f68101b57f0108a041ac81d39383415870ba589382d2adce005/mars_agents-0.7.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2e24f9f55afea6a41f7c42f83efb96b412b3ce0e503f5758c83bee9393957805", size = 3181880, upload-time = "2026-05-27T04:43:24.18Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/90/d3c7cd82b04a373446aa6dbef131be51e8182255ba582444c656eec34011/mars_agents-0.7.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:511b51cb034be9ce61128bf342fc7985137a3ea4f143a007fb163bae48a96214", size = 3385147, upload-time = "2026-05-27T04:43:26.065Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/6c/642d6cb48ab011c8ea6d6b7202274630dffa779e308a41c68bcf6eb972dd/mars_agents-0.7.4-py3-none-win_amd64.whl", hash = "sha256:0e72fe5cf09e60a4699c4bedb0bbe117c9b53240b506459376c79ba13defbd6b", size = 3309130, upload-time = "2026-05-27T04:43:27.789Z" },
 ]
 
 [[package]]
@@ -764,7 +764,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'app'", specifier = ">=0.28" },
     { name = "jinja2", marker = "extra == 'templates'", specifier = ">=3.1" },
     { name = "markdown-it-py", specifier = ">=4.0" },
-    { name = "mars-agents", specifier = "==0.7.3" },
+    { name = "mars-agents", specifier = "==0.7.4" },
     { name = "mcp", specifier = ">=1.0" },
     { name = "pathspec", specifier = ">=1.1.0" },
     { name = "psutil", specifier = ">=7.2.2" },


### PR DESCRIPTION
## Why

`meridian session log` default text output was too noisy: raw XML wrappers, tool-result payloads, and debug entry metadata buried the conversation. Codex tool calls (`exec_command`, `write_stdin`) rendered as raw JSON instead of collapsed one-liners. Tail mode computed but did not display a `Previous:` navigation command.

## Summary

- Added a session-log renderer that cleans known XML wrappers, collapses tool calls/results to one-liners, preserves raw debug formatting behind `--raw`, and truncates after cleaning.
- Added structured `ToolCall` type to the transcript adapter — tool name normalization (`exec_command` → `bash`, `write_stdin` → `stdin`) lives in one place. Renderer uses structured fields instead of regex-parsing text markers.
- Added `meridian session log --raw` and threaded `FormatContext` through text output.
- Fixed tail-mode `Previous:` navigation command generation.
- Bumped mars-agents to v0.7.4.

## Resulting Behavior

Default output is clean, scannable markdown:

```text
# Session c123

34 entries, segment 1 (current) · showing 30-34

---

**Assistant** [33]

  $ uv run pytest tests/ -k session_log
  (failed: exit 1)
  Read src/meridian/lib/ops/session_log.py
  $ uv run pytest tests/ -k session_log

Use --no-truncate to expand tool outputs
```

Works across harnesses — Claude `Bash` and Codex `exec_command` both render as `$ command`. `write_stdin` renders as `(stdin)`.

## Test plan

- [x] `uv run pytest tests/ -k session_log` — 66 passed
- [x] `uv run ruff check .` — passed
- [x] `uv run --extra dev python -m pyright` — 0 errors
- [x] Pre-push: 1150 passed, 11 skipped
- [x] Manual smoke: Codex (p2970), Cursor/Gemini (p2969), Codex impl (p2940) — clean/raw/expanded all verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)