### PR TITLE
fix: Pi quiescence drain hang + missing extension artifacts in PyPI wheel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,8 +80,32 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Build Pi extensions
+        run: |
+          corepack enable
+          cd src/meridian/pi_runtime && pnpm install --frozen-lockfile && pnpm run build:extensions
+
       - name: Build distributions
         run: uv build --no-sources
+
+      - name: Verify Pi extensions in wheel
+        run: |
+          python3 -c "
+          import zipfile, sys
+          whl = next(p for p in __import__('pathlib').Path('dist').glob('*.whl'))
+          with zipfile.ZipFile(whl) as z:
+              ext_files = [n for n in z.namelist() if 'pi_runtime/dist/extensions/' in n]
+              if not ext_files:
+                  print('::error::Wheel is missing Pi extension artifacts', file=sys.stderr)
+                  sys.exit(1)
+              for f in ext_files:
+                  print(f'  included: {f}')
+          "
 
       - name: Validate wheel artifact
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - Pi spawns hanging permanently at quiescence_micro_drain_started — replaced fragile sleep(0)+task.done() heuristic with bounded 50ms asyncio.wait_for timeout. Also fixed O(N) disk watcher creating indefinite awatch tasks for standalone spawn directories (3000+ watchers in production).
+- Pi extension artifacts (managed-bash, meridian-spawn-watch) missing from PyPI wheel — `release.yml` ran `uv build` without building extensions first. Every Pi spawn failed with `Missing Pi extension artifact`. Added Node.js setup, extension build, and wheel contents verification to the release workflow.
 
 ## [0.2.16] - 2026-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Pi spawns hanging permanently at quiescence_micro_drain_started — replaced fragile sleep(0)+task.done() heuristic with bounded 50ms asyncio.wait_for timeout. Also fixed O(N) disk watcher creating indefinite awatch tasks for standalone spawn directories (3000+ watchers in production).
+
 ## [0.2.16] - 2026-05-30
 
 ## [0.2.15] - 2026-05-29

--- a/src/meridian/lib/streaming/disk_watcher.py
+++ b/src/meridian/lib/streaming/disk_watcher.py
@@ -132,7 +132,8 @@ class PiDiskWatcher:
                 )
             self._refresh_cached_state()
             return True
-        return bool(isinstance(parent_id, str) and parent_id)
+        # state.json exists and is non-empty — parent_id is settled (or absent).
+        return bool(data)
 
     def _discover_child_spawns(self) -> None:
         if not self._spawns_dir.is_dir():

--- a/src/meridian/lib/streaming/pi_drain.py
+++ b/src/meridian/lib/streaming/pi_drain.py
@@ -55,6 +55,8 @@ _pi_wait_policy_is_tracked = pi_lifecycle.pi_wait_policy_is_tracked
 _unsupported_pi_schema_version_error = pi_lifecycle.unsupported_pi_schema_version_error
 
 PI_MICRO_DRAIN_TIMEOUT_SECONDS: float = 0.05
+# Non-zero floor to prevent tight loops on expired deadlines.
+_PI_TIMEOUT_FLOOR_SECONDS: float = 0.001
 
 EmitPiPhase = Callable[..., None]
 TerminatePiChildren = Callable[["PiSubspawnTracker", str], Awaitable[None]]
@@ -479,7 +481,7 @@ class PiDrainCoordinator:
         now_monotonic = time.monotonic()
         next_timeout = self.tracker.time_until_next_notification_timeout(now_monotonic)
         if next_timeout is not None and next_timeout <= 0:
-            next_timeout = PI_MICRO_DRAIN_TIMEOUT_SECONDS
+            next_timeout = _PI_TIMEOUT_FLOOR_SECONDS
 
         child_wave_remaining = self._child_wave_remaining(now_monotonic)
         if child_wave_remaining is not None:
@@ -819,14 +821,14 @@ class PiDrainCoordinator:
         ):
             return None
         remaining = deadline - now_monotonic
-        return remaining if remaining > 0 else PI_MICRO_DRAIN_TIMEOUT_SECONDS
+        return remaining if remaining > 0 else _PI_TIMEOUT_FLOOR_SECONDS
 
     def _followup_remaining(self, now_monotonic: float) -> float | None:
         deadline = self.child_wave_timeout_followup_deadline
         if deadline is None:
             return None
         remaining = deadline - now_monotonic
-        return remaining if remaining > 0 else PI_MICRO_DRAIN_TIMEOUT_SECONDS
+        return remaining if remaining > 0 else _PI_TIMEOUT_FLOOR_SECONDS
 
     def _child_wave_timed_out(self, now_monotonic: float) -> bool:
         return (
@@ -879,7 +881,7 @@ def _pi_child_wave_timeout_error() -> str:
 
 
 def _min_timeout(current: float | None, candidate: float) -> float:
-    bounded = candidate if candidate > 0 else PI_MICRO_DRAIN_TIMEOUT_SECONDS
+    bounded = candidate if candidate > 0 else _PI_TIMEOUT_FLOOR_SECONDS
     return bounded if current is None else min(current, bounded)
 
 

--- a/src/meridian/lib/streaming/pi_drain.py
+++ b/src/meridian/lib/streaming/pi_drain.py
@@ -54,7 +54,7 @@ _pi_subspawn_pid = pi_lifecycle.pi_subspawn_pid
 _pi_wait_policy_is_tracked = pi_lifecycle.pi_wait_policy_is_tracked
 _unsupported_pi_schema_version_error = pi_lifecycle.unsupported_pi_schema_version_error
 
-PI_MICRO_DRAIN_TIMEOUT_SECONDS: float = 1e-6
+PI_MICRO_DRAIN_TIMEOUT_SECONDS: float = 0.05
 
 EmitPiPhase = Callable[..., None]
 TerminatePiChildren = Callable[["PiSubspawnTracker", str], Awaitable[None]]

--- a/src/meridian/lib/streaming/spawn_manager.py
+++ b/src/meridian/lib/streaming/spawn_manager.py
@@ -449,24 +449,6 @@ class SpawnManager:
                     next_timeout = pi_drain.next_timeout()
                     if pending_event_task is None:
                         pending_event_task = asyncio.ensure_future(anext(events_iter))
-                        # Give already-buffered/in-memory event iterators one loop tick before
-                        # applying tiny policy timeouts such as Pi micro-drain.
-                        await asyncio.sleep(0)
-                    if (
-                        pi_drain.quiescence_candidate is not None
-                        and not pending_event_task.done()
-                    ):
-                        # Pi micro-drain is a scheduler-yield boundary, not a real wait.
-                        # Resolving it explicitly avoids relying on sub-millisecond
-                        # wait_for() timers, which can leave an idle spawned Pi session
-                        # parked forever after quiescence_micro_drain_started.
-                        timeout_outcome = await pi_drain.handle_timeout(
-                            _terminate_tracked_pi_children,
-                        )
-                        if timeout_outcome is not None:
-                            recorded_terminal_outcome = timeout_outcome
-                            break
-                        continue
                     if next_timeout is not None:
                         event = await asyncio.wait_for(
                             asyncio.shield(pending_event_task),

--- a/tests/unit/streaming/test_pi_disk_watcher.py
+++ b/tests/unit/streaming/test_pi_disk_watcher.py
@@ -17,6 +17,47 @@ def _write_json(path: Path, payload: object) -> None:
     path.write_text(json.dumps(payload), encoding="utf-8")
 
 
+def test_try_adopt_candidate_stops_for_settled_non_child_spawn(tmp_path: Path) -> None:
+    parent_id = SpawnId("p-parent")
+    standalone_dir = tmp_path / "spawns" / "p-standalone"
+    standalone_dir.mkdir(parents=True)
+    _write_json(
+        standalone_dir / "state.json",
+        {"id": "p-standalone", "status": "running"},
+    )
+
+    watcher = PiDiskWatcher(tmp_path, parent_id)
+    assert watcher._try_adopt_candidate("p-standalone", standalone_dir) is True
+    assert "p-standalone" not in watcher._child_spawn_ids
+
+
+def test_try_adopt_candidate_stops_for_other_parent_spawn(tmp_path: Path) -> None:
+    parent_id = SpawnId("p-parent")
+    other_child_dir = tmp_path / "spawns" / "p-other-child"
+    other_child_dir.mkdir(parents=True)
+    _write_json(
+        other_child_dir / "state.json",
+        {"id": "p-other-child", "parent_id": "p-other-parent", "status": "running"},
+    )
+
+    watcher = PiDiskWatcher(tmp_path, parent_id)
+    assert watcher._try_adopt_candidate("p-other-child", other_child_dir) is True
+    assert "p-other-child" not in watcher._child_spawn_ids
+
+
+def test_try_adopt_candidate_keeps_watching_until_state_settles(tmp_path: Path) -> None:
+    parent_id = SpawnId("p-parent")
+    candidate_dir = tmp_path / "spawns" / "p-new"
+    candidate_dir.mkdir(parents=True)
+
+    watcher = PiDiskWatcher(tmp_path, parent_id)
+    assert watcher._try_adopt_candidate("p-new", candidate_dir) is False
+
+    _write_json(candidate_dir / "state.json", {"id": "p-new", "status": "running"})
+    assert watcher._try_adopt_candidate("p-new", candidate_dir) is True
+    assert "p-new" not in watcher._child_spawn_ids
+
+
 @pytest.mark.asyncio
 async def test_pi_disk_watcher_tracks_child_spawn_state_from_disk(tmp_path: Path) -> None:
     parent_id = SpawnId("p-parent")

--- a/tests/unit/streaming/test_pi_quiescence.py
+++ b/tests/unit/streaming/test_pi_quiescence.py
@@ -21,7 +21,7 @@ from meridian.lib.harness.connections.base import (
 )
 from meridian.lib.launch.launch_types import ResolvedLaunchSpec
 from meridian.lib.safety.permissions import UnsafeNoOpPermissionResolver
-from meridian.lib.streaming.pi_drain import PI_MICRO_DRAIN_TIMEOUT_SECONDS, PiSubspawnTracker
+from meridian.lib.streaming.pi_drain import PiSubspawnTracker
 from meridian.lib.streaming.spawn_manager import SpawnManager
 
 
@@ -523,9 +523,8 @@ async def test_spawn_manager_pi_cleanup_escalation_does_not_block_terminal_succe
         await manager.stop_spawn(spawn_id)
 
 @pytest.mark.asyncio
-async def test_spawn_manager_pi_micro_drain_resolves_without_wait_for_timer(
+async def test_spawn_manager_pi_micro_drain_resolves_with_bounded_timeout(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class _OpenAfterTerminalConnection(_FakePiConnection):
         async def events(self):  # type: ignore[no-untyped-def]
@@ -546,15 +545,6 @@ async def test_spawn_manager_pi_micro_drain_resolves_without_wait_for_timer(
         await fake_connection.start(config, spec)
         return fake_connection
 
-    original_wait_for = asyncio.wait_for
-
-    async def _guarded_wait_for(awaitable: Any, timeout: float | None = None) -> Any:
-        if timeout == PI_MICRO_DRAIN_TIMEOUT_SECONDS:
-            raise AssertionError("Pi micro-drain must not rely on wait_for's tiny timer")
-        return await original_wait_for(awaitable, timeout=timeout)
-
-    monkeypatch.setattr(asyncio, "wait_for", _guarded_wait_for)
-
     manager = SpawnManager(
         runtime_root=tmp_path,
         project_root=tmp_path,
@@ -562,7 +552,7 @@ async def test_spawn_manager_pi_micro_drain_resolves_without_wait_for_timer(
         control_server_factory=lambda _spawn_id, _socket_path, _manager: _NoopControlServer(),
     )
 
-    spawn_id = SpawnId("p-pi-micro-drain-no-timer")
+    spawn_id = SpawnId("p-pi-micro-drain-bounded-timeout")
     await manager.start_spawn(
         ConnectionConfig(
             spawn_id=spawn_id,
@@ -580,7 +570,7 @@ async def test_spawn_manager_pi_micro_drain_resolves_without_wait_for_timer(
     )
 
     try:
-        outcome = await original_wait_for(manager.wait_for_completion(spawn_id), timeout=1.0)
+        outcome = await asyncio.wait_for(manager.wait_for_completion(spawn_id), timeout=1.0)
         assert outcome is not None
         assert outcome.status == "succeeded"
         assert outcome.error is None
@@ -725,7 +715,7 @@ async def test_spawn_manager_pi_child_wave_timeout_not_cleared_by_turn_active(
                     {"messages": [{"role": "assistant", "stopReason": "stop"}]},
                 ),
             ),
-            (0.03, _pi_event("agent_start", {})),
+            (0.15, _pi_event("agent_start", {})),
         ]
     )
 
@@ -752,7 +742,7 @@ async def test_spawn_manager_pi_child_wave_timeout_not_cleared_by_turn_active(
             control_root=tmp_path,
             env_overrides={},
             pi_session_role="spawned",
-            pi_child_wave_timeout_seconds=0.02,
+            pi_child_wave_timeout_seconds=0.1,
         ),
         ResolvedLaunchSpec(
             harness=HarnessId.PI,


### PR DESCRIPTION
## Why

Two separate bugs making Pi spawns completely non-functional:
1. Every Pi spawn installed from PyPI fails at launch — `Missing Pi extension artifact`
2. Pi spawns that DO launch (from source) hang forever at `quiescence_micro_drain_started`

## Goal

Pi spawns work end-to-end: launch from PyPI install and complete without hanging.

## Summary

### Extension packaging (root cause of current failures)
- `release.yml` ran `uv build --no-sources` without building Pi extension JS bundles first
- Since `src/meridian/pi_runtime/dist/` is gitignored, the PyPI wheel shipped without `managed-bash/index.js`
- Added Node.js setup + `pnpm run build:extensions` + wheel verification step to `release.yml`

### Quiescence micro-drain hang
- The drain loop's `sleep(0) + task.done()` heuristic failed under event-loop pressure from 3000+ `awatch` watchers
- Replaced with a real 50ms `asyncio.wait_for` timeout — the `TimeoutError` path that already existed handles micro-drain resolution correctly
- 18 lines removed from `spawn_manager.py`, net simplification

### Disk watcher pressure (contributing factor)
- `_try_adopt_candidate` created indefinite `awatch` tasks for every non-child spawn directory (3248+ in production)
- Fixed: stop watching once `state.json` exists and is non-empty, regardless of `parent_id`
- Split `PI_MICRO_DRAIN_TIMEOUT_SECONDS` (50ms quiescence window) from `_PI_TIMEOUT_FLOOR_SECONDS` (1ms expired-deadline floor)

## Resulting behavior

- `release.yml` builds Pi extensions before wheel creation, verifies they're included
- After `agent_end` with all quiescence conditions met, spawn transitions to `succeeded` within ~50ms
- No indefinite `awatch` watchers created for non-child directories

## Verification

- [x] 1181 tests pass
- [x] ruff clean, pyright clean
- [x] Pre-push preflight passes
- [ ] Manual: install from PyPI after release, verify Pi spawn launches and completes

## Release label

`release:patch`

## Cleanup

- PR #295 superseded by this PR (cherry-picked into this branch)
- Follow-up: disk watcher O(N) startup scan → O(children) redesign (separate work item)

🤖 Generated with [Claude Code](https://claude.com/claude-code)