### PR TITLE
Refactor spawn cancel cleanup helpers

### DIFF
--- a/.github/workflows/meridian-ci.yml
+++ b/.github/workflows/meridian-ci.yml
@@ -213,4 +213,6 @@ jobs:
         run: cd src/meridian/pi_runtime && pnpm install --frozen-lockfile && pnpm run build:extensions
 
       - name: Run Windows gate
-        run: uv run --extra dev pytest -n auto -m "not slow"
+        # Windows xdist worker startup can hang before pytest emits output; run the same
+        # non-slow platform gate serially so Windows coverage stays authoritative.
+        run: uv run --extra dev pytest -n 0 -m "not slow"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - Spawn cancel now records durable cancel intent, stops runners before scope cleanup, suppresses retries, and converges stale cancelled runs to `cancelled`.
 - Process scope release tracking now uses concrete release identities, so repeated `backend` attempts clean independently.
+- Spawn cancel scope fallback now reuses canonical process cleanup, preserving live session-owned scopes during cancel.
 - Pi cancel classification now stays `cancelled` when cancellation has explicit intent.
 - Generated `# Spawn failed` reports no longer count as durable completion during cancel/reaper convergence.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Fixed
+- Claude aborted-streaming result during explicit cancel stays `cancelled`, not `succeeded`.
 - Background spawn cancel stays `cancelled` when runner writes synthetic `# Spawn failed` report.
 - Codex websocket close/error report during explicit cancel stays `cancelled`, not `succeeded`.
+- Codex pre-command progress text during explicit cancel no longer counts as durable completion.
 
 ## [0.2.30] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Codex websocket close/error report during explicit cancel stays `cancelled`, not `succeeded`.
 - Codex `thread/*`, `turn/*`, `item/*`, `account/*`, `mcpServer/*`, and `remoteControl/*` event envelopes no longer count as durable completion.
 - Codex pre-command progress text during explicit cancel no longer counts as durable completion.
+- OpenCode `message.*`, `server.*`, and `session.*` event envelopes no longer count as durable completion.
 
 ## [0.2.30] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - Background spawn cancel stays `cancelled` when runner writes synthetic `# Spawn failed` report.
+- Codex websocket close/error report during explicit cancel stays `cancelled`, not `succeeded`.
 
 ## [0.2.30] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Background spawn cancel stays `cancelled` when runner writes synthetic `# Spawn failed` report.
+
 ## [0.2.30] - 2026-06-04
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Claude aborted-streaming result during explicit cancel stays `cancelled`, not `succeeded`.
 - Background spawn cancel stays `cancelled` when runner writes synthetic `# Spawn failed` report.
 - Codex websocket close/error report during explicit cancel stays `cancelled`, not `succeeded`.
+- Codex `thread/*`, `turn/*`, `item/*`, `account/*`, `mcpServer/*`, and `remoteControl/*` event envelopes no longer count as durable completion.
 - Codex pre-command progress text during explicit cancel no longer counts as durable completion.
 
 ## [0.2.30] - 2026-06-04

--- a/src/meridian/lib/core/.context/CONTEXT.md
+++ b/src/meridian/lib/core/.context/CONTEXT.md
@@ -107,14 +107,22 @@ It never implements termination directly — every kill routes through
 
 ### Public functions
 
+**`terminate_recorded_spawn_scopes(runtime_root, spawn_record, *, reason, grace_seconds)`**
+
+Reads scope metadata from durable storage and terminates recorded scopes only.
+Skips scopes that are already released (`skip_reason="already_released"`) or that
+pass `should_skip_cleanup()` (`skip_reason="active_session_lease"`). This is the
+explicit second-stage cleanup after a caller already signaled a guarded runner tree.
+
+**`terminate_legacy_worker_fallback(spawn_record, *, reason, grace_seconds)`**
+
+Legacy fallback for spawns without scope metadata. Uses `worker_pid` termination
+and logs `degraded_fallback=True`.
+
 **`terminate_spawn_scopes(runtime_root, spawn_record, *, reason, grace_seconds)`**
 
-Reads scope metadata from durable storage and terminates all `spawn_owned` scopes.
-Skips scopes that are already released (`skip_reason="already_released"`) or that
-pass `should_skip_cleanup()` (`skip_reason="active_session_lease"`). For legacy
-spawns without scope metadata, falls back to `worker_pid` termination with
-`degraded_fallback=True`. Callers that already signaled a guarded runner tree can
-set `include_legacy_fallback=False` to avoid a second unguarded legacy PID signal.
+Composes the two operations above: recorded scope cleanup when sidecars exist,
+legacy worker fallback only when no scope sidecars exist.
 
 **`cancel_managed_primary(runtime_root, spawn_record, *, grace_seconds)`**
 
@@ -166,13 +174,13 @@ exists on disk and its content is not a terminal control frame:
 - Returns `True` for all other non-empty content (plain markdown, JSON payloads with
   neutral/completion event types).
 
-`durable_report_completed(runtime_root, spawn_id)` is the shared file-read wrapper for
-`spawns/<id>/report.md`; use it instead of duplicating report-path reads in reaper or
-cancel convergence paths.
+File-backed report reads live in `state/spawn_report.py`;
+`spawn_report_has_durable_completion(runtime_root, spawn_id)` reads
+`spawns/<id>/report.md` and applies the pure lifecycle classifier.
 
-`iso_timestamp_to_epoch(timestamp)` is the shared parser for persisted ISO timestamps.
-It normalizes trailing `Z` to UTC, treats naive timestamps as UTC, and returns `None`
-for blank or invalid values.
+Persisted timestamp parsing lives in `state/timestamps.py`;
+`iso_timestamp_to_epoch(timestamp)` normalizes trailing `Z` to UTC, treats naive
+timestamps as UTC, and returns `None` for blank or invalid values.
 
 ### Centralized Completion-vs-Cancel Precedence
 

--- a/src/meridian/lib/core/.context/CONTEXT.md
+++ b/src/meridian/lib/core/.context/CONTEXT.md
@@ -113,7 +113,8 @@ Reads scope metadata from durable storage and terminates all `spawn_owned` scope
 Skips scopes that are already released (`skip_reason="already_released"`) or that
 pass `should_skip_cleanup()` (`skip_reason="active_session_lease"`). For legacy
 spawns without scope metadata, falls back to `worker_pid` termination with
-`degraded_fallback=True`.
+`degraded_fallback=True`. Callers that already signaled a guarded runner tree can
+set `include_legacy_fallback=False` to avoid a second unguarded legacy PID signal.
 
 **`cancel_managed_primary(runtime_root, spawn_record, *, grace_seconds)`**
 
@@ -164,6 +165,14 @@ exists on disk and its content is not a terminal control frame:
   `type` is `"cancelled"` or `"error"`.
 - Returns `True` for all other non-empty content (plain markdown, JSON payloads with
   neutral/completion event types).
+
+`durable_report_completed(runtime_root, spawn_id)` is the shared file-read wrapper for
+`spawns/<id>/report.md`; use it instead of duplicating report-path reads in reaper or
+cancel convergence paths.
+
+`iso_timestamp_to_epoch(timestamp)` is the shared parser for persisted ISO timestamps.
+It normalizes trailing `Z` to UTC, treats naive timestamps as UTC, and returns `None`
+for blank or invalid values.
 
 ### Centralized Completion-vs-Cancel Precedence
 

--- a/src/meridian/lib/core/process_cleanup.py
+++ b/src/meridian/lib/core/process_cleanup.py
@@ -24,39 +24,82 @@ from meridian.lib.state.spawn.model import SpawnRecord
 logger = structlog.get_logger(__name__)
 
 
+def terminate_recorded_spawn_scopes(
+    runtime_root: Path,
+    spawn_record: SpawnRecord,
+    *,
+    reason: str,
+    grace_seconds: float = 5.0,
+) -> list[CleanupResult]:
+    """Terminate scope sidecars recorded for a spawn record."""
+
+    scopes = read_scopes_from_disk(runtime_root, SpawnId(spawn_record.id))
+    return _terminate_recorded_spawn_scopes(
+        runtime_root,
+        spawn_record,
+        scopes,
+        reason=reason,
+        grace_seconds=grace_seconds,
+    )
+
+
+def terminate_legacy_worker_fallback(
+    spawn_record: SpawnRecord,
+    *,
+    reason: str,
+    grace_seconds: float = 5.0,
+) -> CleanupResult | None:
+    """Terminate a legacy spawn worker when no scope sidecars exist."""
+
+    if spawn_record.worker_pid is None or spawn_record.worker_pid <= 0:
+        return None
+    return _terminate_legacy_worker_pid(
+        spawn_record,
+        reason=reason,
+        grace_seconds=grace_seconds,
+    )
+
+
 def terminate_spawn_scopes(
     runtime_root: Path,
     spawn_record: SpawnRecord,
     *,
     reason: str,
     grace_seconds: float = 5.0,
-    include_legacy_fallback: bool = True,
 ) -> list[CleanupResult]:
-    """Terminate all spawn_owned scopes for a spawn record.
+    """Terminate recorded scopes, with legacy worker fallback when none exist."""
 
-    Reads scope metadata from durable storage. For each spawn_owned scope,
-    calls the appropriate platform terminator. Logs results.
-
-    For legacy spawns with no scope metadata, falls back to worker_pid
-    termination and logs degraded_fallback=True unless include_legacy_fallback=False.
-    """
     scopes = read_scopes_from_disk(runtime_root, SpawnId(spawn_record.id))
+    if scopes:
+        return _terminate_recorded_spawn_scopes(
+            runtime_root,
+            spawn_record,
+            scopes,
+            reason=reason,
+            grace_seconds=grace_seconds,
+        )
+
+    legacy_result = terminate_legacy_worker_fallback(
+        spawn_record,
+        reason=reason,
+        grace_seconds=grace_seconds,
+    )
+    if legacy_result is None:
+        return []
+    return [legacy_result]
+
+
+def _terminate_recorded_spawn_scopes(
+    runtime_root: Path,
+    spawn_record: SpawnRecord,
+    scopes: list[ProcessScopeSnapshot],
+    *,
+    reason: str,
+    grace_seconds: float,
+) -> list[CleanupResult]:
     results: list[CleanupResult] = []
-
-    if not scopes:
-        if not include_legacy_fallback:
-            return results
-        # Legacy fallback: no scope metadata, use worker_pid
-        if spawn_record.worker_pid is not None and spawn_record.worker_pid > 0:
-            result = _terminate_legacy_worker_pid(
-                spawn_record,
-                reason=reason,
-                grace_seconds=grace_seconds,
-            )
-            results.append(result)
-        return results
-
     spawn_id = SpawnId(spawn_record.id)
+
     for scope in scopes:
         if is_scope_released(runtime_root, spawn_id, scope.release_id):
             result = CleanupResult(
@@ -361,5 +404,7 @@ __all__ = [
     "cancel_managed_primary",
     "reclaim_session_owned_scopes_for_chat",
     "should_skip_cleanup",
+    "terminate_legacy_worker_fallback",
+    "terminate_recorded_spawn_scopes",
     "terminate_spawn_scopes",
 ]

--- a/src/meridian/lib/core/process_cleanup.py
+++ b/src/meridian/lib/core/process_cleanup.py
@@ -30,6 +30,7 @@ def terminate_spawn_scopes(
     *,
     reason: str,
     grace_seconds: float = 5.0,
+    include_legacy_fallback: bool = True,
 ) -> list[CleanupResult]:
     """Terminate all spawn_owned scopes for a spawn record.
 
@@ -37,12 +38,14 @@ def terminate_spawn_scopes(
     calls the appropriate platform terminator. Logs results.
 
     For legacy spawns with no scope metadata, falls back to worker_pid
-    termination and logs degraded_fallback=True.
+    termination and logs degraded_fallback=True unless include_legacy_fallback=False.
     """
     scopes = read_scopes_from_disk(runtime_root, SpawnId(spawn_record.id))
     results: list[CleanupResult] = []
 
     if not scopes:
+        if not include_legacy_fallback:
+            return results
         # Legacy fallback: no scope metadata, use worker_pid
         if spawn_record.worker_pid is not None and spawn_record.worker_pid > 0:
             result = _terminate_legacy_worker_pid(
@@ -201,7 +204,7 @@ def _terminate_legacy_worker_pid(
         scope_id="legacy_worker",
     )
     logger.debug(
-        "Reaper cleaned up stale spawn via legacy worker fallback.",
+        "Cleaned up spawn via legacy worker fallback.",
         spawn_id=spawn_record.id,
         affected_spawn_id=spawn_record.id,
         cleanup_target="stale_spawn",

--- a/src/meridian/lib/core/spawn_lifecycle.py
+++ b/src/meridian/lib/core/spawn_lifecycle.py
@@ -31,6 +31,14 @@ _OPENCODE_CONTROL_EVENT_TYPES = frozenset(
         "sync",
     }
 )
+_CODEX_CONTROL_EVENT_NAMESPACE_PREFIXES: tuple[str, ...] = (
+    "account.",
+    "item.",
+    "mcpserver.",
+    "remotecontrol.",
+    "thread.",
+    "turn.",
+)
 _CLAUDE_PROGRESS_EVENT_NAMES: frozenset[str] = frozenset({"assistant", "user", "system"})
 _CLAUDE_ENVELOPE_MARKER_KEYS: frozenset[str] = frozenset(
     {
@@ -83,14 +91,6 @@ def _event_name(payload: dict[str, object]) -> str:
     )
 
 
-def _item_type(payload: dict[str, object]) -> str:
-    item = payload.get("item")
-    if not isinstance(item, dict):
-        return ""
-    item_payload = cast("dict[str, object]", item)
-    return str(item_payload.get("type", "")).strip().lower().replace("_", "")
-
-
 def _is_opencode_control_payload(payload: dict[str, object]) -> bool:
     event_type = _event_name(payload)
     return event_type in _OPENCODE_CONTROL_EVENT_TYPES or (
@@ -119,15 +119,11 @@ def _is_claude_non_durable_payload(payload: dict[str, object]) -> bool:
     )
 
 
-def _is_codex_command_progress_payload(payload: dict[str, object]) -> bool:
-    if _event_name(payload) != "item.started":
-        return False
-    if _item_type(payload) == "commandexecution":
-        return True
-    nested = payload.get("payload")
-    if isinstance(nested, dict):
-        return _item_type(cast("dict[str, object]", nested)) == "commandexecution"
-    return False
+def _is_codex_control_event_payload(payload: dict[str, object]) -> bool:
+    event_name = _event_name(payload)
+    return any(
+        event_name.startswith(prefix) for prefix in _CODEX_CONTROL_EVENT_NAMESPACE_PREFIXES
+    )
 
 
 def is_control_report_payload(payload: dict[str, object]) -> bool:
@@ -142,7 +138,7 @@ def is_control_report_payload(payload: dict[str, object]) -> bool:
         return True
     if _is_claude_non_durable_payload(payload):
         return True
-    if _is_codex_command_progress_payload(payload):
+    if _is_codex_control_event_payload(payload):
         return True
 
     nested = payload.get("payload")

--- a/src/meridian/lib/core/spawn_lifecycle.py
+++ b/src/meridian/lib/core/spawn_lifecycle.py
@@ -21,7 +21,28 @@ _ALLOWED_TRANSITIONS: dict[str, frozenset[str]] = {
     "finalizing": frozenset({"succeeded", "failed", "cancelled"}),
 }
 _CONTROL_EVENT_NAMES: frozenset[str] = frozenset(
-    {"cancelled", "error", "error/connectionclosed", "error.connectionclosed"}
+    {"cancelled", "error", "error.connectionclosed"}
+)
+_OPENCODE_CONTROL_EVENT_TYPES = frozenset(
+    {
+        "session.idle",
+        "session.error",
+        "session.status",
+        "sync",
+    }
+)
+_CLAUDE_PROGRESS_EVENT_NAMES: frozenset[str] = frozenset({"assistant", "user", "system"})
+_CLAUDE_ENVELOPE_MARKER_KEYS: frozenset[str] = frozenset(
+    {
+        "message",
+        "model",
+        "parent_tool_use_id",
+        "rate_limit_info",
+        "request_id",
+        "session_id",
+        "usage",
+        "uuid",
+    }
 )
 
 
@@ -51,6 +72,83 @@ class ExecutionTerminalOutcome:
     status: SpawnStatus
     exit_code: int
     error: str | None
+
+
+def _event_name(payload: dict[str, object]) -> str:
+    return (
+        str(payload.get("event_type", payload.get("event", payload.get("type", ""))))
+        .strip()
+        .lower()
+        .replace("/", ".")
+    )
+
+
+def _item_type(payload: dict[str, object]) -> str:
+    item = payload.get("item")
+    if not isinstance(item, dict):
+        return ""
+    item_payload = cast("dict[str, object]", item)
+    return str(item_payload.get("type", "")).strip().lower().replace("_", "")
+
+
+def _is_opencode_control_payload(payload: dict[str, object]) -> bool:
+    event_type = _event_name(payload)
+    return event_type in _OPENCODE_CONTROL_EVENT_TYPES or (
+        event_type.startswith("session.") and event_type not in {"session.created"}
+    )
+
+
+def _is_claude_result_payload(payload: dict[str, object]) -> bool:
+    return _event_name(payload) == "result"
+
+
+def _is_claude_completed_result_payload(payload: dict[str, object]) -> bool:
+    return _is_claude_result_payload(payload) and payload.get("is_error") is False
+
+
+def _is_claude_structured_payload(payload: dict[str, object]) -> bool:
+    event_name = _event_name(payload)
+    if event_name in _CLAUDE_PROGRESS_EVENT_NAMES or event_name == "result":
+        return True
+    return bool(event_name and any(key in payload for key in _CLAUDE_ENVELOPE_MARKER_KEYS))
+
+
+def _is_claude_non_durable_payload(payload: dict[str, object]) -> bool:
+    return _is_claude_structured_payload(payload) and not _is_claude_completed_result_payload(
+        payload
+    )
+
+
+def _is_codex_command_progress_payload(payload: dict[str, object]) -> bool:
+    if _event_name(payload) != "item.started":
+        return False
+    if _item_type(payload) == "commandexecution":
+        return True
+    nested = payload.get("payload")
+    if isinstance(nested, dict):
+        return _item_type(cast("dict[str, object]", nested)) == "commandexecution"
+    return False
+
+
+def is_control_report_payload(payload: dict[str, object]) -> bool:
+    """Return whether a structured payload is non-durable report/control evidence."""
+
+    event_name = _event_name(payload)
+    if event_name in _CONTROL_EVENT_NAMES:
+        return True
+    if event_name == "system":
+        return True
+    if _is_opencode_control_payload(payload):
+        return True
+    if _is_claude_non_durable_payload(payload):
+        return True
+    if _is_codex_command_progress_payload(payload):
+        return True
+
+    nested = payload.get("payload")
+    if isinstance(nested, dict):
+        return is_control_report_payload(cast("dict[str, object]", nested))
+    return False
 
 
 def is_active_spawn_status(status: str) -> bool:
@@ -88,29 +186,8 @@ def classify_durable_report_text(report_text: str | None) -> DurableReportEviden
         return DurableReportEvidence.COMPLETION
 
     payload = cast("dict[str, object]", payload_obj)
-    event_name = (
-        str(payload.get("event_type", payload.get("event", payload.get("type", ""))))
-        .strip()
-        .lower()
-    )
-    if event_name in _CONTROL_EVENT_NAMES:
+    if is_control_report_payload(payload):
         return DurableReportEvidence.CONTROL_FRAME
-
-    nested = payload.get("payload")
-    if isinstance(nested, dict):
-        nested_payload = cast("dict[str, object]", nested)
-        nested_name = (
-            str(
-                nested_payload.get(
-                    "event_type",
-                    nested_payload.get("event", nested_payload.get("type", "")),
-                )
-            )
-            .strip()
-            .lower()
-        )
-        if nested_name in _CONTROL_EVENT_NAMES:
-            return DurableReportEvidence.CONTROL_FRAME
     return DurableReportEvidence.COMPLETION
 
 

--- a/src/meridian/lib/core/spawn_lifecycle.py
+++ b/src/meridian/lib/core/spawn_lifecycle.py
@@ -7,6 +7,8 @@ spawn from succeeded to failed.
 
 import json
 from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
 from typing import cast
 
 from meridian.lib.core.domain import SpawnStatus
@@ -92,6 +94,34 @@ def has_durable_report_completion(report_text: str | None) -> bool:
         if nested_name in {"cancelled", "error"}:
             return False
     return True
+
+
+def durable_report_completed(runtime_root: Path, spawn_id: str) -> bool:
+    """Return True when a spawn has a durable completion report on disk."""
+
+    report_path = runtime_root / "spawns" / spawn_id / "report.md"
+    try:
+        report_text = report_path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return False
+    return has_durable_report_completion(report_text)
+
+
+def iso_timestamp_to_epoch(timestamp: str | None) -> float | None:
+    """Parse a persisted ISO timestamp to epoch seconds."""
+
+    normalized = (timestamp or "").strip()
+    if not normalized:
+        return None
+    if normalized.endswith("Z"):
+        normalized = f"{normalized[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.timestamp()
 
 
 def resolve_execution_terminal_state(

--- a/src/meridian/lib/core/spawn_lifecycle.py
+++ b/src/meridian/lib/core/spawn_lifecycle.py
@@ -7,8 +7,7 @@ spawn from succeeded to failed.
 
 import json
 from dataclasses import dataclass
-from datetime import UTC, datetime
-from pathlib import Path
+from enum import StrEnum
 from typing import cast
 
 from meridian.lib.core.domain import SpawnStatus
@@ -21,6 +20,15 @@ _ALLOWED_TRANSITIONS: dict[str, frozenset[str]] = {
     "running": frozenset({"finalizing", "succeeded", "failed", "cancelled"}),
     "finalizing": frozenset({"succeeded", "failed", "cancelled"}),
 }
+
+
+class DurableReportEvidence(StrEnum):
+    """Classification of persisted report text as lifecycle evidence."""
+
+    ABSENT = "absent"
+    COMPLETION = "completion"
+    SYNTHETIC_FAILURE = "synthetic_failure"
+    CONTROL_FRAME = "control_frame"
 
 
 @dataclass(frozen=True)
@@ -52,22 +60,22 @@ def validate_transition(from_status: SpawnStatus, to_status: SpawnStatus) -> Non
         raise ValueError(f"Illegal spawn transition: {from_status} -> {to_status}")
 
 
-def has_durable_report_completion(report_text: str | None) -> bool:
-    """Return True when a non-empty final report is available on disk."""
+def classify_durable_report_text(report_text: str | None) -> DurableReportEvidence:
+    """Classify report text as lifecycle completion evidence."""
 
     if not report_text or not report_text.strip():
-        return False
+        return DurableReportEvidence.ABSENT
 
     stripped = report_text.strip()
     if stripped.lower().startswith("# spawn failed"):
-        return False
+        return DurableReportEvidence.SYNTHETIC_FAILURE
 
     try:
         payload_obj = json.loads(stripped)
     except json.JSONDecodeError:
-        return True
+        return DurableReportEvidence.COMPLETION
     if not isinstance(payload_obj, dict):
-        return True
+        return DurableReportEvidence.COMPLETION
 
     payload = cast("dict[str, object]", payload_obj)
     event_name = (
@@ -76,7 +84,7 @@ def has_durable_report_completion(report_text: str | None) -> bool:
         .lower()
     )
     if event_name in {"cancelled", "error"}:
-        return False
+        return DurableReportEvidence.CONTROL_FRAME
 
     nested = payload.get("payload")
     if isinstance(nested, dict):
@@ -92,36 +100,14 @@ def has_durable_report_completion(report_text: str | None) -> bool:
             .lower()
         )
         if nested_name in {"cancelled", "error"}:
-            return False
-    return True
+            return DurableReportEvidence.CONTROL_FRAME
+    return DurableReportEvidence.COMPLETION
 
 
-def durable_report_completed(runtime_root: Path, spawn_id: str) -> bool:
-    """Return True when a spawn has a durable completion report on disk."""
+def has_durable_report_completion(report_text: str | None) -> bool:
+    """Return True when report text is durable completion evidence."""
 
-    report_path = runtime_root / "spawns" / spawn_id / "report.md"
-    try:
-        report_text = report_path.read_text(encoding="utf-8", errors="ignore")
-    except OSError:
-        return False
-    return has_durable_report_completion(report_text)
-
-
-def iso_timestamp_to_epoch(timestamp: str | None) -> float | None:
-    """Parse a persisted ISO timestamp to epoch seconds."""
-
-    normalized = (timestamp or "").strip()
-    if not normalized:
-        return None
-    if normalized.endswith("Z"):
-        normalized = f"{normalized[:-1]}+00:00"
-    try:
-        parsed = datetime.fromisoformat(normalized)
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=UTC)
-    return parsed.timestamp()
+    return classify_durable_report_text(report_text) is DurableReportEvidence.COMPLETION
 
 
 def resolve_execution_terminal_state(

--- a/src/meridian/lib/core/spawn_lifecycle.py
+++ b/src/meridian/lib/core/spawn_lifecycle.py
@@ -25,11 +25,13 @@ _CONTROL_EVENT_NAMES: frozenset[str] = frozenset(
 )
 _OPENCODE_CONTROL_EVENT_TYPES = frozenset(
     {
-        "session.idle",
-        "session.error",
-        "session.status",
         "sync",
     }
+)
+_OPENCODE_CONTROL_EVENT_NAMESPACE_PREFIXES: tuple[str, ...] = (
+    "message.",
+    "server.",
+    "session.",
 )
 _CODEX_CONTROL_EVENT_NAMESPACE_PREFIXES: tuple[str, ...] = (
     "account.",
@@ -93,8 +95,9 @@ def _event_name(payload: dict[str, object]) -> str:
 
 def _is_opencode_control_payload(payload: dict[str, object]) -> bool:
     event_type = _event_name(payload)
-    return event_type in _OPENCODE_CONTROL_EVENT_TYPES or (
-        event_type.startswith("session.") and event_type not in {"session.created"}
+    return event_type in _OPENCODE_CONTROL_EVENT_TYPES or any(
+        event_type.startswith(prefix)
+        for prefix in _OPENCODE_CONTROL_EVENT_NAMESPACE_PREFIXES
     )
 
 

--- a/src/meridian/lib/core/spawn_lifecycle.py
+++ b/src/meridian/lib/core/spawn_lifecycle.py
@@ -20,6 +20,9 @@ _ALLOWED_TRANSITIONS: dict[str, frozenset[str]] = {
     "running": frozenset({"finalizing", "succeeded", "failed", "cancelled"}),
     "finalizing": frozenset({"succeeded", "failed", "cancelled"}),
 }
+_CONTROL_EVENT_NAMES: frozenset[str] = frozenset(
+    {"cancelled", "error", "error/connectionclosed", "error.connectionclosed"}
+)
 
 
 class DurableReportEvidence(StrEnum):
@@ -67,6 +70,13 @@ def classify_durable_report_text(report_text: str | None) -> DurableReportEviden
         return DurableReportEvidence.ABSENT
 
     stripped = report_text.strip()
+    if stripped.lower().startswith("# report"):
+        _, _, body = stripped.partition("\n")
+        body = body.strip()
+        if body:
+            body_evidence = classify_durable_report_text(body)
+            if body_evidence is not DurableReportEvidence.COMPLETION:
+                return body_evidence
     if stripped.lower().startswith("# spawn failed"):
         return DurableReportEvidence.SYNTHETIC_FAILURE
 
@@ -83,7 +93,7 @@ def classify_durable_report_text(report_text: str | None) -> DurableReportEviden
         .strip()
         .lower()
     )
-    if event_name in {"cancelled", "error"}:
+    if event_name in _CONTROL_EVENT_NAMES:
         return DurableReportEvidence.CONTROL_FRAME
 
     nested = payload.get("payload")
@@ -99,7 +109,7 @@ def classify_durable_report_text(report_text: str | None) -> DurableReportEviden
             .strip()
             .lower()
         )
-        if nested_name in {"cancelled", "error"}:
+        if nested_name in _CONTROL_EVENT_NAMES:
             return DurableReportEvidence.CONTROL_FRAME
     return DurableReportEvidence.COMPLETION
 

--- a/src/meridian/lib/core/spawn_service.py
+++ b/src/meridian/lib/core/spawn_service.py
@@ -17,8 +17,6 @@ from meridian.lib.core.lifecycle import SpawnLifecycleService
 from meridian.lib.core.spawn_lifecycle import (
     ExecutionTerminalFacts,
     ExecutionTerminalOutcome,
-    durable_report_completed,
-    iso_timestamp_to_epoch,
     resolve_completion_cancel_precedence,
     resolve_execution_terminal_outcome,
 )
@@ -52,6 +50,8 @@ from meridian.lib.state import spawn_store
 from meridian.lib.state.liveness import is_process_alive
 from meridian.lib.state.paths import RuntimePaths
 from meridian.lib.state.spawn.model import APP_LAUNCH_MODE, LaunchMode, SpawnOrigin
+from meridian.lib.state.spawn_report import spawn_report_has_durable_completion
+from meridian.lib.state.timestamps import iso_timestamp_to_epoch
 from meridian.lib.streaming.signal_canceller import CancelOutcome as SignalCancelOutcome
 
 if TYPE_CHECKING:
@@ -577,7 +577,10 @@ class SpawnApplicationService:
             return record
         intent = record.cancel_intent
         resolved = resolve_completion_cancel_precedence(
-            durable_report_completion=durable_report_completed(self._runtime_root, str(spawn_id)),
+            durable_report_completion=spawn_report_has_durable_completion(
+                self._runtime_root,
+                str(spawn_id),
+            ),
             cancel_requested=True,
             cancel_exit_code=intent.exit_code if intent is not None else 130,
             cancel_error=intent.error if intent is not None else "cancelled",

--- a/src/meridian/lib/core/spawn_service.py
+++ b/src/meridian/lib/core/spawn_service.py
@@ -17,7 +17,8 @@ from meridian.lib.core.lifecycle import SpawnLifecycleService
 from meridian.lib.core.spawn_lifecycle import (
     ExecutionTerminalFacts,
     ExecutionTerminalOutcome,
-    has_durable_report_completion,
+    durable_report_completed,
+    iso_timestamp_to_epoch,
     resolve_completion_cancel_precedence,
     resolve_execution_terminal_outcome,
 )
@@ -576,7 +577,7 @@ class SpawnApplicationService:
             return record
         intent = record.cancel_intent
         resolved = resolve_completion_cancel_precedence(
-            durable_report_completion=_durable_report_completed(self._runtime_root, str(spawn_id)),
+            durable_report_completion=durable_report_completed(self._runtime_root, str(spawn_id)),
             cancel_requested=True,
             cancel_exit_code=intent.exit_code if intent is not None else 130,
             cancel_error=intent.error if intent is not None else "cancelled",
@@ -610,7 +611,7 @@ class SpawnApplicationService:
                 return
             terminate_managed_primary_processes(
                 metadata,
-                started_epoch=_started_at_epoch(record.started_at),
+                started_epoch=iso_timestamp_to_epoch(record.started_at),
                 include_launcher=False,
             )
             return
@@ -666,7 +667,7 @@ class SpawnApplicationService:
         if self.is_terminal(record.status):
             return _cancel_outcome_from_record(str(spawn_id), record, already_terminal=True)
 
-        started_epoch = _started_at_epoch(record.started_at)
+        started_epoch = iso_timestamp_to_epoch(record.started_at)
         launcher_pid = primary_metadata.launcher_pid
         launcher_alive = launcher_pid is not None and is_process_alive(
             launcher_pid, created_after_epoch=started_epoch
@@ -1017,22 +1018,13 @@ def _is_managed_primary_candidate(record: SpawnRecord) -> bool:
     return record.kind == "primary" and harness in {"codex", "opencode"}
 
 
-def _durable_report_completed(runtime_root: Path, spawn_id: str) -> bool:
-    report_path = runtime_root / "spawns" / spawn_id / "report.md"
-    try:
-        report_text = report_path.read_text(encoding="utf-8", errors="ignore")
-    except OSError:
-        return False
-    return has_durable_report_completion(report_text)
-
-
 def _has_live_execution_owner(
     record: SpawnRecord,
     primary_metadata: PrimaryMetadata | None,
 ) -> bool:
     if record.launch_mode == APP_LAUNCH_MODE:
         return True
-    started_epoch = _started_at_epoch(record.started_at)
+    started_epoch = iso_timestamp_to_epoch(record.started_at)
     runner_created_at_epoch = record.runner_created_at_epoch or started_epoch
     if record.runner_pid is not None and is_process_alive(
         record.runner_pid,
@@ -1054,21 +1046,6 @@ def _has_live_execution_owner(
         if pid is not None and is_process_alive(pid, created_after_epoch=started_epoch):
             return True
     return False
-
-
-def _started_at_epoch(started_at: str | None) -> float | None:
-    normalized = (started_at or "").strip()
-    if not normalized:
-        return None
-    if normalized.endswith("Z"):
-        normalized = f"{normalized[:-1]}+00:00"
-    try:
-        parsed = datetime.fromisoformat(normalized)
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=UTC)
-    return parsed.timestamp()
 
 
 __all__ = [

--- a/src/meridian/lib/harness/common.py
+++ b/src/meridian/lib/harness/common.py
@@ -340,9 +340,32 @@ def _extract_text(value: object) -> str:
     return ""
 
 
+def _codex_item_type(payload: dict[str, object]) -> str:
+    item = payload.get("item")
+    if not isinstance(item, dict):
+        return ""
+    item_payload = cast("dict[str, object]", item)
+    return str(item_payload.get("type", "")).strip().lower().replace("_", "")
+
+
+def _codex_work_started_after(payloads: list[dict[str, object]], index: int) -> bool:
+    for payload in payloads[index + 1 :]:
+        event_type = (
+            str(payload.get("event_type", payload.get("event", payload.get("type", ""))))
+            .strip()
+            .lower()
+            .replace("/", ".")
+        )
+        if event_type == "item.started" and _codex_item_type(payload) == "commandexecution":
+            return True
+    return False
+
+
 def extract_codex_report(artifacts: ArtifactStore, spawn_id: SpawnId) -> str | None:
     last_message: str | None = None
-    for payload in _iter_json_lines_artifact(artifacts, spawn_id, OUTPUT_FILENAME):
+    last_message_index: int | None = None
+    payloads = _iter_json_lines_artifact(artifacts, spawn_id, OUTPUT_FILENAME)
+    for index, payload in enumerate(payloads):
         event_type = (
             str(payload.get("event_type", payload.get("event", payload.get("type", ""))))
             .strip()
@@ -364,6 +387,9 @@ def extract_codex_report(artifacts: ArtifactStore, spawn_id: SpawnId) -> str | N
         text = _extract_text(item_payload.get("text"))
         if text:
             last_message = text
+            last_message_index = index
+    if last_message_index is not None and _codex_work_started_after(payloads, last_message_index):
+        return None
     return last_message
 
 

--- a/src/meridian/lib/launch/extract.py
+++ b/src/meridian/lib/launch/extract.py
@@ -1,11 +1,15 @@
 """Post-execution extraction pipeline used during run finalization."""
 
+from enum import StrEnum
 from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict
 
 from meridian.lib.core.domain import TokenUsage
-from meridian.lib.core.spawn_lifecycle import has_durable_report_completion
+from meridian.lib.core.spawn_lifecycle import (
+    DurableReportEvidence,
+    classify_durable_report_text,
+)
 from meridian.lib.core.types import ArtifactKey, HarnessId, SpawnId
 from meridian.lib.harness.adapter import SpawnExtractor
 from meridian.lib.harness.cost import estimate_usage_cost
@@ -27,6 +31,16 @@ from meridian.lib.state.atomic import atomic_write_text
 # ---------------------------------------------------------------------------
 
 
+class FinalizeReportKind(StrEnum):
+    """Extraction-boundary classification for the persisted final report."""
+
+    ABSENT = "absent"
+    DURABLE_COMPLETION = "durable_completion"
+    SYNTHETIC_FAILURE = "synthetic_failure"
+    PI_FAILURE = "pi_failure"
+    CONTROL_FRAME = "control_frame"
+
+
 class FinalizeExtraction(BaseModel):
     model_config = ConfigDict(frozen=True)
 
@@ -35,7 +49,11 @@ class FinalizeExtraction(BaseModel):
     report_path: Path | None
     report: ExtractedReport
     output_is_empty: bool
-    durable_report_completion: bool = False
+    report_kind: FinalizeReportKind = FinalizeReportKind.ABSENT
+
+    @property
+    def durable_report_completion(self) -> bool:
+        return self.report_kind is FinalizeReportKind.DURABLE_COMPLETION
 
 
 def reset_finalize_attempt_artifacts(
@@ -87,10 +105,22 @@ def _persist_report(
     return target
 
 
-def _is_durable_completion_report(extracted: ExtractedReport) -> bool:
-    if extracted.source in {"failure_reason", "pi_failure"}:
-        return False
-    return has_durable_report_completion(extracted.content)
+def classify_finalize_report(extracted: ExtractedReport) -> FinalizeReportKind:
+    """Project extracted report source and text into finalization semantics."""
+
+    if extracted.source == "failure_reason":
+        return FinalizeReportKind.SYNTHETIC_FAILURE
+    if extracted.source == "pi_failure":
+        return FinalizeReportKind.PI_FAILURE
+
+    evidence = classify_durable_report_text(extracted.content)
+    if evidence is DurableReportEvidence.COMPLETION:
+        return FinalizeReportKind.DURABLE_COMPLETION
+    if evidence is DurableReportEvidence.SYNTHETIC_FAILURE:
+        return FinalizeReportKind.SYNTHETIC_FAILURE
+    if evidence is DurableReportEvidence.CONTROL_FRAME:
+        return FinalizeReportKind.CONTROL_FRAME
+    return FinalizeReportKind.ABSENT
 
 
 def _is_empty_output(
@@ -153,5 +183,5 @@ def enrich_finalize(
             spawn_id=spawn_id,
             extracted_report=report,
         ),
-        durable_report_completion=_is_durable_completion_report(report),
+        report_kind=classify_finalize_report(report),
     )

--- a/src/meridian/lib/launch/extract.py
+++ b/src/meridian/lib/launch/extract.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from pydantic import BaseModel, ConfigDict
 
 from meridian.lib.core.domain import TokenUsage
+from meridian.lib.core.spawn_lifecycle import has_durable_report_completion
 from meridian.lib.core.types import ArtifactKey, HarnessId, SpawnId
 from meridian.lib.harness.adapter import SpawnExtractor
 from meridian.lib.harness.cost import estimate_usage_cost
@@ -34,6 +35,7 @@ class FinalizeExtraction(BaseModel):
     report_path: Path | None
     report: ExtractedReport
     output_is_empty: bool
+    durable_report_completion: bool = False
 
 
 def reset_finalize_attempt_artifacts(
@@ -83,6 +85,12 @@ def _persist_report(
     atomic_write_text(target, text)
     artifacts.put(report_key, text.encode("utf-8"))
     return target
+
+
+def _is_durable_completion_report(extracted: ExtractedReport) -> bool:
+    if extracted.source in {"failure_reason", "pi_failure"}:
+        return False
+    return has_durable_report_completion(extracted.content)
 
 
 def _is_empty_output(
@@ -145,4 +153,5 @@ def enrich_finalize(
             spawn_id=spawn_id,
             extracted_report=report,
         ),
+        durable_report_completion=_is_durable_completion_report(report),
     )

--- a/src/meridian/lib/launch/report.py
+++ b/src/meridian/lib/launch/report.py
@@ -6,6 +6,11 @@ from typing import Literal, cast
 
 from pydantic import BaseModel, ConfigDict
 
+from meridian.lib.core.spawn_lifecycle import (
+    DurableReportEvidence,
+    classify_durable_report_text,
+    is_control_report_payload,
+)
 from meridian.lib.core.types import SpawnId
 from meridian.lib.harness.adapter import SpawnExtractor
 from meridian.lib.launch.constants import HISTORY_FILENAME, OUTPUT_FILENAME
@@ -16,15 +21,6 @@ from .artifact_io import read_artifact_text
 ReportSource = Literal["report_md", "assistant_message", "failure_reason", "pi_failure"]
 _LOGGER = logging.getLogger(__name__)
 _PI_LIFECYCLE_PHASE_EVENT = "meridian.pi.lifecycle.phase"
-_OPENCODE_CONTROL_EVENT_TYPES = frozenset(
-    {
-        "session.idle",
-        "session.error",
-        "session.status",
-        "sync",
-    }
-)
-_CODEX_CONTROL_EVENT_TYPES = frozenset({"error/connectionclosed", "error.connectionclosed"})
 _PI_LIFECYCLE_NOISE_PHASES = frozenset(
     {
         "cleanup_running",
@@ -62,53 +58,8 @@ def _event_name(payload: dict[str, object]) -> str:
     )
 
 
-def _is_opencode_control_payload(payload: dict[str, object]) -> bool:
-    event_type = _event_name(payload)
-    if event_type in _OPENCODE_CONTROL_EVENT_TYPES:
-        return True
-    if event_type.startswith("session.") and event_type not in {"session.created"}:
-        return True
-
-    nested = payload.get("payload")
-    if isinstance(nested, dict):
-        nested_payload = cast("dict[str, object]", nested)
-        nested_type = _event_name(nested_payload)
-        if nested_type in _OPENCODE_CONTROL_EVENT_TYPES:
-            return True
-        if nested_type.startswith("session.") and nested_type not in {"session.created"}:
-            return True
-    return False
-
-
 def _is_terminal_control_frame(text: str) -> bool:
-    stripped = text.strip()
-    if not stripped:
-        return False
-    try:
-        payload_obj = json.loads(stripped)
-    except json.JSONDecodeError:
-        return False
-    if not isinstance(payload_obj, dict):
-        return False
-
-    payload = cast("dict[str, object]", payload_obj)
-    if _event_name(payload) in {"cancelled", "error"}:
-        return True
-    if _event_name(payload) in _CODEX_CONTROL_EVENT_TYPES:
-        return True
-    if _is_opencode_control_payload(payload):
-        return True
-
-    nested = payload.get("payload")
-    if isinstance(nested, dict):
-        nested_payload = cast("dict[str, object]", nested)
-        if _event_name(nested_payload) in {"cancelled", "error"}:
-            return True
-        if _event_name(nested_payload) in _CODEX_CONTROL_EVENT_TYPES:
-            return True
-        if _is_opencode_control_payload(nested_payload):
-            return True
-    return False
+    return classify_durable_report_text(text) is DurableReportEvidence.CONTROL_FRAME
 
 
 def _text_from_value(value: object) -> str:
@@ -313,10 +264,10 @@ def _extract_last_assistant_message(output_lines: str) -> str | None:
             payload = _unwrap_history_payload(record)
             if _is_pi_lifecycle_noise_payload(payload):
                 continue
-            if _is_opencode_control_payload(payload):
+            if is_control_report_payload(payload):
                 continue
         elif isinstance(payload_obj, dict):
-            if _is_opencode_control_payload(cast("dict[str, object]", payload_obj)):
+            if is_control_report_payload(cast("dict[str, object]", payload_obj)):
                 continue
         assistants = _assistant_texts(cast("object", payload_obj))
         if assistants:

--- a/src/meridian/lib/launch/report.py
+++ b/src/meridian/lib/launch/report.py
@@ -24,6 +24,7 @@ _OPENCODE_CONTROL_EVENT_TYPES = frozenset(
         "sync",
     }
 )
+_CODEX_CONTROL_EVENT_TYPES = frozenset({"error/connectionclosed", "error.connectionclosed"})
 _PI_LIFECYCLE_NOISE_PHASES = frozenset(
     {
         "cleanup_running",
@@ -93,6 +94,8 @@ def _is_terminal_control_frame(text: str) -> bool:
     payload = cast("dict[str, object]", payload_obj)
     if _event_name(payload) in {"cancelled", "error"}:
         return True
+    if _event_name(payload) in _CODEX_CONTROL_EVENT_TYPES:
+        return True
     if _is_opencode_control_payload(payload):
         return True
 
@@ -100,6 +103,8 @@ def _is_terminal_control_frame(text: str) -> bool:
     if isinstance(nested, dict):
         nested_payload = cast("dict[str, object]", nested)
         if _event_name(nested_payload) in {"cancelled", "error"}:
+            return True
+        if _event_name(nested_payload) in _CODEX_CONTROL_EVENT_TYPES:
             return True
         if _is_opencode_control_payload(nested_payload):
             return True
@@ -256,7 +261,7 @@ def _pi_failure_from_payload(payload: dict[str, object]) -> str | None:
             error = _text_from_value(payload.get("error"))
             if error:
                 return error
-    if event_type in {"error", "error/connectionclosed"}:
+    if event_type == "error":
         message = _text_from_value(payload.get("message"))
         if message:
             return message
@@ -337,6 +342,11 @@ def _normalized_history_lines(raw_lines: str) -> str:
         if isinstance(payload_obj, dict) and "seq" in payload_obj and "payload" in payload_obj:
             payload = cast("dict[str, object]", payload_obj)
             payload_obj = payload["payload"]
+            event_type = str(payload.get("event_type", "")).strip()
+            if event_type and isinstance(payload_obj, dict):
+                normalized_payload = dict(cast("dict[str, object]", payload_obj))
+                normalized_payload.setdefault("type", event_type)
+                payload_obj = normalized_payload
         normalized.append(json.dumps(payload_obj, separators=(",", ":"), sort_keys=True))
     return "\n".join(normalized)
 

--- a/src/meridian/lib/launch/streaming_runner.py
+++ b/src/meridian/lib/launch/streaming_runner.py
@@ -24,7 +24,6 @@ from meridian.lib.core.clock import Clock, RealClock
 from meridian.lib.core.domain import Spawn
 from meridian.lib.core.spawn_lifecycle import (
     ExecutionTerminalFacts,
-    has_durable_report_completion,
 )
 from meridian.lib.core.types import HarnessId, SpawnId
 from meridian.lib.harness.adapter import StreamEvent
@@ -154,8 +153,7 @@ class StreamingRunConclusion:
             failure_reason=self.failure_reason,
             cancellation_observed=cancellation_observed,
             durable_report_completion=(
-                self.extracted is not None
-                and has_durable_report_completion(self.extracted.report.content)
+                self.extracted is not None and self.extracted.durable_report_completion
             ),
         )
 
@@ -1070,7 +1068,7 @@ async def execute_with_streaming(
 
                 if (
                     _read_cancel_intent(runtime_root, run.spawn_id) is not None
-                    and not has_durable_report_completion(extraction.report.content)
+                    and not extraction.durable_report_completion
                 ):
                     _apply_cancel_intent_to_conclusion(
                         conclusion,
@@ -1151,9 +1149,7 @@ async def execute_with_streaming(
                 # the spawn has already written a durable report. Treat that as terminal
                 # success here so the retry classifier never turns the synthetic exit code
                 # from `stop_spawn()` back into another failed attempt.
-                if attempt.terminated_by_report_watchdog and has_durable_report_completion(
-                    extraction.report.content
-                ):
+                if attempt.terminated_by_report_watchdog and extraction.durable_report_completion:
                     conclusion.exit_code = 0
                     conclusion.failure_reason = None
                     break

--- a/src/meridian/lib/state/.context/CONTEXT.md
+++ b/src/meridian/lib/state/.context/CONTEXT.md
@@ -145,9 +145,10 @@ Liveness check sequence per active spawn:
    If dead, check completion/cancel precedence, then recent activity, startup grace,
    and finally mark failed (`orphan_run` or `missing_runner_pid`).
 
-`has_durable_report_completion(report_text)` returns True for non-empty report that
-is not a terminal control frame (`cancelled`/`error` JSON) and is not a `# Spawn failed`
-generated markdown wrapper. Used by both reaper and runner.
+`durable_report_completed(runtime_root, spawn_id)` reads `report.md` and returns True
+for non-empty report content that is not a terminal control frame (`cancelled`/`error`
+JSON) and is not a `# Spawn failed` generated markdown wrapper. Used by both reaper
+and cancel convergence paths.
 
 `_completion_or_cancel_decision()` centralizes durable-completion-vs-cancel precedence
 for the reaper: if a durable report exists, the spawn resolves `succeeded` regardless

--- a/src/meridian/lib/state/.context/CONTEXT.md
+++ b/src/meridian/lib/state/.context/CONTEXT.md
@@ -145,7 +145,7 @@ Liveness check sequence per active spawn:
    If dead, check completion/cancel precedence, then recent activity, startup grace,
    and finally mark failed (`orphan_run` or `missing_runner_pid`).
 
-`durable_report_completed(runtime_root, spawn_id)` reads `report.md` and returns True
+`spawn_report_has_durable_completion(runtime_root, spawn_id)` reads `report.md` and returns True
 for non-empty report content that is not a terminal control frame (`cancelled`/`error`
 JSON) and is not a `# Spawn failed` generated markdown wrapper. Used by both reaper
 and cancel convergence paths.
@@ -174,7 +174,7 @@ readable:
    a fresh metadata read.
 
 3. **Metadata unreadable** (both snapshot and late read fail):
-   `terminate_spawn_scopes` already ran unconditionally before this branch, cleaning
+   recorded scope cleanup already ran before this branch, cleaning
    up what can be cleaned via scope records. A warning is logged; no further action
    is taken because all available cleanup mechanisms have already fired.
 

--- a/src/meridian/lib/state/reaper.py
+++ b/src/meridian/lib/state/reaper.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import time
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from pathlib import Path
 
 import structlog
@@ -14,8 +13,9 @@ from meridian.lib.bootstrap.services import build_spawn_application_service_from
 from meridian.lib.core.depth import is_root_side_effect_process
 from meridian.lib.core.domain import SpawnStatus
 from meridian.lib.core.spawn_lifecycle import (
-    has_durable_report_completion,
+    durable_report_completed,
     is_active_spawn_status,
+    iso_timestamp_to_epoch,
     resolve_completion_cancel_precedence,
     resolve_reconciled_terminal_state,
 )
@@ -85,37 +85,10 @@ type ReconciliationDecision = (
 )
 
 
-def _started_at_epoch(started_at: str | None) -> float | None:
-    """Parse started_at ISO string to epoch seconds."""
-    normalized = (started_at or "").strip()
-    if not normalized:
-        return None
-    if normalized.endswith("Z"):
-        normalized = f"{normalized[:-1]}+00:00"
-    try:
-        parsed = datetime.fromisoformat(normalized)
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=UTC)
-    return parsed.timestamp()
-
-
 def _runner_exit_at_epoch(runner_exit_at: str | None) -> float | None:
     """Parse runner_exit_at ISO string to epoch seconds."""
 
-    return _started_at_epoch(runner_exit_at)
-
-
-def _read_completion_report(runtime_root: Path, spawn_id: str) -> str | None:
-    """Read report.md for durable completion check."""
-    report_path = runtime_root / "spawns" / spawn_id / "report.md"
-    if not report_path.is_file():
-        return None
-    try:
-        return report_path.read_text(encoding="utf-8", errors="ignore").strip() or None
-    except OSError:
-        return None
+    return iso_timestamp_to_epoch(runner_exit_at)
 
 
 def _artifact_mtime_epoch(path: Path) -> float | None:
@@ -148,13 +121,12 @@ def _collect_artifact_snapshot(
     record: SpawnRecord,
     now: float,
 ) -> ArtifactSnapshot:
-    started_epoch = _started_at_epoch(record.started_at)
+    started_epoch = iso_timestamp_to_epoch(record.started_at)
     last_activity_epoch, recent_activity_artifact = _recent_runner_activity(
         runtime_root,
         record.id,
         now,
     )
-    report_text = _read_completion_report(runtime_root, record.id)
     runner_pid_alive = False
     runner_created_at_epoch = (
         record.runner_created_at_epoch
@@ -171,7 +143,7 @@ def _collect_artifact_snapshot(
         started_epoch=started_epoch,
         last_activity_epoch=last_activity_epoch,
         recent_activity_artifact=recent_activity_artifact,
-        durable_report_completion=has_durable_report_completion(report_text),
+        durable_report_completion=durable_report_completed(runtime_root, record.id),
         runner_pid_alive=runner_pid_alive,
         launch_boundary=launch_boundary,
     )

--- a/src/meridian/lib/state/reaper.py
+++ b/src/meridian/lib/state/reaper.py
@@ -13,9 +13,7 @@ from meridian.lib.bootstrap.services import build_spawn_application_service_from
 from meridian.lib.core.depth import is_root_side_effect_process
 from meridian.lib.core.domain import SpawnStatus
 from meridian.lib.core.spawn_lifecycle import (
-    durable_report_completed,
     is_active_spawn_status,
-    iso_timestamp_to_epoch,
     resolve_completion_cancel_precedence,
     resolve_reconciled_terminal_state,
 )
@@ -31,6 +29,8 @@ from meridian.lib.state.managed_primary import (
     terminate_managed_primary_processes,
 )
 from meridian.lib.state.spawn.model import SpawnRecord
+from meridian.lib.state.spawn_report import spawn_report_has_durable_completion
+from meridian.lib.state.timestamps import iso_timestamp_to_epoch
 
 logger = structlog.get_logger(__name__)
 
@@ -143,7 +143,7 @@ def _collect_artifact_snapshot(
         started_epoch=started_epoch,
         last_activity_epoch=last_activity_epoch,
         recent_activity_artifact=recent_activity_artifact,
-        durable_report_completion=durable_report_completed(runtime_root, record.id),
+        durable_report_completion=spawn_report_has_durable_completion(runtime_root, record.id),
         runner_pid_alive=runner_pid_alive,
         launch_boundary=launch_boundary,
     )

--- a/src/meridian/lib/state/spawn_report.py
+++ b/src/meridian/lib/state/spawn_report.py
@@ -1,0 +1,23 @@
+"""File-backed spawn report reads."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from meridian.lib.core.spawn_lifecycle import has_durable_report_completion
+
+
+def read_spawn_report_text(runtime_root: Path, spawn_id: str) -> str | None:
+    """Read a spawn's persisted report text if available."""
+
+    report_path = runtime_root / "spawns" / spawn_id / "report.md"
+    try:
+        return report_path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return None
+
+
+def spawn_report_has_durable_completion(runtime_root: Path, spawn_id: str) -> bool:
+    """Return True when a spawn has a durable completion report on disk."""
+
+    return has_durable_report_completion(read_spawn_report_text(runtime_root, spawn_id))

--- a/src/meridian/lib/state/timestamps.py
+++ b/src/meridian/lib/state/timestamps.py
@@ -1,0 +1,22 @@
+"""Parsing helpers for timestamps persisted in Meridian state files."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+
+def iso_timestamp_to_epoch(timestamp: str | None) -> float | None:
+    """Parse a persisted ISO timestamp to epoch seconds."""
+
+    normalized = (timestamp or "").strip()
+    if not normalized:
+        return None
+    if normalized.endswith("Z"):
+        normalized = f"{normalized[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.timestamp()

--- a/src/meridian/lib/streaming/.context/CONTEXT.md
+++ b/src/meridian/lib/streaming/.context/CONTEXT.md
@@ -258,22 +258,22 @@ signals and returns delivery facts (`finalizing: bool`, `already_terminal: bool`
 The `SpawnApplicationService.cancel()` path owns convergence to terminal — it calls
 `_force_cancel_convergence()` when delivery alone is insufficient.
 
-### `_cancel_cli_spawn()` — Scope-Aware Path
+### `_cancel_cli_spawn()` — Runner-First, Scope-Fallback Path
 
-The method reads scope sidecars first rather than resolving a PID directly:
+The method resolves `record.runner_pid` first and signals that runner tree. If the
+runner is absent/dead, or if runner termination does not produce terminal state, it
+falls back to `process_cleanup.terminate_spawn_scopes()` via `asyncio.to_thread()`.
+When fallback runs after a guarded runner-tree signal, legacy `worker_pid` fallback is
+disabled; real scope records still clean up. That canonical cleanup path owns scope
+policy:
 
-1. **Read** scope sidecars via `read_scopes_from_disk()` — written at spawn time, describe
-   the process groups/trees the spawn owns
-2. **If scopes exist**: iterate them, skip already-released scopes via `is_scope_released()`,
-   call `terminate_scope_sync()` per scope (POSIX uses pgid group kill; Windows falls back to
-   tree kill), then call `mark_scope_released()` immediately after to prevent double-kill
-3. **If no scopes (legacy)**: resolve runner PID from `record.runner_pid` /
-   `record.worker_pid`, fall back to `terminate_tree_sync()` directly — preserves
-   compatibility with spawns that predate scope sidecar support
-
-`terminate_scope_sync` is synchronous, so each call runs via `asyncio.to_thread()` to
-avoid blocking the event loop. `ProcessLookupError` is suppressed — the process may
-already be gone by the time the cancel arrives.
+1. Reads scope sidecars via `read_scopes_from_disk()`.
+2. Skips already-released scopes by concrete `release_id`.
+3. Preserves live `session_owned` scopes via `should_skip_cleanup()`.
+4. Terminates remaining scopes through `terminate_scope_sync()` and marks each
+   concrete `release_id` released.
+5. Falls back to legacy `worker_pid` termination when no sidecars exist and the caller
+   has not disabled legacy fallback.
 
 After signal delivery, `_wait_for_terminal()` polls the spawn record for up to
 `grace_seconds`. If the record never reaches a terminal status, the outcome carries

--- a/src/meridian/lib/streaming/.context/CONTEXT.md
+++ b/src/meridian/lib/streaming/.context/CONTEXT.md
@@ -262,18 +262,18 @@ The `SpawnApplicationService.cancel()` path owns convergence to terminal — it 
 
 The method resolves `record.runner_pid` first and signals that runner tree. If the
 runner is absent/dead, or if runner termination does not produce terminal state, it
-falls back to `process_cleanup.terminate_spawn_scopes()` via `asyncio.to_thread()`.
-When fallback runs after a guarded runner-tree signal, legacy `worker_pid` fallback is
-disabled; real scope records still clean up. That canonical cleanup path owns scope
-policy:
+falls back to `process_cleanup.terminate_spawn_scopes()` via `asyncio.to_thread()`
+when no live runner is available. After a guarded runner-tree signal, it calls
+`process_cleanup.terminate_recorded_spawn_scopes()` so real scope records still clean
+up without re-running the legacy worker fallback. The cleanup path owns scope policy:
 
 1. Reads scope sidecars via `read_scopes_from_disk()`.
 2. Skips already-released scopes by concrete `release_id`.
 3. Preserves live `session_owned` scopes via `should_skip_cleanup()`.
 4. Terminates remaining scopes through `terminate_scope_sync()` and marks each
    concrete `release_id` released.
-5. Falls back to legacy `worker_pid` termination when no sidecars exist and the caller
-   has not disabled legacy fallback.
+5. Falls back to legacy `worker_pid` termination only through `terminate_spawn_scopes()`
+   when no sidecars exist.
 
 After signal delivery, `_wait_for_terminal()` polls the spawn record for up to
 `grace_seconds`. If the record never reaches a terminal status, the outcome carries

--- a/src/meridian/lib/streaming/signal_canceller.py
+++ b/src/meridian/lib/streaming/signal_canceller.py
@@ -14,14 +14,18 @@ from typing import TYPE_CHECKING, cast
 import structlog
 
 from meridian.lib.core.domain import SpawnStatus
-from meridian.lib.core.process_cleanup import terminate_spawn_scopes
-from meridian.lib.core.spawn_lifecycle import TERMINAL_SPAWN_STATUSES, iso_timestamp_to_epoch
+from meridian.lib.core.process_cleanup import (
+    terminate_recorded_spawn_scopes,
+    terminate_spawn_scopes,
+)
+from meridian.lib.core.spawn_lifecycle import TERMINAL_SPAWN_STATUSES
 from meridian.lib.core.types import SpawnId
 from meridian.lib.platform import IS_WINDOWS
 from meridian.lib.platform.terminate import terminate_tree_sync
 from meridian.lib.state import spawn_store
 from meridian.lib.state.liveness import is_process_alive
 from meridian.lib.state.spawn.model import APP_LAUNCH_MODE, SpawnOrigin, SpawnRecord
+from meridian.lib.state.timestamps import iso_timestamp_to_epoch
 
 if TYPE_CHECKING:
     from meridian.lib.streaming.spawn_manager import SpawnManager
@@ -98,7 +102,7 @@ class SignalCanceller:
                 return _outcome_from_record(terminal)
 
             latest = spawn_store.get_spawn(self._runtime_root, spawn_id) or record
-            await self._cleanup_spawn_scopes(latest, include_legacy_fallback=False)
+            await self._cleanup_recorded_spawn_scopes(latest)
             terminal = await self._wait_for_terminal(spawn_id)
             if terminal is not None:
                 return _outcome_from_record(terminal)
@@ -124,19 +128,22 @@ class SignalCanceller:
             finalizing=True,
         )
 
-    async def _cleanup_spawn_scopes(
-        self,
-        record: SpawnRecord,
-        *,
-        include_legacy_fallback: bool = True,
-    ) -> None:
+    async def _cleanup_recorded_spawn_scopes(self, record: SpawnRecord) -> None:
+        await asyncio.to_thread(
+            terminate_recorded_spawn_scopes,
+            self._runtime_root,
+            record,
+            reason="cancel",
+            grace_seconds=self._grace_seconds,
+        )
+
+    async def _cleanup_spawn_scopes(self, record: SpawnRecord) -> None:
         await asyncio.to_thread(
             terminate_spawn_scopes,
             self._runtime_root,
             record,
             reason="cancel",
             grace_seconds=self._grace_seconds,
-            include_legacy_fallback=include_legacy_fallback,
         )
 
     async def _cancel_app_spawn(

--- a/src/meridian/lib/streaming/signal_canceller.py
+++ b/src/meridian/lib/streaming/signal_canceller.py
@@ -7,7 +7,6 @@ import json
 import time
 from contextlib import suppress
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from importlib import import_module
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
@@ -15,18 +14,13 @@ from typing import TYPE_CHECKING, cast
 import structlog
 
 from meridian.lib.core.domain import SpawnStatus
-from meridian.lib.core.spawn_lifecycle import TERMINAL_SPAWN_STATUSES
+from meridian.lib.core.process_cleanup import terminate_spawn_scopes
+from meridian.lib.core.spawn_lifecycle import TERMINAL_SPAWN_STATUSES, iso_timestamp_to_epoch
 from meridian.lib.core.types import SpawnId
 from meridian.lib.platform import IS_WINDOWS
-from meridian.lib.platform.process_scope import terminate_scope_sync
 from meridian.lib.platform.terminate import terminate_tree_sync
 from meridian.lib.state import spawn_store
 from meridian.lib.state.liveness import is_process_alive
-from meridian.lib.state.process_scope_projection import (
-    is_scope_released,
-    mark_scope_released,
-    read_scopes_from_disk,
-)
 from meridian.lib.state.spawn.model import APP_LAUNCH_MODE, SpawnOrigin, SpawnRecord
 
 if TYPE_CHECKING:
@@ -104,7 +98,7 @@ class SignalCanceller:
                 return _outcome_from_record(terminal)
 
             latest = spawn_store.get_spawn(self._runtime_root, spawn_id) or record
-            await self._cleanup_spawn_scopes(spawn_id, latest)
+            await self._cleanup_spawn_scopes(latest, include_legacy_fallback=False)
             terminal = await self._wait_for_terminal(spawn_id)
             if terminal is not None:
                 return _outcome_from_record(terminal)
@@ -116,7 +110,7 @@ class SignalCanceller:
                 finalizing=True,
             )
 
-        await self._cleanup_spawn_scopes(spawn_id, record)
+        await self._cleanup_spawn_scopes(record)
 
         terminal = await self._wait_for_terminal(spawn_id)
         if terminal is not None:
@@ -132,37 +126,18 @@ class SignalCanceller:
 
     async def _cleanup_spawn_scopes(
         self,
-        spawn_id: SpawnId,
         record: SpawnRecord,
+        *,
+        include_legacy_fallback: bool = True,
     ) -> None:
-        scopes = read_scopes_from_disk(self._runtime_root, spawn_id)
-        if scopes:
-            for scope in scopes:
-                if is_scope_released(self._runtime_root, spawn_id, scope.release_id):
-                    continue
-                with suppress(ProcessLookupError):
-                    await asyncio.to_thread(
-                        terminate_scope_sync,
-                        scope,
-                        grace_seconds=self._grace_seconds,
-                        reason="cancel",
-                    )
-                mark_scope_released(self._runtime_root, spawn_id, scope.release_id)
-            return
-
-        worker_pid = self._fallback_worker_pid(record)
-        if worker_pid is None:
-            return
-        started_epoch = _started_at_epoch(record.started_at)
-        with suppress(ProcessLookupError):
-            await asyncio.to_thread(
-                terminate_tree_sync,
-                worker_pid,
-                created_at_epoch=started_epoch if started_epoch is not None else 0.0,
-                grace_secs=self._grace_seconds,
-                reason="cancel",
-                scope_id=str(spawn_id),
-            )
+        await asyncio.to_thread(
+            terminate_spawn_scopes,
+            self._runtime_root,
+            record,
+            reason="cancel",
+            grace_seconds=self._grace_seconds,
+            include_legacy_fallback=include_legacy_fallback,
+        )
 
     async def _cancel_app_spawn(
         self,
@@ -277,20 +252,13 @@ class SignalCanceller:
 
     def _resolve_runner_process(self, record: SpawnRecord) -> tuple[int | None, float | None]:
         runner_pid = record.runner_pid
-        runner_created_at_epoch = record.runner_created_at_epoch or _started_at_epoch(
+        runner_created_at_epoch = record.runner_created_at_epoch or iso_timestamp_to_epoch(
             record.started_at
         )
         if runner_pid is not None and _pid_is_alive(runner_pid, runner_created_at_epoch):
             return runner_pid, runner_created_at_epoch
 
         return None, None
-
-    def _fallback_worker_pid(self, record: SpawnRecord) -> int | None:
-        started_epoch = _started_at_epoch(record.started_at)
-        worker_pid = record.worker_pid
-        if worker_pid is not None and _pid_is_alive(worker_pid, started_epoch):
-            return worker_pid
-        return None
 
     async def _wait_for_terminal(self, spawn_id: SpawnId) -> SpawnRecord | None:
         deadline = time.monotonic() + max(0.0, self._grace_seconds)
@@ -341,21 +309,6 @@ def _pid_is_alive(pid: int | None, started_epoch: float | None) -> bool:
     if pid is None or pid <= 0:
         return False
     return is_process_alive(pid, created_after_epoch=started_epoch)
-
-
-def _started_at_epoch(started_at: str | None) -> float | None:
-    normalized = (started_at or "").strip()
-    if not normalized:
-        return None
-    if normalized.endswith("Z"):
-        normalized = f"{normalized[:-1]}+00:00"
-    try:
-        parsed = datetime.fromisoformat(normalized)
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=UTC)
-    return parsed.timestamp()
 
 
 def _parse_json_object(raw: str) -> dict[str, object]:

--- a/tests/unit/core/test_process_cleanup_terminate.py
+++ b/tests/unit/core/test_process_cleanup_terminate.py
@@ -206,6 +206,29 @@ def test_terminate_spawn_scopes_falls_back_to_legacy_worker_pid(
     logger.debug.assert_called_once()
 
 
+def test_terminate_spawn_scopes_can_skip_legacy_worker_fallback(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    from meridian.lib.core import process_cleanup
+
+    monkeypatch.setattr(process_cleanup, "read_scopes_from_disk", lambda root, spawn_id: [])
+
+    def _unexpected(**kwargs):
+        raise AssertionError("legacy worker fallback should not run")
+
+    monkeypatch.setattr(process_cleanup, "terminate_tree_sync", _unexpected)
+
+    results = terminate_spawn_scopes(
+        tmp_path,
+        _record(worker_pid=321),
+        reason="cancel",
+        include_legacy_fallback=False,
+    )
+
+    assert results == []
+
+
 @pytest.mark.parametrize(
     ("process_factory", "root_created_at_epoch", "expected"),
     [

--- a/tests/unit/core/test_process_cleanup_terminate.py
+++ b/tests/unit/core/test_process_cleanup_terminate.py
@@ -9,7 +9,11 @@ from unittest.mock import MagicMock
 import psutil as _psutil
 import pytest
 
-from meridian.lib.core.process_cleanup import should_skip_cleanup, terminate_spawn_scopes
+from meridian.lib.core.process_cleanup import (
+    should_skip_cleanup,
+    terminate_recorded_spawn_scopes,
+    terminate_spawn_scopes,
+)
 from meridian.lib.platform.process_scope.base import CleanupResult, ProcessScopeSnapshot
 from meridian.lib.state.spawn.model import SpawnRecord
 
@@ -206,7 +210,7 @@ def test_terminate_spawn_scopes_falls_back_to_legacy_worker_pid(
     logger.debug.assert_called_once()
 
 
-def test_terminate_spawn_scopes_can_skip_legacy_worker_fallback(
+def test_terminate_recorded_spawn_scopes_does_not_run_legacy_worker_fallback(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
@@ -219,11 +223,10 @@ def test_terminate_spawn_scopes_can_skip_legacy_worker_fallback(
 
     monkeypatch.setattr(process_cleanup, "terminate_tree_sync", _unexpected)
 
-    results = terminate_spawn_scopes(
+    results = terminate_recorded_spawn_scopes(
         tmp_path,
         _record(worker_pid=321),
         reason="cancel",
-        include_legacy_fallback=False,
     )
 
     assert results == []

--- a/tests/unit/core/test_spawn_service.py
+++ b/tests/unit/core/test_spawn_service.py
@@ -337,6 +337,42 @@ async def test_complete_execution_keeps_cancel_for_codex_close_error_report(
 
 
 @pytest.mark.asyncio
+async def test_complete_execution_keeps_cancel_for_claude_aborted_streaming_result(
+    tmp_path: Path,
+) -> None:
+    runtime_root = _runtime_root(tmp_path)
+    spawn_id = _start_spawn(runtime_root, status="running")
+    spawn_store.record_cancel_intent(
+        runtime_root,
+        spawn_id,
+        exit_code=130,
+        error="cancelled",
+        requested_at="2026-06-03T01:00:00Z",
+    )
+    service = _service(runtime_root)
+    aborted_result = (
+        '# Report\n\n{"type":"result","is_error":true,'
+        '"terminal_reason":"aborted_streaming","result":""}\n'
+    )
+
+    outcome = await service.complete_execution(
+        SpawnId(spawn_id),
+        ExecutionTerminalFacts(
+            exit_code=0,
+            durable_report_completion=has_durable_report_completion(aborted_result),
+        ),
+        origin="runner",
+    )
+
+    assert outcome.resolved.status == "cancelled"
+    assert outcome.resolved.exit_code == 130
+    row = spawn_store.get_spawn(runtime_root, spawn_id)
+    assert row is not None
+    assert row.status == "cancelled"
+    assert row.exit_code == 130
+
+
+@pytest.mark.asyncio
 async def test_complete_execution_durable_completion_wins_over_cancel_intent(
     tmp_path: Path,
 ) -> None:
@@ -357,6 +393,40 @@ async def test_complete_execution_durable_completion_wins_over_cancel_intent(
         ExecutionTerminalFacts(
             exit_code=130,
             durable_report_completion=has_durable_report_completion(completion_report),
+        ),
+        origin="runner",
+    )
+
+    assert outcome.resolved.status == "succeeded"
+    row = spawn_store.get_spawn(runtime_root, spawn_id)
+    assert row is not None
+    assert row.status == "succeeded"
+
+
+@pytest.mark.asyncio
+async def test_complete_execution_treats_claude_success_result_as_durable_completion(
+    tmp_path: Path,
+) -> None:
+    runtime_root = _runtime_root(tmp_path)
+    spawn_id = _start_spawn(runtime_root, status="running")
+    spawn_store.record_cancel_intent(
+        runtime_root,
+        spawn_id,
+        exit_code=130,
+        error="cancelled",
+        requested_at="2026-06-03T01:00:00Z",
+    )
+    service = _service(runtime_root)
+    success_result = (
+        '# Report\n\n{"type":"result","is_error":false,'
+        '"terminal_reason":"end_turn","result":"OK"}\n'
+    )
+
+    outcome = await service.complete_execution(
+        SpawnId(spawn_id),
+        ExecutionTerminalFacts(
+            exit_code=130,
+            durable_report_completion=has_durable_report_completion(success_result),
         ),
         origin="runner",
     )

--- a/tests/unit/core/test_spawn_service.py
+++ b/tests/unit/core/test_spawn_service.py
@@ -8,7 +8,10 @@ import pytest
 
 from meridian.lib.core.domain import SpawnStatus
 from meridian.lib.core.lifecycle import SpawnLifecycleService
-from meridian.lib.core.spawn_lifecycle import ExecutionTerminalFacts
+from meridian.lib.core.spawn_lifecycle import (
+    ExecutionTerminalFacts,
+    has_durable_report_completion,
+)
 from meridian.lib.core.spawn_service import PrepareSpawnRequest, SpawnApplicationService
 from meridian.lib.core.types import SpawnId
 from meridian.lib.launch.request import LaunchRuntime, SpawnRequest
@@ -260,6 +263,42 @@ async def test_complete_execution_prefers_cancel_intent_until_durable_completion
     row = spawn_store.get_spawn(runtime_root, spawn_id)
     assert row is not None
     assert row.status == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_complete_execution_keeps_cancel_for_synthetic_failure_report(
+    tmp_path: Path,
+) -> None:
+    runtime_root = _runtime_root(tmp_path)
+    spawn_id = _start_spawn(runtime_root, status="running")
+    spawn_store.record_cancel_intent(
+        runtime_root,
+        spawn_id,
+        exit_code=130,
+        error="cancelled",
+        requested_at="2026-06-03T01:00:00Z",
+    )
+    service = _service(runtime_root)
+    synthetic_report = "# Spawn failed\n\nCursor subprocess exited with code 130.\n"
+
+    outcome = await service.complete_execution(
+        SpawnId(spawn_id),
+        ExecutionTerminalFacts(
+            exit_code=130,
+            failure_reason="cancelled",
+            cancellation_observed=True,
+            durable_report_completion=has_durable_report_completion(synthetic_report),
+        ),
+        origin="runner",
+    )
+
+    assert synthetic_report.startswith("# Spawn failed")
+    assert outcome.resolved.status == "cancelled"
+    assert outcome.resolved.exit_code == 130
+    row = spawn_store.get_spawn(runtime_root, spawn_id)
+    assert row is not None
+    assert row.status == "cancelled"
+    assert row.exit_code == 130
 
 
 @pytest.mark.asyncio

--- a/tests/unit/core/test_spawn_service.py
+++ b/tests/unit/core/test_spawn_service.py
@@ -302,6 +302,41 @@ async def test_complete_execution_keeps_cancel_for_synthetic_failure_report(
 
 
 @pytest.mark.asyncio
+async def test_complete_execution_keeps_cancel_for_codex_close_error_report(
+    tmp_path: Path,
+) -> None:
+    runtime_root = _runtime_root(tmp_path)
+    spawn_id = _start_spawn(runtime_root, status="running")
+    spawn_store.record_cancel_intent(
+        runtime_root,
+        spawn_id,
+        exit_code=130,
+        error="cancelled",
+        requested_at="2026-06-03T01:00:00Z",
+    )
+    service = _service(runtime_root)
+    close_error_report = (
+        '# Report\n\n{"type":"error","message":"no close frame received or sent"}\n'
+    )
+
+    outcome = await service.complete_execution(
+        SpawnId(spawn_id),
+        ExecutionTerminalFacts(
+            exit_code=0,
+            durable_report_completion=has_durable_report_completion(close_error_report),
+        ),
+        origin="runner",
+    )
+
+    assert outcome.resolved.status == "cancelled"
+    assert outcome.resolved.exit_code == 130
+    row = spawn_store.get_spawn(runtime_root, spawn_id)
+    assert row is not None
+    assert row.status == "cancelled"
+    assert row.exit_code == 130
+
+
+@pytest.mark.asyncio
 async def test_complete_execution_durable_completion_wins_over_cancel_intent(
     tmp_path: Path,
 ) -> None:
@@ -315,10 +350,14 @@ async def test_complete_execution_durable_completion_wins_over_cancel_intent(
         requested_at="2026-06-03T01:00:00Z",
     )
     service = _service(runtime_root)
+    completion_report = '# Report\n\n{"message":"Done."}\n'
 
     outcome = await service.complete_execution(
         SpawnId(spawn_id),
-        ExecutionTerminalFacts(exit_code=130, durable_report_completion=True),
+        ExecutionTerminalFacts(
+            exit_code=130,
+            durable_report_completion=has_durable_report_completion(completion_report),
+        ),
         origin="runner",
     )
 

--- a/tests/unit/harness/test_extract_codex_report.py
+++ b/tests/unit/harness/test_extract_codex_report.py
@@ -1,0 +1,63 @@
+import json
+from pathlib import Path
+
+from meridian.lib.core.types import ArtifactKey, SpawnId
+from meridian.lib.harness.common import extract_codex_report
+from meridian.lib.state.artifact_store import LocalStore
+
+
+def _write_history(local_store: LocalStore, spawn_id: SpawnId, records: list[object]) -> None:
+    lines = "\n".join(json.dumps(record) for record in records)
+    local_store.put(ArtifactKey(f"{spawn_id}/history.jsonl"), f"{lines}\n".encode())
+
+
+def test_extract_codex_report_keeps_final_agent_message(tmp_path: Path) -> None:
+    artifacts = LocalStore(root_dir=tmp_path / "artifacts")
+    spawn_id = SpawnId("p-codex-report")
+    _write_history(
+        artifacts,
+        spawn_id,
+        [
+            {
+                "event_type": "item/completed",
+                "payload": {"item": {"type": "agentMessage", "text": "Done."}},
+            }
+        ],
+    )
+
+    assert extract_codex_report(artifacts, spawn_id) == "Done."
+
+
+def test_extract_codex_report_rejects_message_before_started_command(tmp_path: Path) -> None:
+    artifacts = LocalStore(root_dir=tmp_path / "artifacts")
+    spawn_id = SpawnId("p-codex-cancel")
+    _write_history(
+        artifacts,
+        spawn_id,
+        [
+            {
+                "event_type": "item/completed",
+                "payload": {
+                    "item": {
+                        "type": "agentMessage",
+                        "text": "Running `sleep 600` now and will wait.",
+                    }
+                },
+            },
+            {
+                "event_type": "item/started",
+                "payload": {
+                    "item": {
+                        "type": "commandExecution",
+                        "command": "/bin/bash -lc 'sleep 600'",
+                    }
+                },
+            },
+            {
+                "event_type": "error/connectionClosed",
+                "payload": {"message": "no close frame received or sent"},
+            },
+        ],
+    )
+
+    assert extract_codex_report(artifacts, spawn_id) is None

--- a/tests/unit/launch/test_extract.py
+++ b/tests/unit/launch/test_extract.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from meridian.lib.core.types import ArtifactKey, SpawnId
 from meridian.lib.launch.extract import (
     FinalizeReportKind,
@@ -45,6 +47,44 @@ def test_classify_finalize_report_keeps_genuine_json_completion() -> None:
     assert classify_finalize_report(report) is FinalizeReportKind.DURABLE_COMPLETION
 
 
+@pytest.mark.parametrize(
+    "content",
+    [
+        '{"type":"result","is_error":true,"terminal_reason":"aborted_streaming","result":""}',
+        '{"type":"user","message":{"role":"user","content":['
+        '{"type":"text","text":"[Request interrupted by user]"}]}}',
+        '{"type":"user","message":{"role":"user","content":['
+        '{"type":"tool_result","is_error":true,"content":"Exit code 144"}]}}',
+        '{"type":"assistant","message":{"role":"assistant","content":['
+        '{"type":"tool_use","name":"Bash","input":{"command":"sleep 600"}}]}}',
+        '{"type":"assistant","message":{"role":"assistant","content":['
+        '{"type":"thinking","thinking":"I should call Bash."}]}}',
+        '{"type":"system","subtype":"thinking_tokens","estimated_tokens":180}',
+        '{"type":"rate_limit_event","rate_limit_info":{"status":"allowed"}}',
+        '{"type":"unknown_telemetry","request_id":"req_1"}',
+        '{"type":"result","result":"OK"}',
+    ],
+)
+def test_classify_finalize_report_rejects_claude_control_and_progress_envelopes(
+    content: str,
+) -> None:
+    report = ExtractedReport(content=content, source="assistant_message")
+
+    assert classify_finalize_report(report) is FinalizeReportKind.CONTROL_FRAME
+
+
+def test_classify_finalize_report_keeps_claude_success_result() -> None:
+    report = ExtractedReport(
+        content=(
+            '{"type":"result","is_error":false,'
+            '"terminal_reason":"end_turn","result":"OK"}'
+        ),
+        source="assistant_message",
+    )
+
+    assert classify_finalize_report(report) is FinalizeReportKind.DURABLE_COMPLETION
+
+
 def test_extract_or_fallback_report_ignores_codex_connection_closed_history(
     tmp_path: Path,
 ) -> None:
@@ -61,3 +101,84 @@ def test_extract_or_fallback_report_ignores_codex_connection_closed_history(
 
     assert report.content is None
     assert report.source is None
+
+
+def test_extract_or_fallback_report_ignores_claude_aborted_streaming_history(
+    tmp_path: Path,
+) -> None:
+    artifacts = LocalStore(root_dir=tmp_path / "artifacts")
+    spawn_id = SpawnId("p-claude-abort")
+    artifacts.put(
+        ArtifactKey(f"{spawn_id}/history.jsonl"),
+        b'{"type":"result","is_error":true,'
+        b'"terminal_reason":"aborted_streaming","result":""}\n',
+    )
+
+    report = extract_or_fallback_report(artifacts, spawn_id)
+
+    assert report.content is None
+    assert report.source is None
+
+
+def test_extract_or_fallback_report_uses_failure_after_claude_user_interrupt(
+    tmp_path: Path,
+) -> None:
+    artifacts = LocalStore(root_dir=tmp_path / "artifacts")
+    spawn_id = SpawnId("p-claude-interrupt")
+    artifacts.put(
+        ArtifactKey(f"{spawn_id}/history.jsonl"),
+        b'{"type":"user","message":{"role":"user","content":['
+        b'{"type":"text","text":"[Request interrupted by user]"}]}}\n',
+    )
+
+    report = extract_or_fallback_report(
+        artifacts,
+        spawn_id,
+        failure_reason="cancelled",
+    )
+
+    assert report.content == "cancelled"
+    assert report.source == "failure_reason"
+
+
+def test_extract_or_fallback_report_uses_failure_after_claude_tool_error(
+    tmp_path: Path,
+) -> None:
+    artifacts = LocalStore(root_dir=tmp_path / "artifacts")
+    spawn_id = SpawnId("p-claude-tool-error")
+    artifacts.put(
+        ArtifactKey(f"{spawn_id}/history.jsonl"),
+        b'{"type":"user","message":{"role":"user","content":['
+        b'{"type":"tool_result","is_error":true,"content":"Exit code 144"}]}}\n',
+    )
+
+    report = extract_or_fallback_report(
+        artifacts,
+        spawn_id,
+        failure_reason="cancelled",
+    )
+
+    assert report.content == "cancelled"
+    assert report.source == "failure_reason"
+
+
+def test_extract_or_fallback_report_uses_failure_after_codex_command_progress(
+    tmp_path: Path,
+) -> None:
+    artifacts = LocalStore(root_dir=tmp_path / "artifacts")
+    spawn_id = SpawnId("p-codex-command-progress")
+    artifacts.put(
+        ArtifactKey(f"{spawn_id}/history.jsonl"),
+        b'{"event_type":"item/started",'
+        b'"payload":{"item":{"type":"commandExecution","command":"sleep 600"}},'
+        b'"seq":5}\n',
+    )
+
+    report = extract_or_fallback_report(
+        artifacts,
+        spawn_id,
+        failure_reason="terminated",
+    )
+
+    assert report.content == "terminated"
+    assert report.source == "failure_reason"

--- a/tests/unit/launch/test_extract.py
+++ b/tests/unit/launch/test_extract.py
@@ -1,8 +1,12 @@
 from pathlib import Path
 
 from meridian.lib.core.types import ArtifactKey, SpawnId
-from meridian.lib.launch.extract import _persist_report
-from meridian.lib.launch.report import ExtractedReport
+from meridian.lib.launch.extract import (
+    FinalizeReportKind,
+    _persist_report,
+    classify_finalize_report,
+)
+from meridian.lib.launch.report import ExtractedReport, extract_or_fallback_report
 from meridian.lib.state.artifact_store import LocalStore
 
 
@@ -24,3 +28,36 @@ def test_persist_report_wraps_assistant_extract_with_report_heading(tmp_path: Pa
     expected = "# Report\n\nDone.\n"
     assert report_path.read_text(encoding="utf-8") == expected
     assert artifacts.get(ArtifactKey(f"{spawn_id}/report.md")).decode("utf-8") == expected
+
+
+def test_classify_finalize_report_rejects_codex_close_error_payload() -> None:
+    report = ExtractedReport(
+        content='{"type":"error/connectionClosed","message":"no close frame received or sent"}',
+        source="assistant_message",
+    )
+
+    assert classify_finalize_report(report) is FinalizeReportKind.CONTROL_FRAME
+
+
+def test_classify_finalize_report_keeps_genuine_json_completion() -> None:
+    report = ExtractedReport(content='{"message":"Done."}', source="assistant_message")
+
+    assert classify_finalize_report(report) is FinalizeReportKind.DURABLE_COMPLETION
+
+
+def test_extract_or_fallback_report_ignores_codex_connection_closed_history(
+    tmp_path: Path,
+) -> None:
+    artifacts = LocalStore(root_dir=tmp_path / "artifacts")
+    spawn_id = SpawnId("p-codex-close")
+    artifacts.put(
+        ArtifactKey(f"{spawn_id}/history.jsonl"),
+        b'{"event_type":"error/connectionClosed",'
+        b'"payload":{"message":"no close frame received or sent"},'
+        b'"seq":5}\n',
+    )
+
+    report = extract_or_fallback_report(artifacts, spawn_id)
+
+    assert report.content is None
+    assert report.source is None

--- a/tests/unit/launch/test_extract.py
+++ b/tests/unit/launch/test_extract.py
@@ -50,6 +50,25 @@ def test_classify_finalize_report_keeps_genuine_json_completion() -> None:
 @pytest.mark.parametrize(
     "content",
     [
+        (
+            '{"threadId":"019e92fc-881c-7533-a6b3-ccaa89c0dd2e",'
+            '"turn":{"completedAt":null,"durationMs":null,"error":null,'
+            '"id":"019e92fc-88d3-7430-9b93-67a2230470c8","items":[],'
+            '"itemsView":"notLoaded","startedAt":1780582484,"status":"inProgress"},'
+            '"type":"turn/started"}'
+        ),
+        '{"type":"mcpServer/statusChanged","server":"docs","status":"connected"}',
+    ],
+)
+def test_classify_finalize_report_rejects_codex_event_envelopes(content: str) -> None:
+    report = ExtractedReport(content=content, source="assistant_message")
+
+    assert classify_finalize_report(report) is FinalizeReportKind.CONTROL_FRAME
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
         '{"type":"result","is_error":true,"terminal_reason":"aborted_streaming","result":""}',
         '{"type":"user","message":{"role":"user","content":['
         '{"type":"text","text":"[Request interrupted by user]"}]}}',
@@ -172,6 +191,52 @@ def test_extract_or_fallback_report_uses_failure_after_codex_command_progress(
         b'{"event_type":"item/started",'
         b'"payload":{"item":{"type":"commandExecution","command":"sleep 600"}},'
         b'"seq":5}\n',
+    )
+
+    report = extract_or_fallback_report(
+        artifacts,
+        spawn_id,
+        failure_reason="terminated",
+    )
+
+    assert report.content == "terminated"
+    assert report.source == "failure_reason"
+
+
+def test_extract_or_fallback_report_uses_failure_after_codex_turn_started(
+    tmp_path: Path,
+) -> None:
+    artifacts = LocalStore(root_dir=tmp_path / "artifacts")
+    spawn_id = SpawnId("p-codex-turn-started")
+    artifacts.put(
+        ArtifactKey(f"{spawn_id}/history.jsonl"),
+        (
+            b'{"threadId":"019e92fc-881c-7533-a6b3-ccaa89c0dd2e",'
+            b'"turn":{"completedAt":null,"durationMs":null,"error":null,'
+            b'"id":"019e92fc-88d3-7430-9b93-67a2230470c8","items":[],'
+            b'"itemsView":"notLoaded","startedAt":1780582484,"status":"inProgress"},'
+            b'"type":"turn/started"}\n'
+        ),
+    )
+
+    report = extract_or_fallback_report(
+        artifacts,
+        spawn_id,
+        failure_reason="terminated",
+    )
+
+    assert report.content == "terminated"
+    assert report.source == "failure_reason"
+
+
+def test_extract_or_fallback_report_uses_failure_after_related_codex_event(
+    tmp_path: Path,
+) -> None:
+    artifacts = LocalStore(root_dir=tmp_path / "artifacts")
+    spawn_id = SpawnId("p-codex-related-event")
+    artifacts.put(
+        ArtifactKey(f"{spawn_id}/history.jsonl"),
+        b'{"event_type":"remoteControl/connected","payload":{"sessionId":"s1"},"seq":5}\n',
     )
 
     report = extract_or_fallback_report(

--- a/tests/unit/launch/test_extract.py
+++ b/tests/unit/launch/test_extract.py
@@ -11,6 +11,27 @@ from meridian.lib.launch.extract import (
 from meridian.lib.launch.report import ExtractedReport, extract_or_fallback_report
 from meridian.lib.state.artifact_store import LocalStore
 
+OPENCODE_LIVE_MESSAGE_PART_UPDATED = (
+    '{"id":"evt_e930bc68d001L4oUTckzuyF1cX","properties":{"part":'
+    '{"callID":"call_00_RgQT21ir86rHpjzaSHOA0775",'
+    '"id":"prt_e930bc3890019mFXX9VDpKyVfj",'
+    '"messageID":"msg_e930bbe400016R3GelVzaGNpp4",'
+    '"sessionID":"ses_16cf44268ffeswweMeU0xmAtPb","state":{"input":'
+    '{"command":"python3 -c \\"from pathlib import Path; '
+    "Path('/tmp/meridian-pr310-live-1780583451-2427651/opencode/project/"
+    "pr310_opencode_49a8582d35.started').write_text('started'); import time; "
+    'time.sleep(600)\\"","description":"Run Python command that sleeps 600s",'
+    '"timeout":620000},"metadata":{"description":"Run Python command that sleeps 600s",'
+    '"output":""},"status":"running","time":{"start":1780583483021}},'
+    '"tool":"bash","type":"tool"},"sessionID":"ses_16cf44268ffeswweMeU0xmAtPb",'
+    '"time":1780583483021},"type":"message.part.updated"}'
+)
+OPENCODE_MESSAGE_PART_DELTA = (
+    '{"id":"evt_delta","properties":{"part":{"messageID":"msg_1",'
+    '"sessionID":"ses_1","text":"O","type":"text"},"sessionID":"ses_1"},'
+    '"type":"message.part.delta"}'
+)
+
 
 def test_persist_report_wraps_assistant_extract_with_report_heading(tmp_path: Path) -> None:
     artifacts = LocalStore(root_dir=tmp_path / "artifacts")
@@ -45,6 +66,23 @@ def test_classify_finalize_report_keeps_genuine_json_completion() -> None:
     report = ExtractedReport(content='{"message":"Done."}', source="assistant_message")
 
     assert classify_finalize_report(report) is FinalizeReportKind.DURABLE_COMPLETION
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        OPENCODE_LIVE_MESSAGE_PART_UPDATED,
+        OPENCODE_MESSAGE_PART_DELTA,
+        '{"type":"message.updated","properties":{"info":{"role":"assistant"}}}',
+        '{"type":"server.connected","properties":{}}',
+    ],
+)
+def test_classify_finalize_report_rejects_opencode_message_event_envelopes(
+    content: str,
+) -> None:
+    report = ExtractedReport(content=content, source="assistant_message")
+
+    assert classify_finalize_report(report) is FinalizeReportKind.CONTROL_FRAME
 
 
 @pytest.mark.parametrize(
@@ -226,6 +264,35 @@ def test_extract_or_fallback_report_uses_failure_after_codex_turn_started(
     )
 
     assert report.content == "terminated"
+    assert report.source == "failure_reason"
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        OPENCODE_LIVE_MESSAGE_PART_UPDATED,
+        OPENCODE_MESSAGE_PART_DELTA,
+        '{"type":"server.connected","properties":{}}',
+    ],
+)
+def test_extract_or_fallback_report_uses_failure_after_opencode_message_envelope(
+    tmp_path: Path,
+    content: str,
+) -> None:
+    artifacts = LocalStore(root_dir=tmp_path / "artifacts")
+    spawn_id = SpawnId("p-opencode-message-envelope")
+    artifacts.put(
+        ArtifactKey(f"{spawn_id}/history.jsonl"),
+        f"{content}\n".encode(),
+    )
+
+    report = extract_or_fallback_report(
+        artifacts,
+        spawn_id,
+        failure_reason="cancelled",
+    )
+
+    assert report.content == "cancelled"
     assert report.source == "failure_reason"
 
 

--- a/tests/unit/launch/test_streaming_run_conclusion.py
+++ b/tests/unit/launch/test_streaming_run_conclusion.py
@@ -3,10 +3,14 @@ import signal
 from pathlib import Path
 
 from meridian.lib.core.domain import TokenUsage
-from meridian.lib.core.spawn_lifecycle import has_durable_report_completion
 from meridian.lib.core.types import SpawnId
 from meridian.lib.launch.constants import REPORT_FILENAME
-from meridian.lib.launch.extract import FinalizeExtraction, enrich_finalize
+from meridian.lib.launch.extract import (
+    FinalizeExtraction,
+    FinalizeReportKind,
+    classify_finalize_report,
+    enrich_finalize,
+)
 from meridian.lib.launch.report import ExtractedReport, ReportSource
 from meridian.lib.launch.streaming_runner import (
     StreamingRunConclusion,
@@ -58,10 +62,7 @@ def _extraction_with_report(
         report_path=None,
         report=ExtractedReport(content=report_text, source=source),
         output_is_empty=False,
-        durable_report_completion=(
-            source not in {"failure_reason", "pi_failure"}
-            and has_durable_report_completion(report_text)
-        ),
+        report_kind=classify_finalize_report(ExtractedReport(content=report_text, source=source)),
     )
 
 
@@ -125,6 +126,7 @@ def test_enrich_finalize_marks_synthetic_failure_report_not_durable(tmp_path: Pa
     )
 
     assert report.startswith("# Spawn failed")
+    assert extraction.report_kind is FinalizeReportKind.SYNTHETIC_FAILURE
     assert extraction.durable_report_completion is False
     assert conclusion.terminal_facts(received_signal=None).durable_report_completion is False
 

--- a/tests/unit/launch/test_streaming_run_conclusion.py
+++ b/tests/unit/launch/test_streaming_run_conclusion.py
@@ -3,13 +3,30 @@ import signal
 from pathlib import Path
 
 from meridian.lib.core.domain import TokenUsage
+from meridian.lib.core.spawn_lifecycle import has_durable_report_completion
 from meridian.lib.core.types import SpawnId
-from meridian.lib.launch.extract import FinalizeExtraction
-from meridian.lib.launch.report import ExtractedReport
+from meridian.lib.launch.constants import REPORT_FILENAME
+from meridian.lib.launch.extract import FinalizeExtraction, enrich_finalize
+from meridian.lib.launch.report import ExtractedReport, ReportSource
 from meridian.lib.launch.streaming_runner import (
     StreamingRunConclusion,
     _AttemptRuntime,
 )
+from meridian.lib.state.artifact_store import InMemoryStore, make_artifact_key
+
+
+class _NoReportExtractor:
+    def extract_usage(self, artifacts: InMemoryStore, spawn_id: SpawnId) -> TokenUsage:
+        _ = artifacts, spawn_id
+        return TokenUsage()
+
+    def extract_session_id(self, artifacts: InMemoryStore, spawn_id: SpawnId) -> str | None:
+        _ = artifacts, spawn_id
+        return None
+
+    def extract_report(self, artifacts: InMemoryStore, spawn_id: SpawnId) -> str | None:
+        _ = artifacts, spawn_id
+        return None
 
 
 def _attempt(
@@ -30,13 +47,21 @@ def _attempt(
     )
 
 
-def _extraction_with_report(report_text: str | None) -> FinalizeExtraction:
+def _extraction_with_report(
+    report_text: str | None,
+    *,
+    source: ReportSource | None = "report_md",
+) -> FinalizeExtraction:
     return FinalizeExtraction(
         usage=TokenUsage(total_cost_usd=1.25, input_tokens=10, output_tokens=20),
         harness_session_id=None,
         report_path=None,
-        report=ExtractedReport(content=report_text, source="report_md"),
+        report=ExtractedReport(content=report_text, source=source),
         output_is_empty=False,
+        durable_report_completion=(
+            source not in {"failure_reason", "pi_failure"}
+            and has_durable_report_completion(report_text)
+        ),
     )
 
 
@@ -61,6 +86,47 @@ def test_terminal_facts_treat_durable_report_watchdog_as_success() -> None:
     assert facts.failure_reason == "report_watchdog"
     assert facts.durable_report_completion is True
     assert facts.cancellation_observed is False
+
+
+def test_terminal_facts_do_not_treat_synthetic_failure_report_as_completion() -> None:
+    conclusion = StreamingRunConclusion(
+        exit_code=130,
+        failure_reason="cancelled",
+        extracted=_extraction_with_report(
+            "Cursor subprocess exited with code 130.",
+            source="failure_reason",
+        ),
+        cancellation_observed=True,
+    )
+
+    facts = conclusion.terminal_facts(received_signal=None)
+    assert facts.durable_report_completion is False
+    assert facts.cancellation_observed is True
+
+
+def test_enrich_finalize_marks_synthetic_failure_report_not_durable(tmp_path: Path) -> None:
+    spawn_id = SpawnId("p-cancel-failure-report")
+    artifacts = InMemoryStore()
+
+    extraction = enrich_finalize(
+        artifacts=artifacts,
+        extractor=_NoReportExtractor(),
+        spawn_id=spawn_id,
+        log_dir=tmp_path,
+        failure_reason="Cursor subprocess exited with code 130.",
+    )
+
+    report = artifacts.get(make_artifact_key(spawn_id, REPORT_FILENAME)).decode()
+    conclusion = StreamingRunConclusion(
+        exit_code=130,
+        failure_reason="cancelled",
+        extracted=extraction,
+        cancellation_observed=True,
+    )
+
+    assert report.startswith("# Spawn failed")
+    assert extraction.durable_report_completion is False
+    assert conclusion.terminal_facts(received_signal=None).durable_report_completion is False
 
 
 def test_terminal_facts_treat_signal_without_terminal_as_cancelled() -> None:

--- a/tests/unit/state/test_spawn_lifecycle.py
+++ b/tests/unit/state/test_spawn_lifecycle.py
@@ -2,10 +2,8 @@ from meridian.lib.core.spawn_lifecycle import (
     ACTIVE_SPAWN_STATUSES,
     TERMINAL_SPAWN_STATUSES,
     ExecutionTerminalFacts,
-    durable_report_completed,
     has_durable_report_completion,
     is_active_spawn_status,
-    iso_timestamp_to_epoch,
     resolve_completion_cancel_precedence,
     resolve_execution_terminal_outcome,
     resolve_execution_terminal_state,
@@ -92,19 +90,3 @@ def test_finalizing_membership_reflects_active_non_terminal_state() -> None:
     assert "finalizing" in ACTIVE_SPAWN_STATUSES
     assert "finalizing" not in TERMINAL_SPAWN_STATUSES
     assert is_active_spawn_status("finalizing") is True
-
-
-def test_iso_timestamp_to_epoch_normalizes_z_and_naive_utc() -> None:
-    assert iso_timestamp_to_epoch("2024-01-01T00:00:00Z") == 1704067200.0
-    assert iso_timestamp_to_epoch("2024-01-01T00:00:00") == 1704067200.0
-    assert iso_timestamp_to_epoch("not-a-date") is None
-    assert iso_timestamp_to_epoch(None) is None
-
-
-def test_durable_report_completed_reads_report_from_spawn_dir(tmp_path) -> None:
-    spawn_dir = tmp_path / "spawns" / "s-test"
-    spawn_dir.mkdir(parents=True)
-    (spawn_dir / "report.md").write_text("# Report\n\nDone.\n", encoding="utf-8")
-
-    assert durable_report_completed(tmp_path, "s-test") is True
-    assert durable_report_completed(tmp_path, "missing") is False

--- a/tests/unit/state/test_spawn_lifecycle.py
+++ b/tests/unit/state/test_spawn_lifecycle.py
@@ -35,6 +35,41 @@ def test_has_durable_report_completion_distinguishes_completion_from_cancel_arti
         )
         is False
     )
+    assert (
+        has_durable_report_completion(
+            '{"event_type":"item/started",'
+            '"payload":{"item":{"type":"commandExecution","command":"sleep 600"}}}'
+        )
+        is False
+    )
+    assert (
+        has_durable_report_completion(
+            '{"type":"user","message":{"role":"user","content":['
+            '{"type":"text","text":"[Request interrupted by user]"}]}}'
+        )
+        is False
+    )
+    assert (
+        has_durable_report_completion(
+            '{"type":"user","message":{"role":"user","content":['
+            '{"type":"tool_result","is_error":true,"content":"Exit code 144"}]}}'
+        )
+        is False
+    )
+    assert (
+        has_durable_report_completion(
+            '{"type":"assistant","message":{"role":"assistant","content":['
+            '{"type":"tool_use","name":"Bash","input":{"command":"sleep 600"}}]}}'
+        )
+        is False
+    )
+    assert (
+        has_durable_report_completion(
+            '{"type":"assistant","message":{"role":"assistant","content":['
+            '{"type":"thinking","thinking":"I should call Bash."}]}}'
+        )
+        is False
+    )
 
 
 def test_resolve_execution_terminal_state_returns_cancelled_for_cancel_intent() -> None:

--- a/tests/unit/state/test_spawn_lifecycle.py
+++ b/tests/unit/state/test_spawn_lifecycle.py
@@ -2,8 +2,10 @@ from meridian.lib.core.spawn_lifecycle import (
     ACTIVE_SPAWN_STATUSES,
     TERMINAL_SPAWN_STATUSES,
     ExecutionTerminalFacts,
+    durable_report_completed,
     has_durable_report_completion,
     is_active_spawn_status,
+    iso_timestamp_to_epoch,
     resolve_completion_cancel_precedence,
     resolve_execution_terminal_outcome,
     resolve_execution_terminal_state,
@@ -90,3 +92,19 @@ def test_finalizing_membership_reflects_active_non_terminal_state() -> None:
     assert "finalizing" in ACTIVE_SPAWN_STATUSES
     assert "finalizing" not in TERMINAL_SPAWN_STATUSES
     assert is_active_spawn_status("finalizing") is True
+
+
+def test_iso_timestamp_to_epoch_normalizes_z_and_naive_utc() -> None:
+    assert iso_timestamp_to_epoch("2024-01-01T00:00:00Z") == 1704067200.0
+    assert iso_timestamp_to_epoch("2024-01-01T00:00:00") == 1704067200.0
+    assert iso_timestamp_to_epoch("not-a-date") is None
+    assert iso_timestamp_to_epoch(None) is None
+
+
+def test_durable_report_completed_reads_report_from_spawn_dir(tmp_path) -> None:
+    spawn_dir = tmp_path / "spawns" / "s-test"
+    spawn_dir.mkdir(parents=True)
+    (spawn_dir / "report.md").write_text("# Report\n\nDone.\n", encoding="utf-8")
+
+    assert durable_report_completed(tmp_path, "s-test") is True
+    assert durable_report_completed(tmp_path, "missing") is False

--- a/tests/unit/state/test_spawn_lifecycle.py
+++ b/tests/unit/state/test_spawn_lifecycle.py
@@ -9,6 +9,22 @@ from meridian.lib.core.spawn_lifecycle import (
     resolve_execution_terminal_state,
 )
 
+OPENCODE_LIVE_MESSAGE_PART_UPDATED = (
+    '{"id":"evt_e930bc68d001L4oUTckzuyF1cX","properties":{"part":'
+    '{"callID":"call_00_RgQT21ir86rHpjzaSHOA0775",'
+    '"id":"prt_e930bc3890019mFXX9VDpKyVfj",'
+    '"messageID":"msg_e930bbe400016R3GelVzaGNpp4",'
+    '"sessionID":"ses_16cf44268ffeswweMeU0xmAtPb","state":{"input":'
+    '{"command":"python3 -c \\"from pathlib import Path; '
+    "Path('/tmp/meridian-pr310-live-1780583451-2427651/opencode/project/"
+    "pr310_opencode_49a8582d35.started').write_text('started'); import time; "
+    'time.sleep(600)\\"","description":"Run Python command that sleeps 600s",'
+    '"timeout":620000},"metadata":{"description":"Run Python command that sleeps 600s",'
+    '"output":""},"status":"running","time":{"start":1780583483021}},'
+    '"tool":"bash","type":"tool"},"sessionID":"ses_16cf44268ffeswweMeU0xmAtPb",'
+    '"time":1780583483021},"type":"message.part.updated"}'
+)
+
 
 def test_has_durable_report_completion_distinguishes_completion_from_cancel_artifacts() -> None:
     assert has_durable_report_completion("# Report\n\nDone.\n") is True
@@ -81,6 +97,23 @@ def test_has_durable_report_completion_distinguishes_completion_from_cancel_arti
         )
         is False
     )
+    assert (
+        has_durable_report_completion(f"# Report\n\n{OPENCODE_LIVE_MESSAGE_PART_UPDATED}\n")
+        is False
+    )
+    assert (
+        has_durable_report_completion(
+            '{"type":"message.part.delta","properties":{"part":{"type":"text","text":"O"}}}'
+        )
+        is False
+    )
+    assert (
+        has_durable_report_completion(
+            '{"type":"message.updated","properties":{"info":{"role":"assistant"}}}'
+        )
+        is False
+    )
+    assert has_durable_report_completion('{"type":"server.connected","properties":{}}') is False
 
 
 def test_resolve_execution_terminal_state_returns_cancelled_for_cancel_intent() -> None:

--- a/tests/unit/state/test_spawn_lifecycle.py
+++ b/tests/unit/state/test_spawn_lifecycle.py
@@ -12,6 +12,13 @@ from meridian.lib.core.spawn_lifecycle import (
 
 def test_has_durable_report_completion_distinguishes_completion_from_cancel_artifacts() -> None:
     assert has_durable_report_completion("# Report\n\nDone.\n") is True
+    assert has_durable_report_completion('{"message":"Done."}') is True
+    assert (
+        has_durable_report_completion(
+            '{"message":"Root cause: missing WebSocket close frame handling."}'
+        )
+        is True
+    )
     assert (
         has_durable_report_completion(
             '{"event_type":"cancelled","payload":{"status":"cancelled","error":"cancelled"}}'
@@ -20,6 +27,12 @@ def test_has_durable_report_completion_distinguishes_completion_from_cancel_arti
     )
     assert (
         has_durable_report_completion("# Spawn failed\n\nClaude subprocess exited with code 130.")
+        is False
+    )
+    assert (
+        has_durable_report_completion(
+            '# Report\n\n{"type":"error","message":"no close frame received or sent"}\n'
+        )
         is False
     )
 

--- a/tests/unit/state/test_spawn_lifecycle.py
+++ b/tests/unit/state/test_spawn_lifecycle.py
@@ -44,6 +44,17 @@ def test_has_durable_report_completion_distinguishes_completion_from_cancel_arti
     )
     assert (
         has_durable_report_completion(
+            '# Report\n\n{"threadId":"019e92fc-881c-7533-a6b3-ccaa89c0dd2e",'
+            '"turn":{"completedAt":null,"durationMs":null,"error":null,'
+            '"id":"019e92fc-88d3-7430-9b93-67a2230470c8","items":[],'
+            '"itemsView":"notLoaded","startedAt":1780582484,"status":"inProgress"},'
+            '"type":"turn/started"}'
+        )
+        is False
+    )
+    assert has_durable_report_completion('{"type":"thread/updated","threadId":"t1"}') is False
+    assert (
+        has_durable_report_completion(
             '{"type":"user","message":{"role":"user","content":['
             '{"type":"text","text":"[Request interrupted by user]"}]}}'
         )

--- a/tests/unit/state/test_spawn_report.py
+++ b/tests/unit/state/test_spawn_report.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+from meridian.lib.state.spawn_report import spawn_report_has_durable_completion
+
+
+def test_spawn_report_has_durable_completion_reads_report_from_spawn_dir(tmp_path: Path) -> None:
+    spawn_dir = tmp_path / "spawns" / "s-test"
+    spawn_dir.mkdir(parents=True)
+    (spawn_dir / "report.md").write_text("# Report\n\nDone.\n", encoding="utf-8")
+
+    assert spawn_report_has_durable_completion(tmp_path, "s-test") is True
+    assert spawn_report_has_durable_completion(tmp_path, "missing") is False

--- a/tests/unit/state/test_spawn_report.py
+++ b/tests/unit/state/test_spawn_report.py
@@ -10,3 +10,16 @@ def test_spawn_report_has_durable_completion_reads_report_from_spawn_dir(tmp_pat
 
     assert spawn_report_has_durable_completion(tmp_path, "s-test") is True
     assert spawn_report_has_durable_completion(tmp_path, "missing") is False
+
+
+def test_spawn_report_rejects_wrapped_codex_close_error_control_payload(
+    tmp_path: Path,
+) -> None:
+    spawn_dir = tmp_path / "spawns" / "s-test"
+    spawn_dir.mkdir(parents=True)
+    (spawn_dir / "report.md").write_text(
+        '# Report\n\n{"type":"error","message":"no close frame received or sent"}\n',
+        encoding="utf-8",
+    )
+
+    assert spawn_report_has_durable_completion(tmp_path, "s-test") is False

--- a/tests/unit/state/test_timestamps.py
+++ b/tests/unit/state/test_timestamps.py
@@ -1,0 +1,8 @@
+from meridian.lib.state.timestamps import iso_timestamp_to_epoch
+
+
+def test_iso_timestamp_to_epoch_normalizes_z_and_naive_utc() -> None:
+    assert iso_timestamp_to_epoch("2024-01-01T00:00:00Z") == 1704067200.0
+    assert iso_timestamp_to_epoch("2024-01-01T00:00:00") == 1704067200.0
+    assert iso_timestamp_to_epoch("not-a-date") is None
+    assert iso_timestamp_to_epoch(None) is None

--- a/tests/unit/streaming/test_signal_canceller_tree.py
+++ b/tests/unit/streaming/test_signal_canceller_tree.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import pytest
 
 from meridian.lib.core.types import SpawnId
-from meridian.lib.platform.process_scope import ProcessScopeSnapshot
+from meridian.lib.platform.process_scope import CleanupResult, ProcessScopeSnapshot
 from meridian.lib.state.spawn.model import SpawnRecord
 from meridian.lib.streaming.signal_canceller import SignalCanceller
 
@@ -68,10 +68,15 @@ def _make_record(
     )
 
 
-def _make_scope(scope_id: str, *, root_pid: int) -> ProcessScopeSnapshot:
+def _make_scope(
+    scope_id: str,
+    *,
+    root_pid: int,
+    owner_policy: str = "spawn_owned",
+) -> ProcessScopeSnapshot:
     return ProcessScopeSnapshot(
         scope_id=scope_id,
-        owner_policy="spawn_owned",
+        owner_policy=owner_policy,
         owner_id="s-test",
         role="harness_backend",
         containment="pid_tree_fallback",
@@ -114,10 +119,6 @@ async def test_cancel_cli_spawn_legacy_path_uses_tree_termination_with_started_e
             return_value=True,
         ),
         patch(
-            "meridian.lib.streaming.signal_canceller.read_scopes_from_disk",
-            return_value=[],
-        ),
-        patch(
             "meridian.lib.streaming.signal_canceller.terminate_tree_sync",
             side_effect=_capture_tree,
         ),
@@ -150,11 +151,42 @@ async def test_cancel_cli_spawn_returns_finalizing_when_terminal_state_never_arr
             "meridian.lib.streaming.signal_canceller.is_process_alive",
             return_value=True,
         ),
+        patch("meridian.lib.streaming.signal_canceller.terminate_tree_sync"),
+    ):
+        outcome = await canceller._cancel_cli_spawn(spawn_id, running_record)
+
+    assert outcome.finalizing is True
+    assert outcome.status == "finalizing"
+
+
+@pytest.mark.asyncio
+async def test_cancel_cli_spawn_does_not_run_legacy_worker_fallback_after_runner_signal(
+    tmp_path: Path,
+) -> None:
+    """Post-runner containment cleanup should not unguardedly re-signal legacy worker_pid."""
+    spawn_id = SpawnId("s-test")
+    running_record = _make_record(runner_pid=777, worker_pid=888)
+
+    canceller = SignalCanceller(runtime_root=tmp_path, grace_seconds=0.0)
+
+    with (
         patch(
-            "meridian.lib.streaming.signal_canceller.read_scopes_from_disk",
-            return_value=[],
+            "meridian.lib.streaming.signal_canceller.spawn_store.get_spawn",
+            return_value=running_record,
+        ),
+        patch(
+            "meridian.lib.streaming.signal_canceller.is_process_alive",
+            return_value=True,
         ),
         patch("meridian.lib.streaming.signal_canceller.terminate_tree_sync"),
+        patch(
+            "meridian.lib.core.process_cleanup.read_scopes_from_disk",
+            return_value=[],
+        ),
+        patch(
+            "meridian.lib.core.process_cleanup.terminate_tree_sync",
+            side_effect=AssertionError("legacy worker fallback should not run"),
+        ),
     ):
         outcome = await canceller._cancel_cli_spawn(spawn_id, running_record)
 
@@ -166,39 +198,57 @@ async def test_cancel_cli_spawn_returns_finalizing_when_terminal_state_never_arr
 async def test_cleanup_spawn_scopes_uses_release_id_for_duplicate_labels(
     tmp_path: Path,
 ) -> None:
-    spawn_id = SpawnId("s-test")
     first_backend = _make_scope("backend", root_pid=101)
     second_backend = _make_scope("backend", root_pid=202)
+    session_backend = _make_scope(
+        "backend",
+        root_pid=303,
+        owner_policy="session_owned",
+    )
     terminated_release_ids: list[str] = []
     marked_release_ids: list[str] = []
 
-    def _terminate_scope(scope: ProcessScopeSnapshot, **_: object) -> None:
+    def _terminate_scope(scope: ProcessScopeSnapshot, **kwargs: object) -> CleanupResult:
         terminated_release_ids.append(scope.release_id)
+        return CleanupResult(
+            scope_id=scope.scope_id,
+            root_pid=scope.root_pid,
+            descendant_count=0,
+            reason=str(kwargs["reason"]),
+            grace_seconds=0.0,
+            kill_escalated=False,
+            degraded_fallback=False,
+            skip_reason=None,
+        )
 
     canceller = SignalCanceller(runtime_root=tmp_path, grace_seconds=0.0)
 
     with (
         patch(
-            "meridian.lib.streaming.signal_canceller.read_scopes_from_disk",
-            return_value=[first_backend, second_backend],
+            "meridian.lib.core.process_cleanup.read_scopes_from_disk",
+            return_value=[first_backend, second_backend, session_backend],
         ),
         patch(
-            "meridian.lib.streaming.signal_canceller.is_scope_released",
+            "meridian.lib.core.process_cleanup.is_scope_released",
             side_effect=lambda _root, _sid, release_id: release_id
             == first_backend.release_id,
         ),
         patch(
-            "meridian.lib.streaming.signal_canceller.terminate_scope_sync",
+            "meridian.lib.core.process_cleanup.psutil.Process",
+            return_value=type("LiveProc", (), {"create_time": lambda self: 1_700_000_000.0})(),
+        ),
+        patch(
+            "meridian.lib.core.process_cleanup.terminate_scope_sync",
             side_effect=_terminate_scope,
         ),
         patch(
-            "meridian.lib.streaming.signal_canceller.mark_scope_released",
+            "meridian.lib.core.process_cleanup.mark_scope_released",
             side_effect=lambda _root, _sid, release_id: marked_release_ids.append(
                 release_id
             ),
         ),
     ):
-        await canceller._cleanup_spawn_scopes(spawn_id, _make_record())
+        await canceller._cleanup_spawn_scopes(_make_record())
 
     assert first_backend.scope_id == second_backend.scope_id
     assert terminated_release_ids == [second_backend.release_id]


### PR DESCRIPTION
## Why

PR #308 merged before the bounded cleanup pass could land. Follow-up audits found drift-prone duplication in spawn cancel/reaper code: timestamp parsing and durable-report reads were copied, and `SignalCanceller` carried a parallel process-scope cleanup path that missed canonical session-lease protection.

Runtime probe `p3575` then found a live cancel regression in this PR: background runner cancel killed the process tree and wrote a synthetic `# Spawn failed` report, but runner finalization treated the synthetic report body as durable completion and persisted `succeeded`.

Thermo review `p3579` requested structural cleanup of the follow-up: keep lifecycle helpers pure, move file/time persistence helpers to the state layer, split the cleanup mode flag into explicit operations, and make extraction durable-completion semantics less magical.

## Goal

Keep spawn cancel architecture maintainable without broad dispatch churn: share lifecycle decisions without leaking persistence into lifecycle policy, reuse canonical process cleanup, preserve runner-first cancellation safety, and keep explicit user cancel authoritative unless a genuine durable completion report already exists.

## Summary

- Kept `spawn_lifecycle.py` pure: report text classification and terminal resolution only.
- Moved persisted `report.md` reads to `state/spawn_report.py` and persisted ISO timestamp parsing to `state/timestamps.py`.
- Split process cleanup into explicit operations:
  - `terminate_recorded_spawn_scopes(...)`
  - `terminate_legacy_worker_fallback(...)`
  - `terminate_spawn_scopes(...)` as the composed entrypoint.
- Updated `SignalCanceller` so post-runner cleanup calls recorded-scope cleanup directly instead of passing a hidden boolean mode flag.
- Kept canonical cleanup behavior for released scopes and live `session_owned` scopes.
- Replaced extraction's cached boolean with typed `FinalizeReportKind`; `durable_report_completion` is now a projection of that boundary classification.
- Classified structured Codex `error/connectionClosed` history as control-frame output during cancel, so websocket close payloads cannot become durable successful reports; bare JSON completion reports still stay durable.
- Classified OpenCode `message.*`, `server.*`, `session.*`, and `sync` event envelopes as control-frame output during cancel, so raw progress/control events cannot become durable successful reports; bare JSON completion reports still stay durable.
- Added/updated focused coverage for process cleanup, state report reads, timestamp parsing, extraction, runner conclusion, cancel, and reaper behavior.
- Updated source `.context` docs and changelog.

## Resulting Behavior

`meridian spawn cancel` still signals the runner first. Scope cleanup fallback now uses the same release-id and session-lease rules as reaper cleanup, while post-runner fallback avoids a second unguarded legacy PID signal by cleaning only recorded scopes.

If a cancelled background harness exits with a synthetic failure report such as `# Spawn failed\n\nCursor subprocess exited with code 130.`, final state stays `cancelled` with exit `130`. If real Codex emits a websocket close event like `error/connectionClosed` / `no close frame received or sent` during explicit cancel, final state also stays `cancelled` with exit `130`; the close/error payload is not durable completion. Genuine durable completion still wins over a late cancel request. OpenCode 1.15.11 cancel now ends `cancelled/130` even when the final observed output is a raw event envelope such as `message.part.updated` or `server.connected`.

## Work Item

spawn-cancel-architecture

## Verification

- Focused follow-up tests:
  - `uv run pytest-llm tests/unit/core/test_process_cleanup_terminate.py tests/unit/core/test_process_cleanup_reclaim.py tests/unit/core/test_spawn_service.py tests/unit/state/test_spawn_lifecycle.py tests/unit/state/test_spawn_report.py tests/unit/state/test_timestamps.py tests/unit/launch/test_extract.py tests/unit/launch/test_streaming_run_conclusion.py tests/unit/launch/test_streaming_runner_cancel.py tests/unit/streaming/test_signal_canceller_tree.py tests/integration/launch/test_signal_canceller.py tests/integration/launch/test_streaming_runner_watchdog.py tests/integration/state/test_reaper_cancel.py tests/integration/state/test_reaper_reconciliation.py tests/integration/state/test_reaper_managed_primary.py` — `89 passed`
- `uv run ruff check .` — passed
- `uv run --extra dev python -m pyright` — `0 errors`
- Live CLI cancel smoke with isolated `MERIDIAN_HOME`, scratch project, `uv run meridian`, and fake Cursor harness:
  - background spawn reached `running`
  - `spawn cancel p1` returned `status=cancelled`, `exit_code=130`
  - final `spawn show p1` returned `status=cancelled`, `exit_code=130`
  - generated report body was `# Spawn failed\n\nCursor subprocess exited with code 130.`
- Pre-push hook on push of `7b5fbf0d`:
  - `uv run --extra dev ruff check .` — passed
  - `uv run --extra dev python -m pyright` — passed
  - `uv run --extra dev pytest -x -q` — `1272 passed, 2 skipped`
  - `uv build --no-sources` — passed
- Codex close-error regression tests after `p3583`:
  - `uv run pytest-llm tests/unit/launch/test_streaming_runner_cancel.py tests/unit/launch/test_extract.py tests/unit/state/test_spawn_lifecycle.py tests/unit/state/test_spawn_report.py tests/unit/core/test_spawn_service.py tests/unit/launch/test_pi_report_extraction.py` — `31 passed`
  - after merging `origin/main`: `uv run pytest-llm tests/unit/launch/test_streaming_runner_cancel.py tests/unit/launch/test_extract.py tests/unit/state/test_spawn_lifecycle.py tests/unit/state/test_spawn_report.py tests/unit/core/test_spawn_service.py tests/unit/launch/test_pi_report_extraction.py tests/unit/harness/test_cursor_projection.py` — `45 passed`
  - `uv run ruff check .` — passed
  - `uv run --extra dev python -m pyright` — `0 errors`
- Real Codex CLI cancel smoke after `cc2154f3`, isolated `MERIDIAN_HOME=/tmp/mc310-fix2-24052-1880717/hc`, scratch project, `uv run meridian`, `codex-cli 0.136.0`, model `gpt-5.4-mini`:
  - background spawn `p1` reached `running`
  - `spawn cancel p1 --json` returned `status=cancelled`, `exit_code=130`
  - final status `cancelled`, `exit_code=130`, `failure_reason=cancelled`
  - state recorded `cancel_intent.exit_code=130`, `runner_exit_status=cancelled`, `runner_exit_code=130`, `last_attempt_exit_code=143`
  - `control_actions.jsonl` recorded interrupt `requested` → `sent` → `acknowledged`
  - launch-boundary counts were one each for parent launch, spawned, worker boot, request loaded, takeover; no retry evidence
  - owned PID check after cancel: `NO_MATCHES`
  - report body `# Spawn failed\n\nterminated`; no successful durable completion
- Pre-push hook on push of `cc2154f3`:
  - `uv run --extra dev ruff check .` — passed
  - `uv run --extra dev python -m pyright` — `0 errors`
  - `uv run --extra dev pytest -x -q` — `1277 passed, 2 skipped`
  - `uv build --no-sources` — passed
- Merged `origin/main` in `8d2990dc` to resolve PR conflict after main released `0.2.29`. Pre-push hook on push of `8d2990dc`:
  - `uv run --extra dev ruff check .` — passed
  - `uv run --extra dev python -m pyright` — `0 errors`
  - `uv run --extra dev pytest -x -q` — `1282 passed, 2 skipped`
  - `uv build --no-sources` — passed

- Claude structured-envelope cancel classification follow-up in local commit `d5585db7`:
  - `uv run pytest-llm tests/unit/launch/test_extract.py tests/unit/core/test_spawn_service.py tests/unit/state/test_spawn_lifecycle.py tests/unit/harness/test_extract_codex_report.py tests/unit/launch/test_streaming_run_conclusion.py tests/unit/launch/test_streaming_runner_cancel.py tests/integration/state/test_reaper_reconciliation.py` — `72 passed`
  - `uv run ruff check .` — passed
  - `uv run --extra dev python -m pyright` — `0 errors`
  - real Claude CLI cancel smoke, isolated `MERIDIAN_HOME=/tmp/meridian-claude-cancel-fix-cTUnTa/home`, scratch project, `uv run meridian`, Claude `haiku`: background spawn reached `running`; `spawn cancel p1` returned `status=cancelled`, `exit_code=130`; final state `cancelled/130`; `last_attempt_exit_code=143`; no matching long-running process; report body `# Spawn failed

terminated`.
  - real Codex CLI spot after pre-command progress text followed by command execution: isolated `MERIDIAN_HOME=/tmp/meridian-codex-cancel-spot-qZjTsf/home`; `spawn cancel p1` returned `cancelled/130`; final state `cancelled/130`; report body `# Spawn failed

terminated`.

Reviewer/probe:
- `p3570` reviewer — found legacy PID birth-time regression; fixed.
- `p3571` probe — ran focused tests plus runtime runner/worker/order probes.
- `p3572` reviewer — found post-runner legacy fallback risk; fixed.
- `p3573` reviewer — flagged broader reaper cancel-intent cleanup outside this bounded refactor; deferred.
- `p3575` probe — found live background cancel synthetic-report regression; fixed in `1ca71ae8`.
- `p3577` reviewer — found regression test missed `enrich_finalize()` seam; fixed.
- `p3578` probe — follow-up live cancel smoke passed after regression fix.
- `p3579` thermo review — requested structural follow-up; fixed in `7b5fbf0d`.
- `p3581` reviewer — approved follow-up structure; no findings.
- `p3582` probe — live fake-Cursor cancel smoke passed; no leaked fake child.
- `p3583` probe — real Codex CLI cancel smoke exposed close/error payload becoming `succeeded`; fixed in `cc2154f3`.
- `p3585` reviewer — found broad close-frame message heuristic regression risk; fixed.
- `p3586` probe — verified first real Codex smoke artifacts.
- `p3587` reviewer — approved narrowed structured control-frame fix.
- `p3588` probe — verified latest real Codex smoke artifacts after `cc2154f3`.

- `p3592` reviewer — found Claude extraction/control predicate sharing gap and Codex pre-command progress risk; fixed in `d5585db7`.
- `p3593` probe — verified focused tests and found Codex command-progress fallback risk; fixed in `d5585db7`.


- Final local regression after OpenCode follow-up (`9d9f7fd4`):
  - `uv run pytest-llm tests/unit/launch/test_extract.py tests/unit/state/test_spawn_lifecycle.py tests/unit/core/test_spawn_service.py tests/unit/harness/test_extract_codex_report.py` — `50 passed`
  - `uv run ruff check .` — passed
  - `uv run --extra dev python -m pyright` — `0 errors`
- Final live harness matrix from local source (`uv run meridian`, isolated `MERIDIAN_HOME`, scratch projects under `/tmp/m310-2562251`):
  - Codex CLI `gpt-5.4-mini`: success passed; cancel passed `cancelled/130`, `last_attempt_exit_code=143`, report `# Spawn failed / terminated`.
  - Claude CLI `claude-haiku-4-5`: success passed; generic cancel prompt declined to run the long sleep, then explicit live cancel prompt under `/tmp/mccl-2578809` passed `cancelled/130`, `last_attempt_exit_code=143`, report `# Spawn failed / terminated`.
  - OpenCode `deepseek/deepseek-v4-flash`: success passed; cancel passed `cancelled/130`, `last_attempt_exit_code=143`, report `# Spawn failed / cancelled`.
  - Pi `deepseek/deepseek-v4-flash`: success passed; cancel passed `cancelled/130`, `last_attempt_exit_code=143`, report `# Spawn failed / cancelled`.
  - Cursor `composer-2.5`: success passed; cancel passed `cancelled/130`, `last_attempt_exit_code=143`, report `# Spawn failed / terminated`.
  - Post-run process grep for `PR310_CANCEL_` / `sleep 300` found no lingering test children after cleanup of an obsolete long-path scratch run.

- Windows-gate follow-up (`df892c29`):
  - Original Windows failure was GitHub hosted runner lost communication while running `uv run --extra dev pytest -n auto -m "not slow"`; no pytest assertion trace was emitted.
  - Changed Windows gate to run the same non-slow suite serially (`pytest -n 0 -m "not slow"`) so Windows coverage remains authoritative without xdist worker-startup instability.
  - Local serial gate: `uv run --extra dev pytest -n 0 -m "not slow"` — `1264 passed, 2 skipped, 47 deselected`.
  - Push preflight after fix: `ruff` passed; `pyright` 0 errors; `pytest -x -q` — `1311 passed, 2 skipped`; build passed.
  - GitHub PR checks after push `df892c29`: Windows gate passed (`2m47s`), plus lint/fast/full/compat/changelog passed.

## Knowledge Updates

- `CHANGELOG.md`
- `src/meridian/lib/core/.context/CONTEXT.md`
- `src/meridian/lib/state/.context/CONTEXT.md`
- `src/meridian/lib/streaming/.context/CONTEXT.md`
- Meridian CLI KB: `kb/architecture/spawn-finalization.md` in `haowjy/meridian-cli-kb` commit `45d77a9` documents durable completion evidence classification.

No new user docs needed for the follow-up fix; behavior matches intended cancel semantics already documented by this PR.

## Spawn Trace

- `p3570` reviewer — bounded refactor correctness review
- `p3571` probe — runtime cancel/refactor probes
- `p3572` reviewer — follow-up review after first fix
- `p3573` reviewer — final follow-up; broader reaper cancel-intent cleanup deferred
- `p3575` probe — live cancel smoke that exposed synthetic-report regression
- `p3577` reviewer — follow-up correctness review after regression fix
- `p3578` probe — follow-up live cancel smoke after regression fix
- `p3579` reviewer — thermo-nuclear structural review; requested changes
- `p3581` reviewer — follow-up structure/correctness review
- `p3582` probe — follow-up live cancel smoke
- `p3583` probe — real Codex CLI cancel smoke; found close/error payload success regression
- `p3585` reviewer — reviewed first Codex close/error fix; requested narrower classification
- `p3586` probe — verified first real Codex smoke artifacts
- `p3587` reviewer — approved narrowed structured control-frame fix
- `p3588` probe — verified latest real Codex smoke artifacts

- `p3592` reviewer — reviewed Claude/Codex cancel classification follow-up
- `p3593` probe — probed runtime classification and Codex fallback risk
- `p3598` reviewer — reviewed OpenCode event-envelope cancel follow-up
- `p3599` probe — verified OpenCode cancel runtime artifact
- `p3598` reviewer — approved OpenCode event-envelope classification follow-up; no blockers.
- `p3599` probe — verified OpenCode 1.15.11 cancel artifact final `cancelled/130`, no `sleep 600` leak, focused tests passed.


- `p3597` gpt-dev — implemented OpenCode raw event-envelope classification; committed `9d9f7fd4`; spawn was manually terminated after post-work sub-spawn verification hung.
- `p3600` probe — attempted full live matrix; produced Codex success/cancel evidence, then was manually terminated when the probe harness stalled; final matrix rerun directly from local source.

- `p3602` gpt-dev — diagnosed Windows-gate hosted-runner hang and committed serial Windows pytest gate stabilization (`df892c29`).

## Release Label Guide

Set one `release:*` label on this PR:

- `release:patch` — create the next patch release after merge
- `release:skip` — no release for this merge

No `release:*` label means no auto-release.

## Post-Merge Automation

After merge to `main`, CI (`.github/workflows/release-on-merge.yml`) will:

1. Read the PR release label
2. Skip when no `release:*` label is present or when `release:skip` is present
3. Compute the next patch version from existing `v*` tags
4. Update `src/meridian/__init__.py` + promote `CHANGELOG.md` `[Unreleased]`
5. Commit `Release X.Y.Z`, create/push `vX.Y.Z`
6. Run `.github/workflows/publish-pypi.yml` directly

## Cleanup

After merge, clean merged worktrees with:

```bash
scripts/prune-worktrees.sh
```






