### PR TITLE
fix: Codex primary-attach crash + spawn stacktrace suppression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Foreground Codex primary attach no longer kills the app-server when the TUI displaces the observer stream after attach.
+
 ## [0.3.4] - 2026-06-11
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "cyclopts>=3.0",
   "fastapi>=0.115",
   "markdown-it-py>=4.0",
-  "mars-agents==0.8.3",
+  "mars-agents==0.8.4",
   "mcp>=1.0",
   "pathspec>=1.1.0",
   "psutil>=7.2.2",

--- a/src/meridian/lib/launch/process/primary_attach.py
+++ b/src/meridian/lib/launch/process/primary_attach.py
@@ -277,6 +277,15 @@ class PrimaryAttachLauncher:
                 with suppress(asyncio.CancelledError, Exception):
                     writer_task.result()
                 self._event_writer_task = None
+                if self._connection.harness_id is HarnessId.CODEX:
+                    # Codex TUI takes over the observer endpoint after attach;
+                    # the displaced observer stream closing is normal.
+                    launched = await launch_task
+                    return PrimaryAttachOutcome(
+                        exit_code=launched.exit_code,
+                        session_id=session_id,
+                        tui_pid=launched.pid,
+                    )
                 await self._connection.stop(reason="event_stream_closed")
                 await self._terminate_tui_scope()
                 launched = await launch_task

--- a/src/meridian/lib/ops/spawn/api.py
+++ b/src/meridian/lib/ops/spawn/api.py
@@ -393,7 +393,7 @@ def _prepare_spawn_create_with_expected_failures(
             prepared=prepared,
             failure_payload=failure_payload,
         )
-    except EXPECTED_PRE_INIT_EXCEPTIONS as exc:
+    except (*EXPECTED_PRE_INIT_EXCEPTIONS, RuntimeError) as exc:
         raise PreInitFailure(str(exc)) from exc
 
 

--- a/tests/integration/launch/test_primary_attach.py
+++ b/tests/integration/launch/test_primary_attach.py
@@ -35,10 +35,16 @@ from meridian.lib.state.process_scope_projection import read_scopes_from_disk, r
 _BACKEND_SCOPE_EPOCH = 12_345.0
 
 
-def _build_config(*, spawn_id: SpawnId, control_root: Path, ws_port: int = 0) -> ConnectionConfig:
+def _build_config(
+    *,
+    spawn_id: SpawnId,
+    control_root: Path,
+    ws_port: int = 0,
+    harness_id: HarnessId = HarnessId.CODEX,
+) -> ConnectionConfig:
     return ConnectionConfig(
         spawn_id=spawn_id,
-        harness_id=HarnessId.CODEX,
+        harness_id=harness_id,
         prompt="hello",
         control_root=control_root,
         env_overrides={},
@@ -62,15 +68,18 @@ class FakeManagedConnection:
         session_id: str = "thread-123",
         subprocess_pid: int = 913,
         port_bind_failures: int = 0,
+        harness_id: HarnessId = HarnessId.CODEX,
     ) -> None:
         self.state = "created"
         self._spawn_id = SpawnId("")
+        self._harness_id = harness_id
         self._events = events
         self._session_id = session_id
         self._subprocess_pid = subprocess_pid
         self._port_bind_failures = port_bind_failures
         self._stop_event = asyncio.Event()
         self.stop_called = False
+        self.stop_reasons: list[str | None] = []
         self.started_primary_observer_mode: bool | None = None
         self.started_ports: list[int] = []
         self.start_calls = 0
@@ -86,7 +95,7 @@ class FakeManagedConnection:
 
     @property
     def harness_id(self) -> HarnessId:
-        return HarnessId.CODEX
+        return self._harness_id
 
     @property
     def spawn_id(self) -> SpawnId:
@@ -158,8 +167,8 @@ class FakeManagedConnection:
         await self.start(config, spec)
 
     async def stop(self, *, reason: str | None = None) -> None:
-        _ = reason
         self.stop_called = True
+        self.stop_reasons.append(reason)
         self.state = "stopped"
         self._stop_event.set()
 
@@ -240,13 +249,22 @@ class BlockingProcessLauncher(ProcessLauncher):
 
 
 class FailingEventConnection(FakeManagedConnection):
-    def __init__(self, *, fail_after_started: asyncio.Event, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        *,
+        fail_after_started: asyncio.Event,
+        stream_closed: asyncio.Event | None = None,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(**kwargs)
         self._fail_after_started = fail_after_started
+        self._stream_closed = stream_closed
 
     async def events(self):  # type: ignore[no-untyped-def]
         await self._fail_after_started.wait()
         self.state = "failed"
+        if self._stream_closed is not None:
+            self._stream_closed.set()
         if False:
             yield HarnessEvent(event_type="unreachable", payload={}, harness_id="opencode")
 
@@ -297,6 +315,7 @@ async def test_primary_attach_event_writer_failure_stops_connection_and_tui(
         fail_after_started=tui_started,
         events=[],
         session_id="sess-dead",
+        harness_id=HarnessId.OPENCODE,
     )
     process_launcher = BlockingProcessLauncher(spawn_dir=spawn_dir)
     terminated_scopes: list[str] = []
@@ -319,7 +338,11 @@ async def test_primary_attach_event_writer_failure_stops_connection_and_tui(
 
     outcome = await asyncio.wait_for(
         launcher.run(
-            config=_build_config(spawn_id=SpawnId("p900-liveness"), control_root=tmp_path),
+            config=_build_config(
+                spawn_id=SpawnId("p900-liveness"),
+                control_root=tmp_path,
+                harness_id=HarnessId.OPENCODE,
+            ),
             spec=_build_spec(),
             cwd=tmp_path,
             env={},
@@ -328,8 +351,65 @@ async def test_primary_attach_event_writer_failure_stops_connection_and_tui(
     )
 
     assert outcome.exit_code == 1
-    assert connection.stop_called is True
+    assert connection.stop_reasons == ["event_stream_closed", None]
     assert terminated_scopes == ["tui:event_stream_closed"]
+    assert _read_metadata(spawn_dir)["tui_pid"] == 5252
+
+
+@pytest.mark.asyncio
+async def test_primary_attach_codex_event_stream_closure_does_not_stop_backend_or_tui(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spawn_dir = tmp_path / "spawns" / "p900-codex-stream"
+    tui_started = asyncio.Event()
+    stream_closed = asyncio.Event()
+    connection = FailingEventConnection(
+        fail_after_started=tui_started,
+        stream_closed=stream_closed,
+        events=[],
+        session_id="sess-codex",
+    )
+    process_launcher = BlockingProcessLauncher(spawn_dir=spawn_dir)
+    terminated_scopes: list[str] = []
+
+    def _terminate_scope(scope: Any, *, grace_seconds: float, reason: str) -> None:
+        _ = grace_seconds
+        terminated_scopes.append(f"{scope.scope_id}:{reason}")
+        return None
+
+    monkeypatch.setattr(primary_attach_module, "terminate_scope_sync", _terminate_scope)
+    launcher = PrimaryAttachLauncher(
+        spawn_id=SpawnId("p900-codex-stream"),
+        spawn_dir=spawn_dir,
+        connection=connection,
+        tui_command_builder=lambda session_id: ("codex", "resume", session_id),
+        process_launcher=process_launcher,
+        on_running=lambda _pid: tui_started.set(),
+    )
+
+    run_task = asyncio.create_task(
+        launcher.run(
+            config=_build_config(spawn_id=SpawnId("p900-codex-stream"), control_root=tmp_path),
+            spec=_build_spec(),
+            cwd=tmp_path,
+            env={},
+        )
+    )
+
+    await asyncio.wait_for(stream_closed.wait(), timeout=2.0)
+    await asyncio.sleep(0)
+
+    assert run_task.done() is False
+    assert connection.stop_reasons == []
+    assert terminated_scopes == []
+
+    process_launcher.release.set()
+    outcome = await asyncio.wait_for(run_task, timeout=2.0)
+
+    assert outcome.exit_code == 143
+    assert connection.stop_reasons == [None]
+    assert terminated_scopes == []
     assert _read_metadata(spawn_dir)["tui_pid"] == 5252
 
 

--- a/tests/integration/ops/test_spawn_api_create.py
+++ b/tests/integration/ops/test_spawn_api_create.py
@@ -206,7 +206,7 @@ def test_spawn_create_unexpected_pre_init_exception_logs_traceback_and_distinct_
     prepared = prepare_for_runtime_write(project_root)
 
     def _raise_build_create_payload(*_args: object, **_kwargs: object) -> object:
-        raise RuntimeError("bug in launch composition")
+        raise TypeError("bug in launch composition")
 
     monkeypatch.setattr(spawn_api, "build_create_payload", _raise_build_create_payload)
 
@@ -229,13 +229,13 @@ def test_spawn_create_unexpected_pre_init_exception_logs_traceback_and_distinct_
     assert result.status == "failed"
     assert result.error == "pre_init_unexpected_error"
     assert result.message is not None
-    assert "RuntimeError: bug in launch composition" in result.message
+    assert "TypeError: bug in launch composition" in result.message
     failure_log = next(
         (log for log in logs if log["event"] == "spawn_pre_init_unexpected_exception"),
         None,
     )
     assert failure_log is not None
-    assert failure_log["error_type"] == "RuntimeError"
+    assert failure_log["error_type"] == "TypeError"
     assert failure_log["exc_info"] is True
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -666,15 +666,15 @@ wheels = [
 
 [[package]]
 name = "mars-agents"
-version = "0.8.3"
+version = "0.8.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2d/00/7c3173f32a0ac18b4a0dba429d422a339c419c303a670d31d33981bef0ef/mars_agents-0.8.3.tar.gz", hash = "sha256:823174113463257e5f625b0161a2743abfd6c25b21e5514c12701ea024eeea92", size = 624355, upload-time = "2026-06-07T04:01:52.213Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/28/6cc094f26c2b73b9376be658e6156d18e39d718fa0acdfba43f90610c103/mars_agents-0.8.4.tar.gz", hash = "sha256:19be292c3184a55b85fb4218423f00819e6defc97d47bc390b087d64bfda6699", size = 624645, upload-time = "2026-06-11T03:00:48.869Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/12/2b80a1330473bd178d6d93f7f8325732748a6f51ee21384ab45945e755e9/mars_agents-0.8.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9cecccaf479a7ca04dbcda91aea4a771de07aa9a7643d7e6816cae29aa2d5d65", size = 3370814, upload-time = "2026-06-07T04:01:42.746Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/b7/d2192dd6fd7893c3612efa4a61305dcbfdd8a82123e87802369d9409efd3/mars_agents-0.8.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7f7514534391b452a8477aa22f620f6706128793c5e50fd7213b1e0133258631", size = 3220895, upload-time = "2026-06-07T04:01:44.455Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/32/173a01c2275e5145bf41785c606ebbc1a0c165498bbb5b038e0bb7aa4743/mars_agents-0.8.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:211f817b8c50b5a0a5b8263ee0965c525a85bfd23c15067965a6f0ede6d0ba64", size = 3272443, upload-time = "2026-06-07T04:01:46.392Z" },
-    { url = "https://files.pythonhosted.org/packages/23/15/2955ff36054a69d2f78c829e6693e3b6d2e47f14e4572ed2e023836be2cd/mars_agents-0.8.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:20f44612c36ccd9fb9215209f614d512048ea6d157be54b557afe4713a6d2966", size = 3488020, upload-time = "2026-06-07T04:01:48.234Z" },
-    { url = "https://files.pythonhosted.org/packages/36/09/de8a2b027558186dcea13a60fedafb9b6e923c6160a2e20ea32a61aa034e/mars_agents-0.8.3-py3-none-win_amd64.whl", hash = "sha256:34a3726ad15300aa90a79735e1791d3b48ce6ec93dcd37b404a064d411f99a1a", size = 3449256, upload-time = "2026-06-07T04:01:49.964Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/31/7a7cca0ab180ccdf25d3dad372ddce7b3061f4d578dfaaf79c5d91591ff2/mars_agents-0.8.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4cd1049aba05566539ed64c1298980514ae8e555c6fa44b7acd36cb3b7f581a4", size = 3364211, upload-time = "2026-06-11T03:00:39.404Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/70/c11c551ab816c77181795e8b69e8ceb8ac3ec87b1051cf65fac938f5d074/mars_agents-0.8.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:349218ca0185ad5c37fb99bdfce34a29d079a04d45ee713027b098989532b44a", size = 3235207, upload-time = "2026-06-11T03:00:41.328Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/5d/d3910bf8c4850afea86c611e512b663fb9d983eef4bf3985c75fa87a2994/mars_agents-0.8.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:97652c0ef1b18096791d580276b5e1ae4e5c2b44191617b58dc1a98cc1fc9b40", size = 3276717, upload-time = "2026-06-11T03:00:43.217Z" },
+    { url = "https://files.pythonhosted.org/packages/39/33/aafb828c12de5f1b2d20b773050cde56a47aaf01c96a013727dc98589770/mars_agents-0.8.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:edcf42b4ac25e388a05e7ba1caf4ad35d0b2da75d4898e1a91bd0aecdd7d80a4", size = 3491307, upload-time = "2026-06-11T03:00:45.225Z" },
+    { url = "https://files.pythonhosted.org/packages/02/61/71e3f8d3c9631c6fde896ae3a8e805ee7fa73d955e68c27b4cc1f8b2eb0a/mars_agents-0.8.4-py3-none-win_amd64.whl", hash = "sha256:a5462908fc457ccf3d269455f6b235e1153b441233f1d496e14f05bc1c52b968", size = 3439861, upload-time = "2026-06-11T03:00:47.208Z" },
 ]
 
 [[package]]
@@ -766,7 +766,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'app'", specifier = ">=0.28" },
     { name = "jinja2", marker = "extra == 'templates'", specifier = ">=3.1" },
     { name = "markdown-it-py", specifier = ">=4.0" },
-    { name = "mars-agents", specifier = "==0.8.3" },
+    { name = "mars-agents", specifier = "==0.8.4" },
     { name = "mcp", specifier = ">=1.0" },
     { name = "pathspec", specifier = ">=1.1.0" },
     { name = "psutil", specifier = ">=7.2.2" },


### PR DESCRIPTION
## Why

Two spawn-path regressions:

1. Since v0.3.2 (#320), foreground Codex spawns crash with:
   ```
   ERROR: remote app server at `ws://...` transport failed: WebSocket protocol error: Connection reset without closing handshake
   Session failed.
   ```
   The new `PrimaryAttachLauncher.run()` event-writer-first failure branch treats observer-stream closure as fatal for all harnesses — but for Codex, the observer stream closing after TUI attach is normal (TUI takes over the same endpoint).

2. Any spawn with an unresolvable model (typo, unknown alias) dumps ~200 lines of Rich traceback to stderr — a token furnace for agent consumers. The actual error is one line.

## Goal

- Codex foreground primary sessions no longer crash when the observer stream closes after TUI attach.
- Spawn pre-init failures from bundle routing produce clean one-liner errors, not full stacktraces.

## Summary

**Codex fix:** Gate the aggressive `event_stream_closed` teardown path on harness identity. For Codex, when the observer event stream closes before the TUI exits, await the TUI naturally and return its exit code. Non-Codex harnesses retain the existing stop+terminate behavior.

**Stacktrace fix:** `RuntimeError` from `bundle_adapter._raise_bundle_error()` (bad model, no harness route) was not in `EXPECTED_PRE_INIT_EXCEPTIONS`, so `run_pre_init_boundary` treated it as "unexpected" and logged with `exc_info=True`. Now caught by `_prepare_spawn_create_with_expected_failures` and converted to `PreInitFailure`.

## Resulting Behavior

- `meridian spawn -a <agent>` on Codex harness no longer crashes with WebSocket reset errors. The Codex TUI runs to completion and its exit code is returned.
- `meridian spawn -m badmodel -p "hi"` prints one clean error line instead of 200 lines of Rich traceback.

## Changes

- `src/meridian/lib/launch/process/primary_attach.py` — added Codex-specific early return in the `writer_task in done` branch
- `tests/integration/launch/test_primary_attach.py` — made fake connection harness configurable, added Codex-specific regression test
- `src/meridian/lib/ops/spawn/api.py` — added `RuntimeError` to the catch clause in `_prepare_spawn_create_with_expected_failures()`
- `tests/integration/ops/test_spawn_api_create.py` — updated unexpected-exception test to use `TypeError` (genuinely unexpected) instead of `RuntimeError`
- `CHANGELOG.md` — added entries

## Work Item

N/A

## Verification

- `uv run pytest` — 1402 passed, 2 skipped
- `uv run ruff check .` — clean
- `uv run --extra dev python -m pyright` — 0 errors
- Reviewer p4238: approved Codex fix, no blocking findings
- Manual smoke: `meridian spawn -m deekseekflash -p "hi"` → clean one-liner

## Knowledge Updates

N/A

## Spawn Trace

- p4235 gpt-dev — implemented the Codex primary-attach fix
- p4238 reviewer — reviewed the Codex diff
- p4239 prober — smoke-tested CLI

## Release Label Guide

`release:patch` — bugfixes for spawn-path regressions.

## Cleanup

- [ ] Prune worktrees after merge