### PR TITLE
feat(cursor): project sandbox mode to --sandbox CLI flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Cursor harness projection: `--sandbox enabled/disabled` flag from mars sandbox mode. `read-only` → enabled, `workspace-write`/`danger-full-access` → disabled.
+
 ## [0.2.26] - 2026-06-02
 
 ### Changed

--- a/src/meridian/lib/harness/projections/project_cursor.py
+++ b/src/meridian/lib/harness/projections/project_cursor.py
@@ -62,6 +62,26 @@ def _project_approval_flags(spec: ResolvedLaunchSpec) -> tuple[str, ...]:
     )
 
 
+def _project_sandbox_flags(spec: ResolvedLaunchSpec) -> tuple[str, ...]:
+    """Map mars sandbox mode to Cursor ``--sandbox enabled|disabled``.
+
+    Cursor's sandbox is binary — ``enabled`` restricts file access to the
+    workspace, ``disabled`` removes restrictions.  Mars ``workspace-write``
+    and ``danger-full-access`` both map to ``disabled`` (overshoot for
+    ``workspace-write``, but Cursor has no fine-grained equivalent).
+    """
+    sandbox_mode = spec.permission_resolver.config.sandbox
+    if sandbox_mode == "default":
+        return ()
+    if sandbox_mode == "read-only":
+        return ("--sandbox", "enabled")
+    if sandbox_mode in ("workspace-write", "danger-full-access"):
+        return ("--sandbox", "disabled")
+    raise HarnessCapabilityMismatch(
+        f"Cursor projection does not support sandbox mode '{sandbox_mode}'."
+    )
+
+
 def _assert_supported_for_mvp(spec: ResolvedLaunchSpec) -> None:
     if spec.mcp_tools:
         raise HarnessCapabilityMismatch(
@@ -104,6 +124,7 @@ def project_cursor_spec_to_cli_args(
         command.extend(("--model", spec.model))
 
     command.extend(_project_approval_flags(spec))
+    command.extend(_project_sandbox_flags(spec))
 
     workspace = (spec.task_cwd or "").strip()
     if workspace:

--- a/tests/unit/harness/test_cursor_projection.py
+++ b/tests/unit/harness/test_cursor_projection.py
@@ -13,12 +13,15 @@ from meridian.lib.harness.projections.project_cursor import (
 )
 from meridian.lib.launch.constants import BASE_COMMAND_CURSOR_SUBPROCESS
 from meridian.lib.launch.launch_types import PermissionResolver, ResolvedLaunchSpec
-from meridian.lib.safety.permissions import ApprovalMode, PermissionConfig
+from meridian.lib.safety.permissions import ApprovalMode, PermissionConfig, SandboxMode
 
 
 class _Resolver(PermissionResolver):
-    def __init__(self, *, approval: str) -> None:
-        self._config = PermissionConfig(approval=cast("ApprovalMode", approval))
+    def __init__(self, *, approval: str = "default", sandbox: str = "default") -> None:
+        self._config = PermissionConfig(
+            approval=cast("ApprovalMode", approval),
+            sandbox=cast("SandboxMode", sandbox),
+        )
 
     @property
     def config(self) -> PermissionConfig:
@@ -111,3 +114,53 @@ def test_cursor_projection_ignores_projected_roots_for_mvp(tmp_path: Path) -> No
     assert command[command.index("--workspace") + 1] == task_cwd
     assert str(root_a) not in command
     assert str(root_b) not in command
+
+
+@pytest.mark.parametrize(
+    ("sandbox", "expected_flags"),
+    [
+        ("default", []),
+        ("read-only", ["--sandbox", "enabled"]),
+        ("workspace-write", ["--sandbox", "disabled"]),
+        ("danger-full-access", ["--sandbox", "disabled"]),
+    ],
+)
+def test_cursor_projection_maps_sandbox_flags(
+    sandbox: str,
+    expected_flags: list[str],
+    tmp_path: Path,
+) -> None:
+    spec = ResolvedLaunchSpec(
+        harness="cursor",
+        model="composer-2.5",
+        prompt="Reply with exactly OK",
+        permission_resolver=_Resolver(sandbox=sandbox),
+        task_cwd=str(tmp_path / "ws"),
+    )
+
+    command = project_cursor_spec_to_cli_args(spec, base_command=BASE_COMMAND_CURSOR_SUBPROCESS)
+
+    if expected_flags:
+        idx = command.index("--sandbox")
+        assert command[idx : idx + 2] == expected_flags
+    else:
+        assert "--sandbox" not in command
+    # Prompt is always last.
+    assert command[-1] == "Reply with exactly OK"
+
+
+def test_cursor_projection_sandbox_and_approval_together(tmp_path: Path) -> None:
+    spec = ResolvedLaunchSpec(
+        harness="cursor",
+        model="composer-2.5",
+        prompt="do stuff",
+        permission_resolver=_Resolver(approval="yolo", sandbox="danger-full-access"),
+        task_cwd=str(tmp_path / "ws"),
+    )
+
+    command = project_cursor_spec_to_cli_args(spec, base_command=BASE_COMMAND_CURSOR_SUBPROCESS)
+
+    assert "--yolo" in command
+    idx = command.index("--sandbox")
+    assert command[idx + 1] == "disabled"
+    assert command[-1] == "do stuff"


### PR DESCRIPTION
## Why

Cursor supports `--sandbox enabled|disabled` CLI flags, but meridian's Cursor harness projector had zero sandbox projection — the sandbox mode from agent profiles was silently ignored at spawn time.

## Goal

Wire mars sandbox modes to Cursor `--sandbox` CLI flags so agent profiles with `sandbox: workspace-write` or `sandbox: danger-full-access` actually produce unrestricted Cursor spawns.

## Summary

- Added `_project_sandbox_flags()` to `project_cursor.py` mapping mars sandbox modes to Cursor's binary `--sandbox` toggle
- `read-only` → `--sandbox enabled`, `workspace-write`/`danger-full-access` → `--sandbox disabled`, `default` → omit
- 6 new test cases: 4 parametrized sandbox modes + 1 combined sandbox+approval test
- Extended test resolver to accept sandbox parameter

## Resulting Behavior

```bash
# Agent with sandbox: workspace-write now gets:
cursor agent --sandbox disabled --workspace /path ...

# Agent with sandbox: read-only:
cursor agent --sandbox enabled --workspace /path ...

# Default sandbox (unchanged):
cursor agent --workspace /path ...
```

## Work Item

Closes #309

## Verification

- `uv run pytest tests/unit/harness/test_cursor_projection.py` — 14 passed
- `uv run ruff check` — clean
- `uv run pyright` — 0 errors
- Pre-push hook: 1265 passed, 2 skipped

## Knowledge Updates

- KB: `research/cursor-sandbox-architecture.md` — Cursor sandbox internals, approval flags, mapping decisions (committed separately to KB repo)
- mars-agents docs: compilation matrix updated in PR #91 (merged)

## Spawn Trace

Direct implementation, no subagent spawns.

## Cleanup

```bash
scripts/prune-worktrees.sh
```