### PR TITLE
feat: progressive loading phase 3 — launch flags, preamble, bundle v3

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -41,9 +41,9 @@ Common `spawn` flags:
 | `-f FILE` | Attach context file (repeatable) |
 | `--fork [REF]` | Fork into a new session while preserving source agent/model/skills (`REF` defaults to `$MERIDIAN_SPAWN_ID` inside Meridian sessions) |
 | `--fork-fresh [REF]` | Fork into a new session and allow `-m`, `-a`, and `--skills` overrides (`REF` defaults to `$MERIDIAN_SPAWN_ID` inside Meridian sessions) |
-| `--from [REF]` | Start a new spawn seeded with prior context from a spawn ref (`p123`) or chat/session ref (`c123`). `REF` defaults to `$MERIDIAN_SPAWN_ID` inside Meridian sessions. Does not fork transcript lineage. |
+| `--from [REF]` | Start a new spawn seeded with prior context from a spawn ref (`p123`) or chat/session ref (`c123`). `REF` defaults to `$MERIDIAN_SPAWN_ID` inside Meridian sessions. Does not fork transcript lineage. Also inherits the source's work item as a fallback (see Work Precedence below). |
 | `--desc "label"` | Human-readable label in dashboards |
-| `--work SLUG` | Attach to a specific work item |
+| `--work SLUG` | Attach to a specific work item (overrides ambient and --from inheritance) |
 | `--task-dir PATH` | Override source-edit directory for this spawn/fork (must exist) |
 | `--profile NAME` | `spawn list` only: filter by stored agent/profile name |
 | `--primary` | `spawn list` only: include only `kind=primary` spawns |
@@ -61,6 +61,16 @@ Common `spawn` flags:
 `--fork-fresh` is the identity-changing variant. It is useful for role/model swaps, but can reduce prompt-cache locality because the profile/system prompt may change.
 
 Session initiation modes: `--continue` resumes the same transcript, `--fork` branches with identity lock, `--fork-fresh` branches with identity overrides, and `--from [REF]` starts an independent transcript seeded by references only.
+
+#### Work Precedence
+
+When a spawn resolves which work item to attach to, precedence is:
+
+1. **`--work`** (explicit) — always wins
+2. **Ambient session** — the active work item of the current session
+3. **`--from` inheritance** — the work item attached to the referenced spawn/session
+
+`--from` only inherits work as a last-resort fallback. If you pass `--work`, or the current session already has an active work item, `--from` does not override it. This means you can safely use `--from` for context without accidentally pulling in a different work item.
 
 ### Spawn Output
 

--- a/src/meridian/cli/main.py
+++ b/src/meridian/cli/main.py
@@ -67,6 +67,7 @@ from meridian.cli.startup.catalog import COMMAND_CATALOG
 from meridian.cli.startup.classify import classify_invocation
 from meridian.cli.startup.policy import StartupClass, StateRequirement
 from meridian.cli.startup.policy import TelemetryMode as StartupTelemetryMode
+from meridian.cli.utils import parse_csv_list
 from meridian.lib.core.depth import is_nested_meridian_process
 from meridian.lib.core.sink import OutputSink
 from meridian.lib.core.util import FormatContext
@@ -241,6 +242,47 @@ def _interactive_terminal_attached() -> bool:
     return sys.stdin.isatty() and sys.stdout.isatty()
 
 
+def _read_primary_prompt_from_stdin(*, explicit_prompt_file_stdin: bool) -> str:
+    if sys.stdin.isatty():
+        if explicit_prompt_file_stdin:
+            raise ValueError("--prompt-file - requires stdin to be piped or redirected")
+        raise ValueError("prompt stdin requires stdin to be piped or redirected")
+    try:
+        prompt_text = sys.stdin.read()
+    except UnicodeDecodeError as exc:
+        raise ValueError("prompt stdin is not valid UTF-8") from exc
+    if not prompt_text:
+        raise ValueError("prompt stdin is empty")
+    return prompt_text
+
+
+def _read_primary_prompt_from_file(prompt_file: str) -> str:
+    if not prompt_file.strip():
+        raise ValueError("prompt file path is empty")
+    prompt_path = Path(prompt_file)
+    try:
+        prompt_text = prompt_path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise ValueError(f"prompt file not found: {prompt_file}") from exc
+    except UnicodeDecodeError as exc:
+        raise ValueError(f"prompt file is not valid UTF-8: {prompt_file}") from exc
+    if not prompt_text:
+        raise ValueError(f"prompt file is empty: {prompt_file}")
+    return prompt_text
+
+
+def _resolve_primary_prompt(prompt: str | None, prompt_file: str | None) -> str | None:
+    if prompt is not None and prompt_file is not None:
+        raise ValueError("cannot specify both -p and --prompt-file")
+    if prompt is not None:
+        return prompt
+    if prompt_file is not None:
+        if prompt_file == "-":
+            return _read_primary_prompt_from_stdin(explicit_prompt_file_stdin=True)
+        return _read_primary_prompt_from_file(prompt_file)
+    return None
+
+
 @app.default
 def root(
     json_mode: Annotated[
@@ -319,6 +361,44 @@ def root(
             ),
         ),
     ] = None,
+    references: Annotated[
+        tuple[str, ...],
+        Parameter(
+            name=["--file", "-f"],
+            help="Reference files to include in primary prompt context (repeatable).",
+            negative_iterable=(),
+        ),
+    ] = (),
+    prompt_file: Annotated[
+        str | None,
+        Parameter(
+            name="--prompt-file",
+            help="Read primary prompt text from a file. Use '-' to read stdin.",
+            allow_leading_hyphen=True,
+        ),
+    ] = None,
+    prompt: Annotated[
+        str | None,
+        Parameter(
+            name=["-p", "--prompt"],
+            help="Inline literal primary prompt text.",
+        ),
+    ] = None,
+    skills: Annotated[
+        tuple[str, ...],
+        Parameter(
+            name="--skills",
+            help="Comma-separated skill overrides for the primary agent. Repeatable.",
+            negative_iterable=(),
+        ),
+    ] = (),
+    goal: Annotated[
+        str | None,
+        Parameter(
+            name="--goal",
+            help="Completion goal injected as a bounded completion contract.",
+        ),
+    ] = None,
     model: Annotated[
         str,
         Parameter(name=["--model", "-m"], help="Model id or alias for primary harness."),
@@ -391,6 +471,11 @@ def root(
     if yolo and approval is not None:
         raise ValueError("Cannot combine --yolo with --approval.")
 
+    resolved_prompt = _resolve_primary_prompt(prompt, prompt_file)
+    parsed_skills: list[str] = []
+    for token in skills:
+        parsed_skills.extend(parse_csv_list(token, field_name="skills"))
+
     if _GLOBAL_OPTIONS.get() is None:
         resolved = normalize_output_format(requested=output_format, json_mode=json_mode)
         _GLOBAL_OPTIONS.set(
@@ -428,6 +513,10 @@ def root(
         sandbox=sandbox,
         timeout=timeout,
         dry_run=dry_run,
+        reference_files=tuple(references),
+        prompt=resolved_prompt,
+        skills=tuple(parsed_skills),
+        goal=goal,
         # See _split_passthrough_args() for why this reads from GlobalOptions.
         passthrough=get_global_options().passthrough_args,
     )
@@ -500,7 +589,11 @@ def _run_primary_launch(
     sandbox: str | None,
     timeout: float | None,
     dry_run: bool,
-    passthrough: tuple[str, ...],
+    reference_files: tuple[str, ...] = (),
+    prompt: str | None = None,
+    skills: tuple[str, ...] = (),
+    goal: str | None = None,
+    passthrough: tuple[str, ...] = (),
 ) -> None:
     from meridian.cli import primary_launch
 
@@ -523,6 +616,10 @@ def _run_primary_launch(
             timeout=timeout,
             dry_run=dry_run,
             passthrough=passthrough,
+            reference_files=reference_files,
+            prompt=prompt,
+            skills=skills,
+            goal=goal,
         )
     )
 

--- a/src/meridian/cli/primary_launch.py
+++ b/src/meridian/cli/primary_launch.py
@@ -14,8 +14,11 @@ from meridian.lib.core.util import FormatContext
 from meridian.lib.harness.registry import get_default_harness_registry
 from meridian.lib.launch import LaunchRequest, SessionMode, launch_primary
 from meridian.lib.launch.composition import PromptDocument
+from meridian.lib.launch.reference import validate_reference_paths
 from meridian.lib.launch.request import SessionRequest
 from meridian.lib.ops.reference import resolve_session_reference
+from meridian.lib.ops.spawn.models import normalize_goal
+from meridian.lib.state.paths import resolve_kb_dir
 
 
 class PrimaryLaunchOutput(BaseModel):
@@ -130,9 +133,12 @@ def run_primary_launch(
     timeout: float | None,
     dry_run: bool,
     passthrough: tuple[str, ...],
+    reference_files: tuple[str, ...] = (),
+    prompt: str | None = None,
+    skills: tuple[str, ...] = (),
+    goal: str | None = None,
     supplemental_prompt_documents: tuple[PromptDocument, ...] = (),
     include_bootstrap_documents: bool = False,
-    prompt: str | None = None,
 ) -> PrimaryLaunchOutput:
     def _result_message(*, exit_code: int) -> str:
         if dry_run:
@@ -178,6 +184,7 @@ def run_primary_launch(
         context_from=context_from_requested,
         agent=agent,
         model=model,
+        skills=",".join(skills) if skills else None,
     )
     fork_target = fork_resolution.fork_ref
     fork_fresh_target = fork_resolution.fork_fresh_ref
@@ -206,6 +213,8 @@ def run_primary_launch(
             raise ValueError("Cannot combine --continue with --model.")
         if agent is not None and agent.strip():
             raise ValueError("Cannot combine --continue with --agent.")
+        if skills:
+            raise ValueError("Cannot combine --continue with --skills.")
         resolved_continue = resolve_session_target(
             project_root=project_root, continue_ref=resume_target
         )
@@ -305,6 +314,16 @@ def run_primary_launch(
         if requested_work_id is None and resolved_fork.source_work_id is not None:
             requested_work_id = resolved_fork.source_work_id
 
+    validated_reference_files = tuple(
+        path.as_posix()
+        for path in validate_reference_paths(
+            reference_files,
+            reference_anchor=project_root,
+            kb_dir=resolve_kb_dir(project_root),
+        )
+    )
+    resolved_goal = normalize_goal(goal)
+
     launch_result = launch_primary(
         project_root=project_root,
         request=LaunchRequest(
@@ -322,6 +341,10 @@ def run_primary_launch(
             supplemental_prompt_documents=supplemental_prompt_documents,
             include_bootstrap_documents=include_bootstrap_documents,
             context_from=fork_resolution.resolved_context_from,
+            reference_files=validated_reference_files,
+            prompt=prompt,
+            skills=skills,
+            goal=resolved_goal,
             dry_run=dry_run,
             execution_policy=ResolvedExecutionPolicy(
                 approval=resolved_approval if resolved_approval != "default" else None,

--- a/src/meridian/cli/spawn.py
+++ b/src/meridian/cli/spawn.py
@@ -245,8 +245,8 @@ def _spawn_create(
                 "Inherit context from a prior spawn or chat/session.\n"
                 "Spawn refs include the spawn report and files touched;\n"
                 "chat refs point at the session log and primary spawn.\n"
-                "Repeatable. Use when the new spawn needs prior\n"
-                "conversation context."
+                "Repeatable. Also inherits the source's work item as a\n"
+                "fallback when neither --work nor ambient session provides one."
             ),
             negative_iterable=(),
         ),
@@ -278,7 +278,13 @@ def _spawn_create(
     ] = None,
     work: Annotated[
         str,
-        Parameter(name="--work", help="Associate the spawn with a work item id."),
+        Parameter(
+            name="--work",
+            help=(
+                "Associate the spawn with a work item id. Takes precedence\n"
+                "over ambient session work and --from inheritance."
+            ),
+        ),
     ] = "",
     task_dir: Annotated[
         str | None,

--- a/src/meridian/lib/core/spawn_service.py
+++ b/src/meridian/lib/core/spawn_service.py
@@ -318,6 +318,7 @@ class SpawnApplicationService:
             harness_registry=payload.harness_registry,
             dry_run=False,
             runtime_work_id=(payload.work_id or "").strip() or None,
+            launch_mode=payload.launch_mode,
             cache=mars_cache,
         )
 

--- a/src/meridian/lib/launch/bundle_adapter.py
+++ b/src/meridian/lib/launch/bundle_adapter.py
@@ -35,7 +35,7 @@ def _resolve_mars_min_version() -> str:
 
 
 _MARS_BUNDLE_MIN_VERSION = _resolve_mars_min_version()
-_SUPPORTED_BUNDLE_SCHEMA_VERSION = 2
+_SUPPORTED_BUNDLE_SCHEMA_VERSIONS = (2, 3)
 
 
 @dataclass(frozen=True)
@@ -77,6 +77,7 @@ class _BundleResult:
     tools_disallowed: tuple[str, ...]
     tools_mcp: tuple[str, ...]
     skills_loaded: tuple[str, ...]
+    skills_available: tuple[str, ...]
     skills_missing: tuple[str, ...]
 
 
@@ -143,6 +144,41 @@ def _parse_prompt_documents(raw: object) -> tuple[_BundlePromptDocument, ...]:
             )
         )
     return tuple(documents)
+
+
+def _parse_skills_loaded(raw: object) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Parse skills loaded field — handles both v2 flat strings and v3 structured objects.
+
+    Returns (loaded_names, available_names).
+    """
+    if not isinstance(raw, list):
+        return (), ()
+    loaded_names: list[str] = []
+    for item in cast("list[object]", raw):
+        if isinstance(item, str):
+            # v2: flat list of skill name strings
+            normalized = item.strip()
+            if normalized:
+                loaded_names.append(normalized)
+        elif isinstance(item, dict):
+            # v3: list of {name, skill_type, content} objects
+            name = _normalize_str(cast("dict[str, object]", item).get("name"))
+            if name:
+                loaded_names.append(name)
+    return tuple(loaded_names), ()
+
+
+def _parse_skills_available(raw: object) -> tuple[str, ...]:
+    """Parse v3 skills.available field — list of {name, skill_type, description} objects."""
+    if not isinstance(raw, list):
+        return ()
+    names: list[str] = []
+    for item in cast("list[object]", raw):
+        if isinstance(item, dict):
+            name = _normalize_str(cast("dict[str, object]", item).get("name"))
+            if name:
+                names.append(name)
+    return tuple(names)
 
 
 def _bundle_schema_error(message: str) -> RuntimeError:
@@ -283,10 +319,10 @@ def _parse_bundle_payload(
     version = payload.get("version")
     if isinstance(version, bool) or not isinstance(version, int):
         raise _bundle_schema_error("missing numeric 'version'")
-    if version != _SUPPORTED_BUNDLE_SCHEMA_VERSION:
+    if version not in _SUPPORTED_BUNDLE_SCHEMA_VERSIONS:
         raise RuntimeError(
             "Mars launch-bundle schema version "
-            f"{version} is unsupported. Expected {_SUPPORTED_BUNDLE_SCHEMA_VERSION}. "
+            f"{version} is unsupported. Expected one of {_SUPPORTED_BUNDLE_SCHEMA_VERSIONS}. "
             f"Meridian requires mars >= {_MARS_BUNDLE_MIN_VERSION}."
         )
 
@@ -310,7 +346,13 @@ def _parse_bundle_payload(
 
     prompt_surface = _optional_object_field(payload, "prompt_surface")
     tools = _optional_object_field(payload, "tools")
-    skills_metadata = _optional_object_field(payload, "skills_metadata")
+
+    # v3: "skills" with structured loaded[]/available[]; v2: "skills_metadata" with flat strings
+    skills_obj = _optional_object_field(payload, "skills") or _optional_object_field(
+        payload, "skills_metadata"
+    )
+    skills_loaded, _ = _parse_skills_loaded(skills_obj.get("loaded"))
+    skills_available = _parse_skills_available(skills_obj.get("available"))
 
     return _BundleResult(
         model=model,
@@ -328,8 +370,9 @@ def _parse_bundle_payload(
         tools_allowed=_as_str_tuple(tools.get("allowed")),
         tools_disallowed=_as_str_tuple(tools.get("disallowed")),
         tools_mcp=_as_str_tuple(tools.get("mcp")),
-        skills_loaded=_as_str_tuple(skills_metadata.get("loaded")),
-        skills_missing=_as_str_tuple(skills_metadata.get("missing")),
+        skills_loaded=skills_loaded,
+        skills_available=skills_available,
+        skills_missing=_as_str_tuple(skills_obj.get("missing")),
     )
 
 

--- a/src/meridian/lib/launch/composition.py
+++ b/src/meridian/lib/launch/composition.py
@@ -23,6 +23,7 @@ from meridian.lib.launch.reference import (
 
 # Named canonical orders for SYSTEM_INSTRUCTION composition.
 SYSTEM_INSTRUCTION_BLOCK_ORDER: tuple[str, ...] = (
+    "launch_preamble",
     "agent_profile_body",
     "completion_contract",
     "supplemental_documents",
@@ -155,6 +156,9 @@ class ComposedLaunchContent:
 
     completion_contract: str = ""
     """Deterministic bounded completion contract text (spawn goal)."""
+
+    launch_preamble: str = ""
+    """Launch-mode-specific behavioral framing."""
 
 
 @dataclass(frozen=True)

--- a/src/meridian/lib/launch/composition_spawn.py
+++ b/src/meridian/lib/launch/composition_spawn.py
@@ -19,6 +19,7 @@ from meridian.lib.launch.context import (
     prepare_launch_surface,
 )
 from meridian.lib.launch.request import LaunchRuntime, SpawnRequest
+from meridian.lib.state.spawn.model import LaunchMode
 
 
 def compose_spawn_launch_surface(
@@ -28,6 +29,7 @@ def compose_spawn_launch_surface(
     harness_registry: HarnessRegistry,
     dry_run: bool,
     runtime_work_id: str | None = None,
+    launch_mode: LaunchMode | None = None,
     cache: MarsResultCache | None = None,
 ) -> PreparedLaunchSurface:
     """Policy + Mars + surface. No bind."""
@@ -60,6 +62,7 @@ def compose_spawn_launch_surface(
         request=request,
         runtime=runtime,
         prepared_policy=prepared_policy,
+        launch_mode=launch_mode,
     )
 
 

--- a/src/meridian/lib/launch/context.py
+++ b/src/meridian/lib/launch/context.py
@@ -1110,6 +1110,22 @@ def _resolve_primary_projection(
         reference_anchor=project_paths.execution_cwd,
     )
 
+    resolved_work_id = (request.work_id_hint or "").strip() or (
+        active_work_dir.name if active_work_dir is not None else ""
+    )
+    work_goal: str | None = None
+    if resolved_work_id:
+        project_state_dir = resolve_project_paths(project_paths.project_root).root_dir
+        work_item = work_store.get_work_item(project_state_dir, resolved_work_id)
+        if work_item is not None:
+            work_goal = work_item.goal
+    completion_contract = build_goal_instruction(request.goal)
+    work_goal_instruction = build_work_goal_instruction(work_goal)
+    if completion_contract and work_goal_instruction:
+        completion_contract = f"{work_goal_instruction}\n\n{completion_contract}"
+    elif work_goal_instruction:
+        completion_contract = work_goal_instruction
+
     projected = harness.project_content(
         ComposedLaunchContent(
             supplemental_documents=supplemental_documents,
@@ -1117,7 +1133,7 @@ def _resolve_primary_projection(
             report_instruction="",
             inventory_prompt=agent_inventory_prompt or "",
             context_prompt=context_prompt or "",
-            completion_contract="",
+            completion_contract=completion_contract,
             passthrough_system_fragments=passthrough_system_fragments,
             user_task_prompt=request.prompt,
             reference_items=task_ctx.reference_items,

--- a/src/meridian/lib/launch/context.py
+++ b/src/meridian/lib/launch/context.py
@@ -59,6 +59,7 @@ from meridian.lib.state.paths import (
     resolve_work_scratch_dir_for_project,
 )
 from meridian.lib.state.session_store import get_session_active_work_id
+from meridian.lib.state.spawn.model import LaunchMode
 from meridian.lib.telemetry import emit_telemetry
 from meridian.lib.tools import ToolsField
 from meridian.plugin_api.git import resolve_clone_path
@@ -94,6 +95,7 @@ from .prompt import (
     build_goal_instruction,
     build_launch_context_documents,
     build_report_instruction,
+    build_spawn_preamble,
     build_work_goal_instruction,
     compose_skill_injections,
     compose_skill_prompt_documents,
@@ -946,6 +948,7 @@ def _resolve_spawn_prepare_projection(
     project_paths: ProjectConfigPaths,
     active_work_dir: Path | None,
     policy: ResolvedLaunchPolicy,
+    launch_mode: LaunchMode | None = None,
 ) -> PreparedLaunchContent:
     profile = policy.profile
     harness = policy.adapter
@@ -1021,6 +1024,7 @@ def _resolve_spawn_prepare_projection(
             inventory_prompt=agent_inventory_prompt or "",
             context_prompt=context_prompt or "",
             completion_contract=completion_contract,
+            launch_preamble=build_spawn_preamble(launch_mode),
             passthrough_system_fragments=(),
             user_task_prompt=cleaned_user_prompt,
             reference_items=task_ctx.reference_items,
@@ -1143,6 +1147,7 @@ def _prepare_spawn_surface(
     project_paths: ProjectConfigPaths,
     active_work_dir: Path | None,
     policy: ResolvedLaunchPolicy,
+    launch_mode: LaunchMode | None = None,
 ) -> tuple[PreparedLaunchContent, ResolvedContinuation]:
     content = PreparedLaunchContent(
         final_prompt=request.prompt,
@@ -1155,6 +1160,7 @@ def _prepare_spawn_surface(
             project_paths=project_paths,
             active_work_dir=active_work_dir,
             policy=policy,
+            launch_mode=launch_mode,
         )
 
     prompt_policy = policy.adapter.run_prompt_policy()
@@ -1244,6 +1250,7 @@ def prepare_launch_surface(
     request: SpawnRequest,
     runtime: LaunchRuntime,
     prepared_policy: PreparedPolicySurface,
+    launch_mode: LaunchMode | None = None,
 ) -> PreparedLaunchSurface:
     """Resolve the expensive, spawn-stable launch surface."""
     project_paths = prepared_policy.project_paths
@@ -1272,6 +1279,7 @@ def prepare_launch_surface(
             project_paths=project_paths,
             active_work_dir=active_work_dir,
             policy=policies,
+            launch_mode=launch_mode,
         )
         seed_harness_session_id = continuation.harness_session_id
     elif runtime.composition_surface == LaunchCompositionSurface.PRIMARY:

--- a/src/meridian/lib/launch/plan.py
+++ b/src/meridian/lib/launch/plan.py
@@ -70,6 +70,8 @@ def build_primary_spawn_request(
     normalized_session = _normalize_primary_session(request)
     if prompt is not None:
         base_prompt = prompt
+    elif request.prompt is not None:
+        base_prompt = request.prompt
     elif _requires_primary_synthetic_prompt(request):
         base_prompt = build_primary_prompt(request)
     else:
@@ -81,11 +83,14 @@ def build_primary_spawn_request(
         model=(request.model or "").strip() or None,
         harness=(request.harness or "").strip() or None,
         agent=(request.agent or "").strip() or None,
+        skills=request.skills,
         extra_args=request.passthrough_args,
         supplemental_prompt_documents=request.supplemental_prompt_documents,
         context_from=request.context_from,
+        reference_files=request.reference_files,
         execution_policy=request.execution_policy,
         session=normalized_session,
+        goal=request.goal,
         work_id_hint=(request.work_id or "").strip() or None,
     )
 

--- a/src/meridian/lib/launch/prompt.py
+++ b/src/meridian/lib/launch/prompt.py
@@ -136,6 +136,18 @@ def build_goal_instruction(goal: str | None) -> str:
     )
 
 
+def build_spawn_preamble(launch_mode: str | None) -> str:
+    """Render launch-mode behavioral framing for spawned subagents."""
+
+    if launch_mode == "background":
+        return (
+            "# Spawn Context\n\n"
+            "You were spawned to complete a specific objective. Work autonomously. "
+            "Only escalate if blocked."
+        )
+    return ""
+
+
 def build_work_goal_instruction(work_goal: str | None) -> str:
     if work_goal is None:
         return ""
@@ -486,6 +498,7 @@ __all__ = [
     "build_goal_instruction",
     "build_launch_context_documents",
     "build_report_instruction",
+    "build_spawn_preamble",
     "build_work_goal_instruction",
     "compose_run_prompt",
     "compose_run_prompt_text",

--- a/src/meridian/lib/launch/types.py
+++ b/src/meridian/lib/launch/types.py
@@ -53,6 +53,10 @@ class LaunchRequest(BaseModel):
     pinned_context: str = ""
     supplemental_prompt_documents: tuple[PromptDocument, ...] = ()
     context_from: tuple[str, ...] = ()
+    reference_files: tuple[str, ...] = ()
+    prompt: str | None = None
+    skills: tuple[str, ...] = ()
+    goal: str | None = None
     include_bootstrap_documents: bool = False
     dry_run: bool = False
     # Execution policy carrier (replaces flat effort/sandbox/approval/autocompact/etc.)

--- a/src/meridian/lib/ops/spawn/context_ref.py
+++ b/src/meridian/lib/ops/spawn/context_ref.py
@@ -38,6 +38,7 @@ class SpawnContextRef(BaseModel):
     written_files: tuple[str, ...] = ()
     harness_session_id: str | None = None
     chat_id: str | None = None
+    work_id: str | None = None
 
 
 class SessionContextRef(BaseModel):
@@ -53,6 +54,7 @@ class SessionContextRef(BaseModel):
     model: str
     harness: str
     harness_session_id: str | None = None
+    work_id: str | None = None
 
 
 type ContextRef = SpawnContextRef | SessionContextRef
@@ -106,7 +108,7 @@ def resolve_context_ref(project_root: Path, ref: str) -> ContextRef:
         return _spawn_context_ref(spawn_row, project_root)
     if _SESSION_REF_RE.fullmatch(normalized) or _is_tracked_session(project_root, normalized):
         primary_row = _select_primary_spawn_for_session(project_root, normalized)
-        return _session_context_ref(primary_row)
+        return _session_context_ref(primary_row, project_root)
 
     spawn_id = resolve_spawn_reference(project_root, normalized)
     row = read_spawn_row(project_root, spawn_id)
@@ -127,13 +129,18 @@ def _spawn_context_ref(row: SpawnRecord, project_root: Path) -> SpawnContextRef:
         written_files=_load_written_files(project_root, row.id),
         harness_session_id=row.harness_session_id,
         chat_id=row.chat_id,
+        work_id=(row.work_id or "").strip() or None,
     )
 
 
-def _session_context_ref(primary_row: SpawnRecord) -> SessionContextRef:
+def _session_context_ref(primary_row: SpawnRecord, project_root: Path) -> SessionContextRef:
     chat_id = (primary_row.chat_id or "").strip()
     if not chat_id:
         raise ValueError(f"Primary spawn '{primary_row.id}' has no associated session")
+    runtime_root = resolve_runtime_root_for_read(project_root)
+    work_id = (
+        session_store.get_session_active_work_id(runtime_root, chat_id) or ""
+    ).strip() or None
     return SessionContextRef(
         chat_id=chat_id,
         primary_spawn_id=primary_row.id,
@@ -142,6 +149,7 @@ def _session_context_ref(primary_row: SpawnRecord) -> SessionContextRef:
         model=primary_row.model or "",
         harness=primary_row.harness or "",
         harness_session_id=primary_row.harness_session_id,
+        work_id=work_id,
     )
 
 

--- a/src/meridian/lib/ops/spawn/execute_runner.py
+++ b/src/meridian/lib/ops/spawn/execute_runner.py
@@ -276,6 +276,7 @@ async def _prepare_execution_handoff(
                 harness_registry=runtime.harness_registry,
                 dry_run=False,
                 runtime_work_id=runtime_work_id,
+                launch_mode=spawn_record.launch_mode if spawn_record is not None else None,
                 cache=mars_cache,
             )
         elif prepared is not None:

--- a/src/meridian/lib/ops/spawn/prepare.py
+++ b/src/meridian/lib/ops/spawn/prepare.py
@@ -114,6 +114,9 @@ def build_create_payload(
                 ).strip() or None
             except Exception:
                 ambient_work_id = None
+        # Work item precedence: --work (explicit) > ambient session > --from inheritance.
+        # --from is a last-resort fallback — only inherits work when neither the user
+        # nor the current session provides one.
         if ambient_work_id is None and explicit_work_id is None:
             ambient_work_id = _first_context_from_work_id(project_root, payload.context_from)
         project_state_dir = resolve_project_paths(project_root).root_dir

--- a/src/meridian/lib/ops/spawn/prepare.py
+++ b/src/meridian/lib/ops/spawn/prepare.py
@@ -40,6 +40,20 @@ from .models import SpawnCreateInput
 _DRY_RUN_REPORT_PATH = "<spawn-report-path>"
 
 
+def _first_context_from_work_id(project_root: Path, refs: tuple[str, ...]) -> str | None:
+    """Return the first work item attached to resolved ``--from`` context refs."""
+
+    if not refs:
+        return None
+    from meridian.lib.ops.spawn.context_ref import resolve_context_ref
+
+    for ref in refs:
+        work_id = (resolve_context_ref(project_root, ref).work_id or "").strip()
+        if work_id:
+            return work_id
+    return None
+
+
 @dataclass(frozen=True)
 class SpawnCreateArtifacts:
     """Resolved spawn request plus expensive prepared surface for bind-only execute."""
@@ -99,6 +113,8 @@ def build_create_payload(
                 ).strip() or None
             except Exception:
                 ambient_work_id = None
+        if ambient_work_id is None and explicit_work_id is None:
+            ambient_work_id = _first_context_from_work_id(project_root, payload.context_from)
         project_state_dir = resolve_project_paths(project_root).root_dir
         task_cwd_resolution = resolve_task_cwd(
             project_root,

--- a/src/meridian/lib/ops/spawn/prepare.py
+++ b/src/meridian/lib/ops/spawn/prepare.py
@@ -26,6 +26,7 @@ from meridian.lib.launch.request import (
 from meridian.lib.launch.resolve import parse_duration_seconds
 from meridian.lib.state.paths import resolve_kb_dir, resolve_project_paths
 from meridian.lib.state.session_store import get_session_active_work_id
+from meridian.lib.state.spawn.model import BACKGROUND_LAUNCH_MODE, FOREGROUND_LAUNCH_MODE
 from meridian.lib.utils.time import minutes_to_seconds
 
 from ..runtime import (
@@ -212,6 +213,9 @@ def build_create_payload(
             runtime=preview_runtime,
             harness_registry=harness_registry,
             dry_run=composition_dry_run,
+            launch_mode=(
+                BACKGROUND_LAUNCH_MODE if payload.background else FOREGROUND_LAUNCH_MODE
+            ),
         )
         if composition_dry_run:
             preview_context = bind_spawn_launch_context(

--- a/tests/integration/ops/test_spawn_prepare_fork.py
+++ b/tests/integration/ops/test_spawn_prepare_fork.py
@@ -3,12 +3,14 @@ from pathlib import Path
 import pytest
 
 from meridian.lib.config.settings import load_config
+from meridian.lib.core.context import RuntimeContext
 from meridian.lib.core.types import HarnessId
 from meridian.lib.harness.registry import get_default_harness_registry
 from meridian.lib.launch import bundle_adapter
 from meridian.lib.launch.launch_types import ResolvedExecutionPolicy
 from meridian.lib.launch.request import SessionRequest
 from meridian.lib.ops.runtime import build_runtime_from_root_and_config
+from meridian.lib.ops.spawn import context_ref
 from meridian.lib.ops.spawn.models import SpawnCreateInput
 from meridian.lib.ops.spawn.prepare import build_create_payload
 from meridian.lib.state import work_store
@@ -44,6 +46,27 @@ def _prepare_codex_runtime(project_root: Path):
     )
 
 
+def _stub_context_from_work(
+    monkeypatch: pytest.MonkeyPatch,
+    work_id: str | None,
+    *,
+    spawn_id: str = "p123",
+) -> None:
+    def fake_resolve_context_ref(project_root: Path, ref: str) -> context_ref.ContextRef:
+        _ = (project_root, ref)
+        return context_ref.SpawnContextRef(
+            spawn_id=spawn_id,
+            status="succeeded",
+            agent="coder",
+            desc="prior task",
+            model="gpt-5.5",
+            harness="codex",
+            work_id=work_id,
+        )
+
+    monkeypatch.setattr(context_ref, "resolve_context_ref", fake_resolve_context_ref)
+
+
 def _stub_bundle_adapter(monkeypatch: pytest.MonkeyPatch) -> None:
     model_routes = {
         "claude-sonnet-4.5": ("claude-sonnet-4.5", HarnessId.CLAUDE),
@@ -71,6 +94,62 @@ def _stub_bundle_adapter(monkeypatch: pytest.MonkeyPatch) -> None:
         )
 
     monkeypatch.setattr(bundle_adapter, "request_and_resolve", fake_request)
+
+
+def test_build_create_payload_inherits_work_from_context_from(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_bundle_adapter(monkeypatch)
+    _stub_context_from_work(monkeypatch, "feature-x")
+    _, runtime = _prepare_codex_runtime(tmp_path)
+
+    artifacts = build_create_payload(
+        SpawnCreateInput(
+            prompt="continue from prior spawn",
+            project_root=tmp_path.as_posix(),
+            context_from=("p123",),
+        ),
+        runtime=runtime,
+        ctx=RuntimeContext(),
+    )
+
+    assert artifacts.request.task_cwd_work_item == "feature-x"
+    assert artifacts.request.task_cwd_source == "ambient-work-authority-root"
+
+
+def test_build_create_payload_work_precedence_over_context_from(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_bundle_adapter(monkeypatch)
+    _stub_context_from_work(monkeypatch, "from-work")
+    _, runtime = _prepare_codex_runtime(tmp_path)
+
+    explicit = build_create_payload(
+        SpawnCreateInput(
+            prompt="continue from prior spawn",
+            project_root=tmp_path.as_posix(),
+            context_from=("p123",),
+            work="explicit-work",
+        ),
+        runtime=runtime,
+        ctx=RuntimeContext(),
+    )
+    ambient = build_create_payload(
+        SpawnCreateInput(
+            prompt="continue from prior spawn",
+            project_root=tmp_path.as_posix(),
+            context_from=("p123",),
+        ),
+        runtime=runtime,
+        ctx=RuntimeContext(work_id="ambient-work"),
+    )
+
+    assert explicit.request.task_cwd_work_item == "explicit-work"
+    assert explicit.request.task_cwd_source == "explicit-work-authority-root"
+    assert ambient.request.task_cwd_work_item == "ambient-work"
+    assert ambient.request.task_cwd_source == "ambient-work-authority-root"
 
 
 def test_build_create_payload_does_not_forward_meridian_primary_or_legacy_defaults_to_bundle(

--- a/tests/integration/ops/test_spawn_prepare_fork.py
+++ b/tests/integration/ops/test_spawn_prepare_fork.py
@@ -12,7 +12,7 @@ from meridian.lib.launch.request import SessionRequest
 from meridian.lib.ops.runtime import build_runtime_from_root_and_config
 from meridian.lib.ops.spawn import context_ref
 from meridian.lib.ops.spawn.models import SpawnCreateInput
-from meridian.lib.ops.spawn.prepare import build_create_payload
+from meridian.lib.ops.spawn.prepare import SpawnCreateArtifacts, build_create_payload
 from meridian.lib.state import work_store
 from meridian.lib.state.paths import resolve_kb_dir, resolve_project_paths
 from tests.support.launch import FakeBundleResult
@@ -65,6 +65,23 @@ def _stub_context_from_work(
         )
 
     monkeypatch.setattr(context_ref, "resolve_context_ref", fake_resolve_context_ref)
+
+
+def _prompt_surface_text(artifacts: SpawnCreateArtifacts) -> str:
+    prepared = artifacts.prepared
+    request = artifacts.request
+    projected = prepared.projected_content
+    return "\n".join(
+        part
+        for part in (
+            request.prompt,
+            request.prompt_payload.appended_system_prompt,
+            request.prompt_payload.user_turn_content,
+            projected.system_prompt if projected is not None else None,
+            projected.user_turn_content if projected is not None else None,
+        )
+        if part
+    )
 
 
 def _stub_bundle_adapter(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -150,6 +167,38 @@ def test_build_create_payload_work_precedence_over_context_from(
     assert explicit.request.task_cwd_source == "explicit-work-authority-root"
     assert ambient.request.task_cwd_work_item == "ambient-work"
     assert ambient.request.task_cwd_source == "ambient-work-authority-root"
+
+
+def test_background_spawn_prompt_includes_launch_preamble(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_bundle_adapter(monkeypatch)
+    _, runtime = _prepare_codex_runtime(tmp_path)
+
+    background = build_create_payload(
+        SpawnCreateInput(
+            prompt="implement the task",
+            project_root=tmp_path.as_posix(),
+            background=True,
+        ),
+        runtime=runtime,
+    )
+    foreground = build_create_payload(
+        SpawnCreateInput(
+            prompt="implement the task",
+            project_root=tmp_path.as_posix(),
+            background=False,
+        ),
+        runtime=runtime,
+    )
+
+    preamble = (
+        "You were spawned to complete a specific objective. Work autonomously. "
+        "Only escalate if blocked."
+    )
+    assert preamble in _prompt_surface_text(background)
+    assert preamble not in _prompt_surface_text(foreground)
 
 
 def test_build_create_payload_does_not_forward_meridian_primary_or_legacy_defaults_to_bundle(

--- a/tests/unit/cli/test_primary_launch.py
+++ b/tests/unit/cli/test_primary_launch.py
@@ -107,6 +107,52 @@ def test_run_primary_launch_bare_from_resolves_to_context_from(
     assert request.session.continue_fork is False
 
 
+def test_run_primary_launch_forwards_primary_spawn_parity_fields(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    reference = project_root / "design.md"
+    reference.write_text("design notes", encoding="utf-8")
+    captured: dict[str, object] = {}
+
+    def _fake_launch_primary(**kwargs: object) -> LaunchResult:
+        captured.update(kwargs)
+        return LaunchResult(command=("meridian",), exit_code=0)
+
+    monkeypatch.setattr(primary_launch, "launch_primary", _fake_launch_primary)
+
+    primary_launch.run_primary_launch(
+        project_root=project_root,
+        continue_ref=None,
+        fork_ref=None,
+        fork_fresh_ref=None,
+        model="",
+        harness=None,
+        agent="tech-lead",
+        work="",
+        yolo=False,
+        approval=None,
+        autocompact=None,
+        effort=None,
+        sandbox=None,
+        timeout=None,
+        dry_run=True,
+        passthrough=(),
+        reference_files=("design.md",),
+        prompt="Review the design.",
+        skills=("planning", "dev-principles"),
+        goal="  Converge on requirements  ",
+    )
+
+    request = cast("LaunchRequest", captured["request"])
+    assert request.reference_files == (reference.as_posix(),)
+    assert request.prompt == "Review the design."
+    assert request.skills == ("planning", "dev-principles")
+    assert request.goal == "Converge on requirements"
+
+
 def test_run_primary_launch_from_with_continue_reports_conflict_before_inference(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Why

Spawns lack parity with primary sessions for launch configuration (no `-f`, `--skills`, `--goal` on root command), background agents have no orientation about their execution mode, and `--from` context inheritance doesn't propagate work items. Additionally, mars-agents v0.7.9 ships bundle v3 (structured skills) which meridian couldn't parse.

## Goal

Primary launch has full flag parity with spawn, background agents know they're background, work items flow through `--from` as a fallback, and meridian-cli can parse both v2 and v3 mars bundle schemas.

## Summary

- `--from` work inheritance — spawns inherit work item from context refs as last-resort fallback
- Background spawn preamble — background agents receive orientation about their execution mode
- Primary launch flag parity — `-f`, `--prompt-file`, `-p`, `--skills`, `--goal` on root `meridian` command
- Mars bundle v3 compatibility — adapter handles both v2 (`skills_metadata`) and v3 (`skills` with structured `loaded[]/available[]`)
- Work precedence documented in code, CLI help, and docs

## Resulting Behavior

- `meridian -f design.md -s architecture --goal "Design the auth layer"` works (was spawn-only before)
- Background spawns see a preamble explaining they're non-interactive
- `meridian spawn --from p123 -p "continue"` inherits p123's work item when no `--work` or ambient work exists
- Spawns work correctly with mars 0.7.9+ (bundle v3) while remaining compatible with 0.7.7-0.7.8 (v2)

## Work Item

progressive-loading-p3

## Verification

- 1179 tests pass (ruff, pyright, pytest)
- Integration tested end-to-end: mars 0.7.9 structured skills agent → meridian adapter parses loaded + available names
- Backward compat verified: mars 0.7.8 (v2) still works
- `--from` work inheritance only fires when no explicit `--work` or ambient session work exists

## Knowledge Updates

- `docs/commands.md` — added Work Precedence section
- CLI help text updated for `--from` and `--work` flags
- Inline code comment documenting the precedence chain

## Spawn Trace

- p3203 tech-lead — .agents/ cleanup (merged to main separately)
- p3204 session-explorer — mined c3141 for context recovery

## Release Label Guide

Set one `release:*` label on this PR:

- `release:patch` — create the next patch release after merge
- `release:skip` — no release for this merge

## Post-Merge Automation

After merge to `main`, CI (`.github/workflows/release-on-merge.yml`) will:

1. Read the PR release label
2. Skip when no `release:*` label is present or when `release:skip` is present
3. Compute the next patch version from existing `v*` tags
4. Update `src/meridian/__init__.py` + promote `CHANGELOG.md` `[Unreleased]`
5. Commit `Release X.Y.Z`, create/push `vX.Y.Z`
6. Run `.github/workflows/publish-pypi.yml` directly

## Cleanup

After merge, clean merged worktrees with:

```bash
scripts/prune-worktrees.sh
```