### PR TITLE
feat(claude): deny built-in subagents by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Claude adapter denies built-in subagents (`Agent(Explore)`, `Agent(Plan)`, `Agent(general-purpose)`) by default via `--disallowedTools` injection. Opt out with `[claude] allow_builtin_agents = true` in `meridian.toml`.
 
 ### Fixed
+- Claude delegation guidance now appears only for primary launches, not headless spawns.
 - Claude delegation guidance probe now ignores optional `.claude/agents` filesystem errors.
 - `[spawn].deny_headless_harnesses` now loads from TOML instead of being ignored.
 - Codex primary `--from`/`-f`/`-p` now forwards primary user-turn content into the attached TUI; empty launches keep Codex's bootstrap-only idle default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
-- Claude adapter denies built-in subagents (`Agent(Explore)`, `Agent(Plan)`, `Agent(General-purpose)`) by default via `--disallowedTools` injection. Opt out with `[claude] allow_builtin_agents = true` in `meridian.toml`.
+- Claude adapter denies built-in subagents (`Agent(Explore)`, `Agent(Plan)`, `Agent(general-purpose)`) by default via `--disallowedTools` injection. Opt out with `[claude] allow_builtin_agents = true` in `meridian.toml`.
 
 ### Fixed
 - Codex primary `--from`/`-f`/`-p` now forwards primary user-turn content into the attached TUI; empty launches keep Codex's bootstrap-only idle default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Claude adapter denies built-in subagents (`Agent(Explore)`, `Agent(Plan)`, `Agent(general-purpose)`) by default via `--disallowedTools` injection. Opt out with `[claude] allow_builtin_agents = true` in `meridian.toml`.
 
 ### Fixed
+- Claude delegation guidance probe now ignores optional `.claude/agents` filesystem errors.
 - `[spawn].deny_headless_harnesses` now loads from TOML instead of being ignored.
 - Codex primary `--from`/`-f`/`-p` now forwards primary user-turn content into the attached TUI; empty launches keep Codex's bootstrap-only idle default.
 - Primary `meridian --from REF` now inherits source work item when no `--work` or ambient work is active.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Claude adapter denies built-in subagents (`Agent(Explore)`, `Agent(Plan)`, `Agent(general-purpose)`) by default via `--disallowedTools` injection. Opt out with `[claude] allow_builtin_agents = true` in `meridian.toml`.
 
 ### Fixed
+- Headless harness deny errors now name the denied harness without Claude-specific remediation.
 - Claude delegation guidance now appears only for primary launches, not headless spawns.
 - Claude delegation guidance probe now ignores optional `.claude/agents` filesystem errors.
 - `[spawn].deny_headless_harnesses` now loads from TOML instead of being ignored.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Claude adapter denies built-in subagents (`Agent(Explore)`, `Agent(Plan)`, `Agent(general-purpose)`) by default via `--disallowedTools` injection. Opt out with `[claude] allow_builtin_agents = true` in `meridian.toml`.
 
 ### Fixed
+- `[spawn].deny_headless_harnesses` now loads from TOML instead of being ignored.
 - Codex primary `--from`/`-f`/`-p` now forwards primary user-turn content into the attached TUI; empty launches keep Codex's bootstrap-only idle default.
 - Primary `meridian --from REF` now inherits source work item when no `--work` or ambient work is active.
 

--- a/src/meridian/lib/config/AGENTS.md
+++ b/src/meridian/lib/config/AGENTS.md
@@ -71,7 +71,7 @@ Claude profile includes:
 - `[harness.claude] wait_yield_seconds` — polling interval (float, env:
   `MERIDIAN_HARNESS_WAIT_YIELD_SECONDS_CLAUDE`)
 - `[harness.claude] allow_builtin_agents` — whether to permit Claude's built-in
-  subagents (Explore, Plan, General-purpose). Default `false` — Meridian denies them
+  subagents (Explore, Plan, general-purpose). Default `false` — Meridian denies them
   so sessions use custom Meridian agents exclusively. Set `true` to opt out.
 
 ## Depth

--- a/src/meridian/lib/config/settings.py
+++ b/src/meridian/lib/config/settings.py
@@ -434,6 +434,9 @@ def _normalize_spawn_table(raw_value: object, *, source: str) -> dict[str, objec
 
     values: dict[str, object] = {}
     for key, value in cast("dict[str, object]", raw_value).items():
+        if key == "deny_headless_harnesses":
+            values[key] = _parse_toml_list(raw_value=value, source=f"{source}.{key}")
+            continue
         if key not in {"default_wait_yield_seconds", "min_wait_yield_seconds"}:
             logger.warning("Ignoring unknown Meridian config key '%s.%s'.", source, key)
             continue

--- a/src/meridian/lib/config/settings.py
+++ b/src/meridian/lib/config/settings.py
@@ -345,6 +345,15 @@ def _normalize_harness_table(
                         )
                     harness_values["wait_yield_seconds"] = float(harness_value)
                     continue
+                if key == "claude" and harness_key == "allow_builtin_agents":
+                    if not isinstance(harness_value, bool):
+                        raise ValueError(
+                            f"Invalid value for '{source}.{key}.allow_builtin_agents': "
+                            f"expected bool, got "
+                            f"{type(harness_value).__name__} ({harness_value!r})."
+                        )
+                    harness_values["allow_builtin_agents"] = harness_value
+                    continue
                 if key == "pi" and harness_key == "disable_managed_bash":
                     if not isinstance(harness_value, bool):
                         raise ValueError(
@@ -1154,6 +1163,7 @@ class HarnessProfileConfig(BaseModel):
 
 
 class ClaudeHarnessProfileConfig(HarnessProfileConfig):
+    allow_builtin_agents: bool = False
     model: Annotated[
         str,
         config_field(
@@ -1558,6 +1568,23 @@ def resolve_pi_harness_profile_for_launch(
         base_profile=base_profile,
         project_root=project_root if base_profile is None else None,
     )
+
+
+def resolve_claude_allow_builtin_agents_for_launch(
+    *,
+    config_snapshot: dict[str, object] | None,
+    project_root: Path,
+) -> bool:
+    """Resolve ``[harness.claude].allow_builtin_agents`` from a launch config snapshot."""
+
+    if config_snapshot:
+        try:
+            return bool(
+                MeridianConfig.model_validate(config_snapshot).harness.claude.allow_builtin_agents
+            )
+        except Exception:
+            pass
+    return bool(load_config(project_root).harness.claude.allow_builtin_agents)
 
 
 def resolve_pi_disable_managed_bash() -> bool:

--- a/src/meridian/lib/config/settings.py
+++ b/src/meridian/lib/config/settings.py
@@ -1364,6 +1364,14 @@ class MeridianConfig(BaseSettings):
             env_vars=("MERIDIAN_MIN_WAIT_YIELD_SECONDS",),
         ),
     ] = 30.0
+    deny_headless_harnesses: Annotated[
+        tuple[str, ...],
+        config_field(
+            "spawn.deny_headless_harnesses",
+            value_kind="str_list",
+            file_aliases=(file_alias("spawn", "deny_headless_harnesses"),),
+        ),
+    ] = ()
     harness: HarnessConfig = Field(default_factory=HarnessConfig)
     primary: PrimaryConfig = Field(default_factory=PrimaryConfig)
     output: OutputConfig = Field(default_factory=OutputConfig)

--- a/src/meridian/lib/harness/.context/CONTEXT.md
+++ b/src/meridian/lib/harness/.context/CONTEXT.md
@@ -39,7 +39,7 @@ Per-harness mapping:
 - Claude subprocess: `claude -p --output-format stream-json --verbose -`
 - Claude connection: `claude -p --input-format stream-json --output-format stream-json --verbose` (stdin/stdout NDJSON, not WebSocket despite `claude_ws.py` name)
 - **Claude built-in agent denial**: Meridian injects `--disallowedTools
-  Agent(Explore),Agent(Plan),Agent(General-purpose)` by default. Gated by
+  Agent(Explore),Agent(Plan),Agent(general-purpose)` by default. Gated by
   `[harness.claude] allow_builtin_agents` (bool, default `false`). The denials
   merge into permission-derived `--disallowedTools` via `dedupe_nonempty()`.
 - Codex subprocess: `codex exec --json`; connection: `codex app-server` (real WebSocket, JSON-RPC 2.0)
@@ -190,9 +190,9 @@ value. Windows does not support PTY — Claude primary uses a fallback detection
 
 ### Claude: Built-in Subagent Denial
 
-Claude Code ships with three built-in subagents: Explore, Plan, and General-purpose.
+Claude Code ships with three built-in subagents: Explore, Plan, and general-purpose.
 These conflict with Meridian's own agent system. Meridian injects
-`--disallowedTools Agent(Explore),Agent(Plan),Agent(General-purpose)` by default
+`--disallowedTools Agent(Explore),Agent(Plan),Agent(general-purpose)` by default
 so Claude sessions use custom Meridian agents exclusively. The behavior is gated by
 `[harness.claude] allow_builtin_agents` (bool, default `false`).
 
@@ -205,7 +205,7 @@ permission-derived `--disallowedTools` so exactly one flag is emitted.
 This is implemented as a Meridian platform policy (harness adapter injection),
 not as a per-agent `disallowed-tools` field. This means individual agent profiles
 no longer need to carry deny entries like
-`disallowed-tools: [Agent(Explore), Agent(Plan), Agent(General-purpose)]` —
+`disallowed-tools: [Agent(Explore), Agent(Plan), Agent(general-purpose)]` —
 they're inherited from the harness adapter.
 
 ### Claude: System-Prompt File Channel

--- a/src/meridian/lib/harness/AGENTS.md
+++ b/src/meridian/lib/harness/AGENTS.md
@@ -38,7 +38,7 @@ Per-harness commands:
 - Claude subprocess: `claude -p --output-format stream-json --verbose -`
 - Claude connection: stdin/stdout NDJSON (not WebSocket despite `claude_ws.py` name)
 - **Claude built-in agent denial**: Meridian injects
-  `--disallowedTools Agent(Explore),Agent(Plan),Agent(General-purpose)` by default
+  `--disallowedTools Agent(Explore),Agent(Plan),Agent(general-purpose)` by default
   so sessions use custom Meridian agents instead of Claude's built-in subagents.
   Gated by `[harness.claude] allow_builtin_agents` (bool, default `false`).
   The builtin denials merge into permission-derived `--disallowedTools` via

--- a/src/meridian/lib/harness/adapter.py
+++ b/src/meridian/lib/harness/adapter.py
@@ -237,6 +237,7 @@ class SpawnParams(BaseModel):
     context_from_payload: tuple[str, ...] = ()
     reference_items: tuple[Any, ...] = ()
     pi_harness_profile: PiHarnessProfileConfig | None = None
+    claude_allow_builtin_agents: bool = False
 
 
 class McpConfig(BaseModel):

--- a/src/meridian/lib/harness/claude.py
+++ b/src/meridian/lib/harness/claude.py
@@ -265,6 +265,7 @@ class ClaudeAdapter(BaseHarnessAdapter[ResolvedLaunchSpec]):
             "mcp_tools",
             "projected_roots",
             "user_turn_content",
+            "claude_allow_builtin_agents",
         }
     )
     _EXPLICITLY_IGNORED_FIELDS: ClassVar[frozenset[str]] = frozenset(
@@ -374,6 +375,9 @@ class ClaudeAdapter(BaseHarnessAdapter[ResolvedLaunchSpec]):
             prompt_file_path = str(Path(run.control_root) / "system-prompt.md")
         # Extract user_turn_content from run params if available
         user_turn_content = getattr(run, "user_turn_content", None)
+        disallowed_tools: tuple[str, ...] = ()
+        if not run.claude_allow_builtin_agents:
+            disallowed_tools = ("Agent(Explore),Agent(Plan),Agent(General-purpose)",)
         return ResolvedLaunchSpec(
             harness=HarnessId.CLAUDE,
             model=str(run.model).strip() if run.model else None,
@@ -391,6 +395,7 @@ class ClaudeAdapter(BaseHarnessAdapter[ResolvedLaunchSpec]):
             agent_name=run.agent,
             prompt_file_path=prompt_file_path,
             user_turn_content=user_turn_content,
+            disallowed_tools=disallowed_tools,
         )
 
     def preflight(

--- a/src/meridian/lib/harness/claude.py
+++ b/src/meridian/lib/harness/claude.py
@@ -377,7 +377,7 @@ class ClaudeAdapter(BaseHarnessAdapter[ResolvedLaunchSpec]):
         user_turn_content = getattr(run, "user_turn_content", None)
         disallowed_tools: tuple[str, ...] = ()
         if not run.claude_allow_builtin_agents:
-            disallowed_tools = ("Agent(Explore),Agent(Plan),Agent(General-purpose)",)
+            disallowed_tools = ("Agent(Explore),Agent(Plan),Agent(general-purpose)",)
         return ResolvedLaunchSpec(
             harness=HarnessId.CLAUDE,
             model=str(run.model).strip() if run.model else None,

--- a/src/meridian/lib/harness/codex.py
+++ b/src/meridian/lib/harness/codex.py
@@ -286,6 +286,7 @@ class CodexAdapter(BaseHarnessAdapter[ResolvedLaunchSpec]):
             "reference_items",
             "task_cwd",
             "pi_harness_profile",
+            "claude_allow_builtin_agents",
         }
     )
 

--- a/src/meridian/lib/harness/cursor.py
+++ b/src/meridian/lib/harness/cursor.py
@@ -75,6 +75,7 @@ class CursorAdapter(BaseHarnessAdapter[ResolvedLaunchSpec]):
             "continue_fork",
             "effort",
             "pi_harness_profile",
+            "claude_allow_builtin_agents",
         }
     )
 

--- a/src/meridian/lib/harness/opencode.py
+++ b/src/meridian/lib/harness/opencode.py
@@ -350,6 +350,7 @@ class OpenCodeAdapter(BaseHarnessAdapter[ResolvedLaunchSpec]):
             "reference_items",
             "task_cwd",
             "pi_harness_profile",
+            "claude_allow_builtin_agents",
         }
     )
 

--- a/src/meridian/lib/harness/pi.py
+++ b/src/meridian/lib/harness/pi.py
@@ -116,6 +116,7 @@ class PiAdapter(BaseHarnessAdapter[ResolvedLaunchSpec]):
             "context_from_payload",
             "reference_items",
             "task_cwd",
+            "claude_allow_builtin_agents",
         }
     )
 

--- a/src/meridian/lib/harness/projections/project_claude.py
+++ b/src/meridian/lib/harness/projections/project_claude.py
@@ -33,6 +33,7 @@ _PROJECTED_FIELDS: frozenset[str] = frozenset(
         "prompt",
         "prompt_file_path",
         "user_turn_content",
+        "disallowed_tools",
     }
 )
 
@@ -179,6 +180,10 @@ def project_claude_spec_to_cli_args(
 
     permission_flags = resolve_permission_flags(spec.permission_resolver, HarnessId.CLAUDE)
     permission_tail, allowed_tools, disallowed_tools = _extract_claude_tool_flags(permission_flags)
+    spec_disallowed: list[str] = []
+    for entry in spec.disallowed_tools:
+        spec_disallowed.extend(split_csv_entries(entry))
+    disallowed_tools = dedupe_nonempty((*disallowed_tools, *spec_disallowed))
     allowed_tools = dedupe_nonempty((*allowed_tools, *parent_allowed_tools))
     command.extend(permission_tail)
     if allowed_tools:

--- a/src/meridian/lib/harness/projections/project_codex_streaming.py
+++ b/src/meridian/lib/harness/projections/project_codex_streaming.py
@@ -75,6 +75,7 @@ _DELEGATED_FIELDS: frozenset[str] = frozenset(
         "harness",
         "pi_extension_entrypoints",
         "load_all_pi_extensions",
+        "disallowed_tools",
         "prompt_file_path",
         "reference_items",
         "skills",

--- a/src/meridian/lib/harness/projections/project_codex_subprocess.py
+++ b/src/meridian/lib/harness/projections/project_codex_subprocess.py
@@ -43,6 +43,7 @@ _DELEGATED_FIELDS: frozenset[str] = frozenset(
         "harness",
         "pi_extension_entrypoints",
         "load_all_pi_extensions",
+        "disallowed_tools",
         "prompt_file_path",
         "reference_items",
         "skills",

--- a/src/meridian/lib/harness/projections/project_cursor.py
+++ b/src/meridian/lib/harness/projections/project_cursor.py
@@ -43,6 +43,7 @@ _DELEGATED_FIELDS: frozenset[str] = frozenset(
         "reference_items",
         "pi_extension_entrypoints",
         "load_all_pi_extensions",
+        "disallowed_tools",
     }
 )
 

--- a/src/meridian/lib/harness/projections/project_opencode_streaming.py
+++ b/src/meridian/lib/harness/projections/project_opencode_streaming.py
@@ -50,6 +50,7 @@ _DELEGATED_FIELDS: frozenset[str] = frozenset(
         "harness",
         "pi_extension_entrypoints",
         "load_all_pi_extensions",
+        "disallowed_tools",
         "prompt_file_path",
         "report_output_path",
         "task_cwd",

--- a/src/meridian/lib/harness/projections/project_opencode_subprocess.py
+++ b/src/meridian/lib/harness/projections/project_opencode_subprocess.py
@@ -42,6 +42,7 @@ _DELEGATED_FIELDS: frozenset[str] = frozenset(
         "harness",
         "pi_extension_entrypoints",
         "load_all_pi_extensions",
+        "disallowed_tools",
         "prompt_file_path",
         "reference_items",
         "report_output_path",

--- a/src/meridian/lib/harness/projections/project_pi_native_tui.py
+++ b/src/meridian/lib/harness/projections/project_pi_native_tui.py
@@ -45,6 +45,7 @@ _DELEGATED_FIELDS: frozenset[str] = frozenset(
         "mcp_tools",
         "projected_roots",
         "task_cwd",
+        "disallowed_tools",
     }
 )
 

--- a/src/meridian/lib/harness/projections/project_pi_rpc.py
+++ b/src/meridian/lib/harness/projections/project_pi_rpc.py
@@ -46,6 +46,7 @@ _DELEGATED_FIELDS: frozenset[str] = frozenset(
         "skills",
         "reference_items",
         "task_cwd",
+        "disallowed_tools",
     }
 )
 

--- a/src/meridian/lib/launch/context.py
+++ b/src/meridian/lib/launch/context.py
@@ -1761,7 +1761,10 @@ def bind_launch_context(
         if harness.id == HarnessId.CLAUDE
         else False
     )
-    if harness.id == HarnessId.CLAUDE:
+    if (
+        harness.id == HarnessId.CLAUDE
+        and runtime.composition_surface == LaunchCompositionSurface.PRIMARY
+    ):
         prompt_payload = _inject_claude_delegation_guidance(
             prompt_payload, project_root=project_root
         )

--- a/src/meridian/lib/launch/context.py
+++ b/src/meridian/lib/launch/context.py
@@ -23,6 +23,7 @@ from meridian.lib.config.settings import (
     MeridianConfig,
     PiHarnessProfileConfig,
     load_config,
+    resolve_claude_allow_builtin_agents_for_launch,
     resolve_pi_harness_profile_for_launch,
 )
 from meridian.lib.config.workspace import get_projectable_roots
@@ -555,6 +556,7 @@ def materialize_launch_artifacts(
     approval: str | None = None,
     unsafe_no_permissions: bool = False,
     pi_harness_profile: PiHarnessProfileConfig | None = None,
+    claude_allow_builtin_agents: bool = False,
 ) -> MaterializedLaunchArtifacts:
     """Build shared run/spec/permission launch artifacts."""
 
@@ -595,6 +597,7 @@ def materialize_launch_artifacts(
         reference_items=reference_items,
         user_turn_content=prompt_payload.user_turn_content,
         pi_harness_profile=pi_harness_profile,
+        claude_allow_builtin_agents=claude_allow_builtin_agents,
     )
     permission_config, perms = resolve_permission_pipeline(
         sandbox=sandbox,
@@ -1695,6 +1698,14 @@ def bind_launch_context(
         if harness.id == HarnessId.PI
         else None
     )
+    claude_allow_builtin_agents = (
+        resolve_claude_allow_builtin_agents_for_launch(
+            config_snapshot=runtime.config_snapshot,
+            project_root=project_paths.project_root,
+        )
+        if harness.id == HarnessId.CLAUDE
+        else False
+    )
     materialized = materialize_launch_artifacts(
         harness=harness,
         prompt=resolved_request.prompt,
@@ -1724,6 +1735,7 @@ def bind_launch_context(
         approval=resolved_request.execution_policy.approval,
         unsafe_no_permissions=runtime.unsafe_no_permissions,
         pi_harness_profile=pi_harness_profile,
+        claude_allow_builtin_agents=claude_allow_builtin_agents,
     )
     run_params = materialized.run_params
 

--- a/src/meridian/lib/launch/context.py
+++ b/src/meridian/lib/launch/context.py
@@ -646,7 +646,11 @@ def _inject_claude_delegation_guidance(
 ) -> PreparedPromptPayload:
     """Append delegation guidance when Claude has native agents available."""
     claude_agents_dir = project_root / ".claude" / "agents"
-    if not claude_agents_dir.is_dir() or not any(claude_agents_dir.iterdir()):
+    try:
+        has_claude_agents = claude_agents_dir.is_dir() and any(claude_agents_dir.iterdir())
+    except OSError:
+        return prompt_payload
+    if not has_claude_agents:
         return prompt_payload
     existing = prompt_payload.appended_system_prompt or ""
     return replace(

--- a/src/meridian/lib/launch/context.py
+++ b/src/meridian/lib/launch/context.py
@@ -614,6 +614,47 @@ def materialize_launch_artifacts(
     )
 
 
+def _resolve_deny_headless_harnesses(
+    runtime: LaunchRuntime,
+    project_paths: ProjectConfigPaths,
+) -> tuple[str, ...]:
+    """Resolve ``[spawn].deny_headless_harnesses`` from config."""
+    if runtime.config_snapshot:
+        try:
+            return tuple(
+                MeridianConfig.model_validate(
+                    runtime.config_snapshot
+                ).deny_headless_harnesses
+            )
+        except Exception:
+            pass
+    return tuple(load_config(project_paths.project_root).deny_headless_harnesses)
+
+
+_CLAUDE_DELEGATION_GUIDANCE = (
+    "\n\n# Delegation\n"
+    "Prefer Agent() for agents in your agents menu — in-process, fast, visible.\n"
+    "Use `meridian spawn` for agents not in the menu or when you need session\n"
+    "tracking / cross-harness models. Use `/handoff` when the user takes the baton.\n"
+)
+
+
+def _inject_claude_delegation_guidance(
+    prompt_payload: PreparedPromptPayload,
+    *,
+    project_root: Path,
+) -> PreparedPromptPayload:
+    """Append delegation guidance when Claude has native agents available."""
+    claude_agents_dir = project_root / ".claude" / "agents"
+    if not claude_agents_dir.is_dir() or not any(claude_agents_dir.iterdir()):
+        return prompt_payload
+    existing = prompt_payload.appended_system_prompt or ""
+    return replace(
+        prompt_payload,
+        appended_system_prompt=(existing + _CLAUDE_DELEGATION_GUIDANCE).lstrip(),
+    )
+
+
 def _missing_continue_session_error(source_ref: str | None) -> str:
     normalized_source = (source_ref or "").strip()
     if normalized_source:
@@ -1686,6 +1727,16 @@ def bind_launch_context(
                 }
             )
 
+    if (
+        runtime.composition_surface == LaunchCompositionSurface.SPAWN_PREPARE
+        and harness.id.value in _resolve_deny_headless_harnesses(runtime, project_paths)
+    ):
+        raise ValueError(
+            f"Headless spawns on the '{harness.id.value}' harness are denied by "
+            f"'[spawn] deny_headless_harnesses' in meridian.toml. "
+            f"Use the native Agent() tool from a Claude primary session, or /handoff."
+        )
+
     is_primary_launch = runtime.composition_surface == LaunchCompositionSurface.PRIMARY
     inject_task_cwd_instruction = directory_context.should_inject_task_cwd_instruction(
         runtime.composition_surface
@@ -1706,6 +1757,10 @@ def bind_launch_context(
         if harness.id == HarnessId.CLAUDE
         else False
     )
+    if harness.id == HarnessId.CLAUDE:
+        prompt_payload = _inject_claude_delegation_guidance(
+            prompt_payload, project_root=project_root
+        )
     materialized = materialize_launch_artifacts(
         harness=harness,
         prompt=resolved_request.prompt,

--- a/src/meridian/lib/launch/context.py
+++ b/src/meridian/lib/launch/context.py
@@ -1738,7 +1738,8 @@ def bind_launch_context(
         raise ValueError(
             f"Headless spawns on the '{harness.id.value}' harness are denied by "
             f"'[spawn] deny_headless_harnesses' in meridian.toml. "
-            f"Use the native Agent() tool from a Claude primary session, or /handoff."
+            f"Use a native primary session for the {harness.id.value} harness, "
+            "or change the setting in meridian.toml."
         )
 
     is_primary_launch = runtime.composition_surface == LaunchCompositionSurface.PRIMARY

--- a/src/meridian/lib/launch/launch_types.py
+++ b/src/meridian/lib/launch/launch_types.py
@@ -106,6 +106,7 @@ class ResolvedLaunchSpec(BaseModel):
     # Claude only
     agents_payload: str | None = None
     prompt_file_path: str | None = None
+    disallowed_tools: tuple[str, ...] = ()
 
     # Claude + Codex
     user_turn_content: str | None = None

--- a/tests/integration/config/test_settings_paths.py
+++ b/tests/integration/config/test_settings_paths.py
@@ -153,6 +153,25 @@ def test_load_config_reads_harness_wait_yield_settings(tmp_path: Path) -> None:
     assert config.default_model_for_harness("codex") == "gpt-5.4"
 
 
+def test_load_config_reads_spawn_deny_headless_harnesses(tmp_path: Path) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    config_path = project_root / "meridian.toml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "[spawn]",
+                'deny_headless_harnesses = ["claude", "pi"]',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_config(project_root, resolve_models=False)
+
+    assert config.deny_headless_harnesses == ("claude", "pi")
+
+
 def test_load_config_reads_pi_disable_managed_bash(tmp_path: Path) -> None:
     project_root = tmp_path / "repo"
     project_root.mkdir()
@@ -348,4 +367,3 @@ def test_runtime_authority_for_read_falls_back_to_project_state_in_plain_directo
     assert authority.project_root == project_root.resolve()
     assert authority.runtime_root == runtime_root.resolve()
     assert authority.runtime_root_source in {"project-state", "project-state-fallback"}
-

--- a/tests/integration/launch/test_launch_process_claude_prompt.py
+++ b/tests/integration/launch/test_launch_process_claude_prompt.py
@@ -112,6 +112,44 @@ def test_claude_delegation_guidance_ignores_agent_dir_probe_errors(
     )
 
 
+def test_claude_delegation_guidance_is_primary_only(tmp_path: Path) -> None:
+    project_root = tmp_path / "claude-guidance"
+    project_root.mkdir()
+    agents_dir = project_root / ".claude" / "agents"
+    agents_dir.mkdir(parents=True)
+    (agents_dir / "reviewer.md").write_text("# reviewer\n", encoding="utf-8")
+
+    primary_context, _ = _build_primary_launch_context(
+        project_root=project_root,
+        harness_id=HarnessId.CLAUDE,
+        model="claude-sonnet-4-5",
+    )
+    primary_system_prompt = primary_context.binding.run_params.appended_system_prompt or ""
+
+    spawn_context = build_launch_context(
+        spawn_id="dry-run-claude-spawn-guidance",
+        request=SpawnRequest(
+            prompt="spawn prompt",
+            prompt_is_composed=False,
+            model="claude-sonnet-4-5",
+            harness=HarnessId.CLAUDE.value,
+        ),
+        runtime=LaunchRuntime(
+            argv_intent=LaunchArgvIntent.REQUIRED,
+            composition_surface=LaunchCompositionSurface.SPAWN_PREPARE,
+            runtime_root=(project_root / ".meridian").as_posix(),
+            project_paths_project_root=project_root.as_posix(),
+            project_paths_execution_cwd=project_root.as_posix(),
+        ),
+        harness_registry=get_default_harness_registry(),
+        dry_run=True,
+    )
+    spawn_system_prompt = spawn_context.binding.run_params.appended_system_prompt or ""
+
+    assert "# Delegation" in primary_system_prompt
+    assert "# Delegation" not in spawn_system_prompt
+
+
 @pytest.mark.slow
 def test_run_harness_process_writes_prompt_file_before_primary_launch(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integration/launch/test_launch_process_claude_prompt.py
+++ b/tests/integration/launch/test_launch_process_claude_prompt.py
@@ -19,7 +19,11 @@ from meridian.lib.config.settings import load_config
 from meridian.lib.core.types import HarnessId
 from meridian.lib.harness.registry import get_default_harness_registry
 from meridian.lib.launch.constants import OUTPUT_FILENAME
-from meridian.lib.launch.context import build_launch_context
+from meridian.lib.launch.context import (
+    PreparedPromptPayload,
+    _inject_claude_delegation_guidance,
+    build_launch_context,
+)
 from meridian.lib.launch.process.primary_attach import PrimaryAttachOutcome
 from meridian.lib.launch.process.runner import run_harness_process
 from meridian.lib.launch.request import (
@@ -85,6 +89,27 @@ def _build_primary_launch_context(
         dry_run=True,
     )
     return launch_context, harness_registry
+
+
+def test_claude_delegation_guidance_ignores_agent_dir_probe_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    agents_dir = tmp_path / ".claude" / "agents"
+    agents_dir.mkdir(parents=True)
+    payload = PreparedPromptPayload(appended_system_prompt="existing")
+
+    def _raise_on_iterdir(self: Path) -> Any:
+        if self == agents_dir:
+            raise PermissionError("sandbox denied")
+        return iter(())
+
+    monkeypatch.setattr(Path, "iterdir", _raise_on_iterdir)
+
+    assert (
+        _inject_claude_delegation_guidance(payload, project_root=tmp_path)
+        is payload
+    )
 
 
 @pytest.mark.slow

--- a/tests/integration/launch/test_launch_resolution_spawn_prepare.py
+++ b/tests/integration/launch/test_launch_resolution_spawn_prepare.py
@@ -379,3 +379,45 @@ def test_spawn_prepare_claude_projects_profile_auto_approval_without_cli_overrid
     argv = preview.binding.argv
     assert "--permission-mode" in argv
     assert "acceptEdits" in argv
+
+
+def test_spawn_prepare_headless_deny_error_names_denied_harness(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_minimal_mars_config(tmp_path)
+    (tmp_path / "meridian.toml").write_text(
+        "[spawn]\n"
+        'deny_headless_harnesses = ["codex"]\n',
+        encoding="utf-8",
+    )
+    stub_bundle_request_and_resolve(
+        monkeypatch,
+        model="gpt-5.4",
+        harness=HarnessId.CODEX,
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        build_launch_context(
+            spawn_id="dry-run-codex-spawn-denied",
+            request=SpawnRequest(
+                prompt="task",
+                prompt_is_composed=False,
+                model="gpt-5.4",
+                harness="codex",
+            ),
+            runtime=LaunchRuntime(
+                argv_intent=LaunchArgvIntent.REQUIRED,
+                composition_surface=LaunchCompositionSurface.SPAWN_PREPARE,
+                runtime_root=(tmp_path / ".meridian").as_posix(),
+                project_paths_project_root=tmp_path.as_posix(),
+                project_paths_execution_cwd=tmp_path.as_posix(),
+            ),
+            harness_registry=get_default_harness_registry(),
+            dry_run=True,
+        )
+
+    message = str(exc_info.value)
+    assert "Headless spawns on the 'codex' harness are denied" in message
+    assert "native primary session for the codex harness" in message
+    assert "Claude primary session" not in message


### PR DESCRIPTION
## Why

Claude Code ships with built-in subagents (Explore, Plan, general-purpose) that compete with Meridian's own agent system. When both are active, spawned agents may invoke Claude's built-in agents instead of Meridian-managed ones, causing confusion and inconsistent behavior.

## Goal

Meridian-launched Claude Code sessions deny Claude's built-in subagents by default, with an opt-out for users who want them. Delegation guidance and headless-deny behave consistently across harnesses and composition surfaces.

## Summary

- Claude adapter injects `--disallowedTools "Agent(Explore),Agent(Plan),Agent(general-purpose)"` at launch time.
- New `[harness.claude] allow_builtin_agents = true` setting in `meridian.toml` to opt out.
- Lowercase `general-purpose` casing fix — Claude CLI is case-sensitive for agent names.
- Claude delegation guidance injects only on PRIMARY launches when `.claude/agents/` has content and ignores optional probe filesystem errors.
- `[spawn] deny_headless_harnesses` loads from TOML, normalizes harness-name case, and blocks `meridian spawn` from launching via denied harnesses.
- Headless-deny errors name the actual denied harness, avoid Claude-specific remediation, and skip primary-session guidance for harnesses that do not support primary launch.
- Focused regression tests cover the reviewer-fix paths.

## Resulting Behavior

- All Meridian-launched Claude Code sessions deny built-in subagents by default.
- `[harness.claude] allow_builtin_agents = true` in `meridian.toml` restores them.
- Primary Claude sessions with `.claude/agents/` content get delegation guidance in the system prompt.
- Child/headless spawns do not get native-Agent guidance that may contradict spawn permissions.
- `[spawn] deny_headless_harnesses = ["Claude"]` blocks headless Claude spawns despite mixed case.
- `[spawn] deny_headless_harnesses = ["codex"]` blocks headless Codex spawns with Codex-specific guidance.
- `[spawn] deny_headless_harnesses = ["cursor"]` blocks headless Cursor spawns without suggesting unsupported primary launch.

## Work Item

claude-deny-builtin-agents

## Verification

- `uv run ruff check .` — clean
- `uv run --extra dev python -m pyright` — 0 errors
- `uv run pytest-llm` — 1223 passed, 2 skipped
- p3447 probe: focused runtime checks for original 4 reviewer fixes — clean
- p3449 probe: focused runtime checks after non-primary headless-deny refinement — clean

## Knowledge Updates

- `CHANGELOG.md` updated under `[Unreleased]`.
- `src/meridian/lib/config/AGENTS.md` — updated with `allow_builtin_agents` docs.
- `src/meridian/lib/harness/AGENTS.md` — updated with `--disallowedTools` injection docs.

## Spawn Trace

- p3404 — initial implementation (deny built-in agents + casing fix)
- p3430 — kb-lead post-impl knowledge capture
- p3440 — reviewer (correctness) — found blocker + 3 medium issues
- p3441 — reviewer (structural) — found 3 medium + 1 low issues
- p3443 — gpt-dev — implemented all 4 reviewer fixes + tests
- p3444 — reviewer (post-fix) — clean, no findings
- p3445 — probe (post-fix) — runtime smoke verification, clean
- p3446 — reviewer (this pass) — found 3 medium follow-ups; cursor remediation fixed
- p3447 — probe (this pass) — focused runtime verification, clean
- p3448 — reviewer (rerun) — approve with low notes; notes fixed
- p3449 — probe (rerun) — focused runtime verification, clean

## Release Label Guide

release:patch

## Post-Merge Automation

After merge to `main`, CI bumps patch version, promotes changelog, commits, tags, releases.

## Cleanup

- Remove per-agent `disallowed-tools: [Agent(Explore), Agent(Plan), Agent(general-purpose)]` from meridian-base and meridian-dev-workflow prompt packages — now redundant (handled at harness level).
- Prune stale worktree `meridian-cli.worktrees/claude-deny-builtin-agents`.

```bash
scripts/prune-worktrees.sh
```
