### PR TITLE
fix(ci): build Pi extensions before publishing wheel to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,8 +80,32 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Build Pi extensions
+        run: |
+          corepack enable
+          cd src/meridian/pi_runtime && pnpm install --frozen-lockfile && pnpm run build:extensions
+
       - name: Build distributions
         run: uv build --no-sources
+
+      - name: Verify Pi extensions in wheel
+        run: |
+          python3 -c "
+          import zipfile, sys
+          whl = next(p for p in __import__('pathlib').Path('dist').glob('*.whl'))
+          with zipfile.ZipFile(whl) as z:
+              ext_files = [n for n in z.namelist() if 'pi_runtime/dist/extensions/' in n]
+              if not ext_files:
+                  print('::error::Wheel is missing Pi extension artifacts', file=sys.stderr)
+                  sys.exit(1)
+              for f in ext_files:
+                  print(f'  included: {f}')
+          "
 
       - name: Validate wheel artifact
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Pi extension artifacts (managed-bash, meridian-spawn-watch) missing from PyPI wheel — `release.yml` ran `uv build` without building extensions first. Every Pi spawn failed with `Missing Pi extension artifact`. Added Node.js setup, extension build, and wheel contents verification to the release workflow.
+
 ## [0.2.16] - 2026-05-30
 
 ## [0.2.15] - 2026-05-29


### PR DESCRIPTION
## Why

Every Pi spawn fails with `Missing Pi extension artifact: .../managed-bash/index.js` when meridian-cli is installed from PyPI. The published wheel has been missing the Pi extension JS bundles since the extension system was introduced.

## Goal

Pi extension artifacts ship inside the PyPI wheel so `pip install meridian-cli` / `uv tool install meridian-cli` works out of the box for Pi spawns.

## Summary

- `release.yml` (the workflow that builds + publishes to PyPI on `v*` tags) ran `uv build --no-sources` without building extensions first
- `release-on-merge.yml` already builds extensions for preflight, but the actual publish workflow didn't
- Since `src/meridian/pi_runtime/dist/` is gitignored, the CI checkout has no built artifacts → the wheel goes to PyPI without them

## Resulting behavior

- `release.yml` now sets up Node.js 24, runs `pnpm install --frozen-lockfile && pnpm run build:extensions` before `uv build`
- A new verification step asserts that `pi_runtime/dist/extensions/` files exist inside the wheel before upload
- Next release will include working Pi extension bundles

## Verification

- [x] All 1178 tests pass
- [x] ruff clean
- [x] pyright clean
- [x] Preflight passes

## Release label

`release:patch` — this fix requires a release to actually ship the corrected wheel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)