### PR TITLE
[codex] Add task-dir support for primary launches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Primary launches now accept `--task-dir`, matching spawn's explicit task-directory override and rejecting `--continue --task-dir` in favor of `--fork --task-dir`.
+
+### Fixed
+- Meridian CLI processes now default `MERIDIAN_MANAGED=1`, while preserving explicit outer overrides.
+
 ## [0.3.0] - 2026-06-06
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - Primary launches now accept `--task-dir`, matching spawn's explicit task-directory override and rejecting `--continue --task-dir` in favor of `--fork --task-dir`.
 
+### Changed
+- Bump `mars-agents` to 0.8.3.
+
 ### Fixed
 - Meridian CLI processes now default `MERIDIAN_MANAGED=1`, while preserving explicit outer overrides.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -396,7 +396,7 @@ hooks, harness defaults, and primary-session defaults.
 
 `meridian bootstrap --add ... --link ...` runs this same setup flow, then launches a guided bootstrap primary session.
 
-`meridian mars sync` automatically sets `MERIDIAN_MANAGED=1` in the mars subprocess environment. Mars uses this signal to suppress native agent emission to harness directories — agents are read by Meridian from `.mars/agents/`, not duplicated into `.claude/agents/` etc. `[settings.agent_copy] harnesses = ["claude"]` is the selective override when `.claude` is an effective managed target; it materializes qualifying Claude-native copies even under managed mode or `agent_emission = "never"`.
+Meridian CLI processes default `MERIDIAN_MANAGED=1` in their environment, while preserving an explicit outer override. Mars uses this signal to suppress native agent emission to harness directories — agents are read by Meridian from `.mars/agents/`, not duplicated into `.claude/agents/` etc. `[settings.meridian.agent_copy] harnesses = ["claude"]` is the selective override when `.claude` is an effective managed target; it materializes qualifying Claude-native copies even under managed mode or `agent_emission = "never"`.
 
 In Claude launches, native `Agent()` follows that same boundary: generic `Agent` is allowed only with Mars Claude `agent_copy` plus an effective `.claude` managed target. Without it, use `meridian spawn`. Claude built-ins (`Explore`, `Plan`, `General-purpose` / `general-purpose`) stay denied.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -12,6 +12,7 @@ Full command surface. Use `--help` on any command for flags and options.
 | `meridian --fork-fresh [REF]` | Launch a new primary session by forking and allowing launch identity changes (`-m`, `-a`). |
 | `meridian --from [REF]` | Launch a fresh primary session with prior spawn or chat/session context as reference material only. `REF` defaults to `$MERIDIAN_SPAWN_ID` inside Meridian sessions. Does not fork transcript lineage. |
 | `meridian bootstrap` | Launch a primary session with all installed bootstrap docs injected — guides first-time setup |
+| `meridian --task-dir PATH` | Override the source-edit directory for this primary launch only. Does not modify the work item's `task_dir` setting. Relative `-f` paths resolve against this directory. Rejected with `--continue` — use `--fork --task-dir` to diverge. |
 | `meridian spawn -a AGENT -p "task"` | Delegate work to a routed agent/model |
 | `meridian spawn list` | See running and recent spawns |
 | `meridian spawn list --profile reviewer` | Show spawns launched with the `reviewer` profile |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -170,12 +170,12 @@ CLI/env/profile setting is present.
 ### Native agent copies
 
 Meridian normally delegates through `meridian spawn` and reads agents from
-`.mars/agents/`. During `meridian mars sync`, Meridian sets
-`MERIDIAN_MANAGED=1`; Mars therefore suppresses harness-native agent copies by
-default so `.claude/agents/` and similar directories do not compete with
-Meridian routing.
+`.mars/agents/`. Meridian CLI processes default `MERIDIAN_MANAGED=1` in their environment,
+while preserving an explicit outer override. Mars therefore suppresses
+harness-native agent copies by default so `.claude/agents/` and similar
+directories do not compete with Meridian routing.
 
-Use `[settings.agent_copy]` when you intentionally want selected harness-native
+Use `[settings.meridian.agent_copy]` when you intentionally want selected harness-native
 copies under managed mode:
 
 ```toml
@@ -183,7 +183,7 @@ copies under managed mode:
 targets = [".claude", ".codex"]
 agent_emission = "never"  # optional; agent_copy can still emit selected copies
 
-[settings.agent_copy]
+[settings.meridian.agent_copy]
 harnesses = ["claude"]
 ```
 
@@ -217,7 +217,7 @@ spawns fail before launch. To completely avoid Claude-side delegation, combine
 it with no Claude `agent_copy`:
 
 ```toml
-[settings.agent_copy]
+[settings.meridian.agent_copy]
 harnesses = []
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "cyclopts>=3.0",
   "fastapi>=0.115",
   "markdown-it-py>=4.0",
-  "mars-agents==0.8.1",
+  "mars-agents==0.8.3",
   "mcp>=1.0",
   "pathspec>=1.1.0",
   "psutil>=7.2.2",

--- a/src/meridian/cli/bootstrap.py
+++ b/src/meridian/cli/bootstrap.py
@@ -35,6 +35,7 @@ _TOP_LEVEL_VALUE_FLAGS = frozenset(
         "--harness",
         "-a",
         "--work",
+        "--task-dir",
         "--autocompact",
         "--autocompact-pct",
         "--effort",
@@ -422,6 +423,19 @@ def maybe_bootstrap_runtime_state(
         return project_root
     except Exception:
         return None
+
+
+@contextmanager
+def meridian_managed_env_default() -> Generator[None, None, None]:
+    prior = os.environ.get("MERIDIAN_MANAGED")
+    os.environ.setdefault("MERIDIAN_MANAGED", "1")
+    try:
+        yield
+    finally:
+        if prior is None:
+            os.environ.pop("MERIDIAN_MANAGED", None)
+        else:
+            os.environ["MERIDIAN_MANAGED"] = prior
 
 
 @contextmanager

--- a/src/meridian/cli/bootstrap_cmd.py
+++ b/src/meridian/cli/bootstrap_cmd.py
@@ -123,6 +123,7 @@ def register_bootstrap_command(
                 harness=global_harness or explicit_harness,
                 agent=agent,
                 work=work,
+                task_dir=None,
                 yolo=yolo,
                 approval=approval,
                 autocompact=autocompact,

--- a/src/meridian/cli/entrypoint.py
+++ b/src/meridian/cli/entrypoint.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
-from meridian.cli.bootstrap import first_positional_token
+from meridian.cli.bootstrap import first_positional_token, meridian_managed_env_default
 from meridian.cli.startup.catalog import COMMAND_CATALOG
 from meridian.cli.startup.classify import classify_invocation
 
@@ -38,6 +38,11 @@ def _is_version_request(argv: Sequence[str]) -> bool:
 def main() -> None:
     """Thin CLI entrypoint: handles trivial fast paths, delegates the rest."""
 
+    with meridian_managed_env_default():
+        _main_impl()
+
+
+def _main_impl() -> None:
     import sys
 
     if sys.platform == "win32":

--- a/src/meridian/cli/main.py
+++ b/src/meridian/cli/main.py
@@ -42,6 +42,7 @@ from meridian.cli.bootstrap import (
 )
 from meridian.cli.bootstrap import (
     maybe_bootstrap_runtime_state,
+    meridian_managed_env_default,
     temporary_config_env,
 )
 from meridian.cli.bootstrap import (
@@ -418,6 +419,17 @@ def root(
         str,
         Parameter(name="--work", help="Attach the primary session to a work item id."),
     ] = "",
+    task_dir: Annotated[
+        str | None,
+        Parameter(
+            name="--task-dir",
+            help=(
+                "Override the source-code edit directory for this primary launch only. "
+                "Does not modify the work item's task_dir setting. "
+                "Relative -f paths resolve against this directory."
+            ),
+        ),
+    ] = None,
     yolo: Annotated[
         bool,
         Parameter(
@@ -496,29 +508,36 @@ def root(
             f"Conflicting harness selections: '{global_harness}' and '{explicit_harness}'."
         )
 
-    _run_primary_launch(
-        continue_ref=continue_ref,
-        fork_ref=fork_ref,
-        fork_fresh_ref=fork_fresh_ref,
-        from_ref=from_ref,
-        model=model,
-        harness=global_harness or explicit_harness,
-        agent=agent,
-        work=work,
-        yolo=yolo,
-        approval=approval,
-        autocompact=autocompact,
-        autocompact_pct=autocompact_pct,
-        effort=effort,
-        sandbox=sandbox,
-        timeout=timeout,
-        dry_run=dry_run,
-        reference_files=tuple(references),
-        prompt=resolved_prompt,
-        skills=tuple(parsed_skills),
-        goal=goal,
-        # See _split_passthrough_args() for why this reads from GlobalOptions.
-        passthrough=get_global_options().passthrough_args,
+    normalized_task_dir = (task_dir or "").strip() or None
+
+    from meridian.cli import primary_launch
+
+    emit(
+        primary_launch.run_primary_launch(
+            project_root=get_global_options().project_root,
+            continue_ref=continue_ref,
+            fork_ref=fork_ref,
+            fork_fresh_ref=fork_fresh_ref,
+            from_ref=from_ref,
+            model=model,
+            harness=global_harness or explicit_harness,
+            agent=agent,
+            work=work,
+            task_dir=normalized_task_dir,
+            yolo=yolo,
+            approval=approval,
+            autocompact=autocompact,
+            autocompact_pct=autocompact_pct,
+            effort=effort,
+            sandbox=sandbox,
+            timeout=timeout,
+            dry_run=dry_run,
+            passthrough=get_global_options().passthrough_args,
+            reference_files=tuple(references),
+            prompt=resolved_prompt,
+            skills=tuple(parsed_skills),
+            goal=goal,
+        )
     )
 
 
@@ -569,60 +588,6 @@ def mars(
     """Forward all arguments to the bundled mars CLI."""
 
     _run_mars_passthrough(args, output_format=get_global_options().output.format)
-
-
-def _run_primary_launch(
-    *,
-    continue_ref: str | None,
-    fork_ref: str | None,
-    fork_fresh_ref: str | None,
-    from_ref: str | None,
-    model: str,
-    harness: str | None,
-    agent: str | None,
-    work: str,
-    yolo: bool,
-    approval: str | None,
-    autocompact: int | None,
-    autocompact_pct: int | None,
-    effort: str | None,
-    sandbox: str | None,
-    timeout: float | None,
-    dry_run: bool,
-    reference_files: tuple[str, ...] = (),
-    prompt: str | None = None,
-    skills: tuple[str, ...] = (),
-    goal: str | None = None,
-    passthrough: tuple[str, ...] = (),
-) -> None:
-    from meridian.cli import primary_launch
-
-    emit(
-        primary_launch.run_primary_launch(
-            project_root=get_global_options().project_root,
-            continue_ref=continue_ref,
-            fork_ref=fork_ref,
-            fork_fresh_ref=fork_fresh_ref,
-            from_ref=from_ref,
-            model=model,
-            harness=harness,
-            agent=agent,
-            work=work,
-            yolo=yolo,
-            approval=approval,
-            autocompact=autocompact,
-            autocompact_pct=autocompact_pct,
-            effort=effort,
-            sandbox=sandbox,
-            timeout=timeout,
-            dry_run=dry_run,
-            passthrough=passthrough,
-            reference_files=reference_files,
-            prompt=prompt,
-            skills=skills,
-            goal=goal,
-        )
-    )
 
 
 @app.command(name="init")
@@ -1070,6 +1035,11 @@ def _directory_env_scope(
 def main(argv: Sequence[str] | None = None) -> None:
     """CLI entry point used by `meridian` and `python -m meridian`."""
 
+    with meridian_managed_env_default():
+        _main_impl(argv=argv)
+
+
+def _main_impl(argv: Sequence[str] | None = None) -> None:
     from meridian.lib.core.logging import configure_logging
 
     args = list(sys.argv[1:] if argv is None else argv)

--- a/src/meridian/cli/mars_passthrough.py
+++ b/src/meridian/cli/mars_passthrough.py
@@ -18,7 +18,6 @@ from meridian.lib.ops.mars import resolve_mars_executable
 class MarsPassthroughRequest:
     command: tuple[str, ...]
     mars_args: tuple[str, ...]
-    is_sync: bool
     wants_json: bool
     root_override: Path | None
 
@@ -53,25 +52,6 @@ def mars_requested_root(args: Sequence[str]) -> Path | None:
     return None
 
 
-def mars_subcommand(args: Sequence[str]) -> str | None:
-    index = 0
-    while index < len(args):
-        token = args[index]
-        if token == "--":
-            return None
-        if token == "--root":
-            index += 2
-            continue
-        if token.startswith("--root="):
-            index += 1
-            continue
-        if token.startswith("-"):
-            index += 1
-            continue
-        return token
-    return None
-
-
 def decode_json_values(raw_stdout: str) -> list[object] | None:
     decoder = json.JSONDecoder()
     parsed_values: list[object] = []
@@ -98,7 +78,6 @@ def parse_mars_passthrough(
     """Build an executable Mars passthrough request without side effects."""
 
     mars_args = list(args)
-    is_sync = mars_subcommand(mars_args) == "sync"
     wants_json = mars_requested_json(mars_args) or output_format == "json"
     if wants_json and not mars_requested_json(mars_args):
         mars_args = ["--json", *mars_args]
@@ -109,7 +88,6 @@ def parse_mars_passthrough(
     return MarsPassthroughRequest(
         command=(executable, *mars_args),
         mars_args=tuple(mars_args),
-        is_sync=is_sync,
         wants_json=wants_json,
         root_override=mars_requested_root(mars_args),
     )
@@ -124,11 +102,11 @@ def execute_mars_passthrough(
     """Execute a prepared Mars passthrough request."""
 
     stderr_stream = sys.stderr if stderr is None else stderr
-    run_kwargs: dict[str, object] = {}
-    if request.is_sync:
-        # With MERIDIAN_PROJECT_DIR set, parse_mars_passthrough injects --root to the
-        # launcher project; sync materializes .mars/ there, not the task cwd.
-        run_kwargs["env"] = {**os.environ, "MERIDIAN_MANAGED": "1"}
+    # With MERIDIAN_PROJECT_DIR set, parse_mars_passthrough injects --root to the
+    # launcher project; Mars runs under Meridian management for all passthrough commands.
+    run_kwargs: dict[str, object] = {
+        "env": {**os.environ, "MERIDIAN_MANAGED": os.environ.get("MERIDIAN_MANAGED", "1")},
+    }
     try:
         if request.wants_json:
             result = run(
@@ -196,4 +174,3 @@ def resolve_init_project_root(path: str | None) -> Path:
         return Path(path).expanduser().resolve()
     env_root = os.getenv("MERIDIAN_PROJECT_DIR", "").strip()
     return Path(env_root).expanduser().resolve() if env_root else Path.cwd().resolve()
-

--- a/src/meridian/cli/primary_launch.py
+++ b/src/meridian/cli/primary_launch.py
@@ -146,6 +146,7 @@ def run_primary_launch(
     harness: str | None,
     agent: str | None,
     work: str,
+    task_dir: str | None = None,
     yolo: bool,
     approval: str | None,
     autocompact: int | None,
@@ -197,6 +198,11 @@ def run_primary_launch(
     fork_target_requested = raw_fork_target or None
     fork_fresh_target_requested = raw_fork_fresh_target or None
     context_from_requested = (raw_from_target,) if raw_from_target else ()
+    normalized_task_dir = (task_dir or "").strip() or None
+    if resume_target is not None and normalized_task_dir is not None:
+        raise ValueError(
+            "--continue does not accept --task-dir. Use --fork --task-dir to diverge."
+        )
     resolved_approval = approval if approval is not None else ("never" if yolo else "default")
 
     fork_resolution = validate_fork_mode(
@@ -349,6 +355,7 @@ def run_primary_launch(
             ),
             agent=requested_agent,
             work_id=requested_work_id,
+            task_dir=normalized_task_dir,
             passthrough_args=passthrough,
             session_mode=session_mode,
             pinned_context="",

--- a/src/meridian/cli/startup/help.py
+++ b/src/meridian/cli/startup/help.py
@@ -27,6 +27,7 @@ Primary launch/resume:
   meridian --fork p123                  Fork from ref
   meridian --fork-fresh p123 -m MODEL   Fork and switch identity
   meridian --from p123                  Fresh session with prior context
+  meridian --task-dir PATH              Launch against a different edit directory
   continue/fork refs: chat id (c123), spawn id (p123), or raw harness session id
   --from refs: chat id (c123) or spawn id (p123)
   --fork preserves agent/model/skills identity. --fork-fresh allows
@@ -154,6 +155,8 @@ Primary launch/resume:
   meridian --fork-fresh p123 -m MODEL
 
   meridian --from p123
+
+  meridian --task-dir PATH
 
   continue/fork refs: chat id (c123), spawn id (p123), or raw harness session id
   --from refs: chat id (c123) or spawn id (p123)

--- a/src/meridian/lib/launch/__init__.py
+++ b/src/meridian/lib/launch/__init__.py
@@ -107,6 +107,7 @@ def launch_primary(
         project_state_dir=project_state_dir,
         context_from=request.context_from,
         reference_files=request.reference_files,
+        explicit_task_dir=request.task_dir,
         explicit_work_id=preview_work_id,
         ambient_work_id=ambient_work_id,
     )

--- a/src/meridian/lib/launch/types.py
+++ b/src/meridian/lib/launch/types.py
@@ -48,6 +48,7 @@ class LaunchRequest(BaseModel):
     harness: str | None = None
     agent: str | None = None
     work_id: str | None = None
+    task_dir: str | None = None
     session_mode: SessionMode = SessionMode.FRESH
     passthrough_args: tuple[str, ...] = ()
     pinned_context: str = ""

--- a/tests/integration/cli/test_cli_main.py
+++ b/tests/integration/cli/test_cli_main.py
@@ -27,6 +27,60 @@ bootstrap_services = importlib.import_module("meridian.lib.bootstrap.services")
 cli_utils = importlib.import_module("meridian.cli.utils")
 
 
+def test_full_main_defaults_meridian_managed_during_invocation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_run_mars_passthrough(
+        args: tuple[str, ...] | list[str],
+        *,
+        output_format: str | None = None,
+    ) -> None:
+        captured["args"] = tuple(args)
+        captured["output_format"] = output_format
+        captured["managed"] = os.environ.get("MERIDIAN_MANAGED")
+        raise SystemExit(0)
+
+    monkeypatch.delenv("MERIDIAN_MANAGED", raising=False)
+    monkeypatch.setattr(cli_main, "_run_mars_passthrough", _fake_run_mars_passthrough)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["mars", "models", "list"])
+
+    assert exc_info.value.code == 0
+    assert captured["args"] == ("models", "list")
+    assert captured["managed"] == "1"
+    assert "MERIDIAN_MANAGED" not in os.environ
+
+
+def test_full_main_preserves_outer_meridian_managed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_run_mars_passthrough(
+        args: tuple[str, ...] | list[str],
+        *,
+        output_format: str | None = None,
+    ) -> None:
+        captured["args"] = tuple(args)
+        captured["output_format"] = output_format
+        captured["managed"] = os.environ.get("MERIDIAN_MANAGED")
+        raise SystemExit(0)
+
+    monkeypatch.setenv("MERIDIAN_MANAGED", "0")
+    monkeypatch.setattr(cli_main, "_run_mars_passthrough", _fake_run_mars_passthrough)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["mars", "models", "list"])
+
+    assert exc_info.value.code == 0
+    assert captured["args"] == ("models", "list")
+    assert captured["managed"] == "0"
+    assert os.environ["MERIDIAN_MANAGED"] == "0"
+
+
 def test_main_restores_directory_env_after_return(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -346,6 +400,36 @@ def test_directory_flag_supplies_project_root_to_primary_launch(
 
     assert exc_info.value.code == 0
     assert captured["project_root"] == project.resolve()
+
+
+def test_task_dir_flag_supplies_task_dir_to_primary_launch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    task_dir = tmp_path / "task"
+    task_dir.mkdir()
+    captured: dict[str, object] = {}
+
+    monkeypatch.chdir(project)
+    monkeypatch.setattr(
+        cli_main,
+        "maybe_bootstrap_runtime_state",
+        lambda *_args, **_kwargs: project,
+    )
+
+    def _fake_primary_launch(**kwargs: object) -> object:
+        captured.update(kwargs)
+        return primary_launch.PrimaryLaunchOutput(message="ok", exit_code=0)
+
+    monkeypatch.setattr(primary_launch, "run_primary_launch", _fake_primary_launch)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["--task-dir", str(task_dir), "--dry-run"])
+
+    assert exc_info.value.code == 0
+    assert captured["task_dir"] == str(task_dir)
 
 
 def test_primary_launch_prompt_file_value_is_not_treated_as_command(

--- a/tests/integration/cli/test_cli_mars.py
+++ b/tests/integration/cli/test_cli_mars.py
@@ -18,7 +18,6 @@ mars_passthrough = importlib.import_module("meridian.cli.mars_passthrough")
                 request=mars_passthrough.MarsPassthroughRequest(
                     command=("/usr/bin/mars", "--json", "list"),
                     mars_args=("--json", "list"),
-                    is_sync=False,
                     wants_json=True,
                     root_override=None,
                 ),
@@ -36,7 +35,6 @@ mars_passthrough = importlib.import_module("meridian.cli.mars_passthrough")
                 request=mars_passthrough.MarsPassthroughRequest(
                     command=("/usr/bin/mars", "sync"),
                     mars_args=("sync",),
-                    is_sync=True,
                     wants_json=False,
                     root_override=None,
                 ),
@@ -76,16 +74,25 @@ def test_run_mars_passthrough_streaming(
 
 
 @pytest.mark.parametrize(
-    "is_sync",
-    [False, True],
-    ids=["non-sync", "sync"],
+    "mars_args",
+    [
+        ("models", "list"),
+        ("sync",),
+        ("upgrade",),
+        ("link",),
+        ("init", "--link", ".claude"),
+        ("init",),
+    ],
+    ids=["models", "sync", "upgrade", "link", "init-link", "init"],
 )
-def test_execute_mars_passthrough_sets_managed_env_only_for_sync(is_sync: bool) -> None:
-    mars_args = ("sync",) if is_sync else ("models", "list")
+def test_execute_mars_passthrough_sets_managed_env_for_all_commands(
+    mars_args: tuple[str, ...],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MERIDIAN_MANAGED", raising=False)
     request = mars_passthrough.MarsPassthroughRequest(
         command=("/usr/bin/mars", *mars_args),
         mars_args=mars_args,
-        is_sync=is_sync,
         wants_json=False,
         root_override=None,
     )
@@ -101,11 +108,31 @@ def test_execute_mars_passthrough_sets_managed_env_only_for_sync(is_sync: bool) 
     assert result.returncode == 0
     assert observed["cmd"] == ["/usr/bin/mars", *mars_args]
     env = observed["env"]
-    if is_sync:
-        assert isinstance(env, dict)
-        assert env["MERIDIAN_MANAGED"] == "1"
-    else:
-        assert env is None
+    assert isinstance(env, dict)
+    assert env["MERIDIAN_MANAGED"] == "1"
+
+
+def test_execute_mars_passthrough_preserves_outer_meridian_managed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MERIDIAN_MANAGED", "0")
+    request = mars_passthrough.MarsPassthroughRequest(
+        command=("/usr/bin/mars", "models", "list"),
+        mars_args=("models", "list"),
+        wants_json=False,
+        root_override=None,
+    )
+    observed: dict[str, object] = {}
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        observed["env"] = kwargs.get("env")
+        return subprocess.CompletedProcess(args=cmd, returncode=0)
+
+    mars_passthrough.execute_mars_passthrough(request, run=_fake_run)
+
+    env = observed["env"]
+    assert isinstance(env, dict)
+    assert env["MERIDIAN_MANAGED"] == "0"
 
 
 def test_main_mars_defaults_to_text_in_agent_mode(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -130,5 +157,3 @@ def test_main_mars_defaults_to_text_in_agent_mode(monkeypatch: pytest.MonkeyPatc
     assert exc_info.value.code == 0
     assert captured["args"] == ("list",)
     assert captured["output_format"] == "text"
-
-

--- a/tests/integration/launch/test_launch_resolution_runtime.py
+++ b/tests/integration/launch/test_launch_resolution_runtime.py
@@ -298,6 +298,41 @@ def test_primary_launch_resolves_reference_files_from_work_task_dir(
     assert "project shadow" not in prompt
 
 
+def test_primary_launch_resolves_reference_files_from_explicit_task_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "project"
+    task_dir = tmp_path / "task"
+    project_root.mkdir()
+    task_dir.mkdir()
+    _write_minimal_mars_config(project_root)
+    (project_root / "task-only.txt").write_text("project shadow", encoding="utf-8")
+    (task_dir / "task-only.txt").write_text("task marker", encoding="utf-8")
+    stub_bundle_request_and_resolve(
+        monkeypatch,
+        model="gpt-5.4-mini",
+        harness=HarnessId.CODEX,
+    )
+
+    result = launch_primary(
+        project_root=project_root,
+        request=PrimaryLaunchRequest(
+            model="gpt-5.4-mini",
+            harness=HarnessId.CODEX.value,
+            task_dir=task_dir.as_posix(),
+            reference_files=("task-only.txt",),
+            dry_run=True,
+        ),
+        harness_registry=get_default_harness_registry(),
+    )
+
+    prompt = result.command[-1]
+    assert (task_dir / "task-only.txt").as_posix() in prompt
+    assert "task marker" in prompt
+    assert "project shadow" not in prompt
+
+
 def test_primary_launch_invalid_reference_does_not_create_explicit_work(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/cli/test_entrypoint_encoding.py
+++ b/tests/unit/cli/test_entrypoint_encoding.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 import types
 
@@ -34,6 +35,7 @@ def _make_fake_main_module(captured: dict[str, object]) -> types.ModuleType:
 
     def _noop(*, argv: list[str]) -> None:
         captured["argv"] = argv
+        captured["managed"] = os.environ.get("MERIDIAN_MANAGED")
 
     fake.main = _noop  # type: ignore[attr-defined]
     return fake
@@ -100,6 +102,54 @@ def test_reconfigure_not_called_on_posix(
 
     assert fake_stdout._reconfigure_calls == []
     assert fake_stderr._reconfigure_calls == []
+
+
+def test_entrypoint_defaults_meridian_managed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    fake_main_module = _make_fake_main_module(captured)
+    original = sys.modules.get("meridian.cli.main")
+    sys.modules["meridian.cli.main"] = fake_main_module
+
+    try:
+        monkeypatch.delenv("MERIDIAN_MANAGED", raising=False)
+        monkeypatch.setattr(sys, "argv", ["meridian", "spawn", "list"])
+
+        entrypoint_module.main()
+    finally:
+        if original is not None:
+            sys.modules["meridian.cli.main"] = original
+        else:
+            sys.modules.pop("meridian.cli.main", None)
+
+    assert captured["argv"] == ["spawn", "list"]
+    assert captured["managed"] == "1"
+    assert "MERIDIAN_MANAGED" not in os.environ
+
+
+def test_entrypoint_preserves_outer_meridian_managed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    fake_main_module = _make_fake_main_module(captured)
+    original = sys.modules.get("meridian.cli.main")
+    sys.modules["meridian.cli.main"] = fake_main_module
+
+    try:
+        monkeypatch.setenv("MERIDIAN_MANAGED", "0")
+        monkeypatch.setattr(sys, "argv", ["meridian", "spawn", "list"])
+
+        entrypoint_module.main()
+    finally:
+        if original is not None:
+            sys.modules["meridian.cli.main"] = original
+        else:
+            sys.modules.pop("meridian.cli.main", None)
+
+    assert captured["argv"] == ["spawn", "list"]
+    assert captured["managed"] == "0"
+    assert os.environ["MERIDIAN_MANAGED"] == "0"
 
 
 def test_reconfigure_skipped_when_stream_lacks_reconfigure(

--- a/tests/unit/cli/test_mars_passthrough.py
+++ b/tests/unit/cli/test_mars_passthrough.py
@@ -33,7 +33,6 @@ def test_parse_injects_root_from_meridian_project_dir(
         str(project_root),
     )
     assert request.root_override == project_root
-    assert request.is_sync is False
     assert request.wants_json is False
 
 
@@ -73,22 +72,13 @@ def test_parse_respects_user_root_over_meridian_project_dir(
     assert list(request.command).count("--root") == 1
 
 
-def test_parse_json_and_sync_with_meridian_project_dir(
+def test_parse_json_with_meridian_project_dir(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     project_root = tmp_path / "project"
     project_root.mkdir()
     monkeypatch.setenv("MERIDIAN_PROJECT_DIR", str(project_root))
-
-    sync_request = mars_passthrough.parse_mars_passthrough(
-        ["sync"],
-        executable="/usr/bin/mars",
-    )
-    assert sync_request.is_sync is True
-    assert sync_request.wants_json is False
-    assert sync_request.command[-2:] == ("--root", str(project_root))
-
     json_request = mars_passthrough.parse_mars_passthrough(
         ["models", "resolve", "haiku"],
         executable="/usr/bin/mars",

--- a/tests/unit/cli/test_primary_launch.py
+++ b/tests/unit/cli/test_primary_launch.py
@@ -220,6 +220,8 @@ def test_run_primary_launch_forwards_primary_spawn_parity_fields(
 ) -> None:
     project_root = tmp_path / "repo"
     project_root.mkdir()
+    task_dir = tmp_path / "task"
+    task_dir.mkdir()
     reference = project_root / "design.md"
     reference.write_text("design notes", encoding="utf-8")
     captured: dict[str, object] = {}
@@ -239,6 +241,7 @@ def test_run_primary_launch_forwards_primary_spawn_parity_fields(
         harness=None,
         agent="tech-lead",
         work="",
+        task_dir=task_dir.as_posix(),
         yolo=False,
         approval=None,
         autocompact=None,
@@ -255,10 +258,38 @@ def test_run_primary_launch_forwards_primary_spawn_parity_fields(
 
     request = cast("LaunchRequest", captured["request"])
     assert reference.is_file()
+    assert request.task_dir == task_dir.as_posix()
     assert request.reference_files == ("design.md",)
     assert request.prompt == "Review the design."
     assert request.skills == ("planning", "dev-principles")
     assert request.goal == "Converge on requirements"
+
+
+def test_run_primary_launch_task_dir_with_continue_reports_conflict(tmp_path: Path) -> None:
+    task_dir = tmp_path / "task"
+    with pytest.raises(
+        ValueError,
+        match=re.escape("--continue does not accept --task-dir. Use --fork --task-dir to diverge."),
+    ):
+        primary_launch.run_primary_launch(
+            project_root=Path.cwd(),
+            continue_ref="c123",
+            fork_ref=None,
+            fork_fresh_ref=None,
+            model="",
+            harness=None,
+            agent=None,
+            work="",
+            task_dir=task_dir.as_posix(),
+            yolo=False,
+            approval=None,
+            autocompact=None,
+            effort=None,
+            sandbox=None,
+            timeout=None,
+            dry_run=True,
+            passthrough=(),
+        )
 
 
 def test_run_primary_launch_from_with_continue_reports_conflict_before_inference(

--- a/uv.lock
+++ b/uv.lock
@@ -666,15 +666,15 @@ wheels = [
 
 [[package]]
 name = "mars-agents"
-version = "0.8.1"
+version = "0.8.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/87/b5/9ec7d340bd23e2f745c253856714d3831ea9bb18f76605fff5ef5c86a36e/mars_agents-0.8.1.tar.gz", hash = "sha256:b7145fe561457279e0fec3bda8d72d3da34238614aac3cda03577dbd1340a5ac", size = 623300, upload-time = "2026-06-06T20:54:58.942Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/00/7c3173f32a0ac18b4a0dba429d422a339c419c303a670d31d33981bef0ef/mars_agents-0.8.3.tar.gz", hash = "sha256:823174113463257e5f625b0161a2743abfd6c25b21e5514c12701ea024eeea92", size = 624355, upload-time = "2026-06-07T04:01:52.213Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/61/7d7a2efecb60aa41a46c0da2784a1b884f2204c9405a28286e6a0731a991/mars_agents-0.8.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:2ab06284b6e25992c58a715b91109f4754e97470c6c4e070037163e885b0a649", size = 3359525, upload-time = "2026-06-06T20:54:48.195Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/03/b3b5191334ac57953a858e5c08f89ef203f99dbb99b2bd7c45863877e9fb/mars_agents-0.8.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5e6d1b14208609cc7c0a9b92f627e18c747633c7fb60642cfb128055e904a52d", size = 3220209, upload-time = "2026-06-06T20:54:50.516Z" },
-    { url = "https://files.pythonhosted.org/packages/18/21/e4e54946dc79f6f331866c527889215bc23b744de687ba5f9afbf4425786/mars_agents-0.8.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fadeef08a6c2ce2b7b69de37f52b9cb3a743f4514644e83927329b81162f6c6", size = 3251709, upload-time = "2026-06-06T20:54:52.311Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/37/80a005b7a53d5947b92fefd3a7dde9f5439137a7280776f0bee8f354adc6/mars_agents-0.8.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9ab4674fd9971a315a1c16ced3a8b61760fda9a899b81466a424a5db09f7e543", size = 3486207, upload-time = "2026-06-06T20:54:54.693Z" },
-    { url = "https://files.pythonhosted.org/packages/49/54/f184af9c17731f4330ab2e44614faa508d8956ac3e62c90ea78e6cd70ff2/mars_agents-0.8.1-py3-none-win_amd64.whl", hash = "sha256:eb2b862d600618087bb013f25686d8c2899a465fe8275c75bb28cc49d3ce3603", size = 3428727, upload-time = "2026-06-06T20:54:56.517Z" },
+    { url = "https://files.pythonhosted.org/packages/46/12/2b80a1330473bd178d6d93f7f8325732748a6f51ee21384ab45945e755e9/mars_agents-0.8.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9cecccaf479a7ca04dbcda91aea4a771de07aa9a7643d7e6816cae29aa2d5d65", size = 3370814, upload-time = "2026-06-07T04:01:42.746Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b7/d2192dd6fd7893c3612efa4a61305dcbfdd8a82123e87802369d9409efd3/mars_agents-0.8.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7f7514534391b452a8477aa22f620f6706128793c5e50fd7213b1e0133258631", size = 3220895, upload-time = "2026-06-07T04:01:44.455Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/32/173a01c2275e5145bf41785c606ebbc1a0c165498bbb5b038e0bb7aa4743/mars_agents-0.8.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:211f817b8c50b5a0a5b8263ee0965c525a85bfd23c15067965a6f0ede6d0ba64", size = 3272443, upload-time = "2026-06-07T04:01:46.392Z" },
+    { url = "https://files.pythonhosted.org/packages/23/15/2955ff36054a69d2f78c829e6693e3b6d2e47f14e4572ed2e023836be2cd/mars_agents-0.8.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:20f44612c36ccd9fb9215209f614d512048ea6d157be54b557afe4713a6d2966", size = 3488020, upload-time = "2026-06-07T04:01:48.234Z" },
+    { url = "https://files.pythonhosted.org/packages/36/09/de8a2b027558186dcea13a60fedafb9b6e923c6160a2e20ea32a61aa034e/mars_agents-0.8.3-py3-none-win_amd64.whl", hash = "sha256:34a3726ad15300aa90a79735e1791d3b48ce6ec93dcd37b404a064d411f99a1a", size = 3449256, upload-time = "2026-06-07T04:01:49.964Z" },
 ]
 
 [[package]]
@@ -765,7 +765,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'app'", specifier = ">=0.28" },
     { name = "jinja2", marker = "extra == 'templates'", specifier = ">=3.1" },
     { name = "markdown-it-py", specifier = ">=4.0" },
-    { name = "mars-agents", specifier = "==0.8.1" },
+    { name = "mars-agents", specifier = "==0.8.3" },
     { name = "mcp", specifier = ">=1.0" },
     { name = "pathspec", specifier = ">=1.1.0" },
     { name = "psutil", specifier = ">=7.2.2" },


### PR DESCRIPTION
## Why

Primary launches had no `--task-dir`, even though spawn and the shared launch resolver already supported explicit task-directory overrides. That left users unable to start a primary session against a different source-edit directory.

## Goal

`meridian --task-dir <dir>` should behave like spawn's task-dir override for fresh/forked primary launches, while `--continue --task-dir` is rejected with the existing divergence guidance.

## Summary

- Added `--task-dir` to the primary CLI path, startup flag classifier, and custom root help.
- Scoped Meridian CLI startup so child processes default `MERIDIAN_MANAGED=1`, while explicit outer overrides are preserved and restored after the invocation.
- Bumped `mars-agents` to 0.8.3.
- Removed the `_run_primary_launch()` pass-through helper by inlining the primary launch call.
- Added `task_dir` to `LaunchRequest` and threaded it into `resolve_launch_inputs()`.
- Kept bootstrap launches explicit with `task_dir=None`.
- Added CLI, request-forwarding, conflict, and reference-resolution coverage.

## Resulting Behavior

Meridian CLI invocations now default `MERIDIAN_MANAGED=1` for their process tree, while preserving explicit outer overrides and restoring embedding callers' environments after `main()` returns. Mars passthrough inherits that boundary instead of classifying subcommands. The bundled Mars CLI is now `mars-agents` 0.8.3.

`meridian --task-dir /path/to/worktree --dry-run` now launches a primary session whose task instructions and reference resolution use that directory. Relative `-f` references resolve from `--task-dir`.

`meridian --continue c123 --task-dir /path/to/worktree` fails with:

```text
--continue does not accept --task-dir. Use --fork --task-dir to diverge.
```

## Changes

- `src/meridian/cli/main.py`: primary CLI option added; forwarding helper removed.
- `src/meridian/cli/primary_launch.py`: normalizes task dir, rejects continue conflict, and includes it in `LaunchRequest`.
- `src/meridian/lib/launch/types.py` / `src/meridian/lib/launch/__init__.py`: launch DTO and resolver plumbing.
- `src/meridian/cli/bootstrap.py`: startup parse table recognizes `--task-dir` as a value flag.
- `src/meridian/cli/startup/help.py`: root help shows the primary `--task-dir` form.
- `src/meridian/cli/bootstrap.py`, `entrypoint.py`, `main.py`: CLI invocations scope a default `MERIDIAN_MANAGED=1` without leaking it to embedding callers.
- `src/meridian/cli/mars_passthrough.py`: Mars passthrough inherits/copies the scoped env; subcommand classification was removed.
- `pyproject.toml` / `uv.lock`: require `mars-agents==0.8.3`.
- `docs/commands.md` / `docs/configuration.md`: managed Mars command docs updated.
- `src/meridian/cli/bootstrap_cmd.py`: passes `task_dir=None` for bootstrap setup launches.
- Tests cover CLI forwarding, LaunchRequest forwarding, explicit task-dir reference resolution, continue conflict, and managed-env Mars passthrough commands.

## Work Item

primary-task-dir

## Verification

- `uv sync --extra dev`
- `uv run pytest tests/unit/cli/test_primary_launch.py tests/integration/cli/test_cli_main.py tests/integration/launch/test_launch_resolution_runtime.py::test_primary_launch_resolves_reference_files_from_explicit_task_dir -q`
- `uv run ruff check .`
- `uv run ruff check .` after kb-lead doc capture
- `uv run pytest-llm` → `1347 passed, 2 skipped`
- `uv run --extra dev python -m pyright` → `0 errors, 1 existing warning`
- `uv run pytest tests/unit/cli/test_mars_passthrough.py tests/integration/cli/test_cli_mars.py -q` → `19 passed`
- Live fake-Mars CLI smoke: `upgrade`, `models list`, and `doctor` recorded default `MERIDIAN_MANAGED=1`; with outer `MERIDIAN_MANAGED=0`, the same commands recorded `0`.
- Version fast-path smoke: default env is restored to unset after return; explicit outer `MERIDIAN_MANAGED=0` is preserved after return.
- `uv run meridian mars --version` → `mars 0.8.3`
- `uv run meridian mars models list | head -30`
- Live temp-project Mars smoke with this repo's `mars.toml`: `meridian mars sync --no-refresh-models --no-upgrade-hint` installed 83 items and emitted 7 managed native agents under default `MERIDIAN_MANAGED=1`; `meridian mars link .opencode` synced 45 files.
- `uv run meridian --task-dir /tmp --dry-run`
- `uv run meridian --continue c123 --task-dir /tmp --dry-run`
- `uv run meridian --help`
- Pre-push hook: ruff, pyright, pytest, and `uv build --no-sources` passed.

## Knowledge Updates

- Updated `CHANGELOG.md` under `[Unreleased]`.
- Updated docs for managed Mars materialization commands and primary `--task-dir`.

## Spawn Trace

- p3742 reviewer — reviewed primary `--task-dir` diff for correctness/regression risk.
- p3743 prober — ran runtime CLI probes for primary `--task-dir` behavior.
- p3751 reviewer — found `init --link` managed-env gap in the selective version; superseded by unconditional managed env.
- p3753 reviewer — reviewed unconditional managed-env simplification; findings addressed.
- p3756 reviewer — found host env leak in unscoped startup default; fixed with scoped env context.
- p3758 reviewer — reviewed `mars-agents` 0.8.3 bump; requested live sync/link smoke, which passed.
- p3759 kb-lead — ran post-implementation capture; added primary `--task-dir` to `docs/commands.md`.

## Release Label Guide

Set one `release:*` label on this PR:

- `release:patch` / `release:stable` — next stable **patch** release after merge
- `release:minor` — next stable **minor** release after merge
- `release:major` — next stable **major** release after merge
- `release:rc` — next **prerelease (RC)** after merge
- `release:skip` — no release for this merge

No `release:*` label defaults to a prerelease (RC). Unknown `release:*` labels also default to RC.

## Post-Merge Automation

After merge to `main`, CI (`.github/workflows/release-on-merge.yml`) will:

1. Read the PR release label
2. Skip only when `release:skip` is present (no label defaults to RC)
3. Compute the next stable or RC version from existing `v*` tags
4. Update `src/meridian/__init__.py` + promote `CHANGELOG.md` `[Unreleased]`
5. Commit `Release X.Y.Z`, create/push `vX.Y.Z`
6. Run `.github/workflows/publish-pypi.yml`

## Cleanup

After merge, clean merged worktrees with:

```bash
scripts/prune-worktrees.sh
```





