### PR TITLE
fix(pi): reasoning effort via --thinking flag; capture #320 docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ smoke/
 tmp/
 .tmp-*/
 plan/
+temp/
 
 .orchestrate/
 .scratch/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Pi projections now pass reasoning effort with `--thinking <level>` instead of appending `:<level>` to model IDs, fixing fully-qualified provider/model launches such as `deepseek`. Passthrough `--model` overrides suppress the managed `--thinking` flag so user model selection wins cleanly.
+
 ## [0.3.2] - 2026-06-10
 
 ### Added
@@ -22,7 +25,6 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `backend_lifecycle.json` sidecar and `state/backend_lifecycle.py` — a write-once-never-read second source of truth that drifted vs `process_scopes.json`; the parent-death/containment datum now lives on `ProcessScopeSnapshot`.
 
 ### Fixed
-- Pi projections now pass reasoning effort with `--thinking <level>` instead of appending `:<level>` to model IDs, fixing fully-qualified provider/model launches such as `deepseek`.
 - Resident terminal finalization is owned by the coordinator, not raw stream frames: a resident-deadline `timed_out` outcome wins over a late durable-report-completion (no longer mis-finalized `succeeded`), and only coordinator-authored terminal outcomes (resident `timed_out`) suppress launch retries — ordinary single-turn close-without-terminal-frame and Pi drain failures stay retry-eligible. Deadline reap is exception-safe: the parent still finalizes `timed_out` even if descendant teardown raises.
 - Orphaned harness backends: detached Codex/OpenCode backends link to the worker lifetime (POSIX parent-death where available, Windows Job Object) and dead-worker reaping finalizes child spawns while cleaning recorded backend scopes.
 - `detached_process` parent-death linkage is honest about containment: it reports whether linkage was actually installed (Linux `prctl`; other POSIX degrade to new-session-only and log) instead of silently claiming all non-Windows launches are linked.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `backend_lifecycle.json` sidecar and `state/backend_lifecycle.py` — a write-once-never-read second source of truth that drifted vs `process_scopes.json`; the parent-death/containment datum now lives on `ProcessScopeSnapshot`.
 
 ### Fixed
+- Pi projections now pass reasoning effort with `--thinking <level>` instead of appending `:<level>` to model IDs, fixing fully-qualified provider/model launches such as `deepseek`.
 - Resident terminal finalization is owned by the coordinator, not raw stream frames: a resident-deadline `timed_out` outcome wins over a late durable-report-completion (no longer mis-finalized `succeeded`), and only coordinator-authored terminal outcomes (resident `timed_out`) suppress launch retries — ordinary single-turn close-without-terminal-frame and Pi drain failures stay retry-eligible. Deadline reap is exception-safe: the parent still finalizes `timed_out` even if descendant teardown raises.
 - Orphaned harness backends: detached Codex/OpenCode backends link to the worker lifetime (POSIX parent-death where available, Windows Job Object) and dead-worker reaping finalizes child spawns while cleaning recorded backend scopes.
 - `detached_process` parent-death linkage is honest about containment: it reports whether linkage was actually installed (Linux `prctl`; other POSIX degrade to new-session-only and log) instead of silently claiming all non-Windows launches are linked.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -338,3 +338,26 @@ meridian chat --dev --portless-force
 meridian chat --headless
 # → API-only at http://127.0.0.1:<port>
 ```
+
+## Workstation: memory-safe ripgrep
+
+`rg` on this machine is wrapped at `~/.local/bin/rg` to prevent OOM kills. A bare `rg` over a large codebase can mmap hundreds of GB of virtual address space and exhaust RAM (this happened — it killed a tmux session).
+
+The wrapper enforces:
+- `--no-mmap` — sequential reads instead of memory-mapped I/O, keeps VSZ low
+- `--max-filesize 500M` — skips files larger than 500 MB
+- `-j 4` — caps parallel search threads
+- cgroup limits via `systemd-run`: `MemoryHigh=6G`, `MemoryMax=10G`, `MemorySwapMax=4G`
+
+To bypass (e.g. searching a legitimately large file):
+```bash
+~/.local/bin/rg.real [flags] [pattern] [path]
+```
+
+Also recommended — install `earlyoom` as a system-wide backstop:
+```bash
+sudo apt install earlyoom
+# In /etc/default/earlyoom:
+# EARLYOOM_ARGS="-m 4,3 -s 10,5 --prefer '(^|/)(rg|ripgrep)$' --sort-by-rss -g -r 60"
+sudo systemctl enable --now earlyoom
+```

--- a/README.md
+++ b/README.md
@@ -4,18 +4,6 @@ Orchestrate AI coding agents across Claude Code, Codex, and OpenCode. Each model
 
 > **Early development.** Meridian is not stable. Expect breaking changes in any release. If you need a stable workflow, this project is not ready for you yet.
 
-## v0.1.0 Migration
-
-v0.1.0 removes all legacy state format support in the state layer.
-
-If you are upgrading from any pre-0.1.0 build, run:
-
-```bash
-rm -rf ~/.meridian
-```
-
-This is a clean break. There is no automatic migration.
-
 ## Why
 
 Claude Code is (supposed to be) the best way to run Claude. Codex CLI is often the best way to run GPT. Each provider's harness is optimized for their models — sandboxing, tool use, context handling, everything (supposedly).

--- a/docs/agent-profiles.md
+++ b/docs/agent-profiles.md
@@ -166,9 +166,9 @@ Fallback only activates when:
 - the head candidate's harness is unavailable, **and**
 - the user did not explicitly set a model with `-m` / `MERIDIAN_MODEL`
 
-Legacy `fallback-order` and `fanout` are rejected with migration guidance.
-Migrate by ordering `model-policies` rules directly and adding
-`no-fallback: true` for rules that should never be considered for fallback.
+Legacy `fallback-order` and `fanout` are rejected. Order `model-policies`
+rules directly and add `no-fallback: true` for rules that should never be
+considered for fallback.
 
 ## Skills and Skill Variants
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -411,7 +411,7 @@ deny_headless_harnesses = ["claude"]
 That blocks spawn routes after model/profile resolution selects Claude, while
 leaving primary Claude launches available.
 
-See [agent-profiles.md](agent-profiles.md) for the agent profile format including `model-policies`, `no-fallback`, and `mode`. Legacy `fanout` and `fallback-order` are rejected; migrate to `model-policies` list order + `no-fallback: true`.
+See [agent-profiles.md](agent-profiles.md) for the agent profile format including `model-policies`, `no-fallback`, and `mode`. Legacy `fanout` and `fallback-order` are rejected; use `model-policies` list order + `no-fallback: true`.
 
 ## Spawn Statuses
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -12,7 +12,7 @@ Read this only when something looks wrong: a spawn seems stuck, expected output 
 | `missing_spawn_dir` | Crash during launch before spawn artifacts stabilized | Relaunch the spawn |
 | Exit 127 or 2 with empty report | Harness binary missing from `$PATH` | Install or fix PATH for the selected harness |
 | Exit 143 or 137 | Process terminated externally | Check `meridian spawn show <id>` first; if status is `succeeded`, signal hit during cleanup and no retry is needed. Otherwise check host logs for OOM or external kill, then retry |
-| Timeout exit | Runtime budget exceeded | Increase timeout or split task into smaller spawns |
+| `timed_out` status | Runtime budget exceeded | Increase timeout or split task into smaller spawns |
 | Model/API error in `stderr.log` | Model unavailable or API rejected request | Check `meridian mars models list` and provider credentials |
 
 ## Spawn Artifact Layout
@@ -74,7 +74,7 @@ ls -la "$(meridian context kb)"
 
 Meridian reconciles running spawns on read. If a process died, wrote a report without finalizing, or went stale, the next `spawn list`, `spawn show`, `spawn wait`, or `meridian doctor` call detects that and marks it failed.
 
-A spawn in `finalizing` status is **not stuck** — it's in a short transient window between process exit and terminal state commit. Give it a few seconds before treating it as stuck. If a `finalizing` record persists with no recent activity, reconciliation will move it to `failed` with `orphan_finalization` on the next read; the extracted `report.md` may still contain useful content from before the abandonment.
+A spawn in `finalizing` status is **not stuck** — it is in the drain/report/final-status window after the runner has recorded its resolved exit tuple. Give it a few seconds before treating it as stuck. If a `finalizing` record persists with no recent activity, reconciliation uses any durable report or recorded runner-exit tuple first; if neither can prove completion, it moves the spawn to `failed` with `orphan_finalization`.
 
 If a spawn seems stuck, run:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -141,7 +141,6 @@ Existing roots are projected to harness launches automatically — `--add-dir` f
 - [commands.md](commands.md) — full CLI reference
 - [configuration.md](configuration.md) — `mars.toml` vs `meridian.toml`, config keys, model routing, environment variables
 - [agent-profiles.md](agent-profiles.md) — agent profile format, `model-policies`, `no-fallback`, and `mode`
-  (legacy `fanout` and `fallback-order` profiles must be migrated to `model-policies` list order + `no-fallback: true`)
 - [codex-tui-passthrough.md](codex-tui-passthrough.md) — managed Codex startup, bootstrap, and attach behavior
 - [hooks.md](hooks.md) — hook events, builtin hooks, and `git-autosync`
 - [plugin-api.md](plugin-api.md) — stable API for hook and plugin authors

--- a/docs/harness-integration.md
+++ b/docs/harness-integration.md
@@ -280,14 +280,13 @@ caller). The drift guard `check_projection_drift()` runs at import time.
 def project_pi_spec_to_cli_args(spec, *, base_command) -> list[str]:
     command = list(base_command)
 
-    # Model with optional thinking level
+    # Model and separate thinking level
     if spec.model:
-        model = spec.model
-        if spec.effort:
-            thinking = _EFFORT_TO_THINKING.get(spec.effort)
-            if thinking:
-                model = f"{model}:{thinking}"
-        command.extend(("--model", model))
+        command.extend(("--model", spec.model))
+    if spec.effort:
+        thinking = _EFFORT_TO_THINKING.get(spec.effort)
+        if thinking and not _has_model_override_in_passthrough(spec.extra_args):
+            command.extend(("--thinking", thinking))
 
     # System prompt (inline, not file path — differs from Claude)
     if spec.appended_system_prompt:
@@ -328,9 +327,11 @@ def project_pi_spec_to_cli_args(spec, *, base_command) -> list[str]:
 - **Model format**: Pi expects `provider/model-id` (same as OpenCode). Claude
   uses `--model` with the full model string. Codex uses `--model` with the
   anthropic model ID. Pass through whatever the harness expects.
-- **Effort → thinking level**: Pi accepts `:level` suffix on the model string
-  (`sonnet:high`). Map Meridian effort values to harness-specific thinking
-  levels.
+- **Effort → thinking level**: Pi accepts a separate `--thinking <level>` flag.
+  Map Meridian effort values to harness-specific thinking levels. When the
+  user's `extra_args` include a `--model`/`-m` override, suppress the managed
+  `--thinking` flag so the user's model selection wins cleanly (same contract as
+  when effort was encoded in the model token).
 - **Isolation flags**: Every harness has ambient discovery (extensions, MCP
   servers, context files, project config). For spawns, suppress all of it.
   For Pi: `--no-extensions`, `--no-skills`, `--no-context-files`,
@@ -568,7 +569,7 @@ observability.
 ### 2.3 Primary Launch (Native TUI)
 
 ```text
-<resolved-pi> [--model <model[:thinking]>] [--append-system-prompt <text>] [--session <id> | --fork <id>] [permission flags] [extra_args...]
+<resolved-pi> [--model <model>] [--thinking <level>] [--append-system-prompt <text>] [--session <id> | --fork <id>] [permission flags] [extra_args...]
 ```
 
 Environment:
@@ -585,7 +586,7 @@ Primary must not pass `--mode rpc`, managed extensions, or any wrapper-only flag
 ### 2.4 Spawned RPC
 
 ```text
-<resolved-pi> --mode rpc --model <model[:thinking]> --session-dir <dir> --no-extensions -e <managed-bash.js> -e <lifecycle.js> [session flags] [permission flags]
+<resolved-pi> --mode rpc --model <model> [--thinking <level>] --session-dir <dir> --no-extensions -e <managed-bash.js> -e <lifecycle.js> [session flags] [permission flags]
 ```
 
 Environment:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -142,8 +142,8 @@ If a spawn stays in `finalizing` for more than a minute or two, the runner may h
 
 Meridian classifies a spawn as orphaned when its runner process is gone and there has been no recent activity on the spawn's artifacts (heartbeat, output, stderr, or report) for 120 seconds. There are two distinct orphan errors:
 
-- **`orphan_run`** — the spawn record was `status=running` (or `queued`) when reaped. The runner died before completing post-exit work; because output drain and report extraction happen while status is still `running`, a crash during drain also produces this error. The spawn likely produced partial or no output.
-- **`orphan_finalization`** — the spawn record was `status=finalizing` when reaped, meaning the runner completed all post-exit work but crashed in the narrow window before persisting the terminal state. The spawn is likely to have a usable `report.md` on disk even though it was classified as failed.
+- **`orphan_run`** — the spawn record was `status=running` (or `queued`) when reaped. The runner died before the finalization boundary. The spawn likely produced partial or no output.
+- **`orphan_finalization`** — the spawn record was `status=finalizing` when reaped, meaning the runner had left active execution and was in the drain/report/final-status window. If a durable report exists, reconciliation prefers it; otherwise the spawn is marked failed with this error.
 - **`launch_boundary_no_takeover`** — a background spawn's `launch-boundary.jsonl` shows that the parent launched the subprocess but the worker process never recorded a takeover event. The harness process died in the startup window before it could begin work. No output was produced.
 - **`orphan_primary`** — a managed Codex/OpenCode primary lost its Meridian launcher/wrapper. Passive reconciliation records the failed state. Use `meridian spawn cancel ID` to clean up tracked runtime processes — it terminates the launcher first (to let harness-driven shutdown propagate), then terminates backend and TUI processes if they are still running.
 

--- a/src/meridian/lib/harness/connections/.context/CONTEXT.md
+++ b/src/meridian/lib/harness/connections/.context/CONTEXT.md
@@ -45,12 +45,16 @@ Required abstract methods — every subclass must implement all of these:
 - `harness_id`, `spawn_id`, `capabilities` properties
 - `session_id` → `str | None` (None until the transport delivers a session identifier)
 - `subprocess_pid` → `int | None`
+- `resident_backend` → `ResidentBackendControl | None`; Codex/OpenCode expose
+  this for resident-until-done structured liveness and follow-up turns;
+  non-resident transports return None. This is the only public resident control
+  seam — callers do not reach for adapter-specific backend objects.
+- `scope_snapshot` → `ProcessScopeSnapshot | None`; managed backends expose the
+  process-scope facts captured at launch so primary attach and cleanup paths do
+  not reconstruct containment from PID fields.
 - `start(config, spec)` → async; raises if already started
 - `stop()` → async; idempotent
 - `health()` → bool
-- `resident_backend` → `ResidentBackendControl | None`; Codex/OpenCode expose
-  this for resident-until-done structured liveness and follow-up turns;
-  non-resident transports return None.
 - `send_user_message(text)` → async
 - `send_cancel()` → async
 - `events()` → `AsyncIterator[HarnessEvent]`
@@ -61,9 +65,6 @@ supports the capability:
 - `start_observer(config, spec)` — observer mode; guard with `capabilities.supports_primary_observer`
 - `configure_primary_runtime_requests(policy, event_sink, request_handler)`
 - `inject_runtime_event(event)`
-- `inject_turn(message)` — compatibility wrapper that delegates to
-  `resident_backend.begin_followup_turn`; transports should implement follow-up
-  turns through the resident backend seam instead of overriding this directly.
 - `respond_request(request_id, decision, payload)` — Codex only
 - `respond_user_input(request_id, answers)` — Codex only
 

--- a/src/meridian/lib/harness/connections/AGENTS.md
+++ b/src/meridian/lib/harness/connections/AGENTS.md
@@ -11,12 +11,13 @@ Each transport wraps a long-lived process and turns its output into a stream of
 `HarnessEvent` objects consumed by the drain loop. The drain loop calls
 `terminal_outcome(event)` on each event; when that returns non-None, it breaks.
 
-Three transports exist, each different at the wire level:
+Transports differ at the wire level:
 - **Claude** (`claude_ws.py`): stdin/stdout NDJSON. No WebSocket despite the filename.
-- **Codex** (`codex_ws.py`): real WebSocket to `codex app-server`, JSON-RPC 2.0.
+- **Codex** (`codex_ws.py`): real WebSocket to a managed `codex app-server`, JSON-RPC 2.0.
   Codex's `requestApproval` and `requestUserInput` messages are dispatched to
   either `AutoAcceptHandler` (spawn paths) or `InteractiveHandler` (managed-primary attach).
-- **OpenCode** (`opencode_http.py`): HTTP+SSE to `opencode serve`.
+- **OpenCode** (`opencode_http.py`): HTTP+SSE to managed `opencode serve`.
+- **Cursor/Pi**: narrower spawned-session transports; no resident backend seam.
 
 ## Key Rules
 
@@ -31,6 +32,14 @@ distinction.
 implement all abstract methods, register in the bundle. Missing registration →
 `KeyError` at lookup time.
 
+**Resident control goes through `resident_backend`.** Do not add connection-level
+turn-injection or managed-backend shims. Codex/OpenCode return a
+`ResidentBackendControl`; callers use `begin_followup_turn()` through that seam.
+
+**Managed backend liveness belongs to `BackendLivenessPolicy`.** Adapters feed it
+activity, active turns, active requests, backend pid, and birth time; callers consume
+its structured decisions instead of inventing per-adapter alive checks.
+
 ## Entry Points
 
 - `base.py` — `HarnessConnection` ABC, `HarnessEvent`, `ConnectionCapabilities`,
@@ -39,6 +48,11 @@ implement all abstract methods, register in the bundle. Missing registration →
   `ResidentDrainCoordinator` for structured liveness, awaiting-done signaling,
   and follow-up turns. This seam's presence, not the harness id, selects the
   resident drain coordinator.
+- `liveness.py` — `BackendLivenessPolicy`, the shared managed-backend liveness
+  classifier for Codex/OpenCode.
+- `managed_backend.py` — single helper for launching managed backend subprocesses,
+  building `ProcessScopeSnapshot`, linking parent-death behavior when possible,
+  and recording `process_scopes.json`.
 - `__init__.py` — `get_connection_class(harness_id, transport_id)`.
 
 ## Depth

--- a/src/meridian/lib/harness/projections/project_pi_native_tui.py
+++ b/src/meridian/lib/harness/projections/project_pi_native_tui.py
@@ -52,6 +52,7 @@ _DELEGATED_FIELDS: frozenset[str] = frozenset(
 
 _MANAGED_FLAG_ALIASES: dict[str, tuple[str, ...]] = {
     "--model": ("--model", "-m"),
+    "--thinking": ("--thinking",),
     "--append-system-prompt": ("--append-system-prompt",),
     "--session": ("--session",),
     "--fork": ("--fork",),
@@ -148,10 +149,11 @@ def _project_model_arg(spec: ResolvedLaunchSpec) -> str | None:
     if not model:
         return None
 
-    thinking = _EFFORT_TO_THINKING.get((spec.effort or "").strip().lower())
-    if thinking:
-        return f"{model}:{thinking}"
     return model
+
+
+def _project_thinking_level(spec: ResolvedLaunchSpec) -> str | None:
+    return _EFFORT_TO_THINKING.get((spec.effort or "").strip().lower())
 
 
 def project_pi_native_tui_spec_to_cli_args(
@@ -166,6 +168,10 @@ def project_pi_native_tui_spec_to_cli_args(
     model_arg = _project_model_arg(spec)
     if model_arg is not None:
         command.extend(("--model", model_arg))
+
+    thinking_level = _project_thinking_level(spec)
+    if thinking_level is not None:
+        command.extend(("--thinking", thinking_level))
 
     if spec.appended_system_prompt:
         command.extend(("--append-system-prompt", spec.appended_system_prompt))
@@ -182,6 +188,11 @@ def project_pi_native_tui_spec_to_cli_args(
     _log_collision_if_needed(
         managed_flag="--model",
         has_managed_value=model_arg is not None,
+        passthrough_tail=passthrough_tail,
+    )
+    _log_collision_if_needed(
+        managed_flag="--thinking",
+        has_managed_value=thinking_level is not None,
         passthrough_tail=passthrough_tail,
     )
     _log_collision_if_needed(

--- a/src/meridian/lib/harness/projections/project_pi_native_tui.py
+++ b/src/meridian/lib/harness/projections/project_pi_native_tui.py
@@ -164,13 +164,18 @@ def project_pi_native_tui_spec_to_cli_args(
     """Project one ``ResolvedLaunchSpec`` into an ordered native Pi TUI command list."""
 
     command: list[str] = list(base_command)
+    passthrough_tail = spec.extra_args
 
     model_arg = _project_model_arg(spec)
     if model_arg is not None:
         command.extend(("--model", model_arg))
 
     thinking_level = _project_thinking_level(spec)
-    if thinking_level is not None:
+    model_override_in_passthrough = any(
+        _has_flag(passthrough_tail, alias) for alias in _MANAGED_FLAG_ALIASES["--model"]
+    )
+    emit_thinking = thinking_level is not None and not model_override_in_passthrough
+    if emit_thinking and thinking_level is not None:
         command.extend(("--thinking", thinking_level))
 
     if spec.appended_system_prompt:
@@ -179,8 +184,6 @@ def project_pi_native_tui_spec_to_cli_args(
     continue_session_id = (spec.continue_session_id or "").strip()
     has_continue_session = bool(continue_session_id)
     has_continue_fork = has_continue_session and spec.continue_fork
-
-    passthrough_tail = spec.extra_args
     _reject_mode_collisions(passthrough_tail)
     _reject_continue_collisions(passthrough_tail)
     _reject_extension_collisions(passthrough_tail)
@@ -192,7 +195,7 @@ def project_pi_native_tui_spec_to_cli_args(
     )
     _log_collision_if_needed(
         managed_flag="--thinking",
-        has_managed_value=thinking_level is not None,
+        has_managed_value=emit_thinking,
         passthrough_tail=passthrough_tail,
     )
     _log_collision_if_needed(

--- a/src/meridian/lib/harness/projections/project_pi_rpc.py
+++ b/src/meridian/lib/harness/projections/project_pi_rpc.py
@@ -53,6 +53,7 @@ _DELEGATED_FIELDS: frozenset[str] = frozenset(
 
 _MANAGED_FLAG_ALIASES: dict[str, tuple[str, ...]] = {
     "--model": ("--model", "-m"),
+    "--thinking": ("--thinking",),
     "--append-system-prompt": ("--append-system-prompt",),
     "--session": ("--session",),
     "--fork": ("--fork",),
@@ -143,10 +144,11 @@ def _project_model_arg(spec: ResolvedLaunchSpec) -> str | None:
     if not model:
         return None
 
-    thinking = _EFFORT_TO_THINKING.get((spec.effort or "").strip().lower())
-    if thinking:
-        return f"{model}:{thinking}"
     return model
+
+
+def _project_thinking_level(spec: ResolvedLaunchSpec) -> str | None:
+    return _EFFORT_TO_THINKING.get((spec.effort or "").strip().lower())
 
 
 def _default_pi_session_dir() -> str:
@@ -166,6 +168,10 @@ def project_pi_spec_to_cli_args(
     if model_arg is not None:
         command.extend(("--model", model_arg))
 
+    thinking_level = _project_thinking_level(spec)
+    if thinking_level is not None:
+        command.extend(("--thinking", thinking_level))
+
     if spec.appended_system_prompt:
         command.extend(("--append-system-prompt", spec.appended_system_prompt))
 
@@ -181,6 +187,11 @@ def project_pi_spec_to_cli_args(
     _log_collision_if_needed(
         managed_flag="--model",
         has_managed_value=model_arg is not None,
+        passthrough_tail=passthrough_tail,
+    )
+    _log_collision_if_needed(
+        managed_flag="--thinking",
+        has_managed_value=thinking_level is not None,
         passthrough_tail=passthrough_tail,
     )
     _log_collision_if_needed(

--- a/src/meridian/lib/harness/projections/project_pi_rpc.py
+++ b/src/meridian/lib/harness/projections/project_pi_rpc.py
@@ -163,13 +163,18 @@ def project_pi_spec_to_cli_args(
     """Project one ``ResolvedLaunchSpec`` into an ordered Pi RPC command list."""
 
     command: list[str] = list(base_command)
+    passthrough_tail = spec.extra_args
 
     model_arg = _project_model_arg(spec)
     if model_arg is not None:
         command.extend(("--model", model_arg))
 
     thinking_level = _project_thinking_level(spec)
-    if thinking_level is not None:
+    model_override_in_passthrough = any(
+        _has_flag(passthrough_tail, alias) for alias in _MANAGED_FLAG_ALIASES["--model"]
+    )
+    emit_thinking = thinking_level is not None and not model_override_in_passthrough
+    if emit_thinking and thinking_level is not None:
         command.extend(("--thinking", thinking_level))
 
     if spec.appended_system_prompt:
@@ -178,8 +183,6 @@ def project_pi_spec_to_cli_args(
     continue_session_id = (spec.continue_session_id or "").strip()
     has_continue_session = bool(continue_session_id)
     has_continue_fork = has_continue_session and spec.continue_fork
-
-    passthrough_tail = spec.extra_args
     _reject_mode_collisions(passthrough_tail)
     _reject_extension_collisions(passthrough_tail)
     _reject_session_dir_collisions(passthrough_tail)
@@ -191,7 +194,7 @@ def project_pi_spec_to_cli_args(
     )
     _log_collision_if_needed(
         managed_flag="--thinking",
-        has_managed_value=thinking_level is not None,
+        has_managed_value=emit_thinking,
         passthrough_tail=passthrough_tail,
     )
     _log_collision_if_needed(

--- a/src/meridian/lib/state/.context/CONTEXT.md
+++ b/src/meridian/lib/state/.context/CONTEXT.md
@@ -124,8 +124,10 @@ Up to 10 retries; raises `RuntimeError` if exhausted.
 
 `spawn/terminal_policy.py:decide_terminal_write()` implements the projection
 authority rule: a runner-origin terminal write supersedes a reconciler-origin write
-on the same spawn. The reaper checks this before finalizing — it will not overwrite
-a spawn that the runner already terminated with a higher-authority origin.
+on the same spawn. Terminal statuses are `succeeded`, `failed`, `cancelled`, and
+`timed_out`; `timed_out` is a terminal failure class distinct from generic
+`failed`. The reaper checks authority before finalizing — it will not overwrite a
+spawn that the runner already terminated with a higher-authority origin.
 
 ### Reaper Behavior
 
@@ -137,13 +139,15 @@ Liveness check sequence per active spawn:
 1. Skip if status is already terminal.
 2. Skip if not a root-side-effect process (`is_root_side_effect_process()`).
 3. Skip if heartbeat age < 120s (recently alive).
-4. If status = `finalizing`: check `runner_exit_status`, then `cancel_intent`, then
-   durable report through `_completion_or_cancel_decision()`. If none apply → mark
-   failed (`orphan_finalization`).
-5. If status = `running` or `queued`: check if `runner_pid` is alive (using
+4. If status = `finalizing`: prefer durable report / cancel precedence and recorded
+   `runner_exit_status`; if neither proves a terminal outcome and activity is stale,
+   mark failed (`orphan_finalization`).
+5. If `runner_exit_status` is already recorded outside `finalizing`, preserve the
+   runner's terminal tuple after the short post-runner-exit grace.
+6. If status = `running` or `queued`: check if `runner_pid` is alive (using
    `liveness.py:is_process_alive()` with PID reuse guard via recorded start time).
-   If dead, check completion/cancel precedence, then recent activity, startup grace,
-   and finally mark failed (`orphan_run` or `missing_runner_pid`).
+   If dead, check completion/cancel precedence, recent activity, startup grace, and
+   finally mark failed (`orphan_run` or `missing_runner_pid`).
 
 `spawn_report_has_durable_completion(runtime_root, spawn_id)` reads `report.md` and returns True
 for non-empty report content that is not a terminal control frame (`cancelled`/`error`
@@ -160,9 +164,9 @@ violating the rule can let a late cancel downgrade a completed spawn.
 **Managed-primary orphan cleanup:**
 
 When a spawn is flagged as a potential managed primary (Codex / OpenCode kind=primary)
-and must be finalized as failed, `reconcile_active_spawn()` attempts process cleanup
-before writing the terminal state. The tier used depends on how much metadata is
-readable:
+and must be finalized as failed, `reconcile_active_spawn()` first uses recorded
+`process_scopes.json` cleanup, then attempts managed-primary cleanup before writing
+the terminal state. The managed tier used depends on how much metadata is readable:
 
 1. **Managed snapshot available** (`read_managed_primary_snapshot()` succeeded):
    `terminate_managed_primary_processes(managed_snapshot.metadata)` — terminates

--- a/src/meridian/lib/state/AGENTS.md
+++ b/src/meridian/lib/state/AGENTS.md
@@ -79,8 +79,9 @@ Liveness sequence per active spawn:
 1. Skip if already terminal.
 2. Skip if heartbeat age < 120s.
 3. `finalizing` with durable report → mark succeeded.
-4. `finalizing` without durable report → mark failed (`orphan_finalization`).
+4. `finalizing` without durable report or recorded runner terminal tuple → mark failed (`orphan_finalization`).
 5. `running`/`queued` with dead PID (checked with start-time reuse guard) → mark failed (`orphan_run`).
+6. Timeouts are terminal `timed_out`, a failure class distinct from generic `failed`.
 
 ## Entry Points
 

--- a/src/meridian/lib/streaming/.context/CONTEXT.md
+++ b/src/meridian/lib/streaming/.context/CONTEXT.md
@@ -12,6 +12,12 @@ SpawnManager
   ├─ _observers: EventObserverRegistry
   └─ _heartbeat_tasks: dict[SpawnId, Task]
 
+DrainPlan
+  ├─ coordinator: DrainCoordinator | None
+  ├─ policy: DrainPolicy
+  ├─ aux_wake / handle_aux_wake
+  └─ finalizer
+
 SpawnSession
   ├─ connection: HarnessConnection   ← live harness connection
   ├─ drain_task: Task                ← background drain loop
@@ -27,7 +33,9 @@ The implementation is split by responsibility:
 - `spawn_manager.py` — public registry/control API and generic live-spawn lifecycle
 - `spawn_dispatch.py` — connection creation/start dispatch
 - `spawn_drain_loop.py` — drain loop, persistence/observer/fan-out ordering, outcome priority
+- `drain_coordinator.py` — `DrainPlan` plus the narrow `DrainCoordinator` seam
 - `spawn_session.py` — `SpawnSession` and `DrainOutcome` carriers
+- `resident_drain.py` — resident-backend descendant waiting and done-nudge model
 - `pi_drain.py` — Pi spawned-session quiescence coordinator
 - `pi_subspawn_tracker.py` — Pi child-spawn and notification tracking
 - `disk_watcher.py` / `pi_quiescence.py` — disk-backed Pi quiescence inputs
@@ -47,6 +55,18 @@ Each event flows through three stages in strict order:
 Persistence is synchronous and happens before any notification. 10 consecutive
 write failures abort the loop with a `failed` outcome. Do not reorder these stages
 — observers and the subscriber must only see events that are durably written.
+
+### DrainPlan Selection
+
+`SpawnManager._select_drain_plan()` returns the whole drain-loop configuration for
+one active spawn. Codex/OpenCode resident backends get a `ResidentDrainCoordinator`;
+Pi RPC gets `PiDrainCoordinator` plus disk-watcher aux wakes; plain streaming
+harnesses intentionally run with `DrainPlan(coordinator=None)`. There is no public
+no-op coordinator class — absence of a coordinator is the plain path.
+
+`DrainCoordinator` stays narrow: it observes events, handles terminal events,
+provides timeouts, classifies stream close, and handles stream exit. Constant
+configuration belongs in `DrainPlan`, not in coordinator methods.
 
 ### DrainOutcome Priority
 
@@ -130,9 +150,9 @@ Generic policies control terminal event behavior:
 
 `SingleTurnDrainPolicy` is the default. Pass `PersistentDrainPolicy` to
 `start_spawn(drain_policy=...)` for chat sessions where the harness stays alive
-across turns. Pi spawned-session behavior is intentionally not another generic
-policy flag: it is delegated to `PiDrainCoordinator`, because it needs disk-backed
-background-work state, child-wave deadlines, notification state, and cleanup decisions.
+across turns. Pi spawned-session behavior and resident descendant waiting are not
+generic policy flags: `SpawnManager` selects coordinators through `DrainPlan` when
+the connection exposes the needed seam.
 
 ## Pi RPC Quiescence Drain
 

--- a/src/meridian/lib/streaming/AGENTS.md
+++ b/src/meridian/lib/streaming/AGENTS.md
@@ -5,10 +5,12 @@ The async backbone between a live harness connection and the rest of the system.
 core mechanism that moves events from the harness outward to persistence, observers,
 and the subscriber queue.
 
-Mostly mechanism. Generic terminal behavior lives in `DrainPolicy`; Pi spawned-session
-quiescence is the explicit exception. Keep Pi child-wave, notification, disk-state,
-and tracked-process cleanup policy behind the Pi coordinator/tracker modules instead
-of growing `SpawnManager`.
+Mostly mechanism. Generic terminal behavior lives in `DrainPolicy`; harness-specific
+completion waiting enters through `DrainPlan`. Plain streaming harnesses intentionally
+run with `coordinator=None`; Pi and resident Codex/OpenCode paths get narrow
+coordinators only when their connection exposes the needed seam. Keep Pi child-wave,
+notification, disk-state, resident-done nudges, and tracked-process cleanup policy
+behind the coordinator/tracker modules instead of growing `SpawnManager`.
 
 Resident drain selection is capability-driven: a connection participates in the
 resident descendant-wait path only when `connection.resident_backend` is present.
@@ -53,9 +55,9 @@ CLI paths: one short-lived instance per run.
 events are dropped on `QueueFull` (with telemetry). The sentinel evicts one item if
 needed to guarantee it gets through — without it, the subscriber hangs forever.
 
-## DrainPolicy
+## DrainPlan / DrainPolicy
 
-Governs terminal event behavior:
+`DrainPlan` carries the selected coordinator, policy, aux wake, and finalizer for one active spawn. Its `coordinator=None` value is the plain path. `DrainPolicy` governs terminal event behavior:
 
 | Policy | On terminal event | Action |
 |---|---|---|

--- a/tests/integration/state/test_reaper_cancel.py
+++ b/tests/integration/state/test_reaper_cancel.py
@@ -73,6 +73,14 @@ def test_cancel_orphan_primary_after_passive_reconcile_still_terminates(
     )
     fake_reaper_liveness(monkeypatch, set())
     fake_managed_primary_birth_liveness(monkeypatch, {7302, 7303})
+    # Launcher (7301) is dead -> orphan. Fake the non-birth liveness too so the
+    # managed-primary snapshot read does not fall through to real psutil (whose
+    # pid_exists is platform-dependent for synthetic PIDs; on Windows it reached
+    # _FakeProcess.create_time, which the terminate-only fake does not define).
+    monkeypatch.setattr(
+        "meridian.lib.state.managed_primary.is_process_alive",
+        lambda *_args, **_kwargs: False,
+    )
     terminated_pids: list[int] = []
 
     class _FakeProcess:

--- a/tests/unit/harness/test_pi_projection.py
+++ b/tests/unit/harness/test_pi_projection.py
@@ -59,7 +59,10 @@ def test_pi_rpc_projection_includes_rpc_resume_and_meridian_extensions(
 
     assert command[0:3] == ["pi", "--mode", "rpc"]
     assert command.count("--mode") == 1
-    assert command[command.index("--model") + 1] == "anthropic/claude-sonnet-4:high"
+    assert command[command.index("--model") + 1] == "anthropic/claude-sonnet-4"
+    assert ":" not in command[command.index("--model") + 1]
+    assert command[command.index("--thinking") + 1] == "high"
+    assert command.index("--thinking") == command.index("--model") + 2
     assert command[command.index("--append-system-prompt") + 1] == "You are meridian worker"
     assert command[command.index("--fork") + 1] == "019e3113"
     assert command[command.index("--session-dir") + 1] == str(
@@ -197,7 +200,10 @@ def test_pi_native_projection_loads_all_extensions(
         _bundle_path(extension_source_root, "managed-bash"),
         _bundle_path(extension_source_root, "meridian-spawn-watch"),
     ]
-    assert command[command.index("--model") + 1] == "openai-codex/gpt-5.4-mini:high"
+    assert command[command.index("--model") + 1] == "openai-codex/gpt-5.4-mini"
+    assert ":" not in command[command.index("--model") + 1]
+    assert command[command.index("--thinking") + 1] == "high"
+    assert command.index("--thinking") == command.index("--model") + 2
     assert command[command.index("--append-system-prompt") + 1] == "native primary"
     assert command[command.index("--fork") + 1] == "019e3113-edc8-7751-bb29-9648304465d5"
     assert command[-2:] == ["--provider", "openai"]

--- a/tests/unit/harness/test_pi_projection.py
+++ b/tests/unit/harness/test_pi_projection.py
@@ -152,6 +152,39 @@ def test_pi_rpc_projection_uses_session_without_fork_when_continue_fork_false(
     assert "--fork" not in command
 
 
+def test_pi_rpc_projection_suppresses_thinking_when_passthrough_overrides_model() -> None:
+    spec = ResolvedLaunchSpec(
+        harness=HarnessId.PI,
+        model="anthropic/claude-sonnet-4",
+        effort="high",
+        prompt="hello",
+        extra_args=("--model", "provider/other-model"),
+        permission_resolver=UnsafeNoOpPermissionResolver(_suppress_warning=True),
+    )
+
+    command = project_pi_spec_to_cli_args(spec, base_command=BASE_COMMAND_PI_SUBPROCESS)
+
+    assert "--thinking" not in command
+    assert command[-2:] == ["--model", "provider/other-model"]
+
+
+def test_pi_native_projection_suppresses_thinking_when_passthrough_overrides_model() -> None:
+    spec = ResolvedLaunchSpec(
+        harness=HarnessId.PI,
+        model="openai-codex/gpt-5.4-mini",
+        effort="high",
+        prompt="hello",
+        interactive=True,
+        extra_args=("--model", "provider/other-model"),
+        permission_resolver=UnsafeNoOpPermissionResolver(_suppress_warning=True),
+    )
+
+    command = project_pi_native_tui_spec_to_cli_args(spec, base_command=PRIMARY_BASE_COMMAND_PI)
+
+    assert "--thinking" not in command
+    assert command[-2:] == ["--model", "provider/other-model"]
+
+
 def test_pi_rpc_projection_never_embeds_initial_prompt_in_cli_tail() -> None:
     spec = ResolvedLaunchSpec(
         harness=HarnessId.PI,


### PR DESCRIPTION
## Why

Pi spawns with a fully-qualified `provider/id` model — e.g. the `deepseek`
alias resolving to `oc-sdk-go/deepseek-v4-pro` — failed at launch:

```
Error: Model "oc-sdk-go/deepseek-v4-pro:high" not found.
```

Meridian encoded reasoning effort by appending `:<thinking>` to the model id,
but Pi's `:thinking` suffix only parses on bare aliases (e.g. `sonnet:high`),
not on fully-qualified `provider/id` strings — so the suffix was treated as
part of the model name and rejected. This broke every catalog-pinned Pi model
that carries a provider prefix.

Separately, the #320 spawn-lifecycle / orphaned-backend work merged without its
documentation/knowledge capture, and a runaway `rg` OOM (which killed a session)
needed a documented guardrail.

## Goal

Pi reasoning effort works for every model-id form; the #320 spawn-lifecycle
architecture is captured in the in-repo docs and inline `.context`/`AGENTS`; and
the memory-safe `rg` workaround is documented.

## Summary

- Pi projections now pass reasoning effort with Pi's first-class
  `--thinking <level>` flag instead of appending `:<level>` to the model id.
- A passthrough `--model`/`-m` override in `extra_args` suppresses Meridian's
  managed `--thinking`, preserving last-wins model-selection semantics (so a
  user-chosen model isn't forced into Meridian's effort).
- Reconciled in-repo docs + inline knowledge to the #320 model (DrainPlan /
  ResidentDrainCoordinator, process-scope cleanup, resident done/rearm).
- Repo hygiene: ignore `temp/`; document the memory-safe `rg` guardrail.

## Resulting Behavior

`meridian spawn -m deepseek "..."` (and any fully-qualified Pi `provider/id`
model) launches correctly with the requested effort:

```
$ meridian spawn -m deepseek "reply with exactly: OK"
p4190 succeeded
OK
```

A passthrough model override no longer drags Meridian's managed effort onto it:
`extra_args=("--model", "other/model")` runs with that model's default reasoning.

## Changes

- `src/meridian/lib/harness/projections/project_pi_rpc.py`,
  `project_pi_native_tui.py` — emit `--model <model> --thinking <level>`; register
  `--thinking` as a managed flag with collision logging; suppress managed
  `--thinking` when passthrough overrides `--model`.
- `tests/unit/harness/test_pi_projection.py` — pin plain-model + separate
  `--thinking`, fully-qualified `provider/id` (no `:` suffix), and the
  passthrough-override suppression case, for both projections.
- `docs/harness-integration.md` — describe the separate `--thinking` flag.
- `docs/*`, `README.md` (drop dead v0.1.0 migration), and
  `src/meridian/lib/{streaming,state,harness/connections}/.context|AGENTS` —
  #320 knowledge reconciliation.
- `.gitignore` (`temp/`), `DEVELOPMENT.md` (memory-safe `rg` / earlyoom guardrail).

## Work Item

pi-thinking-flag

## Verification

- `uv run pytest-llm tests/unit/harness/test_pi_projection.py` — passing
  (plain-model, fully-qualified, and passthrough-override cases).
- Full `scripts/preflight.sh` (pre-push gate) — **1401 passed**, 2 skipped
  (Windows-only), wheel build OK.
- Real end-to-end Pi spawns against the live `pi` binary: `deepseek` launches
  and completes (`p4189`/`p4190`), previously failed with the `:high`
  not-found error.
- Adversarial review of the increment (`p4196`): found the model-override
  collision regression (fixed here) + a stale-docs nit (fixed here).

## Knowledge Updates

- In-repo: `.context/CONTEXT.md` + `AGENTS.md` for `streaming`, `state`,
  `harness/connections`; `docs/*`; README cleanup. (In this PR.)
- KB repo (`haowjy-meridian-cli-kb`): 10 architecture pages reconciled to #320,
  validated (0 broken links, 84 Mermaid blocks OK) — commit `e95f84b` in that
  **separate repo**, not part of this PR.

## Spawn Trace

- p4184 coder — implemented the Pi `--thinking` flag swap
- p4192 kb-lead — reconciled KB architecture pages to #320 (separate repo)
- p4196 reviewer — adversarial review of the increment
- p4197 coder — fixed the model-override collision regression + stale docs

## Release Label

`release:patch`

## Cleanup

After merge: `scripts/prune-worktrees.sh`.
