### PR TITLE
feat: progressive loading phase 2 — bundle inventory prompt + approval never

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "cyclopts>=3.0",
   "fastapi>=0.115",
   "markdown-it-py>=4.0",
-  "mars-agents==0.7.7",
+  "mars-agents==0.7.8",
   "mcp>=1.0",
   "pathspec>=1.1.0",
   "psutil>=7.2.2",

--- a/src/meridian/cli/bootstrap_cmd.py
+++ b/src/meridian/cli/bootstrap_cmd.py
@@ -55,7 +55,7 @@ def register_bootstrap_command(
         ] = False,
         approval: Annotated[
             str | None,
-            Parameter(name="--approval", help="Approval mode: default, confirm, auto, yolo."),
+            Parameter(name="--approval", help="Approval mode: default, confirm, auto, never."),
         ] = None,
         autocompact: Annotated[
             int | None,

--- a/src/meridian/cli/chat_cmd.py
+++ b/src/meridian/cli/chat_cmd.py
@@ -91,7 +91,7 @@ def _chat(
     ] = (),
     approval: Annotated[
         str | None,
-        Parameter(name="--approval", help="Approval mode: default, confirm, auto, yolo."),
+        Parameter(name="--approval", help="Approval mode: default, confirm, auto, never."),
     ] = None,
     sandbox: Annotated[
         str | None,
@@ -114,7 +114,7 @@ def _chat(
     ] = None,
     yolo: Annotated[
         bool,
-        Parameter(name="--yolo", help="Shorthand for --approval yolo."),
+        Parameter(name="--yolo", help="Shorthand for --approval never."),
     ] = False,
     port: Annotated[int, Parameter(name="--port", help="Port to bind; 0 auto-assigns.")] = 0,
     host: Annotated[
@@ -171,9 +171,9 @@ def _chat(
     effective_harness = harness or get_global_options().harness
     if yolo and approval is not None:
         raise ValueError(
-            "Cannot use --yolo with --approval (--yolo is shorthand for --approval yolo)."
+            "Cannot use --yolo with --approval (--yolo is shorthand for --approval never)."
         )
-    resolved_approval = approval if approval is not None else ("yolo" if yolo else None)
+    resolved_approval = approval if approval is not None else ("never" if yolo else None)
     parsed_skills: list[str] = []
     for token in skills:
         parsed_skills.extend(parse_csv_list(token, field_name="skills"))

--- a/src/meridian/cli/main.py
+++ b/src/meridian/cli/main.py
@@ -374,7 +374,7 @@ def root(
         str | None,
         Parameter(
             name="--approval",
-            help="Approval mode: default, confirm, auto, yolo. Overrides agent profile.",
+            help="Approval mode: default, confirm, auto, never. Overrides agent profile.",
         ),
     ] = None,
     timeout: Annotated[

--- a/src/meridian/cli/primary_launch.py
+++ b/src/meridian/cli/primary_launch.py
@@ -169,7 +169,7 @@ def run_primary_launch(
     fork_target_requested = raw_fork_target or None
     fork_fresh_target_requested = raw_fork_fresh_target or None
     context_from_requested = (raw_from_target,) if raw_from_target else ()
-    resolved_approval = approval if approval is not None else ("yolo" if yolo else "default")
+    resolved_approval = approval if approval is not None else ("never" if yolo else "default")
 
     fork_resolution = validate_fork_mode(
         fork_from=fork_target_requested,

--- a/src/meridian/cli/spawn.py
+++ b/src/meridian/cli/spawn.py
@@ -337,7 +337,7 @@ def _spawn_create(
         str | None,
         Parameter(
             name="--approval",
-            help="Approval mode: default, confirm, auto, yolo. Overrides agent profile.",
+            help="Approval mode: default, confirm, auto, never. Overrides agent profile.",
         ),
     ] = None,
     autocompact: Annotated[
@@ -443,9 +443,9 @@ def _spawn_create(
     # Resolve --yolo / --approval interaction.
     if yolo and approval is not None:
         raise ValueError(
-            "Cannot use --yolo with --approval (--yolo is shorthand for --approval yolo)."
+            "Cannot use --yolo with --approval (--yolo is shorthand for --approval never)."
         )
-    resolved_approval = approval if approval is not None else ("yolo" if yolo else None)
+    resolved_approval = approval if approval is not None else ("never" if yolo else None)
     parsed_skills = parse_csv_list(skills, field_name="skills")
     resolved_goal = normalize_goal(goal)
 

--- a/src/meridian/lib/core/domain.py
+++ b/src/meridian/lib/core/domain.py
@@ -71,6 +71,7 @@ class SkillContent(BaseModel):
     content: str
     path: str
     skill_type: str = "reference"
+    detail: str = ""
 
     def format_text(self, ctx: FormatContext | None = None) -> str:
         return f"{self.name}: {self.description}\n\n{self.content}"

--- a/src/meridian/lib/core/overrides.py
+++ b/src/meridian/lib/core/overrides.py
@@ -60,7 +60,7 @@ def _validate_autocompact_pct_value(v: object) -> object:
 
 AutocompactValue = Annotated[int | None, BeforeValidator(_validate_autocompact_value)]
 AutocompactPctValue = Annotated[int | None, BeforeValidator(_validate_autocompact_pct_value)]
-KNOWN_APPROVAL_VALUES = frozenset({"default", "confirm", "auto", "yolo"})
+KNOWN_APPROVAL_VALUES = frozenset({"default", "confirm", "auto", "never", "yolo"})
 
 
 def _validate_effort_value(v: object) -> object:
@@ -88,6 +88,9 @@ def _validate_approval_value(v: object) -> object:
         return None
     if normalized not in KNOWN_APPROVAL_VALUES:
         raise ValueError(f"expected one of {sorted(KNOWN_APPROVAL_VALUES)}, got {v!r}")
+    # Normalize deprecated spelling to canonical value.
+    if normalized == "yolo":
+        return "never"
     return normalized
 
 

--- a/src/meridian/lib/harness/projections/permission_flags.py
+++ b/src/meridian/lib/harness/projections/permission_flags.py
@@ -40,7 +40,7 @@ def _permission_flags_for_harness(
         return ()
 
     # New harness families that need approval/sandbox projection belong here.
-    if config.approval == "yolo":
+    if config.approval in ("yolo", "never"):
         if harness_id == HarnessId.CLAUDE:
             return ("--dangerously-skip-permissions",)
         if harness_id == HarnessId.CODEX:

--- a/src/meridian/lib/harness/projections/project_codex_common.py
+++ b/src/meridian/lib/harness/projections/project_codex_common.py
@@ -11,6 +11,7 @@ _APPROVAL_POLICY_BY_MODE: dict[str, str | None] = {
     "default": None,
     "auto": "on-request",
     "confirm": "untrusted",
+    "never": "never",
     "yolo": "never",
 }
 

--- a/src/meridian/lib/harness/projections/project_cursor.py
+++ b/src/meridian/lib/harness/projections/project_cursor.py
@@ -49,7 +49,7 @@ _DELEGATED_FIELDS: frozenset[str] = frozenset(
 
 def _project_approval_flags(spec: ResolvedLaunchSpec) -> tuple[str, ...]:
     approval_mode = spec.permission_resolver.config.approval
-    if approval_mode == "yolo":
+    if approval_mode in ("yolo", "never"):
         return ("--yolo",)
     if approval_mode == "auto":
         return ("--force",)

--- a/src/meridian/lib/launch/bundle_adapter.py
+++ b/src/meridian/lib/launch/bundle_adapter.py
@@ -58,6 +58,7 @@ class _BundlePromptDocument:
     name: str
     content: str
     skill_type: str
+    detail: str
 
 
 @dataclass(frozen=True)
@@ -129,6 +130,7 @@ def _parse_prompt_documents(raw: object) -> tuple[_BundlePromptDocument, ...]:
         name = _normalize_str(typed_item.get("name"))
         content = _normalize_str(typed_item.get("content"))
         skill_type = _normalize_str(typed_item.get("skill_type"))
+        detail = _normalize_str(typed_item.get("detail"))
         if not kind or not name or not content:
             continue
         documents.append(
@@ -137,6 +139,7 @@ def _parse_prompt_documents(raw: object) -> tuple[_BundlePromptDocument, ...]:
                 name=name,
                 content=content,
                 skill_type=skill_type,
+                detail=detail,
             )
         )
     return tuple(documents)
@@ -498,6 +501,7 @@ def bundle_to_resolved_policy(
         fallback_chain=(),
         warnings=warnings,
         alias_catalog=alias_catalog,
+        bundle_inventory_prompt=bundle.prompt_surface_inventory_prompt or None,
     )
 
 

--- a/src/meridian/lib/launch/context.py
+++ b/src/meridian/lib/launch/context.py
@@ -981,11 +981,21 @@ def _resolve_spawn_prepare_projection(
         )
         agent_profile_body = f"# Agent Profile\n\n{rendered_agent_body}"
 
-    agent_inventory_prompt, context_prompt = build_launch_context_documents(
-        project_root=project_paths.project_root,
-        alias_catalog=policy.alias_catalog,
-        active_work_dir=active_work_dir,
-    )
+    # Prefer the pre-built, pre-filtered inventory prompt from the bundle.
+    if policy.bundle_inventory_prompt:
+        agent_inventory_prompt: str | None = policy.bundle_inventory_prompt
+        _, context_prompt = build_launch_context_documents(
+            project_root=project_paths.project_root,
+            alias_catalog=policy.alias_catalog,
+            active_work_dir=active_work_dir,
+            include_inventory=False,
+        )
+    else:
+        agent_inventory_prompt, context_prompt = build_launch_context_documents(
+            project_root=project_paths.project_root,
+            alias_catalog=policy.alias_catalog,
+            active_work_dir=active_work_dir,
+        )
 
     resolved_work_id = (request.work_id_hint or "").strip() or (
         active_work_dir.name if active_work_dir is not None else ""
@@ -1045,11 +1055,21 @@ def _resolve_primary_projection(
     agent_inventory_prompt: str | None = None
     context_prompt: str | None = None
     if session_mode != "resume":
-        agent_inventory_prompt, context_prompt = build_launch_context_documents(
-            project_root=project_paths.project_root,
-            alias_catalog=policy.alias_catalog,
-            active_work_dir=active_work_dir,
-        )
+        # Prefer the pre-built, pre-filtered inventory prompt from the bundle.
+        if policy.bundle_inventory_prompt:
+            agent_inventory_prompt = policy.bundle_inventory_prompt
+            _, context_prompt = build_launch_context_documents(
+                project_root=project_paths.project_root,
+                alias_catalog=policy.alias_catalog,
+                active_work_dir=active_work_dir,
+                include_inventory=False,
+            )
+        else:
+            agent_inventory_prompt, context_prompt = build_launch_context_documents(
+                project_root=project_paths.project_root,
+                alias_catalog=policy.alias_catalog,
+                active_work_dir=active_work_dir,
+            )
 
     seed = harness.seed_session(
         is_resume=session_mode == "resume",

--- a/src/meridian/lib/launch/policies.py
+++ b/src/meridian/lib/launch/policies.py
@@ -126,6 +126,7 @@ class ResolvedLaunchPolicy:
     fallback_chain: tuple[dict[str, object], ...] = ()
     warnings: tuple[CompositionWarning, ...] = ()
     alias_catalog: dict[str, AliasEntry] | None = None
+    bundle_inventory_prompt: str | None = None
 
 
 ResolvedPolicies = ResolvedLaunchPolicy

--- a/src/meridian/lib/safety/permissions.py
+++ b/src/meridian/lib/safety/permissions.py
@@ -25,6 +25,7 @@ type SandboxMode = Literal[
 type ApprovalMode = Literal[
     "default",
     "auto",
+    "never",
     "yolo",
     "confirm",
 ]
@@ -43,6 +44,7 @@ _APPROVAL_MODES: frozenset[ApprovalMode] = frozenset(
     {
         "default",
         "auto",
+        "never",
         "yolo",
         "confirm",
     }

--- a/tests/integration/launch/test_launch_resolution_skills.py
+++ b/tests/integration/launch/test_launch_resolution_skills.py
@@ -46,6 +46,7 @@ class _FakeBundleResult:
     execution_policy: ResolvedExecutionPolicy
     provenance: dict[str, str]
     warnings: tuple[str, ...] = ()
+    prompt_surface_inventory_prompt: str = ""
     tools_allowed: tuple[str, ...] = ()
     tools_disallowed: tuple[str, ...] = ()
     tools_mcp: tuple[str, ...] = ()

--- a/tests/support/launch.py
+++ b/tests/support/launch.py
@@ -17,6 +17,7 @@ class FakeBundleResult:
     execution_policy: ResolvedExecutionPolicy
     provenance: dict[str, str]
     warnings: tuple[str, ...] = ()
+    prompt_surface_inventory_prompt: str = ""
     tools_allowed: tuple[str, ...] = ()
     tools_disallowed: tuple[str, ...] = ()
     tools_mcp: tuple[str, ...] = ()

--- a/tests/unit/launch/test_policies.py
+++ b/tests/unit/launch/test_policies.py
@@ -33,6 +33,7 @@ class _FakeBundleResult:
     execution_policy: ResolvedExecutionPolicy
     provenance: dict[str, str]
     warnings: tuple[str, ...] = ()
+    prompt_surface_inventory_prompt: str = ""
     tools_allowed: tuple[str, ...] = ()
     tools_disallowed: tuple[str, ...] = ()
     tools_mcp: tuple[str, ...] = ()

--- a/uv.lock
+++ b/uv.lock
@@ -666,15 +666,15 @@ wheels = [
 
 [[package]]
 name = "mars-agents"
-version = "0.7.7"
+version = "0.7.8"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/ec/758bc953f9fc23a9cb1aff2b757bcf85beb60326995e193293d10f43a8a6/mars_agents-0.7.7.tar.gz", hash = "sha256:ca00509c6233302bf7028116addae5a735bcce9804e93b8d24d7e2eda976d871", size = 587014, upload-time = "2026-05-29T06:32:59.678Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/7a/4d1506390eebab21947cbf69c5f9dd2d9b24a7580ca8dcf9b46aceeb88eb/mars_agents-0.7.8.tar.gz", hash = "sha256:df008ba1e47f8380a0c3b051345d75c01ba2cf34b65708c45072009d5cc21de1", size = 592308, upload-time = "2026-05-29T12:50:25.147Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/b8/e94e4ff41ded10de66059d27f049da5194f7d85d477e94b5a7e8ab41c3b4/mars_agents-0.7.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b82cfec5eced82cd3308942fab873b08dec93995f85b344b52e1101b256e00e2", size = 3262008, upload-time = "2026-05-29T06:32:52.608Z" },
-    { url = "https://files.pythonhosted.org/packages/69/67/c93d047223ba0d53bceff863f0ca5c2b59d54b708b36996d5487376893df/mars_agents-0.7.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:da660f060a33e19b0569dd36e7025bdcb1211b81b98d311caaafddb75ba163b0", size = 3120771, upload-time = "2026-05-29T06:32:54.277Z" },
-    { url = "https://files.pythonhosted.org/packages/19/f4/863f8679b6e5ba7ea96d2e8a46539837609deae7fdbbd6c487cd0e00bc8b/mars_agents-0.7.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bd261586fa0b77afcf7cd9fd598f497bde3751dbb0cb6bb1dedfe664e6d26d6c", size = 3164138, upload-time = "2026-05-29T06:32:55.593Z" },
-    { url = "https://files.pythonhosted.org/packages/40/e3/caee5e446348508f6b538cbf9394d2f1da911db244c5f2c4124841cbc560/mars_agents-0.7.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:566977cd774f48444c9520cfe99b0c640500732adb70969f597ca695b9606b73", size = 3368077, upload-time = "2026-05-29T06:32:56.847Z" },
-    { url = "https://files.pythonhosted.org/packages/54/f2/c48c3f03c5fa63fd7e2ec2ae6cefccc1fbf4b337eeb3874a1a6e70870535/mars_agents-0.7.7-py3-none-win_amd64.whl", hash = "sha256:32be20b0449cd7b847211b80908e0bc84c7cc19e00394d680d64a3a535474ba2", size = 3309407, upload-time = "2026-05-29T06:32:58.273Z" },
+    { url = "https://files.pythonhosted.org/packages/81/cf/813d5df32951be4f0280bf8b8b224244c2d5e1d35b0ea40ba726d5d40c8e/mars_agents-0.7.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:1eaa426e5bf529933e03d994f1598022ed7c05510ab2d271624c13a8af9fd249", size = 3295585, upload-time = "2026-05-29T12:50:15.994Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/20/f2a746bb5787c4a50a55d9a688d30875f0e7fa50214e852b83742127e299/mars_agents-0.7.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:65a60650b2fae992b2fe883c6c29d3ae390546c6020987b6e0eefa62696d3787", size = 3149756, upload-time = "2026-05-29T12:50:18.158Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/98/c4a51cd0a749991c6e1334d7a0c86cc024a94b0b870a872d6b19300f78f6/mars_agents-0.7.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:35a30814ebb7718164b04f07b4f454969cf1ce95705651889498676da37c0fc6", size = 3180779, upload-time = "2026-05-29T12:50:19.736Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/bf/7a3bb9ed458ff66ccf82e67da322e77a7bdbbe171b47a1aa5d5a333e0744/mars_agents-0.7.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdc473f8f13d6ecfbccb33972fb561c6ecddbe219fd9c41ff2e57f39ca1875a4", size = 3395697, upload-time = "2026-05-29T12:50:21.562Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/97/1283d58d5206114277b71c4d60f3c31b754bc92777b7cf0e9af40cf6a250/mars_agents-0.7.8-py3-none-win_amd64.whl", hash = "sha256:126769d1a81e21a7ddb9a8397b349af1ab1d6a2729bde5d71af4270dc2c9b6b2", size = 3352074, upload-time = "2026-05-29T12:50:23.469Z" },
 ]
 
 [[package]]
@@ -765,7 +765,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'app'", specifier = ">=0.28" },
     { name = "jinja2", marker = "extra == 'templates'", specifier = ">=3.1" },
     { name = "markdown-it-py", specifier = ">=4.0" },
-    { name = "mars-agents", specifier = "==0.7.7" },
+    { name = "mars-agents", specifier = "==0.7.8" },
     { name = "mcp", specifier = ">=1.0" },
     { name = "pathspec", specifier = ">=1.1.0" },
     { name = "psutil", specifier = ">=7.2.2" },


### PR DESCRIPTION
## Summary

Phase 2 of the progressive loading architecture (pairs with mars-agents PR #81).

- **Bundle inventory prompt**: meridian-cli now uses the pre-built, pre-filtered `inventory_prompt` from the mars launch bundle instead of rebuilding it from disk. Falls back to disk scan when the bundle doesn't provide one. Threads `bundle_inventory_prompt` through `ResolvedLaunchPolicy` and uses it in both spawn and primary projection paths.
- **Approval `never` normalization**: Accepts `"never"` from the mars bundle's `execution_policy.approval` field. `"yolo"` remains accepted everywhere (CLI flags, profile YAML, env vars) but normalizes to `"never"` at the Pydantic validation boundary. All downstream code (harness projections, CLI surfaces) handles both spellings defensively.
- **`detail` field**: Added to `_BundlePromptDocument` and `SkillContent` for future type-based rendering.

17 files changed, +58 −23 lines.

## Test plan

- [x] `ruff check` — 0 errors
- [x] `pyright` — 0 errors, 0 warnings
- [x] `pytest` — 1175 passed, 11 skipped
- [x] Manual: `RuntimeOverrides(approval='yolo').approval` returns `"never"`
- [x] Manual: `RuntimeOverrides(approval='never').approval` returns `"never"`
- [ ] End-to-end: spawn with mars-agents on `progressive-loading-fields` branch to verify bundle inventory prompt is consumed

🤖 Generated with [Claude Code](https://claude.com/claude-code)