### PR TITLE
feat: prompt composition redesign + work sessions --primary

### DIFF
--- a/docs/agent-profiles.md
+++ b/docs/agent-profiles.md
@@ -172,7 +172,10 @@ Migrate by ordering `model-policies` rules directly and adding
 
 ## Skills and Skill Variants
 
-When Meridian launches an agent, it loads the skills listed in `skills:` and injects them into the system prompt. Skills are read from `.mars/skills/`.
+When Meridian launches an agent, skill content comes from the Mars launch-bundle JSON
+(`skills.loaded[]`), not from reading `.mars/skills/` on disk. Mars owns the `.mars/`
+directory schema, skill variant resolution, and compilation. Meridian consumes the
+structured bundle output.
 
 ```yaml
 skills:
@@ -182,14 +185,25 @@ skills:
 
 `shared-workspace` guidance should set the work item's source-edit directory with `meridian work start ... --task-dir <path>` or `meridian work task-dir <path>` (for example, pointing at a `git worktree add` directory).
 
-**Variant selection.** Skills can ship harness- or model-specific body overrides in a `variants/` subdirectory. Meridian selects the best matching variant at launch time using a 4-step specificity ladder:
+**Bundle interface.** Mars resolves skills through the launch-bundle subcommand and
+delivers structured data to meridian:
 
-1. `variants/<harness>/<model-alias>/SKILL.md` — model alias + harness
-2. `variants/<harness>/<model-canonical-id>/SKILL.md` — canonical model ID + harness
-3. `variants/<harness>/SKILL.md` — harness level only
-4. Base `SKILL.md` — default
+```
+Mars launch-bundle → skills.loaded[{name, skill_type, body}]
+                          │
+                          ▼
+_build_resolved_skills_from_bundle()  → ResolvedSkills.loaded_skills
+```
 
-The base skill's frontmatter metadata is always authoritative; a variant only replaces the instruction body. Variant selection is transparent — the profile doesn't need to declare which variants a skill supports.
+Meridian receives already-resolved content and:
+- Renders type-group headers (`## Principle`, `## Guardrail`, etc.) for loaded skills
+- Groups available (on-demand) skills by type with descriptions and a load nudge
+- Uses synthetic paths for snapshot persistence compatibility
+
+**Variant selection** (harness- or model-specific body overrides from a `variants/`
+subdirectory) is now Mars's responsibility. Meridian receives the final resolved
+content — no variant resolution runs in meridian-cli at launch time. The specificity
+ladder still applies but resolution happens inside Mars, not meridian-cli.
 
 See [mars docs: skill-compilation.md](https://github.com/meridian-flow/mars-agents/blob/main/docs/config/skill-compilation.md) for the skill authoring format.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "cyclopts>=3.0",
   "fastapi>=0.115",
   "markdown-it-py>=4.0",
-  "mars-agents==0.7.9",
+  "mars-agents==0.7.11",
   "mcp>=1.0",
   "pathspec>=1.1.0",
   "psutil>=7.2.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "cyclopts>=3.0",
   "fastapi>=0.115",
   "markdown-it-py>=4.0",
-  "mars-agents==0.7.8",
+  "mars-agents==0.7.9",
   "mcp>=1.0",
   "pathspec>=1.1.0",
   "psutil>=7.2.2",

--- a/src/meridian/cli/work_cmd.py
+++ b/src/meridian/cli/work_cmd.py
@@ -150,8 +150,12 @@ def _work_sessions(
         bool,
         Parameter(name="--all", help="Include historical sessions."),
     ] = False,
+    primary: Annotated[
+        bool,
+        Parameter(name="--primary", help="Show only the primary handoff chain."),
+    ] = False,
 ) -> None:
-    emit(work_sessions_sync(WorkSessionsInput(work_id=work_id, all=all)))
+    emit(work_sessions_sync(WorkSessionsInput(work_id=work_id, all=all, primary=primary)))
 
 
 def _work_update(

--- a/src/meridian/lib/catalog/AGENTS.md
+++ b/src/meridian/lib/catalog/AGENTS.md
@@ -64,7 +64,7 @@ environments silently skip auto-resolve aliases.
 - `catalog_session.py` — `CatalogSession`: per-operation facade; start here
 - `model_aliases.py` — `AliasEntry`, `MarsResultCache`, mars subprocess integration
 - `agent.py` — `AgentProfile`, agent frontmatter parsing for `.mars/agents/*.md`
-- `skill.py` — skill YAML/markdown parsing for `.mars/skills/*/SKILL.md`
+- `skill.py` — skill YAML/markdown parsing for `.mars/skills/*/SKILL.md` (legacy compat; primary path uses mars launch-bundle)
 
 ## Usage Pattern
 

--- a/src/meridian/lib/launch/.context/CONTEXT.md
+++ b/src/meridian/lib/launch/.context/CONTEXT.md
@@ -363,17 +363,42 @@ rationale lives in [concepts/session-initiation.md](../../../../../../../../.mer
 at this layer, the rule is simply to keep `--from` blocks in user-turn context
 blocks and out of `SystemInstruction`.
 
+### Skill Loading — Bundle as Sole Interface
+
+Skill content comes from the Mars launch-bundle JSON (`skills.loaded[]`), not from
+reading `.mars/skills/` on disk. Mars owns the `.mars/` directory schema, skill
+variant resolution, and compilation. Meridian consumes the structured output:
+
+```
+Mars launch-bundle → skills.loaded[{name, skill_type, body}]
+                          │
+                          ▼
+_build_resolved_skills_from_bundle()  ← policies.py
+                          │
+                          ▼
+ResolvedSkills.loaded_skills: tuple[SkillContent, ...]
+```
+
+`_build_resolved_skills_from_bundle` in `policies.py` constructs `SkillContent`
+objects with synthetic paths (`project_root/.mars/skills/{name}/SKILL.md`) for
+downstream heading rendering and snapshot persistence. The parser handles both
+`body` (mars >=0.8) and `content` (mars 0.7.x) field names for backward compat.
+
+**`resolve_skills_from_profile()` still exists** for the snapshot replay path
+(`policy_snapshot.py`) — when replaying from a persisted snapshot whose
+`loaded_skills` field is empty (pre-bundle snapshots), it falls back to disk
+loading. New snapshots always persist `loaded_skills`, so this path is legacy compat.
+
 ### Skill Injection Channels
 
-There are two distinct channels for delivering skill content to agents. They are
-controlled by separate capability flags and must not be conflated:
+Two distinct channels deliver loaded skill content to agents. They are controlled
+by separate capability flags and must not be conflated:
 
 **Channel 1 — `supplemental_documents`** (prompt-embedded):
 Populated by `compose_skill_prompt_documents()` in `_resolve_spawn_prepare_projection()`
 and `_resolve_primary_projection()`. **Gated on `not harness.capabilities.supports_native_skills`.**
 When the harness supports native skills (currently Claude, Codex, and OpenCode), this
-channel is suppressed — `supplemental_documents` is set to an empty tuple. Skills reach
-the agent via Mars-materialized native channels instead.
+channel is suppressed — `supplemental_documents` is set to an empty tuple.
 
 **Channel 2 — `append-system-prompt`** (Claude spawns only):
 Populated by `compose_skill_injections()` in `_prepare_spawn_surface()` when

--- a/src/meridian/lib/launch/AGENTS.md
+++ b/src/meridian/lib/launch/AGENTS.md
@@ -5,6 +5,13 @@ Turns a `SpawnRequest` into a running process. Does not own policy decisions (wh
 to spawn) or harness specifics (how to build argv for Claude/Codex) — it owns the
 composition seam that wires them together.
 
+## Skill Loading
+
+Skill content comes from the Mars launch-bundle JSON (`skills.loaded[].{name, skill_type, body}`),
+not from reading `.mars/skills/` on disk. `_build_resolved_skills_from_bundle()` in `policies.py`
+constructs `ResolvedSkills` from bundle data. `resolve_skills_from_profile()` is kept only for
+legacy snapshot replay when a persisted snapshot's `loaded_skills` field is empty.
+
 ## The Composition Seam (Invariant I-1)
 
 All launch state assembly — argv, env, permissions, prompt, workspace roots — happens

--- a/src/meridian/lib/launch/bundle_adapter.py
+++ b/src/meridian/lib/launch/bundle_adapter.py
@@ -54,6 +54,15 @@ class BundleRequest:
 
 
 @dataclass(frozen=True)
+class LoadedSkillEntry:
+    """Structured loaded skill from the bundle (name + type + body)."""
+
+    name: str
+    skill_type: str
+    body: str
+
+
+@dataclass(frozen=True)
 class _BundlePromptDocument:
     kind: str
     name: str
@@ -77,7 +86,7 @@ class _BundleResult:
     tools_allowed: tuple[str, ...]
     tools_disallowed: tuple[str, ...]
     tools_mcp: tuple[str, ...]
-    skills_loaded: tuple[str, ...]
+    skills_loaded: tuple[LoadedSkillEntry, ...]
     skills_available: tuple[AvailableSkillEntry, ...]
     skills_missing: tuple[str, ...]
 
@@ -147,23 +156,29 @@ def _parse_prompt_documents(raw: object) -> tuple[_BundlePromptDocument, ...]:
     return tuple(documents)
 
 
-def _parse_skills_loaded(raw: object) -> tuple[str, ...]:
+def _parse_skills_loaded(raw: object) -> tuple[LoadedSkillEntry, ...]:
     """Parse skills loaded field — handles both v2 flat strings and v3 structured objects."""
     if not isinstance(raw, list):
         return ()
-    loaded_names: list[str] = []
+    entries: list[LoadedSkillEntry] = []
     for item in cast("list[object]", raw):
         if isinstance(item, str):
-            # v2: flat list of skill name strings
+            # v2: flat list of skill name strings (no body available)
             normalized = item.strip()
             if normalized:
-                loaded_names.append(normalized)
+                entries.append(LoadedSkillEntry(name=normalized, skill_type="reference", body=""))
         elif isinstance(item, dict):
-            # v3: list of {name, skill_type, content} objects
-            name = _normalize_str(cast("dict[str, object]", item).get("name"))
+            # v3: list of {name, skill_type, body/content} objects
+            item_dict = cast("dict[str, object]", item)
+            name = _normalize_str(item_dict.get("name"))
             if name:
-                loaded_names.append(name)
-    return tuple(loaded_names)
+                skill_type = _normalize_str(item_dict.get("skill_type")) or "reference"
+                # "body" is canonical (mars >= 0.8); "content" is compat (mars 0.7.x)
+                body = _normalize_str(item_dict.get("body")) or _normalize_str(
+                    item_dict.get("content")
+                )
+                entries.append(LoadedSkillEntry(name=name, skill_type=skill_type, body=body))
+    return tuple(entries)
 
 
 def _parse_skills_available(raw: object) -> tuple[AvailableSkillEntry, ...]:
@@ -551,6 +566,7 @@ def bundle_to_resolved_policy(
 
 __all__ = [
     "BundleRequest",
+    "LoadedSkillEntry",
     "bundle_to_resolved_policy",
     "request_and_resolve",
 ]

--- a/src/meridian/lib/launch/bundle_adapter.py
+++ b/src/meridian/lib/launch/bundle_adapter.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, cast
 
 from meridian.lib.core.types import HarnessId
 from meridian.lib.launch.compiler import FieldProvenance, ProvenanceLevel
+from meridian.lib.launch.composition import AvailableSkillEntry
 from meridian.lib.launch.launch_types import (
     CompositionWarning,
     ResolvedExecutionPolicy,
@@ -77,7 +78,7 @@ class _BundleResult:
     tools_disallowed: tuple[str, ...]
     tools_mcp: tuple[str, ...]
     skills_loaded: tuple[str, ...]
-    skills_available: tuple[str, ...]
+    skills_available: tuple[AvailableSkillEntry, ...]
     skills_missing: tuple[str, ...]
 
 
@@ -146,13 +147,10 @@ def _parse_prompt_documents(raw: object) -> tuple[_BundlePromptDocument, ...]:
     return tuple(documents)
 
 
-def _parse_skills_loaded(raw: object) -> tuple[tuple[str, ...], tuple[str, ...]]:
-    """Parse skills loaded field — handles both v2 flat strings and v3 structured objects.
-
-    Returns (loaded_names, available_names).
-    """
+def _parse_skills_loaded(raw: object) -> tuple[str, ...]:
+    """Parse skills loaded field — handles both v2 flat strings and v3 structured objects."""
     if not isinstance(raw, list):
-        return (), ()
+        return ()
     loaded_names: list[str] = []
     for item in cast("list[object]", raw):
         if isinstance(item, str):
@@ -165,20 +163,22 @@ def _parse_skills_loaded(raw: object) -> tuple[tuple[str, ...], tuple[str, ...]]
             name = _normalize_str(cast("dict[str, object]", item).get("name"))
             if name:
                 loaded_names.append(name)
-    return tuple(loaded_names), ()
+    return tuple(loaded_names)
 
 
-def _parse_skills_available(raw: object) -> tuple[str, ...]:
+def _parse_skills_available(raw: object) -> tuple[AvailableSkillEntry, ...]:
     """Parse v3 skills.available field — list of {name, skill_type, description} objects."""
     if not isinstance(raw, list):
         return ()
-    names: list[str] = []
+    entries: list[AvailableSkillEntry] = []
     for item in cast("list[object]", raw):
         if isinstance(item, dict):
-            name = _normalize_str(cast("dict[str, object]", item).get("name"))
+            item_dict = cast("dict[str, object]", item)
+            name = _normalize_str(item_dict.get("name"))
+            skill_type = _normalize_str(item_dict.get("skill_type")) or "reference"
             if name:
-                names.append(name)
-    return tuple(names)
+                entries.append(AvailableSkillEntry(name=name, skill_type=skill_type))
+    return tuple(entries)
 
 
 def _bundle_schema_error(message: str) -> RuntimeError:
@@ -351,7 +351,7 @@ def _parse_bundle_payload(
     skills_obj = _optional_object_field(payload, "skills") or _optional_object_field(
         payload, "skills_metadata"
     )
-    skills_loaded, _ = _parse_skills_loaded(skills_obj.get("loaded"))
+    skills_loaded = _parse_skills_loaded(skills_obj.get("loaded"))
     skills_available = _parse_skills_available(skills_obj.get("available"))
 
     return _BundleResult(
@@ -545,6 +545,7 @@ def bundle_to_resolved_policy(
         warnings=warnings,
         alias_catalog=alias_catalog,
         bundle_inventory_prompt=bundle.prompt_surface_inventory_prompt or None,
+        bundle_available_skills=bundle.skills_available,
     )
 
 

--- a/src/meridian/lib/launch/composition.py
+++ b/src/meridian/lib/launch/composition.py
@@ -27,10 +27,10 @@ SYSTEM_INSTRUCTION_BLOCK_ORDER: tuple[str, ...] = (
     "agent_profile_body",
     "completion_contract",
     "supplemental_documents",
+    "available_skills_listing",
     "inventory_prompt",
     "context_prompt",
     "report_instruction",
-    "principle_bookend",
     # passthrough_system_fragments appended last
 )
 
@@ -40,6 +40,14 @@ INLINE_BLOCK_ORDER: tuple[str, ...] = (
     "task_context",
     "user_task_prompt",
 )
+
+
+@dataclass(frozen=True)
+class AvailableSkillEntry:
+    """Lightweight entry for an on-demand skill (name + type only)."""
+
+    name: str
+    skill_type: str = "reference"
 
 
 @dataclass(frozen=True)
@@ -160,6 +168,9 @@ class ComposedLaunchContent:
     launch_preamble: str = ""
     """Launch-mode-specific behavioral framing."""
 
+    available_skills: tuple[AvailableSkillEntry, ...] = ()
+    """On-demand skills listed by name in the prompt (not loaded until triggered)."""
+
 
 @dataclass(frozen=True)
 class ProjectedContent:
@@ -263,12 +274,49 @@ def join_content_blocks(*blocks: str) -> str:
     return "\n\n".join(block.strip() for block in blocks if block.strip())
 
 
+def _render_available_skills_block(available_skills: tuple[AvailableSkillEntry, ...]) -> str:
+    """Render the available skills listing — names only, grouped by type.
+
+    NOTE: mars-agents has a parallel implementation in `src/build/prompt.rs`
+    (compose_system_instruction). Keep format in sync.
+    """
+    if not available_skills:
+        return ""
+
+    lines = ["# Available Skills", "", "Load these when needed."]
+    type_groups: tuple[tuple[str, str], ...] = (
+        ("Principles", "principle"),
+        ("Guardrails", "guardrail"),
+        ("Mode-shift", "mode-shift"),
+        ("Checkpoint", "checkpoint"),
+    )
+    known_types = {t for _, t in type_groups}
+
+    for label, type_key in type_groups:
+        group = [s for s in available_skills if s.skill_type == type_key]
+        if group:
+            lines.append(f"\n## {label}")
+            for skill in group:
+                lines.append(f"- {skill.name}")
+
+    # Remaining (reference and unknown types)
+    other = [s for s in available_skills if s.skill_type not in known_types]
+    if other:
+        lines.append("")
+        for skill in other:
+            lines.append(f"- {skill.name}")
+
+    return "\n".join(lines)
+
+
 def render_system_instruction_blocks(content: ComposedLaunchContent) -> str:
     """Render SYSTEM_INSTRUCTION blocks in canonical order.
 
-    Order: agent_profile_body, completion_contract, supplemental documents
-    (skill type sorted then bootstrap), inventory_prompt, context_prompt,
-    report_instruction, principle skill bookend, then passthrough fragments.
+    Order: agent_profile_body, completion_contract, auto-loaded skills
+    (grouped by type: principles first, then guardrails, then others,
+    then bootstrap), available skills listing (names only),
+    inventory_prompt, context_prompt, report_instruction,
+    then passthrough fragments.
     """
     skill_type_priority = {"principle": 0, "guardrail": 1, "reference": 2}
     skill_documents = tuple(
@@ -283,18 +331,24 @@ def render_system_instruction_blocks(content: ComposedLaunchContent) -> str:
     bootstrap_documents = tuple(
         document for document in content.supplemental_documents if document.kind == "bootstrap"
     )
-    principle_documents = tuple(
-        document for document in ordered_skill_documents if document.skill_type == "principle"
-    )
 
     ordered_blocks: list[str] = []
     for field_name in SYSTEM_INSTRUCTION_BLOCK_ORDER:
         if field_name == "supplemental_documents":
-            ordered_blocks.extend(document.content for document in ordered_skill_documents)
+            # Auto-loaded skills: full content, sorted by type (principles first)
+            # Skills already have their own `# Skill: name` heading; we don't
+            # add intermediate heading levels that would break the hierarchy.
+            if ordered_skill_documents:
+                for doc in ordered_skill_documents:
+                    if doc.content.strip():
+                        ordered_blocks.append(doc.content.strip())
+            # Bootstrap documents after skills
             ordered_blocks.extend(document.content for document in bootstrap_documents)
             continue
-        if field_name == "principle_bookend":
-            ordered_blocks.extend(document.content for document in principle_documents)
+        if field_name == "available_skills_listing":
+            listing = _render_available_skills_block(content.available_skills)
+            if listing:
+                ordered_blocks.append(listing)
             continue
         ordered_blocks.append(getattr(content, field_name))
     return join_content_blocks(*ordered_blocks, *content.passthrough_system_fragments)
@@ -354,6 +408,7 @@ def project_inline_content(content: ComposedLaunchContent) -> ProjectedContent:
 __all__ = [
     "INLINE_BLOCK_ORDER",
     "SYSTEM_INSTRUCTION_BLOCK_ORDER",
+    "AvailableSkillEntry",
     "ComposedLaunchContent",
     "InlineFileReferenceContribution",
     "ProjectedContent",

--- a/src/meridian/lib/launch/composition.py
+++ b/src/meridian/lib/launch/composition.py
@@ -274,6 +274,23 @@ def join_content_blocks(*blocks: str) -> str:
     return "\n\n".join(block.strip() for block in blocks if block.strip())
 
 
+_SKILL_TYPE_DESCRIPTIONS: dict[str, str] = {
+    "principle": "Override other guidance when loaded.",
+    "guardrail": "Load before acting in sensitive areas.",
+    "mode-shift": "Change how you operate when loaded.",
+    "checkpoint": "Load at decision points to verify before continuing.",
+}
+
+
+def _loaded_skill_type_header(skill_type: str) -> str:
+    """Return a group header for a cluster of loaded skills of the same type."""
+    label = skill_type.capitalize()
+    desc = _SKILL_TYPE_DESCRIPTIONS.get(skill_type)
+    if desc:
+        return f"## {label}\n{desc}"
+    return f"## {label}"
+
+
 def _render_available_skills_block(available_skills: tuple[AvailableSkillEntry, ...]) -> str:
     """Render the available skills listing — names only, grouped by type.
 
@@ -288,34 +305,30 @@ def _render_available_skills_block(available_skills: tuple[AvailableSkillEntry, 
         "",
         "Not yet loaded. Load proactively when the task fits.",
     ]
-    type_groups: tuple[tuple[str, str, str], ...] = (
-        ("Principles", "principle", "Override other guidance when loaded."),
-        ("Guardrails", "guardrail", "Load before acting in sensitive areas."),
-        ("Mode-shift", "mode-shift", "Change how you operate when loaded."),
-        ("Checkpoint", "checkpoint", "Load at decision points to verify before continuing."),
-    )
-    known_types = {t for _, t, _ in type_groups}
+    # Render order: known types first (sorted), then remaining by first-seen order.
+    known_type_order = ("principle", "guardrail", "mode-shift", "checkpoint")
 
-    for label, type_key, description in type_groups:
+    # Collect all distinct types preserving order: known first, then rest.
+    seen_types: list[str] = []
+    for t in known_type_order:
+        if any(s.skill_type == t for s in available_skills):
+            seen_types.append(t)
+    for s in available_skills:
+        if s.skill_type not in seen_types:
+            seen_types.append(s.skill_type)
+
+    for type_key in seen_types:
         group = [s for s in available_skills if s.skill_type == type_key]
-        if group:
+        if not group:
+            continue
+        label = type_key.capitalize()
+        desc = _SKILL_TYPE_DESCRIPTIONS.get(type_key)
+        if desc:
+            lines.append(f"\n## {label}\n{desc}")
+        else:
             lines.append(f"\n## {label}")
-            lines.append(f"{description}")
-            for skill in group:
-                lines.append(f"- {skill.name}")
-
-    # Remaining types: each gets its own heading, no description.
-    other = [s for s in available_skills if s.skill_type not in known_types]
-    if other:
-        seen_types: list[str] = []
-        for s in other:
-            if s.skill_type not in seen_types:
-                seen_types.append(s.skill_type)
-        for type_key in seen_types:
-            group = [s for s in other if s.skill_type == type_key]
-            lines.append(f"\n## {type_key.capitalize()}")
-            for skill in group:
-                lines.append(f"- {skill.name}")
+        for skill in group:
+            lines.append(f"- {skill.name}")
 
     return "\n".join(lines)
 
@@ -346,12 +359,16 @@ def render_system_instruction_blocks(content: ComposedLaunchContent) -> str:
     ordered_blocks: list[str] = []
     for field_name in SYSTEM_INSTRUCTION_BLOCK_ORDER:
         if field_name == "supplemental_documents":
-            # Auto-loaded skills: full content, sorted by type (principles first)
-            # Skills already have their own `# Skill: name` heading; we don't
-            # add intermediate heading levels that would break the hierarchy.
+            # Auto-loaded skills: full content, grouped by type with headers.
             if ordered_skill_documents:
+                current_type: str | None = None
                 for doc in ordered_skill_documents:
                     if doc.content.strip():
+                        if doc.skill_type != current_type:
+                            current_type = doc.skill_type
+                            header = _loaded_skill_type_header(current_type)
+                            if header:
+                                ordered_blocks.append(header)
                         ordered_blocks.append(doc.content.strip())
             # Bootstrap documents after skills
             ordered_blocks.extend(document.content for document in bootstrap_documents)

--- a/src/meridian/lib/launch/composition.py
+++ b/src/meridian/lib/launch/composition.py
@@ -286,15 +286,13 @@ def _render_available_skills_block(available_skills: tuple[AvailableSkillEntry, 
     lines = [
         "# Available Skills",
         "",
-        "These skills are registered but not yet loaded. "
-        "Load them when the situation calls for their guidance — "
-        "they exist because this agent benefits from them regularly.",
+        "Not yet loaded. Load proactively when the task fits.",
     ]
     type_groups: tuple[tuple[str, str, str], ...] = (
-        ("Principles", "principle", "Core operating constraints — override other guidance."),
-        ("Guardrails", "guardrail", "Safety and quality boundaries."),
-        ("Mode-shift", "mode-shift", "Change operating posture when loaded."),
-        ("Checkpoint", "checkpoint", "Verification gates — load at decision points."),
+        ("Principles", "principle", "Override other guidance when loaded."),
+        ("Guardrails", "guardrail", "Load before acting in sensitive areas."),
+        ("Mode-shift", "mode-shift", "Change how you operate when loaded."),
+        ("Checkpoint", "checkpoint", "Load at decision points to verify before continuing."),
     )
     known_types = {t for _, t, _ in type_groups}
 

--- a/src/meridian/lib/launch/composition.py
+++ b/src/meridian/lib/launch/composition.py
@@ -304,12 +304,18 @@ def _render_available_skills_block(available_skills: tuple[AvailableSkillEntry, 
             for skill in group:
                 lines.append(f"- {skill.name}")
 
-    # Remaining (reference and unknown types)
+    # Remaining types: each gets its own heading, no description.
     other = [s for s in available_skills if s.skill_type not in known_types]
     if other:
-        lines.append("")
-        for skill in other:
-            lines.append(f"- {skill.name}")
+        seen_types: list[str] = []
+        for s in other:
+            if s.skill_type not in seen_types:
+                seen_types.append(s.skill_type)
+        for type_key in seen_types:
+            group = [s for s in other if s.skill_type == type_key]
+            lines.append(f"\n## {type_key.capitalize()}")
+            for skill in group:
+                lines.append(f"- {skill.name}")
 
     return "\n".join(lines)
 

--- a/src/meridian/lib/launch/composition.py
+++ b/src/meridian/lib/launch/composition.py
@@ -283,19 +283,26 @@ def _render_available_skills_block(available_skills: tuple[AvailableSkillEntry, 
     if not available_skills:
         return ""
 
-    lines = ["# Available Skills", "", "Load these when needed."]
-    type_groups: tuple[tuple[str, str], ...] = (
-        ("Principles", "principle"),
-        ("Guardrails", "guardrail"),
-        ("Mode-shift", "mode-shift"),
-        ("Checkpoint", "checkpoint"),
+    lines = [
+        "# Available Skills",
+        "",
+        "These skills are registered but not yet loaded. "
+        "Load them when the situation calls for their guidance — "
+        "they exist because this agent benefits from them regularly.",
+    ]
+    type_groups: tuple[tuple[str, str, str], ...] = (
+        ("Principles", "principle", "Core operating constraints — override other guidance."),
+        ("Guardrails", "guardrail", "Safety and quality boundaries."),
+        ("Mode-shift", "mode-shift", "Change operating posture when loaded."),
+        ("Checkpoint", "checkpoint", "Verification gates — load at decision points."),
     )
-    known_types = {t for _, t in type_groups}
+    known_types = {t for _, t, _ in type_groups}
 
-    for label, type_key in type_groups:
+    for label, type_key, description in type_groups:
         group = [s for s in available_skills if s.skill_type == type_key]
         if group:
             lines.append(f"\n## {label}")
+            lines.append(f"{description}")
             for skill in group:
                 lines.append(f"- {skill.name}")
 

--- a/src/meridian/lib/launch/context.py
+++ b/src/meridian/lib/launch/context.py
@@ -94,6 +94,7 @@ from .policy_snapshot import build_launch_policy_snapshot
 from .prompt import (
     build_goal_instruction,
     build_launch_context_documents,
+    build_primary_preamble,
     build_report_instruction,
     build_spawn_preamble,
     build_work_goal_instruction,
@@ -1136,6 +1137,7 @@ def _resolve_primary_projection(
             inventory_prompt=agent_inventory_prompt or "",
             context_prompt=context_prompt or "",
             completion_contract=completion_contract,
+            launch_preamble=build_primary_preamble(),
             passthrough_system_fragments=passthrough_system_fragments,
             user_task_prompt=request.prompt,
             reference_items=task_ctx.reference_items,

--- a/src/meridian/lib/launch/context.py
+++ b/src/meridian/lib/launch/context.py
@@ -1019,6 +1019,7 @@ def _resolve_spawn_prepare_projection(
     projected = harness.project_content(
         ComposedLaunchContent(
             supplemental_documents=supplemental_documents,
+            available_skills=policy.bundle_available_skills,
             agent_profile_body=agent_profile_body,
             report_instruction=build_report_instruction(),
             inventory_prompt=agent_inventory_prompt or "",
@@ -1129,6 +1130,7 @@ def _resolve_primary_projection(
     projected = harness.project_content(
         ComposedLaunchContent(
             supplemental_documents=supplemental_documents,
+            available_skills=policy.bundle_available_skills,
             agent_profile_body=agent_profile_body,
             report_instruction="",
             inventory_prompt=agent_inventory_prompt or "",

--- a/src/meridian/lib/launch/policies.py
+++ b/src/meridian/lib/launch/policies.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
+from pathlib import Path
 
 from meridian.lib.catalog.agent import AgentProfile
 from meridian.lib.catalog.catalog_session import CatalogSession
 from meridian.lib.catalog.model_aliases import AliasEntry
 from meridian.lib.config.settings import MeridianConfig
+from meridian.lib.core.domain import SkillContent
 from meridian.lib.core.overrides import (
     EXECUTION_POLICY_FIELDS,
     ExecutionPolicyField,
@@ -22,6 +24,7 @@ from meridian.lib.harness.registry import HarnessRegistry
 from meridian.lib.tools import ToolsField
 
 from . import bundle_adapter
+from .bundle_adapter import LoadedSkillEntry
 from .compiler import (
     FieldProvenance,
     match_model_policy,
@@ -42,7 +45,6 @@ from .resolve import (
     ResolvedSkills,
     dedupe_skill_names,
     load_agent_profile_with_fallback,
-    resolve_skills_from_profile,
     validate_harness_compatibility,
 )
 
@@ -50,6 +52,39 @@ _LOGGER = logging.getLogger(__name__)
 _DEFAULT_EXECUTION_POLICY_FIELDS: frozenset[ExecutionPolicyField] = frozenset(
     EXECUTION_POLICY_FIELDS
 )
+
+
+def _build_resolved_skills_from_bundle(
+    loaded_entries: tuple[LoadedSkillEntry, ...],
+    *,
+    missing: tuple[str, ...],
+    project_root: Path,
+) -> ResolvedSkills:
+    """Construct ResolvedSkills directly from bundle skill data.
+
+    Mars owns the .mars/ directory schema and skill loading. Meridian consumes
+    the structured bundle output without reaching into .mars/skills/ on disk.
+    """
+    loaded_skills: list[SkillContent] = []
+    for entry in loaded_entries:
+        if not entry.body:
+            continue
+        # Synthetic path for downstream heading rendering and snapshot persistence.
+        synthetic_path = (project_root / ".mars" / "skills" / entry.name / "SKILL.md").as_posix()
+        loaded_skills.append(
+            SkillContent(
+                name=entry.name,
+                description="",
+                content=entry.body,
+                path=synthetic_path,
+                skill_type=entry.skill_type,
+            )
+        )
+    return ResolvedSkills(
+        skill_names=tuple(entry.name for entry in loaded_entries),
+        loaded_skills=tuple(loaded_skills),
+        missing_skills=missing,
+    )
 
 
 @dataclass(frozen=True)
@@ -460,13 +495,10 @@ def _resolve_policy_from_bundle(surface: SurfacePolicyInput) -> ResolvedLaunchPo
         timeout=resolved_execution_policy_overrides.timeout,
     )
 
-    resolved_skills = resolve_skills_from_profile(
-        profile_skills=resolved_skill_names,
+    resolved_skills = _build_resolved_skills_from_bundle(
+        bundle_result.skills_loaded,
+        missing=bundle_result.skills_missing,
         project_root=project_root,
-        readonly=surface.skills_readonly,
-        harness_id=resolved_harness.value,
-        selected_model_token=model_selection.selected_model_token,
-        canonical_model_id=model_selection.canonical_model_id,
     )
 
     bundle_model_warning = "\n".join(bundle_result.warnings).strip() or None

--- a/src/meridian/lib/launch/policies.py
+++ b/src/meridian/lib/launch/policies.py
@@ -26,6 +26,7 @@ from .compiler import (
     FieldProvenance,
     match_model_policy,
 )
+from .composition import AvailableSkillEntry
 from .launch_types import (
     CompositionWarning,
     ResolvedExecutionPolicy,
@@ -127,6 +128,8 @@ class ResolvedLaunchPolicy:
     warnings: tuple[CompositionWarning, ...] = ()
     alias_catalog: dict[str, AliasEntry] | None = None
     bundle_inventory_prompt: str | None = None
+    bundle_available_skills: tuple[AvailableSkillEntry, ...] = ()
+    """Available skill entries from bundle (on-demand, not loaded at launch)."""
 
 
 ResolvedPolicies = ResolvedLaunchPolicy

--- a/src/meridian/lib/launch/prompt.py
+++ b/src/meridian/lib/launch/prompt.py
@@ -141,11 +141,27 @@ def build_spawn_preamble(launch_mode: str | None) -> str:
 
     if launch_mode == "background":
         return (
-            "# Spawn Context\n\n"
-            "You were spawned to complete a specific objective. Work autonomously. "
-            "Only escalate if blocked."
+            "# Session Context\n\n"
+            "This is a **sub-agent session**. You are not talking to the user. "
+            "Your final output is a structured report consumed by your parent agent. "
+            "Work autonomously toward your objective. Only escalate if blocked."
+        )
+    if launch_mode == "foreground":
+        return (
+            "# Session Context\n\n"
+            "This is a **sub-agent session**. You are not talking to the user. "
+            "Your final output is a structured report consumed by your parent agent."
         )
     return ""
+
+
+def build_primary_preamble() -> str:
+    """Render session-context framing for primary (user-facing) sessions."""
+
+    return (
+        "# Session Context\n\n"
+        "This is a **primary session**. You are talking directly to the user."
+    )
 
 
 def build_work_goal_instruction(work_goal: str | None) -> str:
@@ -497,6 +513,7 @@ __all__ = [
     "build_context_prompt",
     "build_goal_instruction",
     "build_launch_context_documents",
+    "build_primary_preamble",
     "build_report_instruction",
     "build_spawn_preamble",
     "build_work_goal_instruction",

--- a/src/meridian/lib/ops/work_dashboard.py
+++ b/src/meridian/lib/ops/work_dashboard.py
@@ -330,6 +330,7 @@ class WorkSessionsInput(BaseModel):
 
     work_id: str = ""
     all: bool = False
+    primary: bool = False
     project_root: str | None = None
 
 
@@ -339,13 +340,15 @@ class WorkSessionsOutput(BaseModel):
     work_id: str
     sessions: tuple[WorkSessionItem, ...] = ()
     all: bool = False
+    primary: bool = False
 
     def format_text(self, ctx: FormatContext | None = None) -> str:
         _ = ctx
         lines = _format_session_rows(self.sessions, indent="")
-        if not self.all:
+        if not self.all and not self.primary:
             lines.append("")
             lines.append("Use --all to include historical sessions.")
+            lines.append("Use --primary to show only the primary handoff chain.")
         return "\n".join(lines)
 
 
@@ -381,6 +384,7 @@ def _work_sessions_for_work_id(
     work_id: str,
     *,
     include_all: bool,
+    primary_only: bool = False,
 ) -> tuple[WorkSessionItem, ...]:
     active_chat_ids = set(session_store.list_active_sessions(runtime_root))
     chat_ids = work_session_chat_ids(
@@ -390,6 +394,8 @@ def _work_sessions_for_work_id(
         include_all=include_all,
     )
     records = session_store.get_session_records(runtime_root, chat_ids)
+    if primary_only:
+        records = [r for r in records if r.kind == "primary"]
     records.sort(key=lambda record: (record.started_at, record.chat_id))
     return tuple(
         WorkSessionItem(
@@ -584,9 +590,11 @@ def work_sessions_sync(
             project_root,
             runtime_state_root,
             item.name,
-            include_all=payload.all,
+            include_all=payload.all or payload.primary,
+            primary_only=payload.primary,
         ),
         all=payload.all,
+        primary=payload.primary,
     )
 
 

--- a/tests/integration/launch/test_launch_resolution_skills.py
+++ b/tests/integration/launch/test_launch_resolution_skills.py
@@ -11,6 +11,7 @@ import pytest
 from meridian.lib.core.types import HarnessId
 from meridian.lib.harness.registry import get_default_harness_registry
 from meridian.lib.launch import bundle_adapter
+from meridian.lib.launch.composition import AvailableSkillEntry
 from meridian.lib.launch.context import build_launch_context
 from meridian.lib.launch.launch_types import ResolvedExecutionPolicy
 from meridian.lib.launch.plan import (
@@ -50,6 +51,7 @@ class _FakeBundleResult:
     tools_allowed: tuple[str, ...] = ()
     tools_disallowed: tuple[str, ...] = ()
     tools_mcp: tuple[str, ...] = ()
+    skills_available: tuple[AvailableSkillEntry, ...] = ()
 
 
 def _stub_bundle_resolution(

--- a/tests/integration/launch/test_launch_resolution_skills.py
+++ b/tests/integration/launch/test_launch_resolution_skills.py
@@ -11,6 +11,7 @@ import pytest
 from meridian.lib.core.types import HarnessId
 from meridian.lib.harness.registry import get_default_harness_registry
 from meridian.lib.launch import bundle_adapter
+from meridian.lib.launch.bundle_adapter import LoadedSkillEntry
 from meridian.lib.launch.composition import AvailableSkillEntry
 from meridian.lib.launch.context import build_launch_context
 from meridian.lib.launch.launch_types import ResolvedExecutionPolicy
@@ -19,7 +20,7 @@ from meridian.lib.launch.plan import (
     build_primary_spawn_request,
 )
 from meridian.lib.launch.types import LaunchRequest
-from tests.support.fixtures import write_agent, write_skill
+from tests.support.fixtures import write_agent
 
 pytestmark = pytest.mark.slow
 
@@ -51,13 +52,16 @@ class _FakeBundleResult:
     tools_allowed: tuple[str, ...] = ()
     tools_disallowed: tuple[str, ...] = ()
     tools_mcp: tuple[str, ...] = ()
+    skills_loaded: tuple[LoadedSkillEntry, ...] = ()
     skills_available: tuple[AvailableSkillEntry, ...] = ()
+    skills_missing: tuple[str, ...] = ()
 
 
 def _stub_bundle_resolution(
     monkeypatch: pytest.MonkeyPatch,
     *,
     resolution: _BundleResolution,
+    skills_loaded: tuple[LoadedSkillEntry, ...] = (),
 ) -> None:
     def _fake_request_and_resolve(
         request: bundle_adapter.BundleRequest,
@@ -72,15 +76,21 @@ def _stub_bundle_resolution(
             harness_model=None,
             execution_policy=ResolvedExecutionPolicy(),
             provenance={"model_source": "cli", "harness_source": "cli"},
+            skills_loaded=skills_loaded,
         )
 
     monkeypatch.setattr(bundle_adapter, "request_and_resolve", _fake_request_and_resolve)
 
 
-def test_launch_skill_variants_use_alias_then_canonical_then_harness(
+def test_launch_skill_content_flows_from_bundle_to_composition(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Bundle-provided skill content flows through policy → composition.
+
+    Variant resolution (alias → canonical → harness) is mars's responsibility.
+    Meridian-cli consumes whatever mars resolved and sent in skills.loaded[].
+    """
     _write_minimal_mars_config(tmp_path)
     _stub_bundle_resolution(
         monkeypatch,
@@ -89,6 +99,13 @@ def test_launch_skill_variants_use_alias_then_canonical_then_harness(
             model_token="alias-token",
             harness=HarnessId.CODEX,
         ),
+        skills_loaded=(
+            LoadedSkillEntry(
+                name="variant-skill",
+                skill_type="reference",
+                body="Resolved variant body from mars",
+            ),
+        ),
     )
     write_agent(
         tmp_path,
@@ -96,19 +113,6 @@ def test_launch_skill_variants_use_alias_then_canonical_then_harness(
         model="alias-token",
         skills=["variant-skill"],
     )
-    write_skill(tmp_path, "variant-skill", body="Base body", description="Base metadata")
-    skill_root = tmp_path / ".mars" / "skills" / "variant-skill"
-    token_variant = skill_root / "variants" / "codex" / "alias-token" / "SKILL.md"
-    token_variant.parent.mkdir(parents=True)
-    token_variant.write_text(
-        "---\nname: ignored-token\ndescription: ignored\n---\n\nAlias token body",
-        encoding="utf-8",
-    )
-    canonical_variant = skill_root / "variants" / "codex" / "canonical-id" / "SKILL.md"
-    canonical_variant.parent.mkdir(parents=True)
-    canonical_variant.write_text("Canonical body", encoding="utf-8")
-    harness_variant = skill_root / "variants" / "codex" / "SKILL.md"
-    harness_variant.write_text("Harness body", encoding="utf-8")
 
     preview = build_launch_context(
         spawn_id="dry-run-variant-alias",
@@ -120,83 +124,75 @@ def test_launch_skill_variants_use_alias_then_canonical_then_harness(
         dry_run=True,
     )
 
-    system_prompt = preview.projected_content.system_prompt if preview.projected_content else ""
     # Codex declares supports_native_skills=True, so skill content is suppressed
-    # from supplemental_documents. Skill variant resolution still picks the right path.
-    assert "Alias token body" not in system_prompt
-    assert "Canonical body" not in system_prompt
-    assert "Harness body" not in system_prompt
-    assert preview.resolved_request.skill_paths == (token_variant.resolve().as_posix(),)
+    # from the system prompt (it goes via native skill injection).
+    system_prompt = preview.projected_content.system_prompt if preview.projected_content else ""
+    assert "Resolved variant body from mars" not in system_prompt
+    # Skill path is synthetic (from bundle, not disk)
+    assert preview.resolved_request.skill_paths
+    assert ".mars/skills/variant-skill/SKILL.md" in preview.resolved_request.skill_paths[0]
 
 
-def test_launch_skill_variants_fall_back_to_canonical_then_harness_and_exact_only(
+def test_bundle_skill_content_renders_via_append_for_native_skill_harness(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Native-skill harness (Claude) delivers bundle skill body via append-system-prompt."""
+    from meridian.lib.launch.request import (
+        LaunchArgvIntent,
+        LaunchCompositionSurface,
+        LaunchRuntime,
+        SpawnRequest,
+    )
+
     _write_minimal_mars_config(tmp_path)
     _stub_bundle_resolution(
         monkeypatch,
         resolution=_BundleResolution(
-            model="canonical-id",
-            model_token="alias-token",
-            harness=HarnessId.CODEX,
+            model="claude-sonnet-4-5",
+            model_token="sonnet",
+            harness=HarnessId.CLAUDE,
+        ),
+        skills_loaded=(
+            LoadedSkillEntry(
+                name="my-principle",
+                skill_type="principle",
+                body="Always prefer simplicity over cleverness.",
+            ),
         ),
     )
     write_agent(
         tmp_path,
         name="dev-orchestrator",
-        model="alias-token",
-        skills=["variant-skill"],
+        model="sonnet",
+        skills=["my-principle"],
     )
-    write_skill(tmp_path, "variant-skill", body="Base body")
-    skill_root = tmp_path / ".mars" / "skills" / "variant-skill"
-    prefix_variant = skill_root / "variants" / "codex" / "alias" / "SKILL.md"
-    prefix_variant.parent.mkdir(parents=True)
-    prefix_variant.write_text("Prefix body", encoding="utf-8")
-    canonical_variant = skill_root / "variants" / "codex" / "canonical-id" / "SKILL.md"
-    canonical_variant.parent.mkdir(parents=True)
-    canonical_variant.write_text("Canonical body", encoding="utf-8")
-    harness_variant = skill_root / "variants" / "codex" / "SKILL.md"
-    harness_variant.write_text("Harness body", encoding="utf-8")
 
-    canonical_preview = build_launch_context(
-        spawn_id="dry-run-variant-canonical",
-        request=build_primary_spawn_request(
-            request=LaunchRequest(model="alias-token", agent="dev-orchestrator")
+    preview = build_launch_context(
+        spawn_id="dry-run-claude-skill-spawn",
+        request=SpawnRequest(
+            prompt="do the task",
+            prompt_is_composed=False,
+            model="sonnet",
+            harness="claude",
+            agent="dev-orchestrator",
         ),
-        runtime=build_primary_launch_runtime(project_root=tmp_path),
+        runtime=LaunchRuntime(
+            argv_intent=LaunchArgvIntent.REQUIRED,
+            composition_surface=LaunchCompositionSurface.SPAWN_PREPARE,
+            runtime_root=(tmp_path / ".meridian").as_posix(),
+            project_paths_project_root=tmp_path.as_posix(),
+            project_paths_execution_cwd=tmp_path.as_posix(),
+        ),
         harness_registry=get_default_harness_registry(),
         dry_run=True,
     )
-    canonical_prompt = (
-        canonical_preview.projected_content.system_prompt
-        if canonical_preview.projected_content
-        else ""
-    )
-    # Codex declares supports_native_skills=True, so skill content is suppressed.
-    # Variant resolution still picks canonical over prefix.
-    assert "Canonical body" not in canonical_prompt
-    assert "Prefix body" not in canonical_prompt
-    assert canonical_preview.resolved_request.skill_paths == (
-        canonical_variant.resolve().as_posix(),
-    )
 
-    canonical_variant.unlink()
-    harness_preview = build_launch_context(
-        spawn_id="dry-run-variant-harness",
-        request=build_primary_spawn_request(
-            request=LaunchRequest(model="alias-token", agent="dev-orchestrator")
-        ),
-        runtime=build_primary_launch_runtime(project_root=tmp_path),
-        harness_registry=get_default_harness_registry(),
-        dry_run=True,
-    )
-    harness_prompt = (
-        harness_preview.projected_content.system_prompt if harness_preview.projected_content else ""
-    )
-    # Skill content suppressed for native-skill harness; variant resolution still correct.
-    assert "Harness body" not in harness_prompt
-    assert "Prefix body" not in harness_prompt
-    assert harness_preview.resolved_request.skill_paths == (
-        harness_variant.resolve().as_posix(),
-    )
+    # Claude delivers skills via --append-system-prompt, not in main system_prompt
+    system_prompt = preview.projected_content.system_prompt if preview.projected_content else ""
+    assert "Always prefer simplicity over cleverness." not in system_prompt
+    assert preview.binding.run_params.appended_system_prompt is not None
+    appended = preview.binding.run_params.appended_system_prompt
+    assert "Always prefer simplicity over cleverness." in appended
+    assert preview.resolved_request.skill_paths
+    assert ".mars/skills/my-principle/SKILL.md" in preview.resolved_request.skill_paths[0]

--- a/tests/integration/launch/test_launch_resolution_spawn_prepare.py
+++ b/tests/integration/launch/test_launch_resolution_spawn_prepare.py
@@ -10,6 +10,7 @@ import pytest
 from meridian.lib.core.execution_policy import ResolvedExecutionPolicy
 from meridian.lib.core.types import HarnessId
 from meridian.lib.harness.registry import get_default_harness_registry
+from meridian.lib.launch.bundle_adapter import LoadedSkillEntry
 from meridian.lib.launch.context import build_launch_context
 from meridian.lib.launch.request import (
     LaunchArgvIntent,
@@ -18,7 +19,7 @@ from meridian.lib.launch.request import (
     SessionRequest,
     SpawnRequest,
 )
-from tests.support.fixtures import write_agent, write_skill
+from tests.support.fixtures import write_agent
 from tests.support.launch import stub_bundle_request_and_resolve
 
 pytestmark = pytest.mark.slow
@@ -198,12 +199,13 @@ def test_spawn_prepare_claude_projects_skills_inventory_and_report_to_system_pro
         monkeypatch,
         model="claude-sonnet-4-5",
         harness=HarnessId.CLAUDE,
-    )
-    write_skill(
-        tmp_path,
-        "verification",
-        body="Use verification checklist.",
-        description="Verification helper",
+        skills_loaded=(
+            LoadedSkillEntry(
+                name="verification",
+                skill_type="reference",
+                body="Use verification checklist.",
+            ),
+        ),
     )
     write_agent(
         tmp_path,
@@ -280,12 +282,13 @@ def test_spawn_prepare_claude_continue_session_keeps_skills_in_system_prompt(
         monkeypatch,
         model="claude-sonnet-4-5",
         harness=HarnessId.CLAUDE,
-    )
-    write_skill(
-        tmp_path,
-        "verification",
-        body="Use verification checklist.",
-        description="Verification helper",
+        skills_loaded=(
+            LoadedSkillEntry(
+                name="verification",
+                skill_type="reference",
+                body="Use verification checklist.",
+            ),
+        ),
     )
     write_agent(
         tmp_path,

--- a/tests/integration/ops/test_spawn_prepare_fork.py
+++ b/tests/integration/ops/test_spawn_prepare_fork.py
@@ -193,12 +193,14 @@ def test_background_spawn_prompt_includes_launch_preamble(
         runtime=runtime,
     )
 
-    preamble = (
-        "You were spawned to complete a specific objective. Work autonomously. "
-        "Only escalate if blocked."
-    )
-    assert preamble in _prompt_surface_text(background)
-    assert preamble not in _prompt_surface_text(foreground)
+    # Both background and foreground spawns are sub-agent sessions
+    sub_agent_marker = "This is a **sub-agent session**. You are not talking to the user."
+    assert sub_agent_marker in _prompt_surface_text(background)
+    assert sub_agent_marker in _prompt_surface_text(foreground)
+    # Only background gets the autonomous work directive
+    autonomous = "Work autonomously toward your objective. Only escalate if blocked."
+    assert autonomous in _prompt_surface_text(background)
+    assert autonomous not in _prompt_surface_text(foreground)
 
 
 def test_build_create_payload_does_not_forward_meridian_primary_or_legacy_defaults_to_bundle(

--- a/tests/integration/prompt/test_compose.py
+++ b/tests/integration/prompt/test_compose.py
@@ -174,6 +174,9 @@ def test_system_instruction_renders_reordered_blocks_and_skill_type_groups() -> 
     )
 
     rendered = render_system_instruction_blocks(content)
+    # Composition order: profile, goal, skills sorted by type (principles first,
+    # then guardrails, then reference/other), bootstrap, inventory, context,
+    # report, passthrough. No principle bookend at the end.
     expected_sequence = (
         "PROFILE",
         "GOAL",
@@ -185,11 +188,14 @@ def test_system_instruction_renders_reordered_blocks_and_skill_type_groups() -> 
         "INVENTORY",
         "CONTEXT",
         "REPORT",
-        "PRINCIPLE-A",
-        "PRINCIPLE-B",
         "PASSTHROUGH",
     )
     cursor = -1
     for part in expected_sequence:
         cursor = rendered.find(part, cursor + 1)
-        assert cursor != -1
+        assert cursor != -1, f"Expected '{part}' after position {cursor} in rendered output"
+    # Principle bookend is gone — principles should NOT appear after REPORT
+    report_pos = rendered.find("REPORT")
+    passthrough_pos = rendered.find("PASSTHROUGH")
+    between = rendered[report_pos:passthrough_pos]
+    assert "PRINCIPLE-A" not in between

--- a/tests/support/launch.py
+++ b/tests/support/launch.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from meridian.lib.core.types import HarnessId
 from meridian.lib.launch import bundle_adapter
+from meridian.lib.launch.composition import AvailableSkillEntry
 from meridian.lib.launch.launch_types import ResolvedExecutionPolicy
 
 
@@ -21,6 +22,7 @@ class FakeBundleResult:
     tools_allowed: tuple[str, ...] = ()
     tools_disallowed: tuple[str, ...] = ()
     tools_mcp: tuple[str, ...] = ()
+    skills_available: tuple[AvailableSkillEntry, ...] = ()
 
 
 def stub_bundle_request_and_resolve(

--- a/tests/support/launch.py
+++ b/tests/support/launch.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from meridian.lib.core.types import HarnessId
 from meridian.lib.launch import bundle_adapter
+from meridian.lib.launch.bundle_adapter import LoadedSkillEntry
 from meridian.lib.launch.composition import AvailableSkillEntry
 from meridian.lib.launch.launch_types import ResolvedExecutionPolicy
 
@@ -22,7 +23,9 @@ class FakeBundleResult:
     tools_allowed: tuple[str, ...] = ()
     tools_disallowed: tuple[str, ...] = ()
     tools_mcp: tuple[str, ...] = ()
+    skills_loaded: tuple[LoadedSkillEntry, ...] = ()
     skills_available: tuple[AvailableSkillEntry, ...] = ()
+    skills_missing: tuple[str, ...] = ()
 
 
 def stub_bundle_request_and_resolve(
@@ -38,6 +41,7 @@ def stub_bundle_request_and_resolve(
     tools_allowed: tuple[str, ...] = (),
     tools_disallowed: tuple[str, ...] = (),
     tools_mcp: tuple[str, ...] = (),
+    skills_loaded: tuple[LoadedSkillEntry, ...] = (),
 ) -> list[bundle_adapter.BundleRequest]:
     captured_requests: list[bundle_adapter.BundleRequest] = []
 
@@ -65,6 +69,7 @@ def stub_bundle_request_and_resolve(
             tools_allowed=tools_allowed,
             tools_disallowed=tools_disallowed,
             tools_mcp=tools_mcp,
+            skills_loaded=skills_loaded,
         )
 
     monkeypatch.setattr(bundle_adapter, "request_and_resolve", _fake_request_and_resolve)

--- a/tests/unit/launch/test_launch_context_build.py
+++ b/tests/unit/launch/test_launch_context_build.py
@@ -8,11 +8,11 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from meridian.lib.core.domain import SkillContent
 from meridian.lib.core.execution_policy import ResolvedExecutionPolicy
 from meridian.lib.core.launch_policy_snapshot import LaunchPolicySnapshot
 from meridian.lib.core.types import HarnessId
 from meridian.lib.harness.registry import get_default_harness_registry
+from meridian.lib.launch.bundle_adapter import LoadedSkillEntry
 from meridian.lib.launch.composition import PromptDocument
 from meridian.lib.launch.context import build_launch_context
 from meridian.lib.launch.request import (
@@ -21,7 +21,7 @@ from meridian.lib.launch.request import (
     LaunchRuntime,
     SpawnRequest,
 )
-from tests.support.fixtures import write_agent, write_skill
+from tests.support.fixtures import write_agent
 from tests.support.launch import stub_bundle_request_and_resolve
 
 if TYPE_CHECKING:
@@ -277,12 +277,6 @@ def test_primary_launch_policy_snapshot_persists_loaded_skills(
     tmp_path: Path,
 ) -> None:
     _write_minimal_mars_config(tmp_path)
-    skill_path = write_skill(
-        tmp_path,
-        "testing-principles",
-        body="# testing-principles\n\nBe consistent.\n",
-        description="testing-principles skill",
-    )
     write_agent(
         tmp_path,
         name="coder",
@@ -294,6 +288,13 @@ def test_primary_launch_policy_snapshot_persists_loaded_skills(
         monkeypatch,
         model="gpt-5.4",
         harness=HarnessId.CODEX,
+        skills_loaded=(
+            LoadedSkillEntry(
+                name="testing-principles",
+                skill_type="principle",
+                body="# testing-principles\n\nBe consistent.",
+            ),
+        ),
     )
     request = SpawnRequest(
         model="gpt-5.4",
@@ -317,16 +318,12 @@ def test_primary_launch_policy_snapshot_persists_loaded_skills(
     snapshot = runtime_ctx.resolved_request.launch_policy_snapshot
     assert snapshot is not None
     assert snapshot.skills == ("testing-principles",)
-    assert snapshot.skill_paths == (str(skill_path.resolve()),)
-    assert snapshot.loaded_skills == (
-        SkillContent(
-            name="testing-principles",
-            description="testing-principles skill",
-            path=str(skill_path.resolve()),
-            content=skill_path.read_text(encoding="utf-8"),
-            skill_type="reference",
-        ),
-    )
+    # Skill path is synthetic (from bundle, not disk)
+    assert snapshot.skill_paths
+    assert ".mars/skills/testing-principles/SKILL.md" in snapshot.skill_paths[0]
+    assert snapshot.loaded_skills[0].name == "testing-principles"
+    assert snapshot.loaded_skills[0].content == "# testing-principles\n\nBe consistent."
+    assert snapshot.loaded_skills[0].skill_type == "principle"
 
 
 def test_direct_launch_context_synthesizes_policy_snapshot(tmp_path: Path) -> None:

--- a/tests/unit/launch/test_policies.py
+++ b/tests/unit/launch/test_policies.py
@@ -11,6 +11,7 @@ from meridian.lib.core.types import HarnessId, ModelId
 from meridian.lib.harness.registry import get_default_harness_registry
 from meridian.lib.launch import bundle_adapter
 from meridian.lib.launch.compiler import ModelPolicyRule, ProvenanceLevel
+from meridian.lib.launch.composition import AvailableSkillEntry
 from meridian.lib.launch.context import build_launch_policy_snapshot
 from meridian.lib.launch.launch_types import ResolvedExecutionPolicy
 from meridian.lib.launch.policies import (
@@ -37,6 +38,7 @@ class _FakeBundleResult:
     tools_allowed: tuple[str, ...] = ()
     tools_disallowed: tuple[str, ...] = ()
     tools_mcp: tuple[str, ...] = ()
+    skills_available: tuple[AvailableSkillEntry, ...] = ()
 
 
 def _write_agent_profile(project_root: Path, *, name: str, frontmatter: str) -> None:

--- a/tests/unit/launch/test_policies.py
+++ b/tests/unit/launch/test_policies.py
@@ -10,6 +10,7 @@ from meridian.lib.core.overrides import RuntimeOverrides
 from meridian.lib.core.types import HarnessId, ModelId
 from meridian.lib.harness.registry import get_default_harness_registry
 from meridian.lib.launch import bundle_adapter
+from meridian.lib.launch.bundle_adapter import LoadedSkillEntry
 from meridian.lib.launch.compiler import ModelPolicyRule, ProvenanceLevel
 from meridian.lib.launch.composition import AvailableSkillEntry
 from meridian.lib.launch.context import build_launch_policy_snapshot
@@ -38,7 +39,9 @@ class _FakeBundleResult:
     tools_allowed: tuple[str, ...] = ()
     tools_disallowed: tuple[str, ...] = ()
     tools_mcp: tuple[str, ...] = ()
+    skills_loaded: tuple[LoadedSkillEntry, ...] = ()
     skills_available: tuple[AvailableSkillEntry, ...] = ()
+    skills_missing: tuple[str, ...] = ()
 
 
 def _write_agent_profile(project_root: Path, *, name: str, frontmatter: str) -> None:
@@ -628,6 +631,13 @@ def test_snapshot_replay_uses_persisted_loaded_skills_after_live_catalog_changes
             harness_model="gpt-5.4",
             execution_policy=ResolvedExecutionPolicy(approval="auto"),
             provenance={"harness_source": "provider"},
+            skills_loaded=(
+                LoadedSkillEntry(
+                    name="testing-principles",
+                    skill_type="principle",
+                    body="# testing-principles\n\nBe consistent.",
+                ),
+            ),
         ),
     )
     monkeypatch.setattr(CatalogSession, "alias_map", lambda self: {})
@@ -662,7 +672,7 @@ def test_snapshot_replay_uses_persisted_loaded_skills_after_live_catalog_changes
     skill_path.unlink()
 
     monkeypatch.setattr(
-        "meridian.lib.launch.policies.resolve_skills_from_profile",
+        "meridian.lib.launch.policy_snapshot.resolve_skills_from_profile",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(
             AssertionError("snapshot replay should not re-resolve live skill catalog")
         ),
@@ -690,5 +700,7 @@ def test_snapshot_replay_uses_persisted_loaded_skills_after_live_catalog_changes
     assert replayed_policy.resolved_skills.skill_names == ("testing-principles",)
     assert replayed_policy.resolved_skills.loaded_skills == original_skills
     assert replayed_policy.resolved_skills.loaded_skills[0].name == "testing-principles"
-    assert replayed_policy.resolved_skills.loaded_skills[0].path == str(skill_path)
+    # Path is synthetic (from bundle) — the snapshot preserves whatever path was set at capture time
+    replayed_skill = replayed_policy.resolved_skills.loaded_skills[0]
+    assert ".mars/skills/testing-principles/SKILL.md" in replayed_skill.path
     assert replayed_policy.resolved_skills.loaded_skills[0].content == original_skills[0].content

--- a/uv.lock
+++ b/uv.lock
@@ -666,15 +666,15 @@ wheels = [
 
 [[package]]
 name = "mars-agents"
-version = "0.7.9"
+version = "0.7.11"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/15/e9/24fee60e7486ebf0997c1a488b11f6649c05163eac2d57eaae60ad6c6284/mars_agents-0.7.9.tar.gz", hash = "sha256:04ea46be6cc2b930339f72fe0cfc48295420f2746da3b924683a7f56b52d2d45", size = 594170, upload-time = "2026-05-30T14:29:55.598Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/ce/2ec8ca2f0491a1374be17ec0c442bb0089344b64b4c8d3940f748ddb7653/mars_agents-0.7.11.tar.gz", hash = "sha256:e7856c807ae05b4ee2d9d3e13f087940a23cb47240a192aa33a940f21ba7102b", size = 596411, upload-time = "2026-05-30T18:49:23.867Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/93/f7670ad99eeca370002afef29ebece3e22a1693cf12876944ac3afd1450f/mars_agents-0.7.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:a3d9b63295a81783406cd58b0faaf90b7521dbeea94dfe5b33f4ee4aae3c0b10", size = 3289756, upload-time = "2026-05-30T14:29:46.414Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/45/f096b5d5a631a44a77d95d18806a86fd0015b974268fcb88a5dbd311a65b/mars_agents-0.7.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:8171545ab7e831575ae95952dec0ae96d22ec2a06ba56ebe6bf300d63718dd7b", size = 3152583, upload-time = "2026-05-30T14:29:48.49Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/69/f15b0c1b3974825699fabf61accf76ab419848b5ff62f05bd55793a34512/mars_agents-0.7.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e773d1fcd4063781c553fc89f2aca3b937dfec5f16beeef227c0c823a2d3ca24", size = 3189334, upload-time = "2026-05-30T14:29:50.129Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/38/daff1107b194f232c91811ef3b09ef37c63de24c489e00f33e2287701d47/mars_agents-0.7.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:953cbcfeac92ec0243596795643393972564496dd6cc786e0e050c9586a7aefb", size = 3407383, upload-time = "2026-05-30T14:29:52.017Z" },
-    { url = "https://files.pythonhosted.org/packages/74/cb/09239c179dabdfeb9b58569b96839c77e42accabb4a102b4564bb0c730c0/mars_agents-0.7.9-py3-none-win_amd64.whl", hash = "sha256:d961aea4f9fe8047357f3798cfc5d2dd8977582f294d9db0495c141ad49b682b", size = 3337033, upload-time = "2026-05-30T14:29:53.957Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a4/a84fab7865cf6410adc6ab034ac4e0d9ea851736001f7760f33ece2016ec/mars_agents-0.7.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:79bb08952ba8205f7e3815bbefb0eb43c3d25a271bbe5266468a3c60a3c115ac", size = 3293051, upload-time = "2026-05-30T18:49:16.147Z" },
+    { url = "https://files.pythonhosted.org/packages/07/19/a876785d529095046d84c6d50f2a605900326be93892f51d464f239a6749/mars_agents-0.7.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:435876062ebecd7901910ec011f055cc9092aa403e90dd0486528cca0a3f8ecf", size = 3156308, upload-time = "2026-05-30T18:49:17.731Z" },
+    { url = "https://files.pythonhosted.org/packages/00/50/91f65ed9da5976cf992d3beeb353a46c3fcbe03d96c0be89956b18a62034/mars_agents-0.7.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b89c8c16916207d0615b717b95de690b1d9e20c7a8dce4412559e5448a8501ee", size = 3187380, upload-time = "2026-05-30T18:49:19.099Z" },
+    { url = "https://files.pythonhosted.org/packages/10/ef/37e89e877785b43e26c9dc4bc9b1a1a8ae49fe4ec6231e28c2f9e662b3b4/mars_agents-0.7.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c8870edbc0bb4c85d1320e7af28e493e6fa4d5473812feabadd09c609d25e9f3", size = 3399776, upload-time = "2026-05-30T18:49:20.4Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/72/2881c065c2d9bca0ea79e9e1d9ca6802427673d65a4b5e760b2f43ed8ced/mars_agents-0.7.11-py3-none-win_amd64.whl", hash = "sha256:e26f0723c6d563dbea269e7648d7e62b8c4464312fdc0222072c9872ab73c705", size = 3346855, upload-time = "2026-05-30T18:49:21.991Z" },
 ]
 
 [[package]]
@@ -765,7 +765,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'app'", specifier = ">=0.28" },
     { name = "jinja2", marker = "extra == 'templates'", specifier = ">=3.1" },
     { name = "markdown-it-py", specifier = ">=4.0" },
-    { name = "mars-agents", specifier = "==0.7.9" },
+    { name = "mars-agents", specifier = "==0.7.11" },
     { name = "mcp", specifier = ">=1.0" },
     { name = "pathspec", specifier = ">=1.1.0" },
     { name = "psutil", specifier = ">=7.2.2" },

--- a/uv.lock
+++ b/uv.lock
@@ -666,15 +666,15 @@ wheels = [
 
 [[package]]
 name = "mars-agents"
-version = "0.7.8"
+version = "0.7.9"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8e/7a/4d1506390eebab21947cbf69c5f9dd2d9b24a7580ca8dcf9b46aceeb88eb/mars_agents-0.7.8.tar.gz", hash = "sha256:df008ba1e47f8380a0c3b051345d75c01ba2cf34b65708c45072009d5cc21de1", size = 592308, upload-time = "2026-05-29T12:50:25.147Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/e9/24fee60e7486ebf0997c1a488b11f6649c05163eac2d57eaae60ad6c6284/mars_agents-0.7.9.tar.gz", hash = "sha256:04ea46be6cc2b930339f72fe0cfc48295420f2746da3b924683a7f56b52d2d45", size = 594170, upload-time = "2026-05-30T14:29:55.598Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/cf/813d5df32951be4f0280bf8b8b224244c2d5e1d35b0ea40ba726d5d40c8e/mars_agents-0.7.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:1eaa426e5bf529933e03d994f1598022ed7c05510ab2d271624c13a8af9fd249", size = 3295585, upload-time = "2026-05-29T12:50:15.994Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/20/f2a746bb5787c4a50a55d9a688d30875f0e7fa50214e852b83742127e299/mars_agents-0.7.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:65a60650b2fae992b2fe883c6c29d3ae390546c6020987b6e0eefa62696d3787", size = 3149756, upload-time = "2026-05-29T12:50:18.158Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/98/c4a51cd0a749991c6e1334d7a0c86cc024a94b0b870a872d6b19300f78f6/mars_agents-0.7.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:35a30814ebb7718164b04f07b4f454969cf1ce95705651889498676da37c0fc6", size = 3180779, upload-time = "2026-05-29T12:50:19.736Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/bf/7a3bb9ed458ff66ccf82e67da322e77a7bdbbe171b47a1aa5d5a333e0744/mars_agents-0.7.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdc473f8f13d6ecfbccb33972fb561c6ecddbe219fd9c41ff2e57f39ca1875a4", size = 3395697, upload-time = "2026-05-29T12:50:21.562Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/97/1283d58d5206114277b71c4d60f3c31b754bc92777b7cf0e9af40cf6a250/mars_agents-0.7.8-py3-none-win_amd64.whl", hash = "sha256:126769d1a81e21a7ddb9a8397b349af1ab1d6a2729bde5d71af4270dc2c9b6b2", size = 3352074, upload-time = "2026-05-29T12:50:23.469Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/93/f7670ad99eeca370002afef29ebece3e22a1693cf12876944ac3afd1450f/mars_agents-0.7.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:a3d9b63295a81783406cd58b0faaf90b7521dbeea94dfe5b33f4ee4aae3c0b10", size = 3289756, upload-time = "2026-05-30T14:29:46.414Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/45/f096b5d5a631a44a77d95d18806a86fd0015b974268fcb88a5dbd311a65b/mars_agents-0.7.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:8171545ab7e831575ae95952dec0ae96d22ec2a06ba56ebe6bf300d63718dd7b", size = 3152583, upload-time = "2026-05-30T14:29:48.49Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/69/f15b0c1b3974825699fabf61accf76ab419848b5ff62f05bd55793a34512/mars_agents-0.7.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e773d1fcd4063781c553fc89f2aca3b937dfec5f16beeef227c0c823a2d3ca24", size = 3189334, upload-time = "2026-05-30T14:29:50.129Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/38/daff1107b194f232c91811ef3b09ef37c63de24c489e00f33e2287701d47/mars_agents-0.7.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:953cbcfeac92ec0243596795643393972564496dd6cc786e0e050c9586a7aefb", size = 3407383, upload-time = "2026-05-30T14:29:52.017Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cb/09239c179dabdfeb9b58569b96839c77e42accabb4a102b4564bb0c730c0/mars_agents-0.7.9-py3-none-win_amd64.whl", hash = "sha256:d961aea4f9fe8047357f3798cfc5d2dd8977582f294d9db0495c141ad49b682b", size = 3337033, upload-time = "2026-05-30T14:29:53.957Z" },
 ]
 
 [[package]]
@@ -765,7 +765,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'app'", specifier = ">=0.28" },
     { name = "jinja2", marker = "extra == 'templates'", specifier = ">=3.1" },
     { name = "markdown-it-py", specifier = ">=4.0" },
-    { name = "mars-agents", specifier = "==0.7.8" },
+    { name = "mars-agents", specifier = "==0.7.9" },
     { name = "mcp", specifier = ">=1.0" },
     { name = "pathspec", specifier = ">=1.1.0" },
     { name = "psutil", specifier = ">=7.2.2" },


### PR DESCRIPTION
## Why

Mars owns the `.mars/` directory schema and skill compilation. Meridian-cli was
reading `.mars/skills/` directly via `SkillRegistry` — a layer violation that
duplicated work mars already does and coupled meridian to mars's internal file
layout.

## Goal

Decouple meridian-cli's skill loading from `.mars/skills/` disk layout. Consume
skills purely through the bundle JSON interface. Also: session-context preamble,
available skills listing with type descriptions, loaded skills type-group headers.

## Summary

- **Session-context preamble**: binary signal — primary vs sub-agent session
- **Available skills listing**: type descriptions, grouped headings, load nudge
- **Loaded skills type headers**: `## Principle`, `## Guardrail`, etc.
- **Bundle-based skill loading**: `_build_resolved_skills_from_bundle` constructs
  `ResolvedSkills` from `skills.loaded[].{name, skill_type, body}` — no disk reads
- **mars-agents bump**: 0.7.8 → 0.7.11
- **Dead code removal**: `prompt_surface_supplemental_documents` parsing kept for
  schema compat but no longer consumed; `resolve_skills_from_profile` removed from
  the bundle policy path (kept for snapshot replay)

## Resulting behavior

- `meridian spawn --dry-run` shows skills with type-group headers and content from
  the bundle, not from disk
- Skill variant resolution is mars's responsibility — meridian gets the resolved
  content
- Primary sessions get "talking directly to the user" framing; spawns get
  "sub-agent session" framing
- Available (not-yet-loaded) skills show type descriptions and load nudge

## Verification

- 1178 tests pass (lint, pyright, full suite)
- Manual dry-run: `meridian spawn -a tech-lead --dry-run` shows 12 skills with
  correct type headers, content from bundle, synthetic `.mars/skills/` paths
- Backward compat: parser handles both `body` (mars >=0.8) and `content` (0.7.x)

## Release label

`release:patch`