### PR TITLE
docs: migrate fanout config to [settings.meridian.fanout] peer table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- Fan-out agent config moves from `[settings.meridian.agent_copy].fanout_agents` to peer table `[settings.meridian.fanout].agents`; docs and repo `mars.toml` updated. Legacy `fanout_agents` is deprecated (migration warning, ignored).
+
 ## [0.3.6] - 2026-06-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 - Fan-out agent config moves from `[settings.meridian.agent_copy].fanout_agents` to peer table `[settings.meridian.fanout].agents`; docs and repo `mars.toml` updated. Legacy `fanout_agents` is deprecated (migration warning, ignored).
+- Bump `mars-agents` to `0.8.5`, which parses `[settings.meridian.fanout]` and dual-lists fan-out agents in the launch inventory.
 
 ## [0.3.6] - 2026-06-12
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -186,7 +186,6 @@ agent_emission = "never"  # optional; agent_copy can still emit selected copies
 [settings.meridian.agent_copy]
 harnesses = ["claude"]
 include_fanout = false          # default false: skip fan-out (sub-delegate) agents
-fanout_agents = ["explorer"]    # selectively include specific fan-out agents
 ```
 
 Each listed harness must also have an effective managed target (for Claude,
@@ -198,10 +197,30 @@ unset). Mars then materializes only qualifying agents for that harness;
 `include_fanout` (default `false`) controls whether fan-out agents — sub-delegates
 listed in an agent profile's `fanout` field — are materialized as native copies.
 When `include_fanout = false`, fan-out agents are skipped even if they qualify for
-the selected harness. `fanout_agents` is a selective override: an allowlist of
-specific agent names that still qualify for fan-out emission regardless of
-`include_fanout`. The agent must still qualify for the harness via its model
-policies — `fanout_agents` is a scope filter, not a force-emit.
+the selected harness.
+
+### Fan-out agent routing
+
+`[settings.meridian.fanout]` is a peer table to `[settings.meridian.agent_copy]`,
+not nested under it:
+
+```toml
+[settings.meridian.fanout]
+agents = ["reviewer", "browser-prober", "prober"]
+```
+
+`agents` is an allowlist of fan-out agent names. Each listed agent:
+
+1. **Native-copy emission** — qualifies for harness-native materialization even
+   when `include_fanout = false`. The agent must still qualify for the harness via
+   its model policies; `agents` is a scope filter, not a force-emit.
+2. **Dual inventory listing** — appears in both the Meridian `## Subagent`
+   section (primary route: `meridian spawn -a <name>`) and the native harness
+   section (escalation route: `Agent({subagent_type: "<name>"})` for Claude).
+
+The former `agent_copy` fan-out allowlist key is removed. If present in
+`mars.toml`, mars emits a migration warning pointing to
+`[settings.meridian.fanout].agents` and ignores the old value.
 
 For Claude launches, Meridian uses the same boundary for native `Agent()`
 delegation. Generic Claude `Agent` is allowed only when Mars has Claude

--- a/mars.toml
+++ b/mars.toml
@@ -17,7 +17,9 @@ models_cache_ttl_hours = 24
 [settings.meridian.agent_copy]
 harnesses = ["claude"]
 include_fanout = false
-fanout_agents = [
+
+[settings.meridian.fanout]
+agents = [
     "reviewer",
     "browser-prober",
     "prober",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "cyclopts>=3.0",
   "fastapi>=0.115",
   "markdown-it-py>=4.0",
-  "mars-agents==0.8.4",
+  "mars-agents==0.8.5",
   "mcp>=1.0",
   "pathspec>=1.1.0",
   "psutil>=7.2.2",

--- a/tests/integration/state/test_reaper_runner_liveness.py
+++ b/tests/integration/state/test_reaper_runner_liveness.py
@@ -50,6 +50,12 @@ def _patch_runner_process(
             running=running,
         ),
     )
+    # update_spawn auto-derives runner_created_at_epoch from the real OS when epoch
+    # is None; stub it so PID-reuse tests never leak to live PIDs (Windows CI flake).
+    monkeypatch.setattr(
+        "meridian.lib.state.spawn_store._runner_created_at_epoch_for_pid",
+        lambda _pid: None,
+    )
 
 
 @pytest.mark.parametrize(
@@ -105,6 +111,7 @@ def test_reconcile_active_spawn_falls_back_to_started_epoch_for_pid_reuse_behavi
     expected_error: str | None,
 ) -> None:
     runner_pid = 8124
+    _patch_runner_process(monkeypatch, pid=runner_pid, create_time=process_create_time)
     runtime_root, spawn_id = _create_spawn(
         tmp_path,
         started_at=_OLD_STARTED_AT,
@@ -113,8 +120,8 @@ def test_reconcile_active_spawn_falls_back_to_started_epoch_for_pid_reuse_behavi
     spawn_store.update_spawn(
         runtime_root, spawn_id, runner_pid=runner_pid, runner_created_at_epoch=None
     )
-    _patch_runner_process(monkeypatch, pid=runner_pid, create_time=process_create_time)
     record = _get_spawn(runtime_root, spawn_id)
+    assert record.runner_created_at_epoch is None
 
     reconciled = _reconcile(tmp_path, runtime_root, record)
 

--- a/uv.lock
+++ b/uv.lock
@@ -666,15 +666,15 @@ wheels = [
 
 [[package]]
 name = "mars-agents"
-version = "0.8.4"
+version = "0.8.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/28/6cc094f26c2b73b9376be658e6156d18e39d718fa0acdfba43f90610c103/mars_agents-0.8.4.tar.gz", hash = "sha256:19be292c3184a55b85fb4218423f00819e6defc97d47bc390b087d64bfda6699", size = 624645, upload-time = "2026-06-11T03:00:48.869Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/58/ab80bd826320ef07464fa54cd73b43c417d7f03dd0436ee112f16e8bae6f/mars_agents-0.8.5.tar.gz", hash = "sha256:9c99eed955f5246d49e36efe2345f51d0c4bcae75468791f9c1620be93ccb840", size = 626338, upload-time = "2026-06-12T12:31:43.597Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/31/7a7cca0ab180ccdf25d3dad372ddce7b3061f4d578dfaaf79c5d91591ff2/mars_agents-0.8.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4cd1049aba05566539ed64c1298980514ae8e555c6fa44b7acd36cb3b7f581a4", size = 3364211, upload-time = "2026-06-11T03:00:39.404Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/70/c11c551ab816c77181795e8b69e8ceb8ac3ec87b1051cf65fac938f5d074/mars_agents-0.8.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:349218ca0185ad5c37fb99bdfce34a29d079a04d45ee713027b098989532b44a", size = 3235207, upload-time = "2026-06-11T03:00:41.328Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/5d/d3910bf8c4850afea86c611e512b663fb9d983eef4bf3985c75fa87a2994/mars_agents-0.8.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:97652c0ef1b18096791d580276b5e1ae4e5c2b44191617b58dc1a98cc1fc9b40", size = 3276717, upload-time = "2026-06-11T03:00:43.217Z" },
-    { url = "https://files.pythonhosted.org/packages/39/33/aafb828c12de5f1b2d20b773050cde56a47aaf01c96a013727dc98589770/mars_agents-0.8.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:edcf42b4ac25e388a05e7ba1caf4ad35d0b2da75d4898e1a91bd0aecdd7d80a4", size = 3491307, upload-time = "2026-06-11T03:00:45.225Z" },
-    { url = "https://files.pythonhosted.org/packages/02/61/71e3f8d3c9631c6fde896ae3a8e805ee7fa73d955e68c27b4cc1f8b2eb0a/mars_agents-0.8.4-py3-none-win_amd64.whl", hash = "sha256:a5462908fc457ccf3d269455f6b235e1153b441233f1d496e14f05bc1c52b968", size = 3439861, upload-time = "2026-06-11T03:00:47.208Z" },
+    { url = "https://files.pythonhosted.org/packages/69/7e/c44dd9ec0e114f2ad284af7a58e0090cb04fb88552f1495da82f1d29f1e6/mars_agents-0.8.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0d3215130181692dc12a72df10d599f1b66b557076ae961d927f9304750da3c7", size = 3377177, upload-time = "2026-06-12T12:31:36.009Z" },
+    { url = "https://files.pythonhosted.org/packages/48/20/6715656625232b5132a69bc8507b0dc1f263093422632c4e3608646f0943/mars_agents-0.8.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:93f99dd68011f3cdc1f93abe74868b94d698885b333494def3abc1a1fe069d5b", size = 3243422, upload-time = "2026-06-12T12:31:37.535Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f3/8f0f2bf2cd6ce8e92ac2584a683c0d20036e9b7f5c80e9a348f492fae27c/mars_agents-0.8.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a60e8ca9971c1485a1258dc69c3400d8a37878b0365147ce1bd0bf4ae16c2cd4", size = 3271380, upload-time = "2026-06-12T12:31:39.09Z" },
+    { url = "https://files.pythonhosted.org/packages/66/60/6e3c50bfea96d2b54952d82020f0e95bddd219fbe7adfb32246be449aa8a/mars_agents-0.8.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9361de2b79d765b223b733db2dad3036deb7fe85507cae2f86a4151be32fae45", size = 3491960, upload-time = "2026-06-12T12:31:40.794Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b7/c8824a1885daf44ad78e6f34e865c8eac783f931520b0b1111155f62c518/mars_agents-0.8.5-py3-none-win_amd64.whl", hash = "sha256:b7c084b595ec8fadd417eb8e92c239707a20bee1f5d7f28678498d02adbb0fb1", size = 3433430, upload-time = "2026-06-12T12:31:42.23Z" },
 ]
 
 [[package]]
@@ -766,7 +766,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'app'", specifier = ">=0.28" },
     { name = "jinja2", marker = "extra == 'templates'", specifier = ">=3.1" },
     { name = "markdown-it-py", specifier = ">=4.0" },
-    { name = "mars-agents", specifier = "==0.8.4" },
+    { name = "mars-agents", specifier = "==0.8.5" },
     { name = "mcp", specifier = ">=1.0" },
     { name = "pathspec", specifier = ">=1.1.0" },
     { name = "psutil", specifier = ">=7.2.2" },


### PR DESCRIPTION
## Why

The repo's own `mars.toml` and `docs/configuration.md` documented `fanout_agents` as a key nested under `[settings.meridian.agent_copy]`. The companion mars-agents change (now released as **0.8.5**) moves fanout to a peer table `[settings.meridian.fanout]` and dual-lists fanout agents in the launch inventory. The config, docs, and the pinned mars dependency here must follow.

## Goal

Migrate this repo's config and documentation to the new `[settings.meridian.fanout]` surface, and consume mars-agents 0.8.5, so `meridian spawn -a reviewer` and native `Agent({subagent_type: "reviewer"})` both appear in agent inventories.

## Summary

- `mars.toml`: moved `fanout_agents = ["reviewer", "browser-prober", "prober"]` out of `[settings.meridian.agent_copy]` into the new peer table `[settings.meridian.fanout] agents = [...]`.
- `pyproject.toml` + `uv.lock`: bumped `mars-agents==0.8.4` → `==0.8.5` (the release that parses the new surface and emits the dual listing).
- `docs/configuration.md`: removed `fanout_agents` from the `agent_copy` example/prose; added a `[settings.meridian.fanout]` subsection documenting the dual-routing behavior and the deprecation/migration of the old key.
- `init_ops.py`: no change needed — its default scaffold never emitted `fanout_agents`.

## Resulting Behavior

After `meridian mars sync`, the launch inventory lists `reviewer`, `browser-prober`, and `prober` in both the `## Subagent` section (primary: `meridian spawn -a <name>`) and the `## Claude Agents` section (escalation). Docs describe the peer-table surface and the migration path for the deprecated key.

## Changes

Config + docs + dependency bump; no Python logic touched.

## Work Item

fanout-separation

## Verification

- Bumped to mars-agents 0.8.5 (`uv lock` + `uv sync`); `mars --version` → 0.8.5.
- `mars validate --root .`: clean — production config with `agents = ["reviewer", "browser-prober", "prober"]` parses.
- **End-to-end with the released 0.8.5 wheel**: `mars sync` materialized both `.mars/agents/reviewer.md` and `.claude/agents/reviewer.md`; `mars build launch-bundle --agent reviewer --harness claude` shows `reviewer` in BOTH `## Subagent` (`meridian spawn -a reviewer`) and `## Claude Agents` (`reviewer:`) sections.
- Full pre-push preflight green (pytest 1402 passed, build).
- `grep -rn "fanout_agents"`: no stale references in tracked source/docs/config.

## Knowledge Updates

`docs/configuration.md` updated to document the new `[settings.meridian.fanout]` surface and the deprecation of `agent_copy.fanout_agents`.

## Spawn Trace

- p4288 coder — mars.toml migration + docs/configuration.md update + init_ops.py verification

## Release Label

release:patch

## Cleanup

Worktree prune after merge.


---

### Bundled fix: Windows CI flake in reaper PID-reuse test

`test_reconcile_active_spawn_falls_back_to_started_epoch_for_pid_reuse_behavior` was flaky on Windows (passed on Linux), unrelated to fanout. Root cause: the test set `runner_created_at_epoch=None` via `update_spawn`, which auto-derives the epoch from the **real** OS process for `runner_pid=8124` (the test only patched `liveness.psutil`, not `spawn_store.psutil`). On Windows runners PID 8124 could be a live process, yielding a 2026-era birth time that made the orphaned runner look alive → assertion flipped `failed`→`running`.

Fix (test-only): stub `spawn_store._runner_created_at_epoch_for_pid` in the shared `_patch_runner_process` helper, apply it before `update_spawn`, and assert the record's epoch is `None` so the `started_epoch` fallback path is genuinely exercised. No production code changed. Full suite green (1402 passed).
