### PR TITLE
Fix release metadata publisher compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,9 @@ jobs:
       - name: Verify Pi extensions in distributions
         run: uv run --no-sync python scripts/verify-pi-extension-artifacts.py dist
 
+      - name: Verify release metadata
+        run: uv run --no-sync python scripts/verify-release-metadata.py dist
+
       - name: Validate wheel artifact
         run: |
           uv run --isolated --no-project --with dist/*.whl meridian --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Release builds cap hatchling below 1.28 so wheel/sdist metadata stays PyPI-publisher compatible.
+
 ## [0.2.21] - 2026-06-01
 
 ## [0.2.20] - 2026-05-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Fixed
-- Release builds cap hatchling below 1.28 so wheel/sdist metadata stays PyPI-publisher compatible.
+- Release builds pin hatchling 1.27.0 and verify wheel/sdist metadata stays PyPI-publisher compatible.
 
 ## [0.2.21] - 2026-06-01
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,8 @@ templates = [
 ]
 
 [build-system]
+# Pinned: hatchling >=1.28 emits Metadata-Version 2.5, rejected by pypa/gh-action-pypi-publish.
+# When the publisher supports 2.5, remove the pin and drop scripts/verify-release-metadata.py.
 requires = ["hatchling==1.27.0"]
 build-backend = "hatchling.build"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ templates = [
 ]
 
 [build-system]
-requires = ["hatchling>=1.25.0,<1.28"]
+requires = ["hatchling==1.27.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.version]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ templates = [
 ]
 
 [build-system]
-requires = ["hatchling>=1.25.0"]
+requires = ["hatchling>=1.25.0,<1.28"]
 build-backend = "hatchling.build"
 
 [tool.hatch.version]

--- a/scripts/verify-release-metadata.py
+++ b/scripts/verify-release-metadata.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Verify Python distributions use publisher-compatible core metadata."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tarfile
+import zipfile
+from collections.abc import Sequence
+from pathlib import Path
+
+_EXPECTED_METADATA_VERSION = "2.4"
+
+
+class VerificationError(RuntimeError):
+    """Raised when a distribution has an unexpected metadata version."""
+
+
+def verify_distributions(dist_dir: Path) -> None:
+    wheels = tuple(sorted(dist_dir.glob("*.whl")))
+    sdists = tuple(sorted(dist_dir.glob("*.tar.gz")))
+    if not wheels:
+        raise VerificationError(f"No wheel files found in {dist_dir}")
+    if not sdists:
+        raise VerificationError(f"No sdist files found in {dist_dir}")
+
+    for wheel in wheels:
+        version = _wheel_metadata_version(wheel)
+        _assert_expected(path=wheel, version=version)
+    for sdist in sdists:
+        version = _sdist_metadata_version(sdist)
+        _assert_expected(path=sdist, version=version)
+
+
+def _wheel_metadata_version(path: Path) -> str:
+    with zipfile.ZipFile(path) as archive:
+        metadata_name = next(
+            (name for name in archive.namelist() if name.endswith(".dist-info/METADATA")),
+            None,
+        )
+        if metadata_name is None:
+            raise VerificationError(f"Missing wheel METADATA in {path}")
+        return _metadata_version(archive.read(metadata_name).decode())
+
+
+def _sdist_metadata_version(path: Path) -> str:
+    with tarfile.open(path) as archive:
+        pkg_info_name = next(
+            (name for name in archive.getnames() if name.endswith("/PKG-INFO")),
+            None,
+        )
+        if pkg_info_name is None:
+            raise VerificationError(f"Missing sdist PKG-INFO in {path}")
+        member = archive.extractfile(pkg_info_name)
+        if member is None:
+            raise VerificationError(f"Unreadable sdist PKG-INFO in {path}")
+        return _metadata_version(member.read().decode())
+
+
+def _metadata_version(contents: str) -> str:
+    for line in contents.splitlines():
+        if line.startswith("Metadata-Version:"):
+            return line.split(":", 1)[1].strip()
+    raise VerificationError("Missing Metadata-Version header")
+
+
+def _assert_expected(*, path: Path, version: str) -> None:
+    if version != _EXPECTED_METADATA_VERSION:
+        raise VerificationError(
+            f"{path} has Metadata-Version {version}; expected {_EXPECTED_METADATA_VERSION}"
+        )
+    print(f"Verified release metadata in {path}: Metadata-Version {version}")
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "dist_dir",
+        nargs="?",
+        default="dist",
+        type=Path,
+        help="Directory containing built .whl and .tar.gz distributions.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        verify_distributions(args.dist_dir.resolve())
+    except VerificationError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

Release `v0.2.21` built successfully but PyPI publish failed. The publish action rejected the wheel before upload because the build backend emitted `Metadata-Version: 2.5`, which the current publisher validation path does not accept yet.

## Goal

Stable releases build artifacts whose metadata stays compatible with the configured PyPI publisher, and fail during build validation before publish if that contract changes.

## Summary

- Pin build backend to `hatchling==1.27.0`, the verified version that emits `Metadata-Version: 2.4` for this package.
- Add `scripts/verify-release-metadata.py` to inspect wheel and sdist metadata.
- Run release metadata verification in `.github/workflows/release.yml` after `uv build` and before artifact upload/publish.
- Add changelog entry.

## Resulting Behavior

Future release artifacts should publish through the existing `pypa/gh-action-pypi-publish@release/v1` path instead of failing at publish-time metadata validation. If the artifact metadata drifts away from `2.4`, the release build fails before publishing.

## Work Item

release-metadata-version-cap

## Verification

- `cd src/meridian/pi_runtime && pnpm install --frozen-lockfile && pnpm run build:extensions`
- `uv build --no-sources`
- follow-up push preflight after source comment:
  - `uv run --extra dev ruff check .`
  - `uv run --extra dev python -m pyright`
  - `uv run --extra dev pytest -x -q` — `1249 passed, 2 skipped`
  - `uv build --no-sources`
- `uv run --no-sync python scripts/verify-release-metadata.py dist`
- `uv run --no-sync python scripts/verify-pi-extension-artifacts.py dist`
- `uv run ruff check scripts/verify-release-metadata.py`
- Push preflight:
  - `uv run --extra dev ruff check .`
  - `uv run --extra dev python -m pyright`
  - `uv run --extra dev pytest -x -q` — `1249 passed, 2 skipped`
  - `uv build --no-sources`

## Knowledge Updates

Work artifacts updated:
- `requirements.md`
- `vocab.md`

No repository docs update; this is release plumbing and the workflow/script encode the contract.

## Spawn Trace

- p3461 gpt-dev — implemented release metadata compatibility fix
- p3462 reviewer — found floating backend range / missing metadata gate
- p3463 reviewer — approved exact pin plus metadata verification
- p3464 kb-lead — captured release metadata constraint and added source comment

## Release Label Guide

Set one `release:*` label on this PR:

- `release:patch` — create the next patch release after merge
- `release:skip` — no release for this merge

No `release:*` label means no auto-release.

## Post-Merge Automation

After merge to `main`, CI (`.github/workflows/release-on-merge.yml`) will:

1. Read the PR release label
2. Skip when no `release:*` label is present or when `release:skip` is present
3. Compute the next patch version from existing `v*` tags
4. Update `src/meridian/__init__.py` + promote `CHANGELOG.md` `[Unreleased]`
5. Commit `Release X.Y.Z`, create/push `vX.Y.Z`
6. Run `.github/workflows/publish-pypi.yml` directly

## Cleanup

After merge, clean merged worktrees with:

```bash
scripts/prune-worktrees.sh
```

