### PR TITLE
Document headless spawn harness deny

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Document `[spawn].deny_headless_harnesses` for disabling harness-backed `meridian spawn -a` routes.
+
 ## [0.2.26] - 2026-06-02
 
 ### Changed

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -400,6 +400,16 @@ hooks, harness defaults, and primary-session defaults.
 
 In Claude launches, native `Agent()` follows that same boundary: generic `Agent` is allowed only with Mars Claude `agent_copy` plus an effective `.claude` managed target. Without it, use `meridian spawn`. Claude built-ins (`Explore`, `Plan`, `General-purpose` / `general-purpose`) stay denied.
 
+To prevent `meridian spawn -a <agent>` from launching headless Claude runs, set:
+
+```toml
+[spawn]
+deny_headless_harnesses = ["claude"]
+```
+
+That blocks spawn routes after model/profile resolution selects Claude, while
+leaving primary Claude launches available.
+
 See [agent-profiles.md](agent-profiles.md) for the agent profile format including `model-policies`, `no-fallback`, and `mode`. Legacy `fanout` and `fallback-order` are rejected; migrate to `model-policies` list order + `no-fallback: true`.
 
 ## Spawn Statuses

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -200,6 +200,27 @@ the launch denies native `Agent` and guides delegation back to `meridian spawn`.
 Claude built-in
 agents (`Explore`, `Plan`, `General-purpose` / `general-purpose`) stay denied.
 
+### Deny headless spawn harnesses
+
+Use `[spawn].deny_headless_harnesses` when a project should not launch
+headless subagents through specific harnesses. This applies to
+`meridian spawn`, including `meridian spawn -a <agent>` after the agent/model
+resolves to a harness.
+
+```toml
+[spawn]
+deny_headless_harnesses = ["claude"]
+```
+
+With that setting, a Claude primary session can still run, but headless Claude
+spawns fail before launch. To completely avoid Claude-side delegation, combine
+it with no Claude `agent_copy`:
+
+```toml
+[settings.agent_copy]
+harnesses = []
+```
+
 ### Model aliases
 
 Project-local aliases live under `[models.<alias>]`:


### PR DESCRIPTION
## Why

The Claude-native `Agent()` boundary was documented, but the separate `[spawn].deny_headless_harnesses` knob for blocking harness-backed `meridian spawn -a` routes was only discoverable from changelog/source.

## Goal

Document how to disable headless Claude subagent spawns while leaving primary Claude sessions available.

## Summary

- Add `[spawn].deny_headless_harnesses = ["claude"]` docs to configuration docs.
- Mirror the command-level guidance near the existing native `Agent()` boundary docs.
- Add changelog entry for the documentation update.

## Resulting Behavior

Users can find the supported config for disabling Claude-backed `meridian spawn -a` routes.

## Work Item

N/A — docs follow-up.

## Verification

- `git diff --check`
- `uv run ruff check .`

## Knowledge Updates

Docs updated in `docs/configuration.md` and `docs/commands.md`.

## Spawn Trace

N/A.

## Release Label Guide

Set one `release:*` label on this PR:

- `release:patch` — create the next patch release after merge
No `release:*` label means no auto-release.

## Post-Merge Automation

After merge to `main`, CI (`.github/workflows/release-on-merge.yml`) will:

1. Read the PR release label
2. Skip when no `release:*` label is present
3. Compute the next patch version from existing `v*` tags
4. Update `src/meridian/__init__.py` + promote `CHANGELOG.md` `[Unreleased]`
5. Commit `Release X.Y.Z`, create/push `vX.Y.Z`
6. Run `.github/workflows/publish-pypi.yml` directly

## Cleanup

After merge, clean merged worktrees with:

```bash
scripts/prune-worktrees.sh
```
