### PR TITLE
refactor: eliminate per-directory inotify watchers from PiDiskWatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Pi spawns hanging permanently at quiescence_micro_drain_started — replaced fragile sleep(0)+task.done() heuristic with bounded 50ms asyncio.wait_for timeout. Also fixed O(N) disk watcher creating indefinite awatch tasks for standalone spawn directories (3000+ watchers in production).
 - Pi extension artifacts (managed-bash, meridian-spawn-watch) missing from PyPI wheel — `release.yml` ran `uv build` without building extensions first. Every Pi spawn failed with `Missing Pi extension artifact`. Added Node.js setup, extension build, and wheel contents verification to the release workflow.
 
+### Changed
+- PiDiskWatcher no longer creates per-directory inotify watchers for child or candidate spawns. Children are discovered once at startup (O(N) scan) and polled on demand via `force_rescan()`. New children detected reactively when their directory appears under `spawns/`. Eliminates 3000+ `awatch` tasks that created event-loop pressure.
+
 ## [0.2.16] - 2026-05-30
 
 ## [0.2.15] - 2026-05-29

--- a/src/meridian/lib/streaming/disk_watcher.py
+++ b/src/meridian/lib/streaming/disk_watcher.py
@@ -3,6 +3,9 @@
 Pi background-work coordination is file-backed: spawn records under ``spawns/`` and
 managed bash records under ``pi-bash/<spawn-id>/``. This watcher keeps a cached
 view and can force a synchronous rescan before quiescence decisions.
+
+Child discovery is O(children), not O(total spawns). Known children are polled
+on demand via ``force_rescan()`` — no per-child inotify watchers.
 """
 
 from __future__ import annotations
@@ -35,8 +38,6 @@ class PiDiskWatcher:
         self._last_notification_ts: float | None = None
         self._tasks: list[asyncio.Task[None]] = []
         self._child_spawn_ids: set[str] = set()
-        self._child_tasks: dict[str, asyncio.Task[None]] = {}
-        self._candidate_tasks: dict[str, asyncio.Task[None]] = {}
 
     async def start(self) -> None:
         self._spawns_dir.mkdir(parents=True, exist_ok=True)
@@ -48,19 +49,16 @@ class PiDiskWatcher:
         ]
 
     async def stop(self) -> None:
-        tasks = [*self._tasks, *self._child_tasks.values(), *self._candidate_tasks.values()]
-        for task in tasks:
+        for task in self._tasks:
             task.cancel()
-        if tasks:
-            done, pending = await asyncio.wait(tasks, timeout=0.2)
+        if self._tasks:
+            done, pending = await asyncio.wait(self._tasks, timeout=0.2)
             for task in done:
                 with suppress(asyncio.CancelledError, Exception):
                     task.result()
             for task in pending:
                 task.add_done_callback(_consume_task_result)
         self._tasks = []
-        self._child_tasks = {}
-        self._candidate_tasks = {}
 
     async def force_rescan(self) -> None:
         self._refresh_cached_state(discover=True)
@@ -86,70 +84,51 @@ class PiDiskWatcher:
         return self._last_notification_ts
 
     async def _watch_spawns_dir(self) -> None:
+        """Watch for new child directories appearing under spawns/.
+
+        Only reacts to directory-level changes (new spawn created). Does NOT
+        create per-directory watchers — child state is polled on demand via
+        ``force_rescan()`` when the parent goes idle.
+        """
         async for changes in awatch(self._spawns_dir, recursive=False):
+            found_new = False
             for _change, raw_path in changes:
                 path = Path(str(raw_path))
-                if path.parent == self._spawns_dir and path.name.startswith("p"):
-                    self._watch_candidate_spawn_dir(path.name, path)
-            self._refresh_cached_state()
+                if (
+                    path.parent == self._spawns_dir
+                    and path.name.startswith("p")
+                    and path.name not in self._child_spawn_ids
+                    and path.is_dir()
+                ):
+                    # Check if this new directory is our child.
+                    data = _read_json_object(path / "state.json")
+                    if data.get("parent_id") == self._current_spawn_id:
+                        self._child_spawn_ids.add(path.name)
+                        found_new = True
+            if found_new:
+                self._refresh_cached_state()
 
     async def _watch_bash_dir(self) -> None:
         async for _changes in awatch(self._bash_dir, recursive=False):
             self._refresh_cached_state()
 
-    async def _watch_child_spawn_dir(self, spawn_id: str, directory: Path) -> None:
-        async for _changes in awatch(directory, recursive=False):
-            data = _read_json_object(directory / "state.json")
-            if data.get("parent_id") != self._current_spawn_id:
-                self._child_spawn_ids.discard(spawn_id)
-                return
-            self._refresh_cached_state()
-
-    def _watch_candidate_spawn_dir(self, spawn_id: str, directory: Path) -> None:
-        if spawn_id in self._child_spawn_ids or spawn_id in self._candidate_tasks:
-            return
-        if not directory.is_dir():
-            return
-        task = asyncio.create_task(self._watch_candidate_until_resolved(spawn_id, directory))
-        self._candidate_tasks[spawn_id] = task
-        task.add_done_callback(lambda _task: self._candidate_tasks.pop(spawn_id, None))
-
-    async def _watch_candidate_until_resolved(self, spawn_id: str, directory: Path) -> None:
-        if self._try_adopt_candidate(spawn_id, directory):
-            return
-        async for _changes in awatch(directory, recursive=False):
-            if self._try_adopt_candidate(spawn_id, directory):
-                return
-
-    def _try_adopt_candidate(self, spawn_id: str, directory: Path) -> bool:
-        data = _read_json_object(directory / "state.json")
-        parent_id = data.get("parent_id")
-        if parent_id == self._current_spawn_id:
-            self._child_spawn_ids.add(spawn_id)
-            if spawn_id not in self._child_tasks:
-                self._child_tasks[spawn_id] = asyncio.create_task(
-                    self._watch_child_spawn_dir(spawn_id, directory)
-                )
-            self._refresh_cached_state()
-            return True
-        # state.json exists and is non-empty — parent_id is settled (or absent).
-        return bool(data)
-
     def _discover_child_spawns(self) -> None:
+        """One-time O(N) scan at startup to find existing children.
+
+        After startup, new children are detected reactively via
+        ``_watch_spawns_dir`` when their directory first appears.
+        """
         if not self._spawns_dir.is_dir():
             return
         for child in self._spawns_dir.iterdir():
             if not child.is_dir():
                 continue
+            if child.name in self._child_spawn_ids:
+                continue
             data = _read_json_object(child / "state.json")
             if data.get("parent_id") != self._current_spawn_id:
                 continue
-            spawn_id = child.name
-            self._child_spawn_ids.add(spawn_id)
-            if spawn_id not in self._child_tasks:
-                self._child_tasks[spawn_id] = asyncio.create_task(
-                    self._watch_child_spawn_dir(spawn_id, child)
-                )
+            self._child_spawn_ids.add(child.name)
 
     def _scan_pending_child_spawn_count(self) -> int:
         count = 0

--- a/tests/unit/streaming/test_pi_disk_watcher.py
+++ b/tests/unit/streaming/test_pi_disk_watcher.py
@@ -17,45 +17,53 @@ def _write_json(path: Path, payload: object) -> None:
     path.write_text(json.dumps(payload), encoding="utf-8")
 
 
-def test_try_adopt_candidate_stops_for_settled_non_child_spawn(tmp_path: Path) -> None:
+def test_discover_only_finds_own_children(tmp_path: Path) -> None:
+    """_discover_child_spawns skips dirs with wrong or missing parent_id."""
     parent_id = SpawnId("p-parent")
-    standalone_dir = tmp_path / "spawns" / "p-standalone"
-    standalone_dir.mkdir(parents=True)
+    spawns_dir = tmp_path / "spawns"
+
+    # Our child.
     _write_json(
-        standalone_dir / "state.json",
+        spawns_dir / "p-child" / "state.json",
+        {"id": "p-child", "parent_id": "p-parent", "status": "running"},
+    )
+    # Standalone spawn (no parent_id).
+    _write_json(
+        spawns_dir / "p-standalone" / "state.json",
         {"id": "p-standalone", "status": "running"},
     )
-
-    watcher = PiDiskWatcher(tmp_path, parent_id)
-    assert watcher._try_adopt_candidate("p-standalone", standalone_dir) is True
-    assert "p-standalone" not in watcher._child_spawn_ids
-
-
-def test_try_adopt_candidate_stops_for_other_parent_spawn(tmp_path: Path) -> None:
-    parent_id = SpawnId("p-parent")
-    other_child_dir = tmp_path / "spawns" / "p-other-child"
-    other_child_dir.mkdir(parents=True)
+    # Another parent's child.
     _write_json(
-        other_child_dir / "state.json",
-        {"id": "p-other-child", "parent_id": "p-other-parent", "status": "running"},
+        spawns_dir / "p-other" / "state.json",
+        {"id": "p-other", "parent_id": "p-other-parent", "status": "running"},
     )
 
     watcher = PiDiskWatcher(tmp_path, parent_id)
-    assert watcher._try_adopt_candidate("p-other-child", other_child_dir) is True
-    assert "p-other-child" not in watcher._child_spawn_ids
+    watcher._discover_child_spawns()
+
+    assert watcher._child_spawn_ids == {"p-child"}
 
 
-def test_try_adopt_candidate_keeps_watching_until_state_settles(tmp_path: Path) -> None:
+def test_discover_skips_terminal_children_in_count(tmp_path: Path) -> None:
+    """_scan_pending_child_spawn_count excludes terminal children."""
     parent_id = SpawnId("p-parent")
-    candidate_dir = tmp_path / "spawns" / "p-new"
-    candidate_dir.mkdir(parents=True)
+    spawns_dir = tmp_path / "spawns"
+
+    _write_json(
+        spawns_dir / "p-running" / "state.json",
+        {"id": "p-running", "parent_id": "p-parent", "status": "running"},
+    )
+    _write_json(
+        spawns_dir / "p-done" / "state.json",
+        {"id": "p-done", "parent_id": "p-parent", "status": "succeeded"},
+    )
 
     watcher = PiDiskWatcher(tmp_path, parent_id)
-    assert watcher._try_adopt_candidate("p-new", candidate_dir) is False
+    watcher._discover_child_spawns()
+    count = watcher._scan_pending_child_spawn_count()
 
-    _write_json(candidate_dir / "state.json", {"id": "p-new", "status": "running"})
-    assert watcher._try_adopt_candidate("p-new", candidate_dir) is True
-    assert "p-new" not in watcher._child_spawn_ids
+    assert watcher._child_spawn_ids == {"p-running", "p-done"}
+    assert count == 1
 
 
 @pytest.mark.asyncio
@@ -123,5 +131,29 @@ async def test_pi_disk_watcher_tracks_bash_and_notification_files(tmp_path: Path
         await watcher.force_rescan()
 
         assert watcher.has_tracked_bash_bg() is False
+    finally:
+        await watcher.stop()
+
+
+@pytest.mark.asyncio
+async def test_no_watcher_tasks_for_non_child_spawns(tmp_path: Path) -> None:
+    """After start, only spawns_dir and bash_dir watchers exist — no per-child tasks."""
+    parent_id = SpawnId("p-parent")
+    spawns_dir = tmp_path / "spawns"
+
+    # Create 10 standalone spawn dirs — none are children.
+    for i in range(10):
+        _write_json(
+            spawns_dir / f"p-other-{i}" / "state.json",
+            {"id": f"p-other-{i}", "status": "succeeded"},
+        )
+
+    watcher = PiDiskWatcher(tmp_path, parent_id)
+    await watcher.start()
+    try:
+        # Only 2 background tasks: spawns_dir watcher + bash_dir watcher.
+        assert len(watcher._tasks) == 2
+        assert watcher._child_spawn_ids == set()
+        assert watcher.has_pending_child_spawns() is False
     finally:
         await watcher.stop()


### PR DESCRIPTION
## Why

PiDiskWatcher created one `awatch` inotify watcher per spawn directory — 3248+ in production. These watchers added event-loop pressure that contributed to the quiescence micro-drain hang (fixed in #294). The entire candidate-watcher pattern was architecturally wrong: "watch the world and filter" instead of "track known children."

## Goal

Child spawn tracking is O(children), not O(total spawns). No per-directory inotify watchers.

## Summary

Deleted the entire candidate watcher subsystem:
- `_watch_candidate_spawn_dir`, `_watch_candidate_until_resolved`, `_try_adopt_candidate`
- `_candidate_tasks` dict and per-child `_child_tasks` dict
- Per-child `awatch` watchers

Replaced with:
- One-time `_discover_child_spawns()` at startup (O(N) scan, unavoidable without a reverse index)
- On-demand polling via `force_rescan()` when parent goes idle
- Reactive new-child detection: `_watch_spawns_dir` checks `state.json` of new directories only

**Before**: 2 + N background tasks (spawns_dir watcher + bash watcher + one `awatch` per candidate/child)
**After**: 2 background tasks (spawns_dir watcher + bash watcher). Period.

## Resulting behavior

- `PiDiskWatcher._tasks` has exactly 2 entries regardless of spawn count
- No `_child_tasks` or `_candidate_tasks` dicts exist
- Child state checked synchronously via `_scan_pending_child_spawn_count()` on each `_refresh_cached_state()` call
- New children discovered when their directory appears in `_watch_spawns_dir` and `state.json` contains matching `parent_id`

## Verification

- [x] 1181 tests pass (including 5 disk watcher tests, 15 quiescence tests)
- [x] ruff clean, pyright clean
- [x] Pre-push preflight passes

## Release label

`release:patch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)