### PR TITLE
[codex] Shorten Codex bootstrap message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- Codex fresh-session bootstrap turn now says `Meridian started`.
+
 ## [0.2.22] - 2026-06-01
 
 ### Fixed

--- a/docs/codex-tui-passthrough.md
+++ b/docs/codex-tui-passthrough.md
@@ -59,7 +59,7 @@ Meridian handles that by sending a minimal bootstrap turn, then waiting only
 until the Codex rollout file contains a matching `session_meta` entry for the
 project cwd:
 
-`Meridian bootstrap. Acknowledge readiness only; do not perform a user task.`
+`Meridian started`
 
 This bootstrap is intentionally small and deterministic. Meridian does **not** temporarily override Codex model/reasoning defaults for the bootstrap turn. The session should preserve Codex's own default or last-used settings.
 

--- a/src/meridian/lib/harness/connections/codex_ws.py
+++ b/src/meridian/lib/harness/connections/codex_ws.py
@@ -79,7 +79,7 @@ _ADDRESS_IN_USE_MARKERS: Final[tuple[str, ...]] = (
     "eaddrinuse",
 )
 _BOOTSTRAP_TURN_PROMPT: Final[str] = (
-    "Meridian bootstrap. Acknowledge readiness only; do not perform a user task."
+    "Meridian started"
 )
 
 


### PR DESCRIPTION
## Why

Fresh managed Codex starts showed a verbose bootstrap instruction as a visible turn. The wording was heavier than the lifecycle marker Meridian needs before TUI attach.

## Goal

Fresh managed Codex primary sessions show a short bootstrap message: `Meridian started`.

## Summary

- Changed the Codex websocket bootstrap prompt constant to `Meridian started`.
- Updated the Codex TUI passthrough docs to match the runtime text.
- Added an Unreleased changelog entry.

## Resulting Behavior

Fresh managed Codex primary startup now sends the bootstrap turn text `Meridian started` while preserving the existing rollout materialization gate and Codex model/reasoning defaults.

## Work Item

bootstrap-message

## Verification

- `uv run ruff check src/meridian/lib/harness/connections/codex_ws.py`
- `rg "Meridian bootstrap|Acknowledge readiness only|do not perform a user task" src docs CHANGELOG.md` returned no matches
- Pre-push hook:
  - `uv run --extra dev ruff check .`
  - `uv run --extra dev python -m pyright`
  - `uv run --extra dev pytest -x -q` — 1249 passed, 2 skipped
  - `uv build --no-sources`

## Knowledge Updates

- Updated `docs/codex-tui-passthrough.md` because it quoted the bootstrap text.
- Updated `CHANGELOG.md` under `[Unreleased]`.
- No KB or `.context/` updates needed; this changes a visible runtime string, not a durable architecture contract.

## Spawn Trace

- p3467 kb-lead — checked post-implementation durable knowledge capture; no additional docs needed

## Release Label Guide

Set one `release:*` label on this PR:

- `release:patch` — create the next patch release after merge
- `release:skip` — no release for this merge

No `release:*` label means no auto-release.

## Post-Merge Automation

After merge to `main`, CI (`.github/workflows/release-on-merge.yml`) will:

1. Read the PR release label
2. Skip when no `release:*` label is present or when `release:skip` is present
3. Compute the next patch version from existing `v*` tags
4. Update `src/meridian/__init__.py` + promote `CHANGELOG.md` `[Unreleased]`
5. Commit `Release X.Y.Z`, create/push `vX.Y.Z`
6. Run `.github/workflows/publish-pypi.yml` directly

## Cleanup

After merge, clean merged worktrees with:

```bash
scripts/prune-worktrees.sh
```