### PR TITLE
Fix runtime root derivation for -C

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [0.2.11] - 2026-05-28
 
 ### Changed
+- Stop auto-propagating `MERIDIAN_RUNTIME_DIR` to child processes; `MERIDIAN_PROJECT_DIR` is the single inherited project anchor. Runtime root derives from `.meridian/id` → user home (read paths fall back to repo-local `.meridian/`).
+- `-C` / `--directory` ignores explicit `MERIDIAN_RUNTIME_DIR` override; nested Meridian processes ignore it too. Power-user override remains for top-level invocations.
+- Pi extension state paths prefer `MERIDIAN_PI_STATE_DIR` (always set at Pi launch from resolved runtime root); TypeScript `pi_state_paths.ts` no longer reads `MERIDIAN_RUNTIME_DIR`.
 - Pi `/ps` and `/spawn` selectable task panels now use a full-screen covering overlay, avoiding redraw bleed-through from underlying Pi spinners/status while preserving whole-viewport UX.
 - Pi managed bash now keeps separate stdout/stderr log files behind the combined log, so `/ps` stream filters and tool details use the same source-of-truth logs.
 - Pi `/ps` bash row inspection now supports `s` to switch combined/stdout/stderr log streams.
@@ -36,6 +39,10 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added `--task-dir` on `meridian work start` and `meridian spawn` create/fork flows.
 
 ### Fixed
+- Global `-C` / `--directory` now drives `session log`, `config show`, and other auto-wired ops (not only bootstrap); explicit directory sets `MERIDIAN_DIRECTORY_EXPLICIT` so stale `MERIDIAN_RUNTIME_DIR` cannot override the target project.
+- External hook subprocess env no longer inherits stale parent `MERIDIAN_RUNTIME_DIR`; hook JSON context remains authoritative.
+- `streaming-serve` reuses prepared runtime authority instead of re-resolving via `build_runtime()`.
+- Pi launch no longer maps `MERIDIAN_PI_STATE_DIR` to per-spawn session dirs; session scoping stays on `PI_CODING_AGENT_SESSION_DIR` only.
 - `meridian session log <pi-spawn>` now renders Pi RPC `message_end` transcript events, including prompt text, assistant text, tool calls/results, and custom follow-up pings.
 - Pi full-screen task panels no longer request a render from `invalidate()`, avoiding self-sustaining `/ps` flicker.
 - Pi `$` foreground bash no longer writes to Pi's closed foreground output stream after `/ps:b` backgrounds a still-chatty command.

--- a/src/meridian/cli/bootstrap.py
+++ b/src/meridian/cli/bootstrap.py
@@ -74,6 +74,7 @@ class ParsedGlobalOptions:
     force_agent: bool
     force_human: bool
     directory: str | None
+    directory_explicit: bool = False
 
 
 def _first_positional_token_with_index(argv: Sequence[str]) -> tuple[int, str] | None:
@@ -328,6 +329,7 @@ def extract_global_options(
         config_file=config_file,
         harness=harness,
         directory=directory,
+        directory_explicit=directory is not None,
         yes=yes,
         no_input=no_input,
         output_explicit=output_explicit,
@@ -399,15 +401,18 @@ def maybe_bootstrap_runtime_state(
             return None
 
         project_root = require_established_project_root()
+        from meridian.cli.main import get_global_options
+
+        ignore_runtime_env = get_global_options().directory_explicit
 
         if requirement == StateRequirement.PROJECT_READ:
             prepare_for_project_read(project_root)
         elif requirement == StateRequirement.RUNTIME_READ:
-            prepare_for_runtime_read(project_root)
+            prepare_for_runtime_read(project_root, ignore_runtime_env=ignore_runtime_env)
         elif requirement == StateRequirement.PROJECT_WRITE:
             prepare_for_project_write(project_root)
         elif requirement == StateRequirement.RUNTIME_WRITE:
-            prepare_for_runtime_write(project_root)
+            prepare_for_runtime_write(project_root, ignore_runtime_env=ignore_runtime_env)
 
         return project_root
     except Exception:

--- a/src/meridian/cli/bootstrap.py
+++ b/src/meridian/cli/bootstrap.py
@@ -401,18 +401,15 @@ def maybe_bootstrap_runtime_state(
             return None
 
         project_root = require_established_project_root()
-        from meridian.cli.main import get_global_options
-
-        ignore_runtime_env = get_global_options().directory_explicit
 
         if requirement == StateRequirement.PROJECT_READ:
             prepare_for_project_read(project_root)
         elif requirement == StateRequirement.RUNTIME_READ:
-            prepare_for_runtime_read(project_root, ignore_runtime_env=ignore_runtime_env)
+            prepare_for_runtime_read(project_root)
         elif requirement == StateRequirement.PROJECT_WRITE:
             prepare_for_project_write(project_root)
         elif requirement == StateRequirement.RUNTIME_WRITE:
-            prepare_for_runtime_write(project_root, ignore_runtime_env=ignore_runtime_env)
+            prepare_for_runtime_write(project_root)
 
         return project_root
     except Exception:

--- a/src/meridian/cli/chat_cmd.py
+++ b/src/meridian/cli/chat_cmd.py
@@ -18,7 +18,6 @@ from uuid import uuid4
 from cyclopts import App, Parameter
 
 from meridian.cli.utils import (
-    ignore_runtime_env_override,
     parse_csv_list,
     require_established_project_root,
 )
@@ -365,10 +364,7 @@ def run_chat_server(
     )
     _emit_chat_policy_warnings(policy_snapshot.warnings, output)
     if entrypoint is None:
-        prepared = prepare_for_runtime_write(
-            project_root,
-            ignore_runtime_env=ignore_runtime_env_override(),
-        )
+        prepared = prepare_for_runtime_write(project_root)
         entrypoint = build_chat_entrypoint(prepared)
     project_root = _chat_project_root(entrypoint)
     runtime = build_chat_runtime_from_entrypoint(
@@ -509,10 +505,7 @@ def run_chat_server(
 def _prepare_chat_runtime_read_entrypoint() -> ChatEntryPoint:
     """Prepare the minimal chat entrypoint seam for read-only chat clients."""
 
-    prepared = prepare_for_runtime_read(
-        require_established_project_root(),
-        ignore_runtime_env=ignore_runtime_env_override(),
-    )
+    prepared = prepare_for_runtime_read(require_established_project_root())
     return build_chat_entrypoint(prepared)
 
 

--- a/src/meridian/cli/chat_cmd.py
+++ b/src/meridian/cli/chat_cmd.py
@@ -17,7 +17,11 @@ from uuid import uuid4
 
 from cyclopts import App, Parameter
 
-from meridian.cli.utils import parse_csv_list, require_established_project_root
+from meridian.cli.utils import (
+    ignore_runtime_env_override,
+    parse_csv_list,
+    require_established_project_root,
+)
 from meridian.lib.bootstrap.services import (
     build_chat_entrypoint,
     prepare_for_runtime_read,
@@ -361,7 +365,10 @@ def run_chat_server(
     )
     _emit_chat_policy_warnings(policy_snapshot.warnings, output)
     if entrypoint is None:
-        prepared = prepare_for_runtime_write(project_root)
+        prepared = prepare_for_runtime_write(
+            project_root,
+            ignore_runtime_env=ignore_runtime_env_override(),
+        )
         entrypoint = build_chat_entrypoint(prepared)
     project_root = _chat_project_root(entrypoint)
     runtime = build_chat_runtime_from_entrypoint(
@@ -502,7 +509,10 @@ def run_chat_server(
 def _prepare_chat_runtime_read_entrypoint() -> ChatEntryPoint:
     """Prepare the minimal chat entrypoint seam for read-only chat clients."""
 
-    prepared = prepare_for_runtime_read(require_established_project_root())
+    prepared = prepare_for_runtime_read(
+        require_established_project_root(),
+        ignore_runtime_env=ignore_runtime_env_override(),
+    )
     return build_chat_entrypoint(prepared)
 
 

--- a/src/meridian/cli/config_cmd.py
+++ b/src/meridian/cli/config_cmd.py
@@ -7,7 +7,7 @@ from typing import Any
 from cyclopts import App
 
 from meridian.cli.ext_registration import register_extension_cli_group
-from meridian.cli.utils import implicit_ops_payload
+from meridian.cli.utils import cli_project_root_posix
 from meridian.lib.extensions.registry import get_first_party_registry
 from meridian.lib.ops.config import (
     ConfigGetInput,
@@ -22,15 +22,16 @@ Emitter = Callable[[Any], None]
 
 
 def _config_set(emit: Emitter, key: str, value: str) -> None:
-    emit(config_set_sync(ConfigSetInput(key=key, value=value, **implicit_ops_payload())))
+    root = cli_project_root_posix()
+    emit(config_set_sync(ConfigSetInput(key=key, value=value, project_root=root)))
 
 
 def _config_get(emit: Emitter, key: str) -> None:
-    emit(config_get_sync(ConfigGetInput(key=key, **implicit_ops_payload())))
+    emit(config_get_sync(ConfigGetInput(key=key, project_root=cli_project_root_posix())))
 
 
 def _config_reset(emit: Emitter, key: str) -> None:
-    emit(config_reset_sync(ConfigResetInput(key=key, **implicit_ops_payload())))
+    emit(config_reset_sync(ConfigResetInput(key=key, project_root=cli_project_root_posix())))
 
 
 def register_config_commands(app: App, emit: Emitter) -> tuple[set[str], dict[str, str]]:

--- a/src/meridian/cli/config_cmd.py
+++ b/src/meridian/cli/config_cmd.py
@@ -7,6 +7,7 @@ from typing import Any
 from cyclopts import App
 
 from meridian.cli.ext_registration import register_extension_cli_group
+from meridian.cli.utils import implicit_ops_payload
 from meridian.lib.extensions.registry import get_first_party_registry
 from meridian.lib.ops.config import (
     ConfigGetInput,
@@ -21,15 +22,15 @@ Emitter = Callable[[Any], None]
 
 
 def _config_set(emit: Emitter, key: str, value: str) -> None:
-    emit(config_set_sync(ConfigSetInput(key=key, value=value)))
+    emit(config_set_sync(ConfigSetInput(key=key, value=value, **implicit_ops_payload())))
 
 
 def _config_get(emit: Emitter, key: str) -> None:
-    emit(config_get_sync(ConfigGetInput(key=key)))
+    emit(config_get_sync(ConfigGetInput(key=key, **implicit_ops_payload())))
 
 
 def _config_reset(emit: Emitter, key: str) -> None:
-    emit(config_reset_sync(ConfigResetInput(key=key)))
+    emit(config_reset_sync(ConfigResetInput(key=key, **implicit_ops_payload())))
 
 
 def register_config_commands(app: App, emit: Emitter) -> tuple[set[str], dict[str, str]]:

--- a/src/meridian/cli/ext_cmd.py
+++ b/src/meridian/cli/ext_cmd.py
@@ -12,10 +12,7 @@ from cyclopts import App, Parameter
 
 from meridian.cli.app_tree import ext_app
 from meridian.cli.output import OutputFormat
-from meridian.cli.utils import (
-    ignore_runtime_env_override,
-    require_established_project_root,
-)
+from meridian.cli.utils import require_established_project_root
 from meridian.lib.bootstrap.services import build_extension_entrypoint, prepare_for_runtime_read
 from meridian.lib.extensions.context import (
     ExtensionCommandServices,
@@ -46,10 +43,7 @@ def _prepare_extension_runtime_read() -> tuple[
     ExtensionCommandServices,
     ExtensionInvocationContextBuilder,
 ]:
-    prepared = prepare_for_runtime_read(
-        require_established_project_root(),
-        ignore_runtime_env=ignore_runtime_env_override(),
-    )
+    prepared = prepare_for_runtime_read(require_established_project_root())
     application = build_extension_entrypoint(prepared)
     services = build_extension_command_services(application=application)
     context_builder = ExtensionInvocationContextBuilder(ExtensionSurface.CLI).with_authority(

--- a/src/meridian/cli/ext_cmd.py
+++ b/src/meridian/cli/ext_cmd.py
@@ -12,7 +12,10 @@ from cyclopts import App, Parameter
 
 from meridian.cli.app_tree import ext_app
 from meridian.cli.output import OutputFormat
-from meridian.cli.utils import require_established_project_root
+from meridian.cli.utils import (
+    ignore_runtime_env_override,
+    require_established_project_root,
+)
 from meridian.lib.bootstrap.services import build_extension_entrypoint, prepare_for_runtime_read
 from meridian.lib.extensions.context import (
     ExtensionCommandServices,
@@ -43,7 +46,10 @@ def _prepare_extension_runtime_read() -> tuple[
     ExtensionCommandServices,
     ExtensionInvocationContextBuilder,
 ]:
-    prepared = prepare_for_runtime_read(require_established_project_root())
+    prepared = prepare_for_runtime_read(
+        require_established_project_root(),
+        ignore_runtime_env=ignore_runtime_env_override(),
+    )
     application = build_extension_entrypoint(prepared)
     services = build_extension_command_services(application=application)
     context_builder = ExtensionInvocationContextBuilder(ExtensionSurface.CLI).with_authority(

--- a/src/meridian/cli/ext_registration.py
+++ b/src/meridian/cli/ext_registration.py
@@ -43,9 +43,9 @@ def _make_auto_handler_from_spec(
             return None
 
     def auto_handler() -> None:
-        from meridian.cli.utils import implicit_ops_payload
+        from meridian.cli.utils import cli_project_root_posix
 
-        emit(sync_handler(implicit_ops_payload()))
+        emit(sync_handler({"project_root": cli_project_root_posix()}))
 
     return auto_handler
 

--- a/src/meridian/cli/ext_registration.py
+++ b/src/meridian/cli/ext_registration.py
@@ -43,7 +43,9 @@ def _make_auto_handler_from_spec(
             return None
 
     def auto_handler() -> None:
-        emit(sync_handler({}))
+        from meridian.cli.utils import implicit_ops_payload
+
+        emit(sync_handler(implicit_ops_payload()))
 
     return auto_handler
 

--- a/src/meridian/cli/hooks_authority.py
+++ b/src/meridian/cli/hooks_authority.py
@@ -8,10 +8,7 @@ from contextlib import contextmanager
 
 from meridian.lib.core.depth import is_nested_meridian_process
 
-_MANUAL_HOOK_ENV_OVERRIDES: tuple[str, ...] = (
-    "MERIDIAN_PROJECT_DIR",
-    "MERIDIAN_RUNTIME_DIR",
-)
+_MANUAL_HOOK_ENV_OVERRIDES: tuple[str, ...] = ("MERIDIAN_PROJECT_DIR",)
 
 
 def is_manual_hooks_invocation(argv: Sequence[str]) -> bool:
@@ -29,10 +26,10 @@ def should_suppress_manual_hook_authority(
     *,
     env: Mapping[str, str] | None = None,
 ) -> bool:
-    """Return whether inherited project/runtime env should be ignored.
+    """Return whether inherited project env should be ignored.
 
     We only suppress env overrides for nested manual hooks invocations so
-    top-level callers can still target explicit project/runtime roots via env.
+    top-level callers can still target explicit project roots via env.
     """
 
     source = os.environ if env is None else env

--- a/src/meridian/cli/main.py
+++ b/src/meridian/cli/main.py
@@ -94,6 +94,7 @@ class GlobalOptions(BaseModel):
     sink: OutputSink | None = None
     explicit_format: OutputFormat | None = None
     project_root: Path | None = None
+    directory_explicit: bool = False
 
 
 _GLOBAL_OPTIONS: ContextVar[GlobalOptions | None] = ContextVar("_GLOBAL_OPTIONS", default=None)
@@ -169,6 +170,7 @@ def _extract_global_options(argv: Sequence[str]) -> tuple[list[str], GlobalOptio
         force_human=parsed.force_human,
         explicit_format=explicit_format,
         project_root=project_root,
+        directory_explicit=parsed.directory_explicit,
     )
 
 
@@ -921,6 +923,7 @@ def _maybe_schedule_background_repairs(
     startup_class: StartupClass,
     project_root: Path | None,
     bootstrap_skipped: bool,
+    ignore_runtime_env: bool = False,
 ) -> None:
     """Schedule cheap per-project repairs on PRIMARY_LAUNCH in a daemon thread."""
 
@@ -931,6 +934,15 @@ def _maybe_schedule_background_repairs(
     if project_root is None:
         return
     if not is_root_side_effect_process():
+        return
+
+    from meridian.lib.ops.runtime import resolve_runtime_authority_for_write
+
+    runtime_root = resolve_runtime_authority_for_write(
+        project_root,
+        ignore_runtime_env=ignore_runtime_env,
+    ).runtime_root
+    if runtime_root is None:
         return
 
     import threading
@@ -944,8 +956,8 @@ def _maybe_schedule_background_repairs(
                 _repair_stale_session_locks,  # pyright: ignore[reportPrivateUsage]
             )
 
-            _repair_stale_session_locks(project_root)
-            _repair_orphan_runs(project_root)
+            _repair_stale_session_locks(project_root, runtime_root=runtime_root)
+            _repair_orphan_runs(project_root, runtime_root=runtime_root)
 
     thread = threading.Thread(
         target=_run_repairs,
@@ -1054,32 +1066,66 @@ def main(argv: Sequence[str] | None = None) -> None:
     project_root = (
         bootstrap_project_root if bootstrap_project_root is not None else options.project_root
     )
-    _install_cli_telemetry(
-        telemetry_mode=descriptor.telemetry_mode if descriptor is not None else None,
-        startup_class=startup_class,
-        project_root=project_root,
-    )
-    _maybe_schedule_background_repairs(
-        startup_class=startup_class,
-        project_root=project_root,
-        bootstrap_skipped=bootstrap_skipped,
-    )
-    _emit_usage_command_invoked(cleaned_args)
+    prior_project_dir = os.environ.get("MERIDIAN_PROJECT_DIR")
+    had_prior_project_dir = "MERIDIAN_PROJECT_DIR" in os.environ
+    prior_directory_explicit = os.environ.get("MERIDIAN_DIRECTORY_EXPLICIT")
+    had_prior_directory_explicit = "MERIDIAN_DIRECTORY_EXPLICIT" in os.environ
 
-    active_sink = create_sink(options.output)
-    options = options.model_copy(update={"project_root": project_root, "sink": active_sink})
-    token = _GLOBAL_OPTIONS.set(options)
+    def _apply_cli_directory_env() -> None:
+        if project_root is not None:
+            os.environ["MERIDIAN_PROJECT_DIR"] = project_root.as_posix()
+        if options.directory_explicit:
+            os.environ["MERIDIAN_DIRECTORY_EXPLICIT"] = "1"
+        else:
+            os.environ.pop("MERIDIAN_DIRECTORY_EXPLICIT", None)
+
+    def _restore_cli_directory_env() -> None:
+        if had_prior_project_dir:
+            if prior_project_dir is None:
+                os.environ.pop("MERIDIAN_PROJECT_DIR", None)
+            else:
+                os.environ["MERIDIAN_PROJECT_DIR"] = prior_project_dir
+        else:
+            os.environ.pop("MERIDIAN_PROJECT_DIR", None)
+        if had_prior_directory_explicit:
+            if prior_directory_explicit is None:
+                os.environ.pop("MERIDIAN_DIRECTORY_EXPLICIT", None)
+            else:
+                os.environ["MERIDIAN_DIRECTORY_EXPLICIT"] = prior_directory_explicit
+        else:
+            os.environ.pop("MERIDIAN_DIRECTORY_EXPLICIT", None)
+
+    _apply_cli_directory_env()
     try:
-        _register_commands_for_invocation(cleaned_args, agent_mode=effective_agent_mode)
-        with temporary_config_env(options.config_file):
-            try:
-                app(cleaned_args)
-            except SystemExit:
-                raise
-            except TimeoutError as exc:
-                _emit_error(_operation_error_message(exc), exit_code=124)
-            except (KeyError, ValueError, FileNotFoundError, OSError, RuntimeError) as exc:
-                _emit_error(_operation_error_message(exc))
+        _install_cli_telemetry(
+            telemetry_mode=descriptor.telemetry_mode if descriptor is not None else None,
+            startup_class=startup_class,
+            project_root=project_root,
+        )
+        _maybe_schedule_background_repairs(
+            startup_class=startup_class,
+            project_root=project_root,
+            bootstrap_skipped=bootstrap_skipped,
+            ignore_runtime_env=options.directory_explicit,
+        )
+        _emit_usage_command_invoked(cleaned_args)
+
+        active_sink = create_sink(options.output)
+        options = options.model_copy(update={"project_root": project_root, "sink": active_sink})
+        token = _GLOBAL_OPTIONS.set(options)
+        try:
+            _register_commands_for_invocation(cleaned_args, agent_mode=effective_agent_mode)
+            with temporary_config_env(options.config_file):
+                try:
+                    app(cleaned_args)
+                except SystemExit:
+                    raise
+                except TimeoutError as exc:
+                    _emit_error(_operation_error_message(exc), exit_code=124)
+                except (KeyError, ValueError, FileNotFoundError, OSError, RuntimeError) as exc:
+                    _emit_error(_operation_error_message(exc))
+        finally:
+            flush_sink(active_sink)
+            _GLOBAL_OPTIONS.reset(token)
     finally:
-        flush_sink(active_sink)
-        _GLOBAL_OPTIONS.reset(token)
+        _restore_cli_directory_env()

--- a/src/meridian/cli/main.py
+++ b/src/meridian/cli/main.py
@@ -3,7 +3,8 @@
 import os
 import subprocess
 import sys
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Generator, Sequence
+from contextlib import contextmanager
 from contextvars import ContextVar
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, cast
@@ -923,7 +924,6 @@ def _maybe_schedule_background_repairs(
     startup_class: StartupClass,
     project_root: Path | None,
     bootstrap_skipped: bool,
-    ignore_runtime_env: bool = False,
 ) -> None:
     """Schedule cheap per-project repairs on PRIMARY_LAUNCH in a daemon thread."""
 
@@ -938,10 +938,7 @@ def _maybe_schedule_background_repairs(
 
     from meridian.lib.ops.runtime import resolve_runtime_authority_for_write
 
-    runtime_root = resolve_runtime_authority_for_write(
-        project_root,
-        ignore_runtime_env=ignore_runtime_env,
-    ).runtime_root
+    runtime_root = resolve_runtime_authority_for_write(project_root).runtime_root
     if runtime_root is None:
         return
 
@@ -969,6 +966,32 @@ def _maybe_schedule_background_repairs(
 
 def _print_agent_root_help() -> None:
     print(_AGENT_ROOT_HELP, end="")
+
+
+@contextmanager
+def _directory_env_scope(
+    project_root: Path | None,
+    directory_explicit: bool,
+) -> Generator[None, None, None]:
+    """Set ``MERIDIAN_PROJECT_DIR`` / ``MERIDIAN_DIRECTORY_EXPLICIT`` and restore on exit."""
+
+    keys = ("MERIDIAN_PROJECT_DIR", "MERIDIAN_DIRECTORY_EXPLICIT")
+    saved = {key: os.environ.get(key) for key in keys}
+    if project_root is not None:
+        os.environ["MERIDIAN_PROJECT_DIR"] = project_root.as_posix()
+    if directory_explicit:
+        os.environ["MERIDIAN_DIRECTORY_EXPLICIT"] = "1"
+    else:
+        os.environ.pop("MERIDIAN_DIRECTORY_EXPLICIT", None)
+    try:
+        yield
+    finally:
+        for key in keys:
+            prior = saved[key]
+            if prior is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = prior
 
 
 def main(argv: Sequence[str] | None = None) -> None:
@@ -1066,37 +1089,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     project_root = (
         bootstrap_project_root if bootstrap_project_root is not None else options.project_root
     )
-    prior_project_dir = os.environ.get("MERIDIAN_PROJECT_DIR")
-    had_prior_project_dir = "MERIDIAN_PROJECT_DIR" in os.environ
-    prior_directory_explicit = os.environ.get("MERIDIAN_DIRECTORY_EXPLICIT")
-    had_prior_directory_explicit = "MERIDIAN_DIRECTORY_EXPLICIT" in os.environ
-
-    def _apply_cli_directory_env() -> None:
-        if project_root is not None:
-            os.environ["MERIDIAN_PROJECT_DIR"] = project_root.as_posix()
-        if options.directory_explicit:
-            os.environ["MERIDIAN_DIRECTORY_EXPLICIT"] = "1"
-        else:
-            os.environ.pop("MERIDIAN_DIRECTORY_EXPLICIT", None)
-
-    def _restore_cli_directory_env() -> None:
-        if had_prior_project_dir:
-            if prior_project_dir is None:
-                os.environ.pop("MERIDIAN_PROJECT_DIR", None)
-            else:
-                os.environ["MERIDIAN_PROJECT_DIR"] = prior_project_dir
-        else:
-            os.environ.pop("MERIDIAN_PROJECT_DIR", None)
-        if had_prior_directory_explicit:
-            if prior_directory_explicit is None:
-                os.environ.pop("MERIDIAN_DIRECTORY_EXPLICIT", None)
-            else:
-                os.environ["MERIDIAN_DIRECTORY_EXPLICIT"] = prior_directory_explicit
-        else:
-            os.environ.pop("MERIDIAN_DIRECTORY_EXPLICIT", None)
-
-    _apply_cli_directory_env()
-    try:
+    with _directory_env_scope(project_root, options.directory_explicit):
         _install_cli_telemetry(
             telemetry_mode=descriptor.telemetry_mode if descriptor is not None else None,
             startup_class=startup_class,
@@ -1106,7 +1099,6 @@ def main(argv: Sequence[str] | None = None) -> None:
             startup_class=startup_class,
             project_root=project_root,
             bootstrap_skipped=bootstrap_skipped,
-            ignore_runtime_env=options.directory_explicit,
         )
         _emit_usage_command_invoked(cleaned_args)
 
@@ -1127,5 +1119,3 @@ def main(argv: Sequence[str] | None = None) -> None:
         finally:
             flush_sink(active_sink)
             _GLOBAL_OPTIONS.reset(token)
-    finally:
-        _restore_cli_directory_env()

--- a/src/meridian/cli/main.py
+++ b/src/meridian/cli/main.py
@@ -67,7 +67,7 @@ from meridian.cli.startup.catalog import COMMAND_CATALOG
 from meridian.cli.startup.classify import classify_invocation
 from meridian.cli.startup.policy import StartupClass, StateRequirement
 from meridian.cli.startup.policy import TelemetryMode as StartupTelemetryMode
-from meridian.lib.core.depth import is_nested_meridian_process, is_root_side_effect_process
+from meridian.lib.core.depth import is_nested_meridian_process
 from meridian.lib.core.sink import OutputSink
 from meridian.lib.core.util import FormatContext
 from meridian.lib.telemetry import emit_telemetry
@@ -927,41 +927,12 @@ def _maybe_schedule_background_repairs(
 ) -> None:
     """Schedule cheap per-project repairs on PRIMARY_LAUNCH in a daemon thread."""
 
-    if bootstrap_skipped:
-        return
-    if startup_class != StartupClass.PRIMARY_LAUNCH:
-        return
-    if project_root is None:
-        return
-    if not is_root_side_effect_process():
+    if bootstrap_skipped or startup_class != StartupClass.PRIMARY_LAUNCH or project_root is None:
         return
 
-    from meridian.lib.ops.runtime import resolve_runtime_authority_for_write
+    from meridian.lib.ops.diag import schedule_background_repairs
 
-    runtime_root = resolve_runtime_authority_for_write(project_root).runtime_root
-    if runtime_root is None:
-        return
-
-    import threading
-
-    def _run_repairs() -> None:
-        from contextlib import suppress
-
-        with suppress(Exception):
-            from meridian.lib.ops.diag import (
-                _repair_orphan_runs,  # pyright: ignore[reportPrivateUsage]
-                _repair_stale_session_locks,  # pyright: ignore[reportPrivateUsage]
-            )
-
-            _repair_stale_session_locks(project_root, runtime_root=runtime_root)
-            _repair_orphan_runs(project_root, runtime_root=runtime_root)
-
-    thread = threading.Thread(
-        target=_run_repairs,
-        name="meridian-background-repairs",
-        daemon=True,
-    )
-    thread.start()
+    schedule_background_repairs(project_root)
 
 
 def _print_agent_root_help() -> None:

--- a/src/meridian/cli/main.py
+++ b/src/meridian/cli/main.py
@@ -944,16 +944,20 @@ def _directory_env_scope(
     project_root: Path | None,
     directory_explicit: bool,
 ) -> Generator[None, None, None]:
-    """Set ``MERIDIAN_PROJECT_DIR`` / ``MERIDIAN_DIRECTORY_EXPLICIT`` and restore on exit."""
+    """Set ``MERIDIAN_PROJECT_DIR`` and restore on exit.
 
-    keys = ("MERIDIAN_PROJECT_DIR", "MERIDIAN_DIRECTORY_EXPLICIT")
+    When *directory_explicit* (``-C`` active), also unset ``MERIDIAN_RUNTIME_DIR``
+    so the runtime layer derives from project identity instead of a stale override.
+    """
+
+    keys = ["MERIDIAN_PROJECT_DIR"]
+    if directory_explicit:
+        keys.append("MERIDIAN_RUNTIME_DIR")
     saved = {key: os.environ.get(key) for key in keys}
     if project_root is not None:
         os.environ["MERIDIAN_PROJECT_DIR"] = project_root.as_posix()
     if directory_explicit:
-        os.environ["MERIDIAN_DIRECTORY_EXPLICIT"] = "1"
-    else:
-        os.environ.pop("MERIDIAN_DIRECTORY_EXPLICIT", None)
+        os.environ.pop("MERIDIAN_RUNTIME_DIR", None)
     try:
         yield
     finally:

--- a/src/meridian/cli/session_cmd.py
+++ b/src/meridian/cli/session_cmd.py
@@ -7,6 +7,7 @@ from typing import Annotated, Any, Protocol
 from cyclopts import App, Parameter
 
 from meridian.cli.ext_registration import register_extension_cli_group
+from meridian.cli.utils import implicit_ops_payload, implicit_session_ops_payload
 from meridian.lib.core.util import FormatContext
 from meridian.lib.extensions.registry import get_first_party_registry
 from meridian.lib.ops.session_export import SessionExportInput, session_export_sync
@@ -136,6 +137,7 @@ def _session_log(
             limit=limit,
             context=context,
             file_path=file_path,
+            **implicit_session_ops_payload(file_path=file_path),
         )
     )
     if raw:
@@ -173,6 +175,7 @@ def _session_export(
                 ref=ref,
                 file_path=file_path,
                 include_spawns=include_spawns,
+                **implicit_session_ops_payload(file_path=file_path),
             )
         )
     )
@@ -224,6 +227,7 @@ def _session_search(
                 work_id=work_id,
                 workspace=workspace,
                 global_scope=global_scope,
+                **implicit_session_ops_payload(file_path=file_path),
             )
         )
     )
@@ -242,6 +246,7 @@ def _session_repair(
         repair_session_reference_sync(
             SessionRepairInput(
                 ref=ref,
+                **implicit_ops_payload(),
             )
         )
     )

--- a/src/meridian/cli/session_cmd.py
+++ b/src/meridian/cli/session_cmd.py
@@ -7,13 +7,20 @@ from typing import Annotated, Any, Protocol
 from cyclopts import App, Parameter
 
 from meridian.cli.ext_registration import register_extension_cli_group
-from meridian.cli.utils import implicit_ops_payload, implicit_session_ops_payload
+from meridian.cli.utils import cli_project_root_posix
 from meridian.lib.core.util import FormatContext
 from meridian.lib.extensions.registry import get_first_party_registry
 from meridian.lib.ops.session_export import SessionExportInput, session_export_sync
 from meridian.lib.ops.session_log import SessionLogInput, session_log_sync
 from meridian.lib.ops.session_repair import SessionRepairInput, repair_session_reference_sync
 from meridian.lib.ops.session_search import SessionSearchInput, session_search_sync
+
+
+def _session_project_root(file_path: str | None) -> str | None:
+    """Return CLI project root unless a direct file path bypasses project establishment."""
+    if file_path and file_path.strip():
+        return None
+    return cli_project_root_posix()
 
 
 class Emitter(Protocol):
@@ -137,7 +144,7 @@ def _session_log(
             limit=limit,
             context=context,
             file_path=file_path,
-            **implicit_session_ops_payload(file_path=file_path),
+            project_root=_session_project_root(file_path),
         )
     )
     if raw:
@@ -175,7 +182,7 @@ def _session_export(
                 ref=ref,
                 file_path=file_path,
                 include_spawns=include_spawns,
-                **implicit_session_ops_payload(file_path=file_path),
+                project_root=_session_project_root(file_path),
             )
         )
     )
@@ -227,7 +234,7 @@ def _session_search(
                 work_id=work_id,
                 workspace=workspace,
                 global_scope=global_scope,
-                **implicit_session_ops_payload(file_path=file_path),
+                project_root=_session_project_root(file_path),
             )
         )
     )
@@ -246,7 +253,7 @@ def _session_repair(
         repair_session_reference_sync(
             SessionRepairInput(
                 ref=ref,
-                **implicit_ops_payload(),
+                project_root=cli_project_root_posix(),
             )
         )
     )

--- a/src/meridian/cli/spawn.py
+++ b/src/meridian/cli/spawn.py
@@ -13,7 +13,6 @@ from meridian.cli.argv_normalization import validate_fork_mode
 from meridian.cli.ext_registration import register_extension_cli_group
 from meridian.cli.spawn_inject import inject_message
 from meridian.cli.utils import (
-    ignore_runtime_env_override,
     parse_csv_list,
     require_established_project_root,
 )
@@ -79,17 +78,11 @@ def _current_output_sink() -> Any:
 
 
 def _prepare_spawn_runtime_read() -> RuntimeReadContext:
-    return prepare_for_runtime_read(
-        require_established_project_root(),
-        ignore_runtime_env=ignore_runtime_env_override(),
-    )
+    return prepare_for_runtime_read(require_established_project_root())
 
 
 def _prepare_spawn_runtime_write() -> RuntimeWriteContext:
-    return prepare_for_runtime_write(
-        require_established_project_root(),
-        ignore_runtime_env=ignore_runtime_env_override(),
-    )
+    return prepare_for_runtime_write(require_established_project_root())
 
 
 def _spawn_create_exit_code(result: SpawnActionOutput) -> int:

--- a/src/meridian/cli/spawn.py
+++ b/src/meridian/cli/spawn.py
@@ -12,7 +12,11 @@ from cyclopts import App, Parameter
 from meridian.cli.argv_normalization import validate_fork_mode
 from meridian.cli.ext_registration import register_extension_cli_group
 from meridian.cli.spawn_inject import inject_message
-from meridian.cli.utils import parse_csv_list, require_established_project_root
+from meridian.cli.utils import (
+    ignore_runtime_env_override,
+    parse_csv_list,
+    require_established_project_root,
+)
 from meridian.lib.bootstrap.services import (
     RuntimeReadContext,
     RuntimeWriteContext,
@@ -75,11 +79,17 @@ def _current_output_sink() -> Any:
 
 
 def _prepare_spawn_runtime_read() -> RuntimeReadContext:
-    return prepare_for_runtime_read(require_established_project_root())
+    return prepare_for_runtime_read(
+        require_established_project_root(),
+        ignore_runtime_env=ignore_runtime_env_override(),
+    )
 
 
 def _prepare_spawn_runtime_write() -> RuntimeWriteContext:
-    return prepare_for_runtime_write(require_established_project_root())
+    return prepare_for_runtime_write(
+        require_established_project_root(),
+        ignore_runtime_env=ignore_runtime_env_override(),
+    )
 
 
 def _spawn_create_exit_code(result: SpawnActionOutput) -> int:

--- a/src/meridian/cli/streaming_serve.py
+++ b/src/meridian/cli/streaming_serve.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import time
 from dataclasses import replace
 
-from meridian.cli.utils import require_established_project_root
+from meridian.cli.utils import (
+    ignore_runtime_env_override,
+    require_established_project_root,
+)
 from meridian.lib.bootstrap.services import (
     build_spawn_application_service,
     build_spawn_lifecycle_service_from_roots,
@@ -16,7 +19,7 @@ from meridian.lib.core.types import HarnessId
 from meridian.lib.harness.registry import get_default_harness_registry
 from meridian.lib.launch.request import LaunchArgvIntent, SpawnRequest
 from meridian.lib.launch.streaming_runner import run_streaming_spawn, signal_coordinator
-from meridian.lib.ops.runtime import build_runtime
+from meridian.lib.ops.runtime import OperationRuntime
 from meridian.lib.ops.spawn.execute_init import build_spawn_mars_runtime
 from meridian.lib.state.paths import spawn_output_path
 
@@ -47,7 +50,10 @@ async def streaming_serve(
         supported = ", ".join(item.value for item in HarnessId)
         raise ValueError(f"unsupported harness '{harness}'. Supported: {supported}") from exc
 
-    prepared = prepare_for_runtime_write(require_established_project_root())
+    prepared = prepare_for_runtime_write(
+        require_established_project_root(),
+        ignore_runtime_env=ignore_runtime_env_override(),
+    )
     project_root = prepared.project_root
     if prepared.runtime_root is None:
         raise ValueError("Prepared runtime write context is missing runtime root.")
@@ -62,7 +68,10 @@ async def streaming_serve(
         harness=harness_id.value,
         agent=normalized_agent,
     )
-    operation_runtime = build_runtime(project_root.as_posix())
+    operation_runtime = OperationRuntime.from_prepared(
+        prepared,
+        harness_registry=get_default_harness_registry(),
+    )
     launch_runtime = build_spawn_mars_runtime(
         runtime=operation_runtime,
         runtime_root=runtime_root,

--- a/src/meridian/cli/streaming_serve.py
+++ b/src/meridian/cli/streaming_serve.py
@@ -5,10 +5,7 @@ from __future__ import annotations
 import time
 from dataclasses import replace
 
-from meridian.cli.utils import (
-    ignore_runtime_env_override,
-    require_established_project_root,
-)
+from meridian.cli.utils import require_established_project_root
 from meridian.lib.bootstrap.services import (
     build_spawn_application_service,
     build_spawn_lifecycle_service_from_roots,
@@ -50,10 +47,7 @@ async def streaming_serve(
         supported = ", ".join(item.value for item in HarnessId)
         raise ValueError(f"unsupported harness '{harness}'. Supported: {supported}") from exc
 
-    prepared = prepare_for_runtime_write(
-        require_established_project_root(),
-        ignore_runtime_env=ignore_runtime_env_override(),
-    )
+    prepared = prepare_for_runtime_write(require_established_project_root())
     project_root = prepared.project_root
     if prepared.runtime_root is None:
         raise ValueError("Prepared runtime write context is missing runtime root.")

--- a/src/meridian/cli/utils.py
+++ b/src/meridian/cli/utils.py
@@ -28,6 +28,28 @@ def require_established_project_root() -> Path:
     return resolution.project_root
 
 
+def ignore_runtime_env_override() -> bool:
+    """Return whether ``-C`` / ``--directory`` should suppress ``MERIDIAN_RUNTIME_DIR``."""
+
+    from meridian.cli.main import get_global_options
+
+    return get_global_options().directory_explicit
+
+
+def implicit_ops_payload() -> dict[str, str]:
+    """Build implicit operation input fields from established CLI project root."""
+
+    return {"project_root": require_established_project_root().as_posix()}
+
+
+def implicit_session_ops_payload(*, file_path: str | None = None) -> dict[str, str]:
+    """Build implicit session op fields; direct ``--file`` skips project establishment."""
+
+    if file_path and file_path.strip():
+        return {}
+    return implicit_ops_payload()
+
+
 @overload
 def parse_csv_list(
     raw: str | None,

--- a/src/meridian/cli/utils.py
+++ b/src/meridian/cli/utils.py
@@ -28,26 +28,11 @@ def require_established_project_root() -> Path:
     return resolution.project_root
 
 
-def ignore_runtime_env_override() -> bool:
-    """Return whether ``-C`` / ``--directory`` should suppress ``MERIDIAN_RUNTIME_DIR``."""
 
-    from meridian.cli.main import get_global_options
+def cli_project_root_posix() -> str:
+    """Return the established CLI project root as a POSIX string."""
 
-    return get_global_options().directory_explicit
-
-
-def implicit_ops_payload() -> dict[str, str]:
-    """Build implicit operation input fields from established CLI project root."""
-
-    return {"project_root": require_established_project_root().as_posix()}
-
-
-def implicit_session_ops_payload(*, file_path: str | None = None) -> dict[str, str]:
-    """Build implicit session op fields; direct ``--file`` skips project establishment."""
-
-    if file_path and file_path.strip():
-        return {}
-    return implicit_ops_payload()
+    return require_established_project_root().as_posix()
 
 
 @overload

--- a/src/meridian/lib/bootstrap/services.py
+++ b/src/meridian/lib/bootstrap/services.py
@@ -80,10 +80,17 @@ def prepare_for_project_read(project_root: Path) -> ProjectReadContext:
     )
 
 
-def prepare_for_runtime_read(project_root: Path) -> RuntimeReadContext:
+def prepare_for_runtime_read(
+    project_root: Path,
+    *,
+    ignore_runtime_env: bool = False,
+) -> RuntimeReadContext:
     """Prepare read-only runtime context without creating state."""
 
-    authority = resolve_runtime_authority_for_read(project_root)
+    authority = resolve_runtime_authority_for_read(
+        project_root,
+        ignore_runtime_env=ignore_runtime_env,
+    )
     project_context = ProjectReadContext(
         authority=authority,
         project_root=authority.project_root,
@@ -113,10 +120,17 @@ def prepare_for_project_write(project_root: Path) -> ProjectWriteContext:
     )
 
 
-def prepare_for_runtime_write(project_root: Path) -> RuntimeWriteContext:
+def prepare_for_runtime_write(
+    project_root: Path,
+    *,
+    ignore_runtime_env: bool = False,
+) -> RuntimeWriteContext:
     """Prepare runtime write context, including UUID and runtime dirs."""
 
-    authority = resolve_runtime_authority_for_write(project_root)
+    authority = resolve_runtime_authority_for_write(
+        project_root,
+        ignore_runtime_env=ignore_runtime_env,
+    )
     project_state.ensure_project_dirs(authority.project_root)
     project_state.ensure_project_gitignore(authority.project_root)
     runtime_root = runtime_state.ensure_runtime_root(

--- a/src/meridian/lib/bootstrap/services.py
+++ b/src/meridian/lib/bootstrap/services.py
@@ -82,15 +82,10 @@ def prepare_for_project_read(project_root: Path) -> ProjectReadContext:
 
 def prepare_for_runtime_read(
     project_root: Path,
-    *,
-    ignore_runtime_env: bool = False,
 ) -> RuntimeReadContext:
     """Prepare read-only runtime context without creating state."""
 
-    authority = resolve_runtime_authority_for_read(
-        project_root,
-        ignore_runtime_env=ignore_runtime_env,
-    )
+    authority = resolve_runtime_authority_for_read(project_root)
     project_context = ProjectReadContext(
         authority=authority,
         project_root=authority.project_root,
@@ -122,15 +117,10 @@ def prepare_for_project_write(project_root: Path) -> ProjectWriteContext:
 
 def prepare_for_runtime_write(
     project_root: Path,
-    *,
-    ignore_runtime_env: bool = False,
 ) -> RuntimeWriteContext:
     """Prepare runtime write context, including UUID and runtime dirs."""
 
-    authority = resolve_runtime_authority_for_write(
-        project_root,
-        ignore_runtime_env=ignore_runtime_env,
-    )
+    authority = resolve_runtime_authority_for_write(project_root)
     project_state.ensure_project_dirs(authority.project_root)
     project_state.ensure_project_gitignore(authority.project_root)
     runtime_root = runtime_state.ensure_runtime_root(

--- a/src/meridian/lib/core/child_env.py
+++ b/src/meridian/lib/core/child_env.py
@@ -14,7 +14,6 @@ ALLOWED_CHILD_ENV_KEYS: frozenset[str] = frozenset(
         "MERIDIAN_SPAWN_ID",
         "MERIDIAN_PARENT_SPAWN_ID",
         "MERIDIAN_PROJECT_DIR",
-        "MERIDIAN_RUNTIME_DIR",
         "MERIDIAN_DEPTH",
         "MERIDIAN_CHAT_ID",
         "MERIDIAN_ACTIVE_WORK_ID",

--- a/src/meridian/lib/core/context.py
+++ b/src/meridian/lib/core/context.py
@@ -48,8 +48,6 @@ class RuntimeContext(BaseModel):
             overrides["MERIDIAN_SPAWN_ID"] = str(self.spawn_id)
         if self.project_root is not None:
             overrides["MERIDIAN_PROJECT_DIR"] = self.project_root.as_posix()
-        if self.runtime_root is not None:
-            overrides["MERIDIAN_RUNTIME_DIR"] = self.runtime_root.as_posix()
         if self.chat_id:
             overrides["MERIDIAN_CHAT_ID"] = self.chat_id
         if self.work_id:

--- a/src/meridian/lib/core/resolved_context.py
+++ b/src/meridian/lib/core/resolved_context.py
@@ -70,12 +70,15 @@ class ResolvedContext:
         """Resolve and freeze canonical runtime context from ``MERIDIAN_*`` values.
 
         When *explicit_project_root* or *explicit_runtime_root* are supplied they
-        take precedence over the corresponding ``MERIDIAN_PROJECT_DIR`` /
-        ``MERIDIAN_RUNTIME_DIR`` environment variables, allowing callers to resolve
-        context without mutating process-global state.
+        take precedence over ``MERIDIAN_PROJECT_DIR``. ``runtime_root`` is derived
+        from ``project_root`` (``.meridian/id`` → user home) unless
+        *explicit_runtime_root* is supplied — inherited ``MERIDIAN_RUNTIME_DIR`` is
+        never read.
         """
 
         import os
+
+        from meridian.lib.state.runtime_root import derive_runtime_root_from_project
 
         backend_impl = backend or LocalFilesystemBackend()
 
@@ -83,7 +86,6 @@ class ResolvedContext:
         parent_spawn_id_raw = os.getenv("MERIDIAN_PARENT_SPAWN_ID", "").strip()
         depth_raw = os.getenv(MERIDIAN_DEPTH_ENV, "0").strip()
         project_root_raw = os.getenv("MERIDIAN_PROJECT_DIR", "").strip()
-        runtime_root_raw = os.getenv("MERIDIAN_RUNTIME_DIR", "").strip()
         chat_id_raw = os.getenv("MERIDIAN_CHAT_ID", "").strip()
         work_id_raw = os.getenv("MERIDIAN_ACTIVE_WORK_ID", "").strip()
         work_dir_raw = os.getenv("MERIDIAN_ACTIVE_WORK_DIR", "").strip()
@@ -98,13 +100,12 @@ class ResolvedContext:
             if project_root_raw
             else None
         )
-        runtime_root = (
-            explicit_runtime_root
-            if explicit_runtime_root is not None
-            else Path(runtime_root_raw)
-            if runtime_root_raw
-            else None
-        )
+        if explicit_runtime_root is not None:
+            runtime_root = explicit_runtime_root
+        elif project_root is not None:
+            runtime_root = derive_runtime_root_from_project(project_root)
+        else:
+            runtime_root = None
 
         # Authoritative work-ID precedence:
         # explicit override > MERIDIAN_ACTIVE_WORK_ID > session attachment.
@@ -182,8 +183,6 @@ class ResolvedContext:
             overrides["MERIDIAN_PARENT_SPAWN_ID"] = str(self.spawn_id)
         if self.project_root is not None:
             overrides["MERIDIAN_PROJECT_DIR"] = self.project_root.as_posix()
-        if self.runtime_root is not None:
-            overrides["MERIDIAN_RUNTIME_DIR"] = self.runtime_root.as_posix()
         if self.chat_id:
             overrides["MERIDIAN_CHAT_ID"] = self.chat_id
         if self.work_id:

--- a/src/meridian/lib/harness/connections/pi_rpc.py
+++ b/src/meridian/lib/harness/connections/pi_rpc.py
@@ -37,15 +37,12 @@ from meridian.lib.harness.pi_lifecycle_events import (
     has_unsupported_pi_lifecycle_schema_version,
     redact_pi_command_for_history,
 )
-from meridian.lib.harness.pi_paths import (
-    pi_agent_dir_env_override,
-    pi_meridian_state_dir_env_override,
-)
+from meridian.lib.harness.pi_paths import pi_agent_dir_env_override
 from meridian.lib.harness.pi_runtime_resolver import (
     PiRuntimeResolutionError,
     resolve_pi_runtime,
 )
-from meridian.lib.launch.constants import BASE_COMMAND_PI_SUBPROCESS
+from meridian.lib.launch.constants import BASE_COMMAND_PI_SUBPROCESS, BLOCKED_CHILD_ENV_VARS
 from meridian.lib.launch.env import inherit_child_env
 from meridian.lib.launch.launch_types import ResolvedLaunchSpec
 from meridian.lib.launch.report import compact_pi_failure_output
@@ -69,12 +66,7 @@ _PI_PHASE_EVENT_TYPE: Final[str] = "meridian.pi.lifecycle.phase"
 _PI_FIRST_EVENT_TIMEOUT_REASON: Final[str] = "pi_rpc_no_response_after_initial_prompt"
 _PI_SPAWNED_PROMPT_REQUIRED_REASON: Final[str] = "pi_rpc_spawned_prompt_required"
 _FIRST_STDOUT_AFTER_INITIAL_PROMPT_TIMEOUT_SECONDS: Final[float] = 30.0
-_BLOCKED_CHILD_ENV_VARS: Final[frozenset[str]] = frozenset(
-    {
-        "MERIDIAN_ACTIVE_WORK_ID",
-        "MERIDIAN_ACTIVE_WORK_DIR",
-    }
-)
+_BLOCKED_CHILD_ENV_VARS: Final[frozenset[str]] = BLOCKED_CHILD_ENV_VARS
 _PI_SESSION_DIR_FLAG: Final[str] = "--session-dir"
 _PI_CHILD_WAVE_TIMEOUT_MS_ENV: Final[str] = "MERIDIAN_PI_CHILD_WAVE_TIMEOUT_MS"
 _PI_TASK_PING_INTERVAL_MS_ENV: Final[str] = "MERIDIAN_PI_TASK_PING_INTERVAL_MS"
@@ -456,11 +448,9 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
             blocked=_BLOCKED_CHILD_ENV_VARS,
         )
         env.update(pi_agent_dir_env_override())
-        env.update(pi_meridian_state_dir_env_override(env=env))
         session_dir = env.get("PI_CODING_AGENT_SESSION_DIR", "").strip()
         if session_dir:
             command = self._apply_session_dir_arg(command, session_dir)
-            env["MERIDIAN_PI_STATE_DIR"] = session_dir
         launch_role = "spawned"
         if (self._launch_session_role or "").strip().lower() == "primary":
             launch_role = "primary"

--- a/src/meridian/lib/harness/pi.py
+++ b/src/meridian/lib/harness/pi.py
@@ -240,7 +240,6 @@ class PiAdapter(BaseHarnessAdapter[ResolvedLaunchSpec]):
         record_effective_config_dir: RecordConfigDirFn | None = None,
     ) -> HarnessPrelaunchState:
         _ = (
-            runtime_root,
             spawn_id,
             session,
             resolved_harness_session_id,
@@ -274,17 +273,17 @@ class PiAdapter(BaseHarnessAdapter[ResolvedLaunchSpec]):
             session_dir = scoped_session_dir
         agent_dir_overrides = pi_agent_dir_env_override()
         child_env.update(agent_dir_overrides)
-        state_dir_overrides = pi_meridian_state_dir_env_override(env=child_env)
+        state_dir_overrides = pi_meridian_state_dir_env_override(
+            env=child_env,
+            runtime_root=runtime_root,
+        )
         child_env.update(state_dir_overrides)
         env_overrides: dict[str, str] = {
             "MERIDIAN_PI_BINARY": resolved_runtime.binary_path,
             **agent_dir_overrides,
-            **state_dir_overrides,
         }
         if scoped_session_dir is not None:
             env_overrides["PI_CODING_AGENT_SESSION_DIR"] = scoped_session_dir
-            env_overrides["MERIDIAN_PI_STATE_DIR"] = scoped_session_dir
-            child_env["MERIDIAN_PI_STATE_DIR"] = scoped_session_dir
 
         return HarnessPrelaunchState(
             env_overrides=env_overrides,
@@ -328,7 +327,6 @@ class PiAdapter(BaseHarnessAdapter[ResolvedLaunchSpec]):
         return {
             **pi_agent_dir_env_override(),
             **pi_spawn_session_root_env_override(),
-            **pi_meridian_state_dir_env_override(),
         }
 
     def extract_usage(self, artifacts: ArtifactStore, spawn_id: SpawnId) -> TokenUsage:

--- a/src/meridian/lib/harness/pi_paths.py
+++ b/src/meridian/lib/harness/pi_paths.py
@@ -62,9 +62,6 @@ def resolve_meridian_pi_state_dir(*, env: Mapping[str, str] | None = None) -> Pa
         explicit = env.get(_MERIDIAN_PI_STATE_DIR_ENV, "").strip()
         if explicit:
             return Path(explicit).expanduser()
-        session_dir = env.get(_PI_SESSION_DIR_ENV, "").strip()
-        if session_dir:
-            return Path(session_dir).expanduser()
     return get_user_home() / "meridian-pi" / "state"
 
 
@@ -104,9 +101,12 @@ def pi_spawn_session_root_env_override() -> dict[str, str]:
 def pi_meridian_state_dir_env_override(
     *,
     env: Mapping[str, str] | None = None,
+    runtime_root: Path | None = None,
 ) -> dict[str, str]:
     """Env override for extension runtime state (tasks, spawn-watch tree)."""
 
+    if runtime_root is not None:
+        return {_MERIDIAN_PI_STATE_DIR_ENV: str(runtime_root)}
     return {_MERIDIAN_PI_STATE_DIR_ENV: str(resolve_meridian_pi_state_dir(env=env))}
 
 

--- a/src/meridian/lib/hooks/runner.py
+++ b/src/meridian/lib/hooks/runner.py
@@ -94,7 +94,6 @@ class ExternalHookRunner:
 
         env = {**os.environ, **context.to_env()}
         env.pop("MERIDIAN_RUNTIME_DIR", None)
-        env.pop("MERIDIAN_DIRECTORY_EXPLICIT", None)
         start = time.monotonic()
         process: subprocess.Popen[bytes] | None = None
 

--- a/src/meridian/lib/hooks/runner.py
+++ b/src/meridian/lib/hooks/runner.py
@@ -93,6 +93,8 @@ class ExternalHookRunner:
             )
 
         env = {**os.environ, **context.to_env()}
+        env.pop("MERIDIAN_RUNTIME_DIR", None)
+        env.pop("MERIDIAN_DIRECTORY_EXPLICIT", None)
         start = time.monotonic()
         process: subprocess.Popen[bytes] | None = None
 

--- a/src/meridian/lib/hooks/types.py
+++ b/src/meridian/lib/hooks/types.py
@@ -194,7 +194,6 @@ class HookContext:
             "MERIDIAN_HOOK_TIMESTAMP": self.timestamp,
             "MERIDIAN_HOOK_SCHEMA_VERSION": str(self.schema_version),
             "MERIDIAN_PROJECT_DIR": self.project_root,
-            "MERIDIAN_RUNTIME_DIR": self.runtime_root,
             "MERIDIAN_SPAWN_ID": self.spawn_id,
             "MERIDIAN_SPAWN_STATUS": self.spawn_status,
             "MERIDIAN_SPAWN_AGENT": self.spawn_agent,

--- a/src/meridian/lib/launch/constants.py
+++ b/src/meridian/lib/launch/constants.py
@@ -25,8 +25,6 @@ BLOCKED_CHILD_ENV_VARS: Final[frozenset[str]] = frozenset(
         "MERIDIAN_ACTIVE_WORK_DIR",
         # Runtime root is resolved at launch/bind; do not inherit parent override.
         "MERIDIAN_RUNTIME_DIR",
-        # Explicit -C/--directory is process-local CLI policy, not child scope.
-        "MERIDIAN_DIRECTORY_EXPLICIT",
     }
 )
 

--- a/src/meridian/lib/launch/constants.py
+++ b/src/meridian/lib/launch/constants.py
@@ -23,6 +23,10 @@ BLOCKED_CHILD_ENV_VARS: Final[frozenset[str]] = frozenset(
         # Child work scope must come from runtime overrides only.
         "MERIDIAN_ACTIVE_WORK_ID",
         "MERIDIAN_ACTIVE_WORK_DIR",
+        # Runtime root is resolved at launch/bind; do not inherit parent override.
+        "MERIDIAN_RUNTIME_DIR",
+        # Explicit -C/--directory is process-local CLI policy, not child scope.
+        "MERIDIAN_DIRECTORY_EXPLICIT",
     }
 )
 

--- a/src/meridian/lib/launch/context.py
+++ b/src/meridian/lib/launch/context.py
@@ -1707,6 +1707,8 @@ def bind_launch_context(
     child_context_env["MERIDIAN_HARNESS"] = harness.id.value
     child_context_env["MERIDIAN_PROJECT_ROOT"] = resolved_control_root.as_posix()
     child_context_env["MERIDIAN_TASK_DIR"] = directory_context.logical_task_cwd.as_posix()
+    if harness.id == HarnessId.PI:
+        child_context_env["MERIDIAN_PI_STATE_DIR"] = runtime_root.as_posix()
     if task_cwd is not None:
         child_context_env["MERIDIAN_TASK_CWD"] = task_cwd.as_posix()
     runtime_override_env = (

--- a/src/meridian/lib/ops/diag.py
+++ b/src/meridian/lib/ops/diag.py
@@ -145,23 +145,39 @@ def _check_legacy_worktree_temp(runtime_root: Path) -> DoctorWarning | None:
     )
 
 
-def _repair_stale_session_locks(project_root: Path) -> int:
-    runtime_root = resolve_runtime_authority_for_write(project_root).runtime_root
-    if runtime_root is None:
+def _repair_stale_session_locks(
+    project_root: Path,
+    *,
+    runtime_root: Path | None = None,
+) -> int:
+    resolved_runtime_root = runtime_root
+    if resolved_runtime_root is None:
+        resolved_runtime_root = resolve_runtime_authority_for_write(
+            project_root
+        ).runtime_root
+    if resolved_runtime_root is None:
         raise ValueError("Doctor lock repair requires a runtime root.")
-    cleanup = cleanup_stale_sessions(runtime_root)
+    cleanup = cleanup_stale_sessions(resolved_runtime_root)
     return len(cleanup.cleaned_ids)
 
 
-def _repair_orphan_runs(project_root: Path) -> tuple[int, tuple[str, ...]]:
+def _repair_orphan_runs(
+    project_root: Path,
+    *,
+    runtime_root: Path | None = None,
+) -> tuple[int, tuple[str, ...]]:
     from meridian.lib.state.reaper import reconcile_spawns
 
-    runtime_root = resolve_runtime_authority_for_write(project_root).runtime_root
-    if runtime_root is None:
+    resolved_runtime_root = runtime_root
+    if resolved_runtime_root is None:
+        resolved_runtime_root = resolve_runtime_authority_for_write(
+            project_root
+        ).runtime_root
+    if resolved_runtime_root is None:
         raise ValueError("Doctor orphan-run repair requires a runtime root.")
-    spawns = spawn_store.list_spawns(runtime_root)
+    spawns = spawn_store.list_spawns(resolved_runtime_root)
     running_before = {s.id for s in spawns if is_active_spawn_status(s.status)}
-    reconciled = reconcile_spawns(project_root, runtime_root, spawns)
+    reconciled = reconcile_spawns(project_root, resolved_runtime_root, spawns)
     running_after = {s.id for s in reconciled if is_active_spawn_status(s.status)}
     reconciled_orphans = tuple(sorted(running_before - running_after))
     return len(reconciled_orphans), reconciled_orphans

--- a/src/meridian/lib/ops/diag.py
+++ b/src/meridian/lib/ops/diag.py
@@ -183,6 +183,34 @@ def _repair_orphan_runs(
     return len(reconciled_orphans), reconciled_orphans
 
 
+def schedule_background_repairs(project_root: Path) -> None:
+    """Resolve runtime root and run stale-lock + orphan-run repairs in a daemon thread.
+
+    Callers gate on startup class and side-effect eligibility before calling.
+    """
+
+    if not is_root_side_effect_process():
+        return
+    runtime_root = resolve_runtime_authority_for_write(project_root).runtime_root
+    if runtime_root is None:
+        return
+
+    import threading
+
+    def _run_repairs() -> None:
+        from contextlib import suppress
+
+        with suppress(Exception):
+            _repair_stale_session_locks(project_root, runtime_root=runtime_root)
+            _repair_orphan_runs(project_root, runtime_root=runtime_root)
+
+    threading.Thread(
+        target=_run_repairs,
+        name="meridian-background-repairs",
+        daemon=True,
+    ).start()
+
+
 def doctor_sync(payload: DoctorInput) -> DoctorOutput:
     authority = resolve_project_authority(payload.project_root)
     surface = build_config_surface(authority)

--- a/src/meridian/lib/ops/runtime.py
+++ b/src/meridian/lib/ops/runtime.py
@@ -51,6 +51,30 @@ def _runtime_override_env_root(project_root: Path) -> Path | None:
     return candidate if candidate.is_absolute() else project_root / candidate
 
 
+def _coalesce_ignore_runtime_env(ignore_runtime_env: bool | None) -> bool:
+    """Resolve whether ``MERIDIAN_RUNTIME_DIR`` may override derived runtime roots."""
+
+    if ignore_runtime_env is not None:
+        return ignore_runtime_env
+    explicit_flag = os.getenv("MERIDIAN_DIRECTORY_EXPLICIT", "").strip().lower()
+    return explicit_flag in {"1", "true", "yes"}
+
+
+def _runtime_dir_env_override_applies(*, ignore_runtime_env: bool = False) -> bool:
+    """Return whether ``MERIDIAN_RUNTIME_DIR`` may override derived runtime roots.
+
+    Power-user override applies only at the primary Meridian root. Nested
+    processes derive runtime from ``MERIDIAN_PROJECT_DIR``; ``-C`` forces the
+    same derivation for the explicit project target.
+    """
+
+    if ignore_runtime_env:
+        return False
+    from meridian.lib.core.depth import is_nested_meridian_process
+
+    return not is_nested_meridian_process()
+
+
 def _root_has_runtime_state(runtime_root: Path) -> bool:
     return any(
         path.exists()
@@ -172,20 +196,20 @@ def resolve_runtime_authority_for_read(
     project_root: str | Path | None = None,
     *,
     execution_cwd: Path | None = None,
+    ignore_runtime_env: bool | None = None,
 ) -> RuntimeAuthoritySnapshot:
     """Resolve project/runtime authority for read-only callers."""
 
+    ignore_runtime_env = _coalesce_ignore_runtime_env(ignore_runtime_env)
     authority = resolve_project_authority(project_root, execution_cwd=execution_cwd)
-    override_root = _runtime_override_env_root(authority.project_root)
+    override_root = (
+        _runtime_override_env_root(authority.project_root)
+        if _runtime_dir_env_override_applies(ignore_runtime_env=ignore_runtime_env)
+        else None
+    )
     project_id = read_project_id(authority.project_state_dir)
     if override_root is not None:
         runtime_root = override_root
-        if (
-            runtime_root != authority.project_state_dir
-            and not _root_has_runtime_state(runtime_root)
-            and _root_has_runtime_state(authority.project_state_dir)
-        ):
-            runtime_root = authority.project_state_dir
     elif project_id is not None:
         candidate_runtime_root = get_project_home(project_id)
         runtime_root = (
@@ -224,11 +248,17 @@ def resolve_runtime_authority_for_write(
     project_root: str | Path | None = None,
     *,
     execution_cwd: Path | None = None,
+    ignore_runtime_env: bool | None = None,
 ) -> RuntimeAuthoritySnapshot:
     """Resolve project/runtime authority for mutating callers."""
 
+    ignore_runtime_env = _coalesce_ignore_runtime_env(ignore_runtime_env)
     authority = resolve_project_authority(project_root, execution_cwd=execution_cwd)
-    override = _runtime_override_env_root(authority.project_root)
+    override = (
+        _runtime_override_env_root(authority.project_root)
+        if _runtime_dir_env_override_applies(ignore_runtime_env=ignore_runtime_env)
+        else None
+    )
     runtime_root = override or get_project_home(
         get_or_create_project_id(authority.project_state_dir)
     )

--- a/src/meridian/lib/ops/runtime.py
+++ b/src/meridian/lib/ops/runtime.py
@@ -52,21 +52,13 @@ def _runtime_override_env_root(project_root: Path) -> Path | None:
     return candidate if candidate.is_absolute() else project_root / candidate
 
 
-def _coalesce_ignore_runtime_env(ignore_runtime_env: bool | None) -> bool:
-    """Resolve whether ``MERIDIAN_RUNTIME_DIR`` may override derived runtime roots."""
-
-    if ignore_runtime_env is not None:
-        return ignore_runtime_env
-    explicit_flag = os.getenv("MERIDIAN_DIRECTORY_EXPLICIT", "").strip().lower()
-    return explicit_flag in {"1", "true", "yes"}
-
-
 def _runtime_dir_env_override_applies(*, ignore_runtime_env: bool = False) -> bool:
     """Return whether ``MERIDIAN_RUNTIME_DIR`` may override derived runtime roots.
 
-    Power-user override applies only at the primary Meridian root. Nested
-    processes derive runtime from ``MERIDIAN_PROJECT_DIR``; ``-C`` forces the
-    same derivation for the explicit project target.
+    Power-user override applies only at the primary Meridian root.  Nested
+    processes derive runtime from ``MERIDIAN_PROJECT_DIR``; ``-C`` unsets
+    ``MERIDIAN_RUNTIME_DIR`` at process scope so this check is moot when
+    the flag is active.
     """
 
     if ignore_runtime_env:
@@ -188,11 +180,12 @@ def resolve_runtime_authority_for_read(
 ) -> RuntimeAuthoritySnapshot:
     """Resolve project/runtime authority for read-only callers."""
 
-    ignore_runtime_env = _coalesce_ignore_runtime_env(ignore_runtime_env)
     authority = resolve_project_authority(project_root, execution_cwd=execution_cwd)
     override_root = (
         _runtime_override_env_root(authority.project_root)
-        if _runtime_dir_env_override_applies(ignore_runtime_env=ignore_runtime_env)
+        if _runtime_dir_env_override_applies(
+            ignore_runtime_env=bool(ignore_runtime_env),
+        )
         else None
     )
     project_id = read_project_id(authority.project_state_dir)
@@ -240,11 +233,12 @@ def resolve_runtime_authority_for_write(
 ) -> RuntimeAuthoritySnapshot:
     """Resolve project/runtime authority for mutating callers."""
 
-    ignore_runtime_env = _coalesce_ignore_runtime_env(ignore_runtime_env)
     authority = resolve_project_authority(project_root, execution_cwd=execution_cwd)
     override = (
         _runtime_override_env_root(authority.project_root)
-        if _runtime_dir_env_override_applies(ignore_runtime_env=ignore_runtime_env)
+        if _runtime_dir_env_override_applies(
+            ignore_runtime_env=bool(ignore_runtime_env),
+        )
         else None
     )
     runtime_root = override or get_project_home(

--- a/src/meridian/lib/ops/runtime.py
+++ b/src/meridian/lib/ops/runtime.py
@@ -20,6 +20,7 @@ from meridian.lib.core.context import RuntimeContext
 from meridian.lib.core.sink import NullSink, OutputSink
 from meridian.lib.state.artifact_store import LocalStore
 from meridian.lib.state.paths import resolve_project_paths
+from meridian.lib.state.runtime_root import root_has_runtime_state as _root_has_runtime_state
 from meridian.lib.state.user_paths import (
     get_or_create_project_id,
     get_project_home,
@@ -73,19 +74,6 @@ def _runtime_dir_env_override_applies(*, ignore_runtime_env: bool = False) -> bo
     from meridian.lib.core.depth import is_nested_meridian_process
 
     return not is_nested_meridian_process()
-
-
-def _root_has_runtime_state(runtime_root: Path) -> bool:
-    return any(
-        path.exists()
-        for path in (
-            runtime_root / "spawns.jsonl",
-            runtime_root / "sessions.jsonl",
-            runtime_root / "spawns",
-            runtime_root / "sessions",
-            runtime_root / "telemetry",
-        )
-    )
 
 
 def async_from_sync(sync_fn: Callable[P, T]) -> Callable[P, Coroutine[Any, Any, T]]:

--- a/src/meridian/lib/state/runtime_root.py
+++ b/src/meridian/lib/state/runtime_root.py
@@ -14,7 +14,7 @@ from meridian.lib.state.user_paths import (
 )
 
 
-def _root_has_runtime_state(runtime_root: Path) -> bool:
+def root_has_runtime_state(runtime_root: Path) -> bool:
     return any(
         path.exists()
         for path in (
@@ -43,14 +43,14 @@ def derive_runtime_root_from_project(
     if project_id is not None:
         candidate_runtime_root = get_project_home(project_id)
         if (
-            not _root_has_runtime_state(candidate_runtime_root)
-            and _root_has_runtime_state(project_state_dir)
+            not root_has_runtime_state(candidate_runtime_root)
+            and root_has_runtime_state(project_state_dir)
         ):
             return project_state_dir
         return candidate_runtime_root
-    if _root_has_runtime_state(project_state_dir):
+    if root_has_runtime_state(project_state_dir):
         return project_state_dir
     return None
 
 
-__all__ = ["derive_runtime_root_from_project"]
+__all__ = ["derive_runtime_root_from_project", "root_has_runtime_state"]

--- a/src/meridian/lib/state/runtime_root.py
+++ b/src/meridian/lib/state/runtime_root.py
@@ -1,0 +1,56 @@
+"""Runtime state root derivation from project identity (read-only)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from meridian.lib.state.paths import resolve_project_paths
+from meridian.lib.state.user_paths import (
+    get_or_create_project_id,
+    get_project_home,
+)
+from meridian.lib.state.user_paths import (
+    get_project_id as read_project_id,
+)
+
+
+def _root_has_runtime_state(runtime_root: Path) -> bool:
+    return any(
+        path.exists()
+        for path in (
+            runtime_root / "spawns.jsonl",
+            runtime_root / "sessions.jsonl",
+            runtime_root / "spawns",
+            runtime_root / "sessions",
+            runtime_root / "telemetry",
+        )
+    )
+
+
+def derive_runtime_root_from_project(
+    project_root: Path,
+    *,
+    for_write: bool = False,
+) -> Path | None:
+    """Derive runtime state root from project identity without reading ``MERIDIAN_RUNTIME_DIR``."""
+
+    project_paths = resolve_project_paths(project_root)
+    project_state_dir = project_paths.root_dir
+    if for_write:
+        return get_project_home(get_or_create_project_id(project_state_dir))
+
+    project_id = read_project_id(project_state_dir)
+    if project_id is not None:
+        candidate_runtime_root = get_project_home(project_id)
+        if (
+            not _root_has_runtime_state(candidate_runtime_root)
+            and _root_has_runtime_state(project_state_dir)
+        ):
+            return project_state_dir
+        return candidate_runtime_root
+    if _root_has_runtime_state(project_state_dir):
+        return project_state_dir
+    return None
+
+
+__all__ = ["derive_runtime_root_from_project"]

--- a/src/meridian/pi_runtime/extensions/managed-bash/src/bash_runtime.test.ts
+++ b/src/meridian/pi_runtime/extensions/managed-bash/src/bash_runtime.test.ts
@@ -35,7 +35,7 @@ describe("BashRuntime task pings", () => {
 
   it("sends one ping for a tracked background command", async () => {
     const runtimeRoot = await mkdtemp(path.join(tmpdir(), "pi-bash-ping-"));
-    setEnv("MERIDIAN_RUNTIME_DIR", runtimeRoot);
+    setEnv("MERIDIAN_PI_STATE_DIR", runtimeRoot);
     setEnv("MERIDIAN_SPAWN_ID", "p-test-ping");
     setEnv("MERIDIAN_PI_TASK_PING_INTERVAL_MS", "20");
 

--- a/src/meridian/pi_runtime/extensions/shared/pi_state_paths.ts
+++ b/src/meridian/pi_runtime/extensions/shared/pi_state_paths.ts
@@ -2,17 +2,9 @@ import path from "node:path";
 
 /** Mirrors ``pi_paths.resolve_meridian_pi_state_dir`` — extension runtime state root. */
 export function resolveStateRoot(): string {
-  const runtimeRoot = process.env.MERIDIAN_RUNTIME_DIR?.trim();
-  if (runtimeRoot) {
-    return runtimeRoot;
-  }
   const explicit = process.env.MERIDIAN_PI_STATE_DIR?.trim();
   if (explicit) {
     return explicit;
-  }
-  const sessionDir = process.env.PI_CODING_AGENT_SESSION_DIR?.trim();
-  if (sessionDir) {
-    return sessionDir;
   }
   const agentDir = process.env.PI_CODING_AGENT_DIR?.trim();
   if (agentDir) {

--- a/src/meridian/plugin_api/types.py
+++ b/src/meridian/plugin_api/types.py
@@ -154,7 +154,6 @@ class HookContext:
             "MERIDIAN_HOOK_TIMESTAMP": self.timestamp,
             "MERIDIAN_HOOK_SCHEMA_VERSION": str(self.schema_version),
             "MERIDIAN_PROJECT_DIR": self.project_root,
-            "MERIDIAN_RUNTIME_DIR": self.runtime_root,
             "MERIDIAN_SPAWN_ID": self.spawn_id,
             "MERIDIAN_SPAWN_STATUS": self.spawn_status,
             "MERIDIAN_SPAWN_AGENT": self.spawn_agent,

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -58,14 +58,5 @@ git -C "$SMOKE_REPO" init --quiet
 for var in $(env | awk -F= '/^MERIDIAN_/ {print $1}'); do unset "$var"; done
 export MERIDIAN_PROJECT_DIR="$SMOKE_REPO"
 cd "$REPO_ROOT"
-export RUNTIME_ROOT="$(uv run python - <<'PY'
-import os
-from pathlib import Path
-from meridian.lib.state.paths import resolve_project_paths
-from meridian.lib.state.user_paths import get_or_create_project_id, get_project_home
-
-state_dir = resolve_project_paths(Path(os.environ["SMOKE_REPO"])).root_dir
-print(get_project_home(get_or_create_project_id(state_dir)))
-PY
-)"
+export RUNTIME_ROOT="$(uv run python tests/e2e/resolve-runtime-root.py)"
 ```

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -19,6 +19,7 @@ Use these guides when the test:
 | `adversarial.md` | Intentionally open-ended adversarial exploration |
 | `fork.md` | Real harness lineage with --fork (partially automatable via dry-run) |
 | `models-cache-auto-refresh.md` | Network/cache freshness behavior |
+| `project-resolution.md` | `-C`/`MERIDIAN_PROJECT_DIR` project selection with stale runtime env |
 | `state-integrity.md` | Reconciliation after manual state corruption |
 | `streaming-adapter-parity.md` | Cross-harness streaming behavior |
 | `spawn/lifecycle.md` | Background spawn lifecycle with working harness |
@@ -56,6 +57,15 @@ export SMOKE_REPO="$(mktemp -d)"
 git -C "$SMOKE_REPO" init --quiet
 for var in $(env | awk -F= '/^MERIDIAN_/ {print $1}'); do unset "$var"; done
 export MERIDIAN_PROJECT_DIR="$SMOKE_REPO"
-export MERIDIAN_RUNTIME_DIR="$SMOKE_REPO/.meridian"
 cd "$REPO_ROOT"
+export RUNTIME_ROOT="$(uv run python - <<'PY'
+import os
+from pathlib import Path
+from meridian.lib.state.paths import resolve_project_paths
+from meridian.lib.state.user_paths import get_or_create_project_id, get_project_home
+
+state_dir = resolve_project_paths(Path(os.environ["SMOKE_REPO"])).root_dir
+print(get_project_home(get_or_create_project_id(state_dir)))
+PY
+)"
 ```

--- a/tests/e2e/adversarial.md
+++ b/tests/e2e/adversarial.md
@@ -10,7 +10,17 @@ export SMOKE_REPO="$(mktemp -d /tmp/meridian-adversarial.XXXXXX)"
 git -C "$SMOKE_REPO" init --quiet
 for var in $(env | awk -F= '/^MERIDIAN_/ {print $1}'); do unset "$var"; done
 export MERIDIAN_PROJECT_DIR="$SMOKE_REPO"
-export MERIDIAN_RUNTIME_DIR="$SMOKE_REPO/.meridian"
+cd "$REPO_ROOT"
+export RUNTIME_ROOT="$(uv run python - <<'PY'
+import os
+from pathlib import Path
+from meridian.lib.state.paths import resolve_project_paths
+from meridian.lib.state.user_paths import get_or_create_project_id, get_project_home
+
+state_dir = resolve_project_paths(Path(os.environ["SMOKE_REPO"])).root_dir
+print(get_project_home(get_or_create_project_id(state_dir)))
+PY
+)"
 mkdir -p "$SMOKE_REPO/.mars/agents"
 cat > "$SMOKE_REPO/.mars/agents/reviewer.md" <<'EOF'
 # Reviewer
@@ -62,7 +72,7 @@ fi
 
 ```bash
 uv run meridian --help >/dev/null && \
-printf '{bad json\n' > "$MERIDIAN_RUNTIME_DIR/spawns.jsonl" && \
+printf '{bad json\n' > "$RUNTIME_ROOT/spawns.jsonl" && \
 if timeout 10 uv run meridian --json spawn list >/tmp/meridian-adv-corrupt.out 2>&1; then
   if grep -q 'Traceback' /tmp/meridian-adv-corrupt.out; then
     echo "FAIL: corrupt state crashed noisily"

--- a/tests/e2e/adversarial.md
+++ b/tests/e2e/adversarial.md
@@ -11,16 +11,7 @@ git -C "$SMOKE_REPO" init --quiet
 for var in $(env | awk -F= '/^MERIDIAN_/ {print $1}'); do unset "$var"; done
 export MERIDIAN_PROJECT_DIR="$SMOKE_REPO"
 cd "$REPO_ROOT"
-export RUNTIME_ROOT="$(uv run python - <<'PY'
-import os
-from pathlib import Path
-from meridian.lib.state.paths import resolve_project_paths
-from meridian.lib.state.user_paths import get_or_create_project_id, get_project_home
-
-state_dir = resolve_project_paths(Path(os.environ["SMOKE_REPO"])).root_dir
-print(get_project_home(get_or_create_project_id(state_dir)))
-PY
-)"
+export RUNTIME_ROOT="$(uv run python tests/e2e/resolve-runtime-root.py)"
 mkdir -p "$SMOKE_REPO/.mars/agents"
 cat > "$SMOKE_REPO/.mars/agents/reviewer.md" <<'EOF'
 # Reviewer

--- a/tests/e2e/fork.md
+++ b/tests/e2e/fork.md
@@ -16,16 +16,7 @@ git -C "$SMOKE_REPO" init --quiet
 for var in $(env | awk -F= '/^MERIDIAN_/ {print $1}'); do unset "$var"; done
 export MERIDIAN_PROJECT_DIR="$SMOKE_REPO"
 cd "$REPO_ROOT"
-export RUNTIME_ROOT="$(uv run python - <<'PY'
-import os
-from pathlib import Path
-from meridian.lib.state.paths import resolve_project_paths
-from meridian.lib.state.user_paths import get_or_create_project_id, get_project_home
-
-state_dir = resolve_project_paths(Path(os.environ["SMOKE_REPO"])).root_dir
-print(get_project_home(get_or_create_project_id(state_dir)))
-PY
-)"
+export RUNTIME_ROOT="$(uv run python tests/e2e/resolve-runtime-root.py)"
 mkdir -p "$SMOKE_REPO/.mars/agents"
 cat > "$SMOKE_REPO/.mars/agents/reviewer.md" <<'EOF'
 # Reviewer

--- a/tests/e2e/fork.md
+++ b/tests/e2e/fork.md
@@ -15,7 +15,17 @@ export SMOKE_REPO="$(mktemp -d /tmp/meridian-fork.XXXXXX)"
 git -C "$SMOKE_REPO" init --quiet
 for var in $(env | awk -F= '/^MERIDIAN_/ {print $1}'); do unset "$var"; done
 export MERIDIAN_PROJECT_DIR="$SMOKE_REPO"
-export MERIDIAN_RUNTIME_DIR="$SMOKE_REPO/.meridian"
+cd "$REPO_ROOT"
+export RUNTIME_ROOT="$(uv run python - <<'PY'
+import os
+from pathlib import Path
+from meridian.lib.state.paths import resolve_project_paths
+from meridian.lib.state.user_paths import get_or_create_project_id, get_project_home
+
+state_dir = resolve_project_paths(Path(os.environ["SMOKE_REPO"])).root_dir
+print(get_project_home(get_or_create_project_id(state_dir)))
+PY
+)"
 mkdir -p "$SMOKE_REPO/.mars/agents"
 cat > "$SMOKE_REPO/.mars/agents/reviewer.md" <<'EOF'
 # Reviewer

--- a/tests/e2e/project-resolution.md
+++ b/tests/e2e/project-resolution.md
@@ -1,0 +1,87 @@
+# Project resolution smoke tests
+
+Manual smoke guide for global `-C` / `--directory` project targeting and stale
+runtime-env cleanup.
+
+## Setup
+
+```bash
+export REPO_ROOT="$(pwd)"
+export SMOKE_A="$(mktemp -d /tmp/meridian-proj-a.XXXXXX)"
+export SMOKE_B="$(mktemp -d /tmp/meridian-proj-b.XXXXXX)"
+export MERIDIAN_HOME="$(mktemp -d /tmp/meridian-home.XXXXXX)"
+for var in $(env | awk -F= '/^MERIDIAN_/ {print $1}'); do
+  case "$var" in MERIDIAN_HOME) ;; *) unset "$var" ;; esac
+done
+mkdir -p "$SMOKE_A/.meridian" "$SMOKE_B/.meridian"
+printf 'proj-a\n' > "$SMOKE_A/.meridian/id"
+printf 'proj-b\n' > "$SMOKE_B/.meridian/id"
+
+uv run python - <<'PY'
+from meridian.lib.state.spawn_store import start_spawn
+from meridian.lib.state.user_paths import get_project_home
+
+start_spawn(
+    get_project_home("proj-a"),
+    spawn_id="p-smoke-a",
+    chat_id="c-smoke-a",
+    model="smoke",
+    agent="qa",
+    harness="codex",
+    prompt="project a",
+)
+start_spawn(
+    get_project_home("proj-b"),
+    spawn_id="p-smoke-b",
+    chat_id="c-smoke-b",
+    model="smoke",
+    agent="qa",
+    harness="codex",
+    prompt="project b",
+)
+PY
+```
+
+## PROJECT-1. `-C` wins over stale inherited runtime state [CRITICAL]
+
+```bash
+export MERIDIAN_PROJECT_DIR="$SMOKE_A"
+export MERIDIAN_RUNTIME_DIR="$MERIDIAN_HOME/projects/proj-a"
+uv run meridian -C "$SMOKE_B" --json spawn list > /tmp/meridian-project-c.json && \
+uv run python - <<'PY'
+import json
+
+payload = json.load(open("/tmp/meridian-project-c.json", encoding="utf-8"))
+spawn_ids = {row["spawn_id"] for row in payload["spawns"]}
+assert "p-smoke-b" in spawn_ids, spawn_ids
+assert "p-smoke-a" not in spawn_ids, spawn_ids
+PY
+echo "PASS: -C ignored stale MERIDIAN_RUNTIME_DIR and read target project state"
+```
+
+## PROJECT-2. `MERIDIAN_PROJECT_DIR` remains the inherited project source [CRITICAL]
+
+```bash
+unset MERIDIAN_RUNTIME_DIR
+export MERIDIAN_PROJECT_DIR="$SMOKE_A"
+uv run meridian --json spawn list > /tmp/meridian-project-env.json && \
+uv run python - <<'PY'
+import json
+
+payload = json.load(open("/tmp/meridian-project-env.json", encoding="utf-8"))
+spawn_ids = {row["spawn_id"] for row in payload["spawns"]}
+assert "p-smoke-a" in spawn_ids, spawn_ids
+assert "p-smoke-b" not in spawn_ids, spawn_ids
+PY
+echo "PASS: MERIDIAN_PROJECT_DIR selected inherited project state"
+```
+
+## Cleanup
+
+```bash
+rm -rf "$SMOKE_A" "$SMOKE_B" "$MERIDIAN_HOME" \
+  /tmp/meridian-project-c.json \
+  /tmp/meridian-project-env.json
+unset SMOKE_A SMOKE_B MERIDIAN_HOME MERIDIAN_PROJECT_DIR MERIDIAN_RUNTIME_DIR REPO_ROOT
+echo "PASS: cleanup complete"
+```

--- a/tests/e2e/resolve-runtime-root.py
+++ b/tests/e2e/resolve-runtime-root.py
@@ -1,0 +1,15 @@
+"""Print the user-home runtime root for a project at $SMOKE_REPO.
+
+Usage in E2E smoke guides::
+
+    export RUNTIME_ROOT="$(uv run python tests/e2e/resolve-runtime-root.py)"
+"""
+
+import os
+from pathlib import Path
+
+from meridian.lib.state.paths import resolve_project_paths
+from meridian.lib.state.user_paths import get_or_create_project_id, get_project_home
+
+state_dir = resolve_project_paths(Path(os.environ["SMOKE_REPO"])).root_dir
+print(get_project_home(get_or_create_project_id(state_dir)))

--- a/tests/e2e/spawn/context-from.md
+++ b/tests/e2e/spawn/context-from.md
@@ -11,16 +11,7 @@ git -C "$SMOKE_REPO" init --quiet
 for var in $(env | awk -F= '/^MERIDIAN_/ {print $1}'); do unset "$var"; done
 export MERIDIAN_PROJECT_DIR="$SMOKE_REPO"
 cd "$REPO_ROOT"
-export RUNTIME_ROOT="$(uv run python - <<'PY'
-import os
-from pathlib import Path
-from meridian.lib.state.paths import resolve_project_paths
-from meridian.lib.state.user_paths import get_or_create_project_id, get_project_home
-
-state_dir = resolve_project_paths(Path(os.environ["SMOKE_REPO"])).root_dir
-print(get_project_home(get_or_create_project_id(state_dir)))
-PY
-)"
+export RUNTIME_ROOT="$(uv run python tests/e2e/resolve-runtime-root.py)"
 
 # Create a minimal agent for dry-run
 mkdir -p "$SMOKE_REPO/.mars/agents"

--- a/tests/e2e/spawn/context-from.md
+++ b/tests/e2e/spawn/context-from.md
@@ -10,7 +10,17 @@ export SMOKE_REPO="$(mktemp -d /tmp/meridian-from.XXXXXX)"
 git -C "$SMOKE_REPO" init --quiet
 for var in $(env | awk -F= '/^MERIDIAN_/ {print $1}'); do unset "$var"; done
 export MERIDIAN_PROJECT_DIR="$SMOKE_REPO"
-export MERIDIAN_RUNTIME_DIR="$SMOKE_REPO/.meridian"
+cd "$REPO_ROOT"
+export RUNTIME_ROOT="$(uv run python - <<'PY'
+import os
+from pathlib import Path
+from meridian.lib.state.paths import resolve_project_paths
+from meridian.lib.state.user_paths import get_or_create_project_id, get_project_home
+
+state_dir = resolve_project_paths(Path(os.environ["SMOKE_REPO"])).root_dir
+print(get_project_home(get_or_create_project_id(state_dir)))
+PY
+)"
 
 # Create a minimal agent for dry-run
 mkdir -p "$SMOKE_REPO/.mars/agents"
@@ -216,6 +226,6 @@ test $RC -ne 0 && grep -qi "not found" /tmp/meridian-from-invalid.err && \
 
 ```bash
 rm -rf "$SMOKE_REPO" /tmp/meridian-from-*.json /tmp/meridian-from-*.err
-unset MERIDIAN_PROJECT_DIR MERIDIAN_RUNTIME_DIR SMOKE_REPO
+unset MERIDIAN_PROJECT_DIR RUNTIME_ROOT SMOKE_REPO
 echo "PASS: cleanup complete"
 ```

--- a/tests/e2e/spawn/lifecycle.md
+++ b/tests/e2e/spawn/lifecycle.md
@@ -10,8 +10,18 @@ export SMOKE_REPO="$(mktemp -d /tmp/meridian-lifecycle.XXXXXX)"
 git -C "$SMOKE_REPO" init --quiet
 for var in $(env | awk -F= '/^MERIDIAN_/ {print $1}'); do unset "$var"; done
 export MERIDIAN_PROJECT_DIR="$SMOKE_REPO"
-export MERIDIAN_RUNTIME_DIR="$SMOKE_REPO/.meridian"
-mkdir -p "$SMOKE_REPO/.mars/agents"
+cd "$REPO_ROOT"
+export RUNTIME_ROOT="$(uv run python - <<'PY'
+import os
+from pathlib import Path
+from meridian.lib.state.paths import resolve_project_paths
+from meridian.lib.state.user_paths import get_or_create_project_id, get_project_home
+
+state_dir = resolve_project_paths(Path(os.environ["SMOKE_REPO"])).root_dir
+print(get_project_home(get_or_create_project_id(state_dir)))
+PY
+)"
+mkdir -p "$RUNTIME_ROOT/spawns" "$SMOKE_REPO/.mars/agents"
 cat > "$SMOKE_REPO/.mars/agents/reviewer.md" <<'AGENT'
 # Reviewer
 
@@ -82,7 +92,7 @@ from pathlib import Path
 spawn_id = open('/tmp/meridian-lifecycle-create.json', encoding='utf-8').read()
 doc = json.loads(spawn_id)
 spawn_id = doc['spawn_id']
-root = Path(os.environ['MERIDIAN_RUNTIME_DIR'])
+root = Path(os.environ['RUNTIME_ROOT'])
 state_path = root / 'spawns' / spawn_id / 'state.json'
 prompt_path = root / 'spawns' / spawn_id / 'starting-prompt.md'
 state = json.loads(state_path.read_text(encoding='utf-8'))
@@ -104,7 +114,7 @@ print((json.load(open('/tmp/meridian-lifecycle-create.json'))['spawn_id']))
 PY
 )" && \
 uv run meridian spawn report show "$SPAWN_ID" > /tmp/meridian-lifecycle-report-show.txt && \
-test -s "$MERIDIAN_RUNTIME_DIR/spawns/$SPAWN_ID/report.md" && \
+test -s "$RUNTIME_ROOT/spawns/$SPAWN_ID/report.md" && \
 test -s /tmp/meridian-lifecycle-report-show.txt && \
 echo "PASS: report.md exists and report show returned content" || echo "FAIL: report persistence or report show failed"
 ```
@@ -126,7 +136,7 @@ import json, os, subprocess
 from pathlib import Path
 from meridian.lib.state.spawn_store import start_spawn
 
-root = Path(os.environ['MERIDIAN_RUNTIME_DIR'])
+root = Path(os.environ['RUNTIME_ROOT'])
 spawn_id = str(
     start_spawn(
         root,
@@ -165,7 +175,7 @@ import os
 from pathlib import Path
 from meridian.lib.state.spawn_store import start_spawn
 
-root = Path(os.environ['MERIDIAN_RUNTIME_DIR'])
+root = Path(os.environ['RUNTIME_ROOT'])
 start_spawn(
     root,
     spawn_id='p-finalizing-filter-smoke',
@@ -207,7 +217,7 @@ from meridian.lib.state.spawn_store import (
     update_spawn,
 )
 
-runtime_root = Path(os.environ['MERIDIAN_RUNTIME_DIR'])
+runtime_root = Path(os.environ['RUNTIME_ROOT'])
 spawn_id = str(
     start_spawn(
         runtime_root,

--- a/tests/e2e/spawn/lifecycle.md
+++ b/tests/e2e/spawn/lifecycle.md
@@ -11,16 +11,7 @@ git -C "$SMOKE_REPO" init --quiet
 for var in $(env | awk -F= '/^MERIDIAN_/ {print $1}'); do unset "$var"; done
 export MERIDIAN_PROJECT_DIR="$SMOKE_REPO"
 cd "$REPO_ROOT"
-export RUNTIME_ROOT="$(uv run python - <<'PY'
-import os
-from pathlib import Path
-from meridian.lib.state.paths import resolve_project_paths
-from meridian.lib.state.user_paths import get_or_create_project_id, get_project_home
-
-state_dir = resolve_project_paths(Path(os.environ["SMOKE_REPO"])).root_dir
-print(get_project_home(get_or_create_project_id(state_dir)))
-PY
-)"
+export RUNTIME_ROOT="$(uv run python tests/e2e/resolve-runtime-root.py)"
 mkdir -p "$RUNTIME_ROOT/spawns" "$SMOKE_REPO/.mars/agents"
 cat > "$SMOKE_REPO/.mars/agents/reviewer.md" <<'AGENT'
 # Reviewer

--- a/tests/e2e/spawn/routing-provenance.md
+++ b/tests/e2e/spawn/routing-provenance.md
@@ -11,16 +11,7 @@ git -C "$SMOKE_REPO" init --quiet
 for var in $(env | awk -F= '/^MERIDIAN_/ {print $1}'); do unset "$var"; done
 export MERIDIAN_PROJECT_DIR="$SMOKE_REPO"
 cd "$REPO_ROOT"
-export RUNTIME_ROOT="$(uv run python - <<'PY'
-import os
-from pathlib import Path
-from meridian.lib.state.paths import resolve_project_paths
-from meridian.lib.state.user_paths import get_or_create_project_id, get_project_home
-
-state_dir = resolve_project_paths(Path(os.environ["SMOKE_REPO"])).root_dir
-print(get_project_home(get_or_create_project_id(state_dir)))
-PY
-)"
+export RUNTIME_ROOT="$(uv run python tests/e2e/resolve-runtime-root.py)"
 
 cat > "$SMOKE_REPO/mars.toml" <<'TOML'
 [settings]

--- a/tests/e2e/spawn/routing-provenance.md
+++ b/tests/e2e/spawn/routing-provenance.md
@@ -10,7 +10,17 @@ export SMOKE_REPO="$(mktemp -d /tmp/meridian-routing.XXXXXX)"
 git -C "$SMOKE_REPO" init --quiet
 for var in $(env | awk -F= '/^MERIDIAN_/ {print $1}'); do unset "$var"; done
 export MERIDIAN_PROJECT_DIR="$SMOKE_REPO"
-export MERIDIAN_RUNTIME_DIR="$SMOKE_REPO/.meridian"
+cd "$REPO_ROOT"
+export RUNTIME_ROOT="$(uv run python - <<'PY'
+import os
+from pathlib import Path
+from meridian.lib.state.paths import resolve_project_paths
+from meridian.lib.state.user_paths import get_or_create_project_id, get_project_home
+
+state_dir = resolve_project_paths(Path(os.environ["SMOKE_REPO"])).root_dir
+print(get_project_home(get_or_create_project_id(state_dir)))
+PY
+)"
 
 cat > "$SMOKE_REPO/mars.toml" <<'TOML'
 [settings]
@@ -134,6 +144,6 @@ rm -rf "$SMOKE_REPO" \
   /tmp/meridian-routing-provenance.json \
   /tmp/meridian-routing-provenance.txt \
   /tmp/meridian-routing-project-defaults.json
-unset MERIDIAN_PROJECT_DIR MERIDIAN_RUNTIME_DIR SMOKE_REPO REPO_ROOT
+unset MERIDIAN_PROJECT_DIR RUNTIME_ROOT SMOKE_REPO REPO_ROOT
 echo "PASS: cleanup complete"
 ```

--- a/tests/e2e/spawn/skill-injection.md
+++ b/tests/e2e/spawn/skill-injection.md
@@ -14,16 +14,7 @@ git -C "$SMOKE_REPO" init --quiet
 for var in $(env | awk -F= '/^MERIDIAN_/ {print $1}'); do unset "$var"; done
 export MERIDIAN_PROJECT_DIR="$SMOKE_REPO"
 cd "$REPO_ROOT"
-export RUNTIME_ROOT="$(uv run python - <<'PY'
-import os
-from pathlib import Path
-from meridian.lib.state.paths import resolve_project_paths
-from meridian.lib.state.user_paths import get_or_create_project_id, get_project_home
-
-state_dir = resolve_project_paths(Path(os.environ["SMOKE_REPO"])).root_dir
-print(get_project_home(get_or_create_project_id(state_dir)))
-PY
-)"
+export RUNTIME_ROOT="$(uv run python tests/e2e/resolve-runtime-root.py)"
 mkdir -p \
   "$SMOKE_REPO/.mars/agents" \
   "$SMOKE_REPO/.mars/skills/meridian-orchestrate" \

--- a/tests/e2e/spawn/skill-injection.md
+++ b/tests/e2e/spawn/skill-injection.md
@@ -13,7 +13,17 @@ export SMOKE_REPO="$(mktemp -d /tmp/meridian-skill-inject.XXXXXX)"
 git -C "$SMOKE_REPO" init --quiet
 for var in $(env | awk -F= '/^MERIDIAN_/ {print $1}'); do unset "$var"; done
 export MERIDIAN_PROJECT_DIR="$SMOKE_REPO"
-export MERIDIAN_RUNTIME_DIR="$SMOKE_REPO/.meridian"
+cd "$REPO_ROOT"
+export RUNTIME_ROOT="$(uv run python - <<'PY'
+import os
+from pathlib import Path
+from meridian.lib.state.paths import resolve_project_paths
+from meridian.lib.state.user_paths import get_or_create_project_id, get_project_home
+
+state_dir = resolve_project_paths(Path(os.environ["SMOKE_REPO"])).root_dir
+print(get_project_home(get_or_create_project_id(state_dir)))
+PY
+)"
 mkdir -p \
   "$SMOKE_REPO/.mars/agents" \
   "$SMOKE_REPO/.mars/skills/meridian-orchestrate" \

--- a/tests/e2e/state-integrity.md
+++ b/tests/e2e/state-integrity.md
@@ -11,16 +11,7 @@ git -C "$SMOKE_REPO" init --quiet
 for var in $(env | awk -F= '/^MERIDIAN_/ {print $1}'); do unset "$var"; done
 export MERIDIAN_PROJECT_DIR="$SMOKE_REPO"
 cd "$REPO_ROOT"
-export RUNTIME_ROOT="$(uv run python - <<'PY'
-import os
-from pathlib import Path
-from meridian.lib.state.paths import resolve_project_paths
-from meridian.lib.state.user_paths import get_or_create_project_id, get_project_home
-
-state_dir = resolve_project_paths(Path(os.environ["SMOKE_REPO"])).root_dir
-print(get_project_home(get_or_create_project_id(state_dir)))
-PY
-)"
+export RUNTIME_ROOT="$(uv run python tests/e2e/resolve-runtime-root.py)"
 mkdir -p "$RUNTIME_ROOT/spawns"
 cd "$REPO_ROOT"
 uv run meridian spawn -h >/dev/null 2>&1 && echo "PASS: state fixture setup complete" || echo "FAIL: state fixture setup failed"

--- a/tests/e2e/state-integrity.md
+++ b/tests/e2e/state-integrity.md
@@ -10,8 +10,18 @@ export SMOKE_REPO="$(mktemp -d /tmp/meridian-state.XXXXXX)"
 git -C "$SMOKE_REPO" init --quiet
 for var in $(env | awk -F= '/^MERIDIAN_/ {print $1}'); do unset "$var"; done
 export MERIDIAN_PROJECT_DIR="$SMOKE_REPO"
-export MERIDIAN_RUNTIME_DIR="$SMOKE_REPO/.meridian"
-mkdir -p "$MERIDIAN_RUNTIME_DIR/spawns"
+cd "$REPO_ROOT"
+export RUNTIME_ROOT="$(uv run python - <<'PY'
+import os
+from pathlib import Path
+from meridian.lib.state.paths import resolve_project_paths
+from meridian.lib.state.user_paths import get_or_create_project_id, get_project_home
+
+state_dir = resolve_project_paths(Path(os.environ["SMOKE_REPO"])).root_dir
+print(get_project_home(get_or_create_project_id(state_dir)))
+PY
+)"
+mkdir -p "$RUNTIME_ROOT/spawns"
 cd "$REPO_ROOT"
 uv run meridian spawn -h >/dev/null 2>&1 && echo "PASS: state fixture setup complete" || echo "FAIL: state fixture setup failed"
 ```
@@ -19,8 +29,8 @@ uv run meridian spawn -h >/dev/null 2>&1 && echo "PASS: state fixture setup comp
 ### STATE-1. Core runtime directories exist [CRITICAL]
 
 ```bash
-test -d "$MERIDIAN_RUNTIME_DIR" && \
-test -d "$MERIDIAN_RUNTIME_DIR/spawns" && \
+test -d "$RUNTIME_ROOT" && \
+test -d "$RUNTIME_ROOT/spawns" && \
 echo "PASS: runtime root and spawns directory exist" || echo "FAIL: runtime state directories are incomplete"
 ```
 
@@ -32,7 +42,7 @@ import json, os
 from pathlib import Path
 from meridian.lib.state.spawn_store import start_spawn
 
-root = Path(os.environ["MERIDIAN_RUNTIME_DIR"])
+root = Path(os.environ["RUNTIME_ROOT"])
 spawn_id = str(
     start_spawn(
         root,
@@ -61,7 +71,7 @@ PY
 ```bash
 uv run python - <<'PY'
 import json, os
-path = os.path.join(os.environ["MERIDIAN_RUNTIME_DIR"], "sessions.jsonl")
+path = os.path.join(os.environ["RUNTIME_ROOT"], "sessions.jsonl")
 if not os.path.exists(path):
     print("PASS: sessions.jsonl has not been created yet")
 else:
@@ -81,7 +91,7 @@ import os
 import pathlib
 import sys
 
-root = pathlib.Path(os.environ["MERIDIAN_RUNTIME_DIR"])
+root = pathlib.Path(os.environ["RUNTIME_ROOT"])
 lock_paths = sorted(root.glob("spawns/*/state.lock")) + sorted(root.glob("spawns/migration.lock"))
 if os.name == "nt":
     print("PASS: skipping POSIX flock probe on Windows")
@@ -100,7 +110,7 @@ PY
 ### STATE-5. No stale atomic temp files remain [NICE-TO-HAVE]
 
 ```bash
-if find "$MERIDIAN_RUNTIME_DIR" -name '.*.tmp' -print | grep -q .; then
+if find "$RUNTIME_ROOT" -name '.*.tmp' -print | grep -q .; then
   echo "FAIL: stale atomic temp files remain"
 else
   echo "PASS: no stale atomic temp files remain"
@@ -114,7 +124,7 @@ uv run python - <<'PY'
 import json, os, pathlib, subprocess, time
 from meridian.lib.state.spawn_store import start_spawn
 
-root = pathlib.Path(os.environ["MERIDIAN_RUNTIME_DIR"])
+root = pathlib.Path(os.environ["RUNTIME_ROOT"])
 spawn_id = "p-orphan-heartbeat-smoke"
 start_spawn(
     root,
@@ -158,7 +168,7 @@ uv run python - <<'PY'
 import json, os, pathlib, subprocess, uuid
 from meridian.lib.state.spawn_store import start_spawn
 
-root = pathlib.Path(os.environ["MERIDIAN_RUNTIME_DIR"])
+root = pathlib.Path(os.environ["RUNTIME_ROOT"])
 spawn_id = f"p-origin-cancel-smoke-{uuid.uuid4().hex[:8]}"
 start_spawn(
     root,
@@ -194,7 +204,7 @@ import json, os
 from pathlib import Path
 from meridian.lib.state.spawn_store import finalize_spawn, start_spawn
 
-root = Path(os.environ["MERIDIAN_RUNTIME_DIR"])
+root = Path(os.environ["RUNTIME_ROOT"])
 spawn_id = str(
     start_spawn(
         root,
@@ -221,7 +231,7 @@ uv run python - <<'PY'
 import json, os, pathlib, subprocess, time
 from meridian.lib.state.spawn_store import start_spawn
 
-root = pathlib.Path(os.environ["MERIDIAN_RUNTIME_DIR"])
+root = pathlib.Path(os.environ["RUNTIME_ROOT"])
 spawn_id = "p-orphan-finalizing-stale-smoke"
 start_spawn(
     root,
@@ -264,7 +274,7 @@ uv run python - <<'PY'
 import json, os, pathlib, subprocess, time
 from meridian.lib.state.spawn_store import start_spawn
 
-root = pathlib.Path(os.environ["MERIDIAN_RUNTIME_DIR"])
+root = pathlib.Path(os.environ["RUNTIME_ROOT"])
 spawn_id = "p-orphan-finalizing-fresh-smoke"
 start_spawn(
     root,

--- a/tests/integration/cli/test_cli_hooks.py
+++ b/tests/integration/cli/test_cli_hooks.py
@@ -148,9 +148,6 @@ def _write_hook_env_recorder(path: Path) -> None:
         "        {\n"
         '            "MERIDIAN_RUNTIME_DIR": os.environ.get("MERIDIAN_RUNTIME_DIR"),\n'
         '            "MERIDIAN_PROJECT_DIR": os.environ.get("MERIDIAN_PROJECT_DIR"),\n'
-        '            "MERIDIAN_DIRECTORY_EXPLICIT": os.environ.get(\n'
-        '                "MERIDIAN_DIRECTORY_EXPLICIT"\n'
-        "            ),\n"
         "        }\n"
         "    )\n"
         "    + '\\n',\n"
@@ -177,7 +174,6 @@ def test_hook_subprocess_env_strips_stale_runtime_dir(
     )
     stale_runtime = tmp_path / "stale-runtime"
     monkeypatch.setenv("MERIDIAN_RUNTIME_DIR", stale_runtime.as_posix())
-    monkeypatch.setenv("MERIDIAN_DIRECTORY_EXPLICIT", "1")
     monkeypatch.chdir(project_root)
 
     with pytest.raises(SystemExit) as exc_info:
@@ -186,7 +182,6 @@ def test_hook_subprocess_env_strips_stale_runtime_dir(
     assert exc_info.value.code == 0
     captured = json.loads(marker.read_text(encoding="utf-8"))
     assert captured["MERIDIAN_RUNTIME_DIR"] is None
-    assert captured["MERIDIAN_DIRECTORY_EXPLICIT"] is None
     assert captured["MERIDIAN_PROJECT_DIR"] == project_root.resolve().as_posix()
 
 

--- a/tests/integration/cli/test_cli_hooks.py
+++ b/tests/integration/cli/test_cli_hooks.py
@@ -131,8 +131,63 @@ def test_nested_manual_hooks_ignore_inherited_roots_during_handler_execution(
         cli_main.main(argv)
 
     assert exc_info.value.code == 0
-    assert captured["env"] == (None, None)
+    assert captured["env"] == (None, parent_runtime.as_posix())
     assert captured["project_root"] == child_project.resolve().as_posix()
+
+
+def _write_hook_env_recorder(path: Path) -> None:
+    path.write_text(
+        "import json\n"
+        "import os\n"
+        "import sys\n"
+        "from pathlib import Path\n"
+        "_ = json.loads(sys.stdin.read())\n"
+        "target = Path(sys.argv[1])\n"
+        "target.write_text(\n"
+        "    json.dumps(\n"
+        "        {\n"
+        '            "MERIDIAN_RUNTIME_DIR": os.environ.get("MERIDIAN_RUNTIME_DIR"),\n'
+        '            "MERIDIAN_PROJECT_DIR": os.environ.get("MERIDIAN_PROJECT_DIR"),\n'
+        '            "MERIDIAN_DIRECTORY_EXPLICIT": os.environ.get(\n'
+        '                "MERIDIAN_DIRECTORY_EXPLICIT"\n'
+        "            ),\n"
+        "        }\n"
+        "    )\n"
+        "    + '\\n',\n"
+        "    encoding='utf-8',\n"
+        ")\n",
+        encoding="utf-8",
+    )
+
+
+def test_hook_subprocess_env_strips_stale_runtime_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MERIDIAN_DEPTH", raising=False)
+    project_root = tmp_path / "hooks-env-project"
+    project_root.mkdir()
+    marker = tmp_path / "hook-env.json"
+    recorder = tmp_path / "record_hook_env.py"
+    _write_hook_env_recorder(recorder)
+    command = _python_command(recorder, marker.as_posix())
+    (project_root / "meridian.toml").write_text(
+        f"[[hooks]]\nname = 'record-finalized'\nevent = 'spawn.finalized'\ncommand = '{command}'\n",
+        encoding="utf-8",
+    )
+    stale_runtime = tmp_path / "stale-runtime"
+    monkeypatch.setenv("MERIDIAN_RUNTIME_DIR", stale_runtime.as_posix())
+    monkeypatch.setenv("MERIDIAN_DIRECTORY_EXPLICIT", "1")
+    monkeypatch.chdir(project_root)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["hooks", "run", "record-finalized"])
+
+    assert exc_info.value.code == 0
+    captured = json.loads(marker.read_text(encoding="utf-8"))
+    assert captured["MERIDIAN_RUNTIME_DIR"] is None
+    assert captured["MERIDIAN_DIRECTORY_EXPLICIT"] is None
+    assert captured["MERIDIAN_PROJECT_DIR"] == project_root.resolve().as_posix()
 
 
 def test_top_level_hooks_run_honors_runtime_override_in_hook_context(

--- a/tests/integration/cli/test_cli_main.py
+++ b/tests/integration/cli/test_cli_main.py
@@ -33,7 +33,7 @@ def test_main_restores_directory_env_after_return(
 ) -> None:
     monkeypatch.delenv("MERIDIAN_DEPTH", raising=False)
     monkeypatch.setenv("MERIDIAN_PROJECT_DIR", "/prior/project")
-    monkeypatch.setenv("MERIDIAN_DIRECTORY_EXPLICIT", "1")
+    monkeypatch.setenv("MERIDIAN_RUNTIME_DIR", "/prior/runtime")
     monkeypatch.setattr(cli_main, "_install_cli_telemetry", lambda **_kwargs: None)
     monkeypatch.setattr(cli_main, "_maybe_schedule_background_repairs", lambda **_kwargs: None)
     monkeypatch.setattr(cli_main, "_emit_usage_command_invoked", lambda *_args, **_kwargs: None)
@@ -53,7 +53,7 @@ def test_main_restores_directory_env_after_return(
 
     assert exc_info.value.code == 0
     assert os.environ.get("MERIDIAN_PROJECT_DIR") == "/prior/project"
-    assert os.environ.get("MERIDIAN_DIRECTORY_EXPLICIT") == "1"
+    assert os.environ.get("MERIDIAN_RUNTIME_DIR") == "/prior/runtime"
 
 
 def test_background_repairs_pin_runtime_root_before_env_restore(
@@ -69,8 +69,8 @@ def test_background_repairs_pin_runtime_root_before_env_restore(
     expected_runtime = get_project_home("proj-repair")
 
     monkeypatch.delenv("MERIDIAN_DEPTH", raising=False)
-    monkeypatch.setenv("MERIDIAN_RUNTIME_DIR", stale_runtime.as_posix())
-    monkeypatch.setenv("MERIDIAN_DIRECTORY_EXPLICIT", "1")
+    # Simulate -C scope: MERIDIAN_RUNTIME_DIR is absent (unset by _directory_env_scope)
+    monkeypatch.delenv("MERIDIAN_RUNTIME_DIR", raising=False)
 
     captured: dict[str, Path | None] = {}
 
@@ -80,8 +80,6 @@ def test_background_repairs_pin_runtime_root_before_env_restore(
         runtime_root: Path | None = None,
     ) -> int:
         captured["locks"] = runtime_root
-        monkeypatch.delenv("MERIDIAN_DIRECTORY_EXPLICIT", raising=False)
-        monkeypatch.delenv("MERIDIAN_RUNTIME_DIR", raising=False)
         assert runtime_root == expected_runtime
         return 0
 
@@ -132,14 +130,11 @@ def test_main_sets_directory_env_before_telemetry_install(
     stale_runtime = tmp_path / "stale-runtime"
     stale_runtime.mkdir()
     monkeypatch.setenv("MERIDIAN_RUNTIME_DIR", stale_runtime.as_posix())
-    monkeypatch.delenv("MERIDIAN_DIRECTORY_EXPLICIT", raising=False)
     telemetry_env: dict[str, str | None] = {}
 
     def _capture_telemetry(**_kwargs: object) -> None:
         telemetry_env["MERIDIAN_PROJECT_DIR"] = os.environ.get("MERIDIAN_PROJECT_DIR")
-        telemetry_env["MERIDIAN_DIRECTORY_EXPLICIT"] = os.environ.get(
-            "MERIDIAN_DIRECTORY_EXPLICIT"
-        )
+        telemetry_env["MERIDIAN_RUNTIME_DIR"] = os.environ.get("MERIDIAN_RUNTIME_DIR")
 
     monkeypatch.setattr(cli_main, "_install_cli_telemetry", _capture_telemetry)
     monkeypatch.setattr(cli_main, "_maybe_schedule_background_repairs", lambda **_kwargs: None)
@@ -160,7 +155,8 @@ def test_main_sets_directory_env_before_telemetry_install(
 
     assert exc_info.value.code == 0
     assert telemetry_env["MERIDIAN_PROJECT_DIR"] == project.resolve().as_posix()
-    assert telemetry_env["MERIDIAN_DIRECTORY_EXPLICIT"] == "1"
+    # -C scope unsets stale MERIDIAN_RUNTIME_DIR so runtime derives from project identity
+    assert telemetry_env["MERIDIAN_RUNTIME_DIR"] is None
 
 
 def test_directory_flag_supplies_project_root_to_config_ops(

--- a/tests/integration/cli/test_cli_main.py
+++ b/tests/integration/cli/test_cli_main.py
@@ -1,20 +1,241 @@
 # qa-validated: pi-rpc-quiescence
 import importlib
+import os
 import shlex
+import threading
 from pathlib import Path
+from typing import Any
 
 import pytest
 
+from meridian.cli.startup.catalog import StartupClass
 from meridian.lib.core.types import HarnessId
+from meridian.lib.ops import diag as ops_diag
+from meridian.lib.state.user_paths import get_project_home
 from tests.support.fixtures import write_minimal_mars_config
 from tests.support.launch import stub_bundle_request_and_resolve
 from tests.support.pi_extensions import configure_pi_extension_projection
 
 cli_main = importlib.import_module("meridian.cli.main")
+config_cmd = importlib.import_module("meridian.cli.config_cmd")
+hooks_cli = importlib.import_module("meridian.cli.hooks_commands")
+ops_hooks = importlib.import_module("meridian.lib.ops.hooks")
 primary_launch = importlib.import_module("meridian.cli.primary_launch")
+session_cmd = importlib.import_module("meridian.cli.session_cmd")
 init_ops = importlib.import_module("meridian.lib.ops.init_ops")
 bootstrap_services = importlib.import_module("meridian.lib.bootstrap.services")
 cli_utils = importlib.import_module("meridian.cli.utils")
+
+
+def test_main_restores_directory_env_after_return(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MERIDIAN_DEPTH", raising=False)
+    monkeypatch.setenv("MERIDIAN_PROJECT_DIR", "/prior/project")
+    monkeypatch.setenv("MERIDIAN_DIRECTORY_EXPLICIT", "1")
+    monkeypatch.setattr(cli_main, "_install_cli_telemetry", lambda **_kwargs: None)
+    monkeypatch.setattr(cli_main, "_maybe_schedule_background_repairs", lambda **_kwargs: None)
+    monkeypatch.setattr(cli_main, "_emit_usage_command_invoked", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        cli_main,
+        "maybe_bootstrap_runtime_state",
+        lambda *_args, **_kwargs: tmp_path / "resolved-project",
+    )
+    monkeypatch.setattr(
+        hooks_cli,
+        "hooks_check_sync",
+        lambda _payload: ops_hooks.HookCheckOutput(ok=True, checks=()),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["hooks", "check"])
+
+    assert exc_info.value.code == 0
+    assert os.environ.get("MERIDIAN_PROJECT_DIR") == "/prior/project"
+    assert os.environ.get("MERIDIAN_DIRECTORY_EXPLICIT") == "1"
+
+
+def test_background_repairs_pin_runtime_root_before_env_restore(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = tmp_path / "repo"
+    state_dir = project / ".meridian"
+    state_dir.mkdir(parents=True)
+    (state_dir / "id").write_text("proj-repair", encoding="utf-8")
+    stale_runtime = tmp_path / "stale-runtime"
+    stale_runtime.mkdir()
+    expected_runtime = get_project_home("proj-repair")
+
+    monkeypatch.delenv("MERIDIAN_DEPTH", raising=False)
+    monkeypatch.setenv("MERIDIAN_RUNTIME_DIR", stale_runtime.as_posix())
+    monkeypatch.setenv("MERIDIAN_DIRECTORY_EXPLICIT", "1")
+
+    captured: dict[str, Path | None] = {}
+
+    def _capture_locks(
+        project_root: Path,
+        *,
+        runtime_root: Path | None = None,
+    ) -> int:
+        captured["locks"] = runtime_root
+        monkeypatch.delenv("MERIDIAN_DIRECTORY_EXPLICIT", raising=False)
+        monkeypatch.delenv("MERIDIAN_RUNTIME_DIR", raising=False)
+        assert runtime_root == expected_runtime
+        return 0
+
+    def _capture_orphans(
+        project_root: Path,
+        *,
+        runtime_root: Path | None = None,
+    ) -> tuple[int, tuple[str, ...]]:
+        captured["orphans"] = runtime_root
+        assert runtime_root == expected_runtime
+        return 0, ()
+
+    class _ImmediateThread:
+        def __init__(
+            self,
+            *,
+            target,
+            name: str | None = None,
+            daemon: bool | None = None,
+        ) -> None:
+            self._target = target
+
+        def start(self) -> None:
+            self._target()
+
+    monkeypatch.setattr(threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(ops_diag, "_repair_stale_session_locks", _capture_locks)
+    monkeypatch.setattr(ops_diag, "_repair_orphan_runs", _capture_orphans)
+
+    cli_main._maybe_schedule_background_repairs(
+        startup_class=StartupClass.PRIMARY_LAUNCH,
+        project_root=project,
+        bootstrap_skipped=False,
+        ignore_runtime_env=True,
+    )
+
+    assert captured["locks"] == expected_runtime
+    assert captured["orphans"] == expected_runtime
+
+
+def test_main_sets_directory_env_before_telemetry_install(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MERIDIAN_DEPTH", raising=False)
+    project = tmp_path / "explicit-project"
+    project.mkdir()
+    (project / ".meridian").mkdir()
+    stale_runtime = tmp_path / "stale-runtime"
+    stale_runtime.mkdir()
+    monkeypatch.setenv("MERIDIAN_RUNTIME_DIR", stale_runtime.as_posix())
+    monkeypatch.delenv("MERIDIAN_DIRECTORY_EXPLICIT", raising=False)
+    telemetry_env: dict[str, str | None] = {}
+
+    def _capture_telemetry(**_kwargs: object) -> None:
+        telemetry_env["MERIDIAN_PROJECT_DIR"] = os.environ.get("MERIDIAN_PROJECT_DIR")
+        telemetry_env["MERIDIAN_DIRECTORY_EXPLICIT"] = os.environ.get(
+            "MERIDIAN_DIRECTORY_EXPLICIT"
+        )
+
+    monkeypatch.setattr(cli_main, "_install_cli_telemetry", _capture_telemetry)
+    monkeypatch.setattr(cli_main, "_maybe_schedule_background_repairs", lambda **_kwargs: None)
+    monkeypatch.setattr(cli_main, "_emit_usage_command_invoked", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        cli_main,
+        "maybe_bootstrap_runtime_state",
+        lambda *_args, **_kwargs: project.resolve(),
+    )
+    monkeypatch.setattr(
+        hooks_cli,
+        "hooks_check_sync",
+        lambda _payload: ops_hooks.HookCheckOutput(ok=True, checks=()),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["-C", project.as_posix(), "hooks", "check"])
+
+    assert exc_info.value.code == 0
+    assert telemetry_env["MERIDIAN_PROJECT_DIR"] == project.resolve().as_posix()
+    assert telemetry_env["MERIDIAN_DIRECTORY_EXPLICIT"] == "1"
+
+
+def test_directory_flag_supplies_project_root_to_config_ops(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = tmp_path / "target-project"
+    project.mkdir()
+    parent_project = tmp_path / "parent-project"
+    parent_project.mkdir()
+    stale_runtime = tmp_path / "stale-runtime"
+    stale_runtime.mkdir()
+    captured: dict[str, str | None] = {}
+
+    monkeypatch.delenv("MERIDIAN_DEPTH", raising=False)
+    monkeypatch.setenv("MERIDIAN_PROJECT_DIR", parent_project.as_posix())
+    monkeypatch.setenv("MERIDIAN_RUNTIME_DIR", stale_runtime.as_posix())
+    monkeypatch.setattr(cli_main, "_install_cli_telemetry", lambda **_kwargs: None)
+    monkeypatch.setattr(cli_main, "_maybe_schedule_background_repairs", lambda **_kwargs: None)
+    monkeypatch.setattr(cli_main, "_emit_usage_command_invoked", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        cli_main,
+        "maybe_bootstrap_runtime_state",
+        lambda *_args, **_kwargs: project.resolve(),
+    )
+
+    def _capture_config_get(payload: Any) -> object:
+        captured["project_root"] = payload.project_root
+        raise SystemExit(0)
+
+    monkeypatch.setattr(config_cmd, "config_get_sync", _capture_config_get)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["-C", project.as_posix(), "config", "get", "model"])
+
+    assert exc_info.value.code == 0
+    assert captured["project_root"] == project.resolve().as_posix()
+
+
+def test_directory_flag_supplies_project_root_to_session_log(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = tmp_path / "target-project"
+    project.mkdir()
+    parent_project = tmp_path / "parent-project"
+    parent_project.mkdir()
+    stale_runtime = tmp_path / "stale-runtime"
+    stale_runtime.mkdir()
+    captured: dict[str, str | None] = {}
+
+    monkeypatch.delenv("MERIDIAN_DEPTH", raising=False)
+    monkeypatch.setenv("MERIDIAN_PROJECT_DIR", parent_project.as_posix())
+    monkeypatch.setenv("MERIDIAN_RUNTIME_DIR", stale_runtime.as_posix())
+    monkeypatch.setattr(cli_main, "_install_cli_telemetry", lambda **_kwargs: None)
+    monkeypatch.setattr(cli_main, "_maybe_schedule_background_repairs", lambda **_kwargs: None)
+    monkeypatch.setattr(cli_main, "_emit_usage_command_invoked", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        cli_main,
+        "maybe_bootstrap_runtime_state",
+        lambda *_args, **_kwargs: project.resolve(),
+    )
+
+    def _capture_session_log(payload: Any) -> object:
+        captured["project_root"] = payload.project_root
+        raise SystemExit(0)
+
+    monkeypatch.setattr(session_cmd, "session_log_sync", _capture_session_log)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["-C", project.as_posix(), "session", "log", "c8"])
+
+    assert exc_info.value.code == 0
+    assert captured["project_root"] == project.resolve().as_posix()
 
 
 def test_main_skips_fork_normalization_for_mars_passthrough(
@@ -186,5 +407,3 @@ def test_bootstrap_setup_flags_reject_dry_run_before_setup(
     captured = capsys.readouterr()
     assert captured.out == ""
     assert captured.err == "error: Cannot combine setup flags (--add/--link) with --dry-run.\n"
-
-

--- a/tests/integration/cli/test_cli_main.py
+++ b/tests/integration/cli/test_cli_main.py
@@ -115,7 +115,6 @@ def test_background_repairs_pin_runtime_root_before_env_restore(
         startup_class=StartupClass.PRIMARY_LAUNCH,
         project_root=project,
         bootstrap_skipped=False,
-        ignore_runtime_env=True,
     )
 
     assert captured["locks"] == expected_runtime

--- a/tests/integration/hooks/test_runner.py
+++ b/tests/integration/hooks/test_runner.py
@@ -55,7 +55,7 @@ def test_external_runner_sets_cwd_env_and_json_stdin(tmp_path: Path) -> None:
         "print(os.environ['MERIDIAN_HOOK_EVENT'])\n"
         "print(os.environ['MERIDIAN_HOOK_EVENT_ID'])\n"
         "print(os.environ['MERIDIAN_PROJECT_DIR'])\n"
-        "print(os.environ['MERIDIAN_RUNTIME_DIR'])\n"
+        "print(payload['runtime_root'])\n"
         "print(os.environ['MERIDIAN_SPAWN_ID'])\n"
         "print(payload['event_name'])\n"
         "print(payload['spawn']['id'])\n",

--- a/tests/integration/launch/test_permissions.py
+++ b/tests/integration/launch/test_permissions.py
@@ -5,6 +5,7 @@ import pytest
 from meridian.lib.core.types import HarnessId, ModelId
 from meridian.lib.harness.adapter import SpawnParams
 from meridian.lib.harness.claude import ClaudeAdapter
+from meridian.lib.harness.pi import PiAdapter
 from meridian.lib.harness.projections.permission_flags import resolve_permission_flags
 from meridian.lib.launch.env import (
     build_harness_child_env,
@@ -22,7 +23,6 @@ from meridian.lib.safety.permissions import (
 
 _MERIDIAN_RUNTIME_KEYS = (
     "MERIDIAN_PROJECT_DIR",
-    "MERIDIAN_RUNTIME_DIR",
     "MERIDIAN_DEPTH",
     "MERIDIAN_CHAT_ID",
     "MERIDIAN_CONTEXT_KB_DIR",
@@ -240,6 +240,61 @@ def test_build_harness_child_env_inherits_allowed_vars_and_blocks_adapter_vars()
     assert "CLAUDECODE" not in child_env
 
 
+def test_inherit_child_env_blocks_meridian_runtime_dir() -> None:
+    inherited = inherit_child_env(
+        base_env={
+            "PATH": "/usr/bin",
+            "MERIDIAN_RUNTIME_DIR": "/stale/runtime",
+        },
+        env_overrides={
+            "MERIDIAN_PROJECT_DIR": "/repo",
+            "MERIDIAN_PI_STATE_DIR": "/resolved/runtime",
+        },
+    )
+
+    assert "MERIDIAN_RUNTIME_DIR" not in inherited
+    assert inherited["MERIDIAN_PROJECT_DIR"] == "/repo"
+    assert inherited["MERIDIAN_PI_STATE_DIR"] == "/resolved/runtime"
+
+
+def test_inherit_child_env_blocks_meridian_directory_explicit() -> None:
+    inherited = inherit_child_env(
+        base_env={
+            "PATH": "/usr/bin",
+            "MERIDIAN_DIRECTORY_EXPLICIT": "1",
+        },
+        env_overrides={
+            "MERIDIAN_PROJECT_DIR": "/repo",
+        },
+    )
+
+    assert "MERIDIAN_DIRECTORY_EXPLICIT" not in inherited
+    assert inherited["MERIDIAN_PROJECT_DIR"] == "/repo"
+
+
+def test_build_harness_child_env_pi_state_dir_from_runtime_root() -> None:
+    runtime_root = "/resolved/runtime"
+    child_env = build_harness_child_env(
+        base_env={
+            "PATH": "/usr/bin",
+            "MERIDIAN_PI_STATE_DIR": "/stale/pi-state",
+            "MERIDIAN_RUNTIME_DIR": "/stale/runtime",
+        },
+        adapter=PiAdapter(),
+        run_params=SpawnParams(prompt="test", model=ModelId("openai-codex/gpt-5.4-mini")),
+        permission_config=PermissionConfig(),
+        runtime_env_overrides={
+            "MERIDIAN_PI_STATE_DIR": runtime_root,
+            "MERIDIAN_PROJECT_DIR": "/repo",
+        },
+    )
+
+    assert child_env["MERIDIAN_PI_STATE_DIR"] == runtime_root
+    assert child_env["MERIDIAN_PROJECT_DIR"] == "/repo"
+    assert "MERIDIAN_RUNTIME_DIR" not in child_env
+    assert "PI_CODING_AGENT_SESSION_DIR" in child_env
+
+
 def test_inherit_child_env_runtime_overrides_win() -> None:
     inherited = inherit_child_env(
         base_env={
@@ -277,7 +332,6 @@ def test_merge_env_overrides_rejects_meridian_keys_from_plan_and_preflight() -> 
 def test_merge_env_overrides_accepts_runtime_meridian_keys() -> None:
     runtime_overrides = {
         "MERIDIAN_PROJECT_DIR": "/repo",
-        "MERIDIAN_RUNTIME_DIR": "/repo/.meridian",
         "MERIDIAN_DEPTH": "2",
         "MERIDIAN_CHAT_ID": "c-parent",
         "MERIDIAN_CONTEXT_KB_DIR": "/repo/.meridian/kb",

--- a/tests/integration/launch/test_permissions.py
+++ b/tests/integration/launch/test_permissions.py
@@ -257,21 +257,6 @@ def test_inherit_child_env_blocks_meridian_runtime_dir() -> None:
     assert inherited["MERIDIAN_PI_STATE_DIR"] == "/resolved/runtime"
 
 
-def test_inherit_child_env_blocks_meridian_directory_explicit() -> None:
-    inherited = inherit_child_env(
-        base_env={
-            "PATH": "/usr/bin",
-            "MERIDIAN_DIRECTORY_EXPLICIT": "1",
-        },
-        env_overrides={
-            "MERIDIAN_PROJECT_DIR": "/repo",
-        },
-    )
-
-    assert "MERIDIAN_DIRECTORY_EXPLICIT" not in inherited
-    assert inherited["MERIDIAN_PROJECT_DIR"] == "/repo"
-
-
 def test_build_harness_child_env_pi_state_dir_from_runtime_root() -> None:
     runtime_root = "/resolved/runtime"
     child_env = build_harness_child_env(

--- a/tests/unit/cli/test_cli_utils.py
+++ b/tests/unit/cli/test_cli_utils.py
@@ -3,25 +3,15 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-import pytest
+if TYPE_CHECKING:
+    import pytest
 
 from meridian.cli import utils as cli_utils
 
 
-def test_implicit_session_ops_payload_skips_project_for_direct_file(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        cli_utils,
-        "require_established_project_root",
-        lambda: pytest.fail("project root should not be required for --file"),
-    )
-
-    assert cli_utils.implicit_session_ops_payload(file_path="session.jsonl") == {}
-
-
-def test_implicit_session_ops_payload_requires_project_without_file(
+def test_cli_project_root_posix_returns_posix_string(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -29,9 +19,4 @@ def test_implicit_session_ops_payload_requires_project_without_file(
     project_root.mkdir()
     monkeypatch.setattr(cli_utils, "require_established_project_root", lambda: project_root)
 
-    assert cli_utils.implicit_session_ops_payload(file_path=None) == {
-        "project_root": project_root.as_posix()
-    }
-    assert cli_utils.implicit_session_ops_payload(file_path="   ") == {
-        "project_root": project_root.as_posix()
-    }
+    assert cli_utils.cli_project_root_posix() == project_root.as_posix()

--- a/tests/unit/cli/test_cli_utils.py
+++ b/tests/unit/cli/test_cli_utils.py
@@ -1,0 +1,37 @@
+"""Unit tests for shared CLI helper contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from meridian.cli import utils as cli_utils
+
+
+def test_implicit_session_ops_payload_skips_project_for_direct_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        cli_utils,
+        "require_established_project_root",
+        lambda: pytest.fail("project root should not be required for --file"),
+    )
+
+    assert cli_utils.implicit_session_ops_payload(file_path="session.jsonl") == {}
+
+
+def test_implicit_session_ops_payload_requires_project_without_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    monkeypatch.setattr(cli_utils, "require_established_project_root", lambda: project_root)
+
+    assert cli_utils.implicit_session_ops_payload(file_path=None) == {
+        "project_root": project_root.as_posix()
+    }
+    assert cli_utils.implicit_session_ops_payload(file_path="   ") == {
+        "project_root": project_root.as_posix()
+    }

--- a/tests/unit/core/test_resolved_context_runtime.py
+++ b/tests/unit/core/test_resolved_context_runtime.py
@@ -1,0 +1,145 @@
+"""ResolvedContext runtime-root derivation from project identity."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from meridian.lib.core.resolved_context import ResolvedContext
+from meridian.lib.ops.runtime import resolve_runtime_authority_for_read
+from meridian.lib.state.runtime_root import derive_runtime_root_from_project
+from meridian.lib.state.user_paths import get_project_home
+
+if TYPE_CHECKING:
+    from pytest import MonkeyPatch
+
+
+def test_derive_runtime_root_uses_project_id_user_home(tmp_path: Path) -> None:
+    project_root = tmp_path / "repo"
+    state_dir = project_root / ".meridian"
+    state_dir.mkdir(parents=True)
+    (state_dir / "id").write_text("proj-abc", encoding="utf-8")
+
+    derived = derive_runtime_root_from_project(project_root)
+
+    assert derived == get_project_home("proj-abc")
+
+
+def test_derive_runtime_root_falls_back_to_local_state_without_id(tmp_path: Path) -> None:
+    project_root = tmp_path / "plain"
+    state_dir = project_root / ".meridian"
+    state_dir.mkdir(parents=True)
+    (state_dir / "spawns.jsonl").write_text("", encoding="utf-8")
+
+    derived = derive_runtime_root_from_project(project_root)
+
+    assert derived == state_dir.resolve()
+
+
+def test_from_environment_derives_runtime_from_project_dir_not_runtime_env(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    state_dir = project_root / ".meridian"
+    state_dir.mkdir(parents=True)
+    (state_dir / "id").write_text("proj-env", encoding="utf-8")
+    wrong_runtime = tmp_path / "wrong-runtime"
+    wrong_runtime.mkdir()
+
+    monkeypatch.setenv("MERIDIAN_PROJECT_DIR", project_root.as_posix())
+    monkeypatch.setenv("MERIDIAN_RUNTIME_DIR", wrong_runtime.as_posix())
+
+    ctx = ResolvedContext.from_environment()
+
+    assert ctx.project_root == project_root.resolve()
+    assert ctx.runtime_root == get_project_home("proj-env")
+    assert ctx.runtime_root != wrong_runtime.resolve()
+
+
+def test_child_env_overrides_propagate_project_dir_only(tmp_path: Path) -> None:
+    project_root = tmp_path / "repo"
+    runtime_root = tmp_path / "runtime"
+
+    ctx = ResolvedContext(
+        project_root=project_root,
+        runtime_root=runtime_root,
+    )
+    overrides = ctx.child_env_overrides()
+
+    assert overrides["MERIDIAN_PROJECT_DIR"] == project_root.as_posix()
+    assert "MERIDIAN_RUNTIME_DIR" not in overrides
+
+
+def test_resolve_runtime_authority_ignores_runtime_env_when_flagged(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    state_dir = project_root / ".meridian"
+    state_dir.mkdir(parents=True)
+    (state_dir / "id").write_text("proj-flag", encoding="utf-8")
+    override = tmp_path / "override"
+    override.mkdir()
+    monkeypatch.setenv("MERIDIAN_RUNTIME_DIR", override.as_posix())
+
+    authority = resolve_runtime_authority_for_read(
+        project_root,
+        ignore_runtime_env=True,
+    )
+
+    assert authority.runtime_root == get_project_home("proj-flag")
+
+
+def test_resolve_runtime_authority_honors_directory_explicit_env(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    state_dir = project_root / ".meridian"
+    state_dir.mkdir(parents=True)
+    (state_dir / "id").write_text("proj-explicit", encoding="utf-8")
+    override = tmp_path / "override"
+    override.mkdir()
+    monkeypatch.delenv("MERIDIAN_DEPTH", raising=False)
+    monkeypatch.setenv("MERIDIAN_RUNTIME_DIR", override.as_posix())
+    monkeypatch.setenv("MERIDIAN_DIRECTORY_EXPLICIT", "1")
+
+    authority = resolve_runtime_authority_for_read(project_root)
+
+    assert authority.runtime_root == get_project_home("proj-explicit")
+
+
+def test_resolve_runtime_authority_honors_runtime_env_at_root(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    override = tmp_path / "override"
+    override.mkdir()
+    monkeypatch.delenv("MERIDIAN_DEPTH", raising=False)
+    monkeypatch.setenv("MERIDIAN_RUNTIME_DIR", override.as_posix())
+
+    authority = resolve_runtime_authority_for_read(project_root)
+
+    assert authority.runtime_root == override.resolve()
+
+
+def test_resolve_runtime_authority_honors_empty_override_over_project_state(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    state_dir = project_root / ".meridian"
+    state_dir.mkdir(parents=True)
+    (state_dir / "spawns.jsonl").write_text("", encoding="utf-8")
+    override = tmp_path / "empty-override"
+    override.mkdir()
+    monkeypatch.delenv("MERIDIAN_DEPTH", raising=False)
+    monkeypatch.setenv("MERIDIAN_RUNTIME_DIR", override.as_posix())
+
+    authority = resolve_runtime_authority_for_read(project_root)
+
+    assert authority.runtime_root == override.resolve()
+    assert authority.runtime_root_source == "env"

--- a/tests/unit/core/test_resolved_context_runtime.py
+++ b/tests/unit/core/test_resolved_context_runtime.py
@@ -91,19 +91,17 @@ def test_resolve_runtime_authority_ignores_runtime_env_when_flagged(
     assert authority.runtime_root == get_project_home("proj-flag")
 
 
-def test_resolve_runtime_authority_honors_directory_explicit_env(
+def test_resolve_runtime_authority_derives_when_runtime_dir_absent(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
 ) -> None:
+    """When -C scope unsets MERIDIAN_RUNTIME_DIR, runtime derives from project identity."""
     project_root = tmp_path / "repo"
     state_dir = project_root / ".meridian"
     state_dir.mkdir(parents=True)
     (state_dir / "id").write_text("proj-explicit", encoding="utf-8")
-    override = tmp_path / "override"
-    override.mkdir()
     monkeypatch.delenv("MERIDIAN_DEPTH", raising=False)
-    monkeypatch.setenv("MERIDIAN_RUNTIME_DIR", override.as_posix())
-    monkeypatch.setenv("MERIDIAN_DIRECTORY_EXPLICIT", "1")
+    monkeypatch.delenv("MERIDIAN_RUNTIME_DIR", raising=False)
 
     authority = resolve_runtime_authority_for_read(project_root)
 

--- a/tests/unit/harness/test_pi_paths.py
+++ b/tests/unit/harness/test_pi_paths.py
@@ -41,15 +41,22 @@ def test_meridian_pi_state_dir_prefers_explicit_env() -> None:
     ) == Path("/state/root")
 
 
-def test_meridian_pi_state_dir_falls_back_to_session_dir() -> None:
+def test_meridian_pi_state_dir_defaults_without_session_dir() -> None:
     assert resolve_meridian_pi_state_dir(
         env={"PI_CODING_AGENT_SESSION_DIR": "/sessions/spawn-1"}
-    ) == Path("/sessions/spawn-1")
+    ) == get_user_home() / "meridian-pi" / "state"
 
 
-def test_pi_meridian_state_dir_env_override_matches_resolve() -> None:
+def test_pi_meridian_state_dir_env_override_uses_explicit_runtime_root() -> None:
+    runtime_root = Path("/resolved/runtime")
+    assert pi_meridian_state_dir_env_override(runtime_root=runtime_root) == {
+        "MERIDIAN_PI_STATE_DIR": "/resolved/runtime"
+    }
+
+
+def test_pi_meridian_state_dir_env_override_without_runtime_root_uses_default_state() -> None:
     env = {"PI_CODING_AGENT_SESSION_DIR": "/scoped/session"}
-    expected = str(resolve_meridian_pi_state_dir(env=env))
+    expected = str(get_user_home() / "meridian-pi" / "state")
     assert pi_meridian_state_dir_env_override(env=env) == {
         "MERIDIAN_PI_STATE_DIR": expected
     }

--- a/tests/unit/harness/test_pi_paths.py
+++ b/tests/unit/harness/test_pi_paths.py
@@ -50,7 +50,7 @@ def test_meridian_pi_state_dir_defaults_without_session_dir() -> None:
 def test_pi_meridian_state_dir_env_override_uses_explicit_runtime_root() -> None:
     runtime_root = Path("/resolved/runtime")
     assert pi_meridian_state_dir_env_override(runtime_root=runtime_root) == {
-        "MERIDIAN_PI_STATE_DIR": "/resolved/runtime"
+        "MERIDIAN_PI_STATE_DIR": str(runtime_root)
     }
 
 


### PR DESCRIPTION
## Why

`MERIDIAN_RUNTIME_DIR` was propagated as a cached runtime-root value. In nested sessions, `meridian -C <other-project> ...` could still read the parent project's runtime state because the stale runtime env override beat the explicit project directory.

## Goal

Make `MERIDIAN_PROJECT_DIR` the inherited project-context authority, derive runtime roots from project identity, and keep `MERIDIAN_RUNTIME_DIR` only as a top-level power-user override.

## Summary

- Stops auto-propagating `MERIDIAN_RUNTIME_DIR` through child, hook, and plugin env surfaces.
- Tracks explicit `-C` / `--directory` separately from bootstrap-resolved project roots so stale runtime env is ignored only when the user selected a directory.
- Derives runtime roots from `.meridian/id` via a state-layer helper, with read-only fallback that does not create `.meridian/id`.
- Threads `-C` project context into config/session/extension-backed commands and startup telemetry/repair paths.
- Pins Pi extension state to `MERIDIAN_PI_STATE_DIR` from the resolved runtime root instead of per-session dirs.
- Adds runtime-root, launch-env, hook-env, CLI-main, Pi-path, and E2E smoke-guide coverage.

## Resulting Behavior

- `meridian -C ~/gitrepos/mars-agents spawn list` reads mars-agents state, not the caller's project state.
- `meridian -C ~/gitrepos/mars-agents session log c8` resolves mars-agents' Pi `c8` session record.
- `MERIDIAN_RUNTIME_DIR=/tmp/wrong meridian -C /other/project ...` ignores the stale runtime override.
- Top-level `MERIDIAN_RUNTIME_DIR=/custom/runtime meridian ...` still works when `-C` is not used.
- Read commands on uninitialized git repos do not create `.meridian/id`.
- Pi managed-bash / heartbeat state lands under the resolved runtime root.

## Work Item

global-directory-flag

## Verification

Automated:
- `uv run ruff check .`
- `uv run --extra dev python -m pyright` — 0 errors, 9 existing warnings
- `cd src/meridian/pi_runtime && pnpm test` — 13 passed
- `uv run pytest-llm` — 1209 passed, 11 skipped
- push preflight: `ruff`, `pyright`, `pytest -x -q`, `uv build --no-sources`

Manual smoke:
- `MERIDIAN_RUNTIME_DIR=/tmp/wrong uv run meridian -C ~/gitrepos/mars-agents spawn list --format json` returned mars-agents result, not meridian-cli spawns.
- `uv run meridian -C ~/gitrepos/mars-agents session log c8` resolved `019e6c68-...` / `harness=pi` (mars-agents), not meridian-cli's Claude `c8`.
- `env -u MERIDIAN_PROJECT_DIR -u MERIDIAN_RUNTIME_DIR uv run meridian -C ~/gitrepos/mars-agents config show --json` reported mars-agents project/runtime roots.
- Temp uninitialized git repo `spawn list` returned empty and created no `.meridian/id`.
- Cleared nested env and verified top-level `MERIDIAN_RUNTIME_DIR` reports `runtime_root_source=env`.
- Pi spawn with temp runtime wrote `spawns/p1/heartbeat` and `pi-bash/p1/bash-records.json` under the override runtime root, not the session root.

## Knowledge Updates

- Updated `CHANGELOG.md` under `[Unreleased]`.
- Added `tests/e2e/project-resolution.md` and refreshed E2E setup snippets to derive `RUNTIME_ROOT` from project identity instead of local `.meridian` assumptions.
- Durable KB/prompt-package updates remain follow-up scope from the requirements handoff; this PR keeps repo code/tests/docs current.

## Spawn Trace

- p3095 coder — initial implementation
- p3098/p3099 reviewer — correctness review
- p3100 simplify-reviewer — structural review
- p3101 smoke-tester — initial smoke verification
- p3102 coder — review fixes
- p3105/p3106 reviewer/simplify-reviewer — re-review
- p3107 smoke-tester — re-smoke
- p3108/p3112/p3115 coder — final review fixes
- p3117 qa-lead — test-suite audit and smoke-guide updates
- p3116 reviewer — final targeted review

## Release Label Guide

Set `release:patch`.

## Post-Merge Automation

After merge to `main`, CI (`.github/workflows/release-on-merge.yml`) will:

1. Read the PR release label
2. Skip when no `release:*` label is present or when `release:skip` is present
3. Compute the next patch version from existing `v*` tags
4. Update `src/meridian/__init__.py` + promote `CHANGELOG.md` `[Unreleased]`
5. Commit `Release X.Y.Z`, create/push `vX.Y.Z`
6. Run `.github/workflows/publish-pypi.yml` directly

## Cleanup

After merge, clean merged worktrees with:

```bash
scripts/prune-worktrees.sh
```
