### PR TITLE
Scope OpenCode completion to parent sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - OpenCode DB compactions now render as segment handoffs, not assistant replies.
 - Empty OpenCode DB transcripts now fall back to legacy JSON or spawn history.
 - Default OpenCode `session log` output now shows completed `task` tool result previews instead of making finished tasks look unfinished.
+- OpenCode child task sessions no longer complete, fail, clear signals for, or supply reports for their parent spawn.
 
 ## [0.3.7] - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - OpenCode `session log` now reads completed transcripts from `opencode.db` before legacy JSON or spawn-history fallback.
+- OpenCode DB compactions now render as segment handoffs, not assistant replies.
+- Empty OpenCode DB transcripts now fall back to legacy JSON or spawn history.
 
 ## [0.3.7] - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- OpenCode `session log` now reads completed transcripts from `opencode.db` before legacy JSON or spawn-history fallback.
+
 ## [0.3.7] - 2026-06-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Empty OpenCode DB transcripts now fall back to legacy JSON or spawn history.
 - Default OpenCode `session log` output now shows completed `task` tool result previews instead of making finished tasks look unfinished.
 - OpenCode child task sessions no longer complete, fail, clear signals for, or supply reports for their parent spawn.
+- Launch event scoping now falls back cleanly for duck-typed test connections without weakening Codex/OpenCode primary-scope filtering.
 
 ## [0.3.7] - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - OpenCode `session log` now reads completed transcripts from `opencode.db` before legacy JSON or spawn-history fallback.
 - OpenCode DB compactions now render as segment handoffs, not assistant replies.
 - Empty OpenCode DB transcripts now fall back to legacy JSON or spawn history.
+- Default OpenCode `session log` output now shows completed `task` tool result previews instead of making finished tasks look unfinished.
 
 ## [0.3.7] - 2026-06-12
 

--- a/docs/harness-integration.md
+++ b/docs/harness-integration.md
@@ -459,6 +459,20 @@ if event.harness_id == HarnessId.PI.value:
 by `event.harness_id` first. `turn/completed` is Codex; OpenCode uses
 `session.idle` for the same semantic.
 
+If the harness can multiplex child work on the same stream, also expose
+`HarnessConnection.primary_event_scope`. The scope identifies the parent conversation
+whose terminal events may complete the spawn. Existing examples:
+
+- Codex uses the main turn `threadId`; subagent-thread `turn/completed` events stay in
+  history but do not complete the parent.
+- OpenCode uses the launched parent `sessionID`; child task `session.idle` /
+  `session.error` events stay in history but do not complete/fail the parent, clear
+  parent signals, or supply the parent report.
+
+Only add scope filtering where the harness stream truly mixes parent and child
+activity. The drain loop must still persist child events before classification so
+`meridian session log` remains complete.
+
 ### 1.7 Permission Flag Projection
 
 **File: `src/meridian/lib/harness/projections/permission_flags.py`**

--- a/src/meridian/lib/harness/.context/CONTEXT.md
+++ b/src/meridian/lib/harness/.context/CONTEXT.md
@@ -170,23 +170,37 @@ to inspect without instantiating an adapter. The contract sub-models:
 `semantics.py:terminal_outcome(event)` drives the drain loop's break condition.
 Returns `TerminalEventOutcome(status, exit_code, error)` or `None`.
 `event_type` is NOT globally unique — always qualified by `event.harness_id`.
+For harnesses whose streams can include child work, callers pass a
+`PrimaryEventScope` from `HarnessConnection.primary_event_scope` into
+`terminal_outcome()`, `activity_transition()`, and `clears_signal()`.
 
 Key mappings:
 - Claude: `result` event with `is_error=True` → failed; `subtype in ("", "success")` and `terminal_reason in ("", "completed")` → succeeded
 - Codex: main-thread `turn/completed` → succeeded; `error/connectionClosed` → failed
-- OpenCode: `session.idle` → succeeded; `session.error` → failed
+- OpenCode: parent-session `session.idle` → succeeded; parent-session `session.error` → failed
 - Cursor: `error/connectionClosed` → failed; no explicit success event — stdout EOF
   + process exit code 0 is the success boundary (see `CursorSubprocessConnection.events()`).
 - Pi: `agent_end` → succeeded candidate; `cancelled`/`error` → failed.
   The succeeded candidate is finalized only when `PiDrainCoordinator` confirms
   quiescence (parent idle, no pending children/bash, no pending notifications).
 
-Codex connection sessions are thread-aware. `CodexConnection` captures
-`main_turn_thread_id` from the first main `turn/started` event. The drain loop passes
-that ID into `terminal_outcome()` and activity classification, so a subagent-thread
-`turn/completed` does not end the parent session or supply the extracted final report.
-If Codex omits a thread ID, Meridian falls back to the old conservative behavior and
-treats `turn/completed` as terminal.
+`PrimaryEventScope` is the parent-conversation identity used for this filtering:
+Codex uses the main `threadId`, and OpenCode uses the launched parent `sessionID`.
+The drain loop persists all child events before classification; scope filtering only
+decides whether an event can end the parent turn, clear a pending signal, update the
+parent activity state, or contribute to the parent report.
+
+Codex keeps a conservative unscoped fallback: if a `turn/completed` event has no
+thread ID, it still counts as terminal for the parent. OpenCode does not use that
+fallback once the parent session is known, because its global SSE stream can emit
+unscoped-looking child task `session.idle` / `session.error` events. If no parent
+scope is known at all, Meridian preserves the legacy behavior and treats OpenCode
+terminal events as parent events.
+
+OpenCode report extraction follows the same boundary. `extract_opencode_report()` first
+resolves the parent session from `session_id.txt` or the first parent user
+`message.updated`, then ignores child-session assistant text while building
+`report.md`. Child task text remains visible through `meridian session log`.
 
 ## Rationale
 
@@ -424,13 +438,7 @@ accounting invariant treats any uncovered field as a bug, not a warning.
 
 > KB lives at `$MERIDIAN_CONTEXT_KB_DIR` (see `meridian context kb`).
 
-- `$MERIDIAN_CONTEXT_KB_DIR/codebase/harness-adapters.md` — capability matrix, per-adapter flag projection, connections subpackage
-- `$MERIDIAN_CONTEXT_KB_DIR/codebase/harness/overview.md` — translation pipeline, SpawnParams field table, base commands
-- `$MERIDIAN_CONTEXT_KB_DIR/codebase/harness/event-semantics.md` — full terminal event table, activity transitions, drain policy integration
-- `$MERIDIAN_CONTEXT_KB_DIR/codebase/harness/claude.md` — Claude flags, PTY path, session detection
-- `$MERIDIAN_CONTEXT_KB_DIR/codebase/harness/codex.md` — Codex JSON-RPC, managed-primary, approval routing detail
-- `$MERIDIAN_CONTEXT_KB_DIR/codebase/harness/opencode.md` — OpenCode SSE, SQLite sessions, workspace env merging
-- `$MERIDIAN_CONTEXT_KB_DIR/codebase/harness/pi.md` — Pi RPC, extension architecture, quiescence drain
+- `$MERIDIAN_CONTEXT_KB_DIR/codebase/harness-adapters.md` — capability matrix, per-adapter flag projection, connections subpackage, primary event scope
 - `$MERIDIAN_CONTEXT_KB_DIR/architecture/launch-system.md` — how adapters plug into `build_launch_context()`
 
 ## Related .context/

--- a/src/meridian/lib/harness/.context/CONTEXT.md
+++ b/src/meridian/lib/harness/.context/CONTEXT.md
@@ -186,6 +186,10 @@ Key mappings:
 
 `PrimaryEventScope` is the parent-conversation identity used for this filtering:
 Codex uses the main `threadId`, and OpenCode uses the launched parent `sessionID`.
+This is the single drain-loop scope contract; do not add harness-specific parallel
+parameters (for example, a Codex-only thread-id compatibility argument) to semantic
+helpers or coordinators.
+
 The drain loop persists all child events before classification; scope filtering only
 decides whether an event can end the parent turn, clear a pending signal, update the
 parent activity state, or contribute to the parent report.
@@ -197,10 +201,13 @@ unscoped-looking child task `session.idle` / `session.error` events. If no paren
 scope is known at all, Meridian preserves the legacy behavior and treats OpenCode
 terminal events as parent events.
 
-OpenCode report extraction follows the same boundary. `extract_opencode_report()` first
-resolves the parent session from `session_id.txt` or the first parent user
-`message.updated`, then ignores child-session assistant text while building
-`report.md`. Child task text remains visible through `meridian session log`.
+OpenCode report extraction follows the same boundary and is owned by
+`harness/opencode_report.py`. The OpenCode extractor delegates session-id and report
+parsing there instead of duplicating event-shape logic. `extract_opencode_report()`
+first resolves the parent session from `session_id.txt`, a terminal parent session
+event, or the first parent user `message.updated`, then ignores child-session
+assistant text while building `report.md`. Child task text remains visible through
+`meridian session log`.
 
 ## Rationale
 

--- a/src/meridian/lib/harness/AGENTS.md
+++ b/src/meridian/lib/harness/AGENTS.md
@@ -74,11 +74,14 @@ startup failure.
 Priority: connection session ID → artifact extraction → known ID → filesystem scan.
 Must not mutate adapter-instance state.
 
-**Terminal event classification is harness-scoped.** `event_type` is NOT globally
-unique — always check `event.harness_id`. `turn/completed` is Codex; OpenCode uses
-`session.idle` for the same semantic. For Codex connection sessions, termination is
-thread-aware: `CodexConnection` tracks the main turn thread, and the drain loop ignores
-subagent-thread `turn/completed` events for session completion/report extraction.
+**Terminal event classification is harness- and parent-scope-aware.** `event_type`
+is NOT globally unique — always check `event.harness_id`. `turn/completed` is Codex;
+OpenCode uses `session.idle` for the same semantic. Some harness streams also
+multiplex child work on the same connection, so `connection.primary_event_scope` is
+part of the contract: Codex scopes completion to the main `threadId`; OpenCode scopes
+completion to the launched parent `sessionID`. Child Codex threads and child OpenCode
+task sessions stay in `history.jsonl`, but do not complete/fail the parent, clear
+parent signals, or supply the parent report.
 
 ## Entry Points
 

--- a/src/meridian/lib/harness/common.py
+++ b/src/meridian/lib/harness/common.py
@@ -340,6 +340,25 @@ def _extract_text(value: object) -> str:
     return ""
 
 
+def extract_text(value: object) -> str:
+    return _extract_text(value)
+
+
+def iter_json_lines_artifact(
+    artifacts: ArtifactStore, spawn_id: SpawnId, filename: str
+) -> list[dict[str, object]]:
+    return _iter_json_lines_artifact(artifacts, spawn_id, filename)
+
+
+def read_session_id_artifact(artifacts: ArtifactStore, spawn_id: SpawnId) -> str | None:
+    key = ArtifactKey(f"{spawn_id}/session_id.txt")
+    if not artifacts.exists(key):
+        return None
+    raw = artifacts.get(key)
+    session_id = raw.decode("utf-8", errors="ignore").strip()
+    return session_id or None
+
+
 def extract_codex_thread_id(payload: dict[str, object]) -> str | None:
     """Read a Codex thread id from a turn/item notification payload."""
 
@@ -354,55 +373,6 @@ def extract_codex_thread_id(payload: dict[str, object]) -> str | None:
         if thread_id:
             return thread_id
     return None
-
-
-def extract_opencode_session_id(payload: dict[str, object]) -> str | None:
-    """Read an OpenCode session id from an event payload."""
-
-    normalized_payload = _opencode_message_payload(payload)
-    for candidate in _opencode_session_id_candidates(normalized_payload):
-        session_id = _extract_text(candidate)
-        if session_id:
-            return session_id
-    return None
-
-
-def _opencode_session_id_candidates(payload: dict[str, object]) -> list[object]:
-    candidates: list[object] = []
-    for key in ("sessionID", "sessionId", "session_id"):
-        if key in payload:
-            candidates.append(payload[key])
-
-    properties_obj = payload.get("properties")
-    if isinstance(properties_obj, dict):
-        properties = cast("dict[str, object]", properties_obj)
-        for key in ("sessionID", "sessionId", "session_id"):
-            if key in properties:
-                candidates.append(properties[key])
-        for nested_key in ("info", "part", "message"):
-            nested_obj = properties.get(nested_key)
-            if isinstance(nested_obj, dict):
-                nested = cast("dict[str, object]", nested_obj)
-                for key in ("sessionID", "sessionId", "session_id"):
-                    if key in nested:
-                        candidates.append(nested[key])
-
-    for nested_key in ("info", "part", "message"):
-        nested_obj = payload.get(nested_key)
-        if isinstance(nested_obj, dict):
-            nested = cast("dict[str, object]", nested_obj)
-            for key in ("sessionID", "sessionId", "session_id"):
-                if key in nested:
-                    candidates.append(nested[key])
-
-    session_obj = payload.get("session")
-    if isinstance(session_obj, dict):
-        session = cast("dict[str, object]", session_obj)
-        for key in ("id", "sessionID", "sessionId", "session_id"):
-            if key in session:
-                candidates.append(session[key])
-
-    return candidates
 
 
 def _codex_item_type(payload: dict[str, object]) -> str:
@@ -511,202 +481,6 @@ def extract_claude_report(artifacts: ArtifactStore, spawn_id: SpawnId) -> str | 
     return result_text or assistant_text
 
 
-_OPENCODE_SESSION_ID_JSON_KEYS = ("session_id", "sessionId", "sessionID", "id")
-
-
-def _opencode_event_type(payload: dict[str, object]) -> str:
-    return (
-        str(payload.get("event_type", payload.get("event", payload.get("type", ""))))
-        .strip()
-        .lower()
-    )
-
-
-def _opencode_message_payload(payload: dict[str, object]) -> dict[str, object]:
-    nested = payload.get("payload")
-    if isinstance(nested, dict):
-        return cast("dict[str, object]", nested)
-    return payload
-
-
-def _opencode_message_role(payload: dict[str, object]) -> str:
-    message_payload = _opencode_message_payload(payload)
-    properties_obj = message_payload.get("properties")
-    if not isinstance(properties_obj, dict):
-        return ""
-    properties = cast("dict[str, object]", properties_obj)
-    info_obj = properties.get("info")
-    if not isinstance(info_obj, dict):
-        return ""
-    info = cast("dict[str, object]", info_obj)
-    return str(info.get("role", "")).strip().lower()
-
-
-def _read_session_id_artifact(artifacts: ArtifactStore, spawn_id: SpawnId) -> str | None:
-    key = ArtifactKey(f"{spawn_id}/session_id.txt")
-    if not artifacts.exists(key):
-        return None
-    raw = artifacts.get(key)
-    session_id = raw.decode("utf-8", errors="ignore").strip()
-    return session_id or None
-
-
-def _resolve_opencode_primary_session_id(payloads: list[dict[str, object]]) -> str | None:
-    for payload in payloads:
-        event_type = _opencode_event_type(payload)
-        message_payload = _opencode_message_payload(payload)
-        inner_type = _opencode_event_type(message_payload)
-        effective_type = event_type or inner_type
-        if effective_type != "message.updated":
-            continue
-        if _opencode_message_role(payload) != "user":
-            continue
-        session_id = extract_opencode_session_id(payload)
-        if session_id:
-            return session_id
-    return None
-
-
-def _opencode_event_matches_session(
-    payload: dict[str, object],
-    *,
-    primary_session_id: str | None,
-) -> bool:
-    if primary_session_id is None:
-        return True
-    session_id = extract_opencode_session_id(payload)
-    return session_id == primary_session_id
-
-
-def _extract_opencode_report_from_stream(
-    payloads: list[dict[str, object]],
-    *,
-    primary_session_id: str | None = None,
-) -> str | None:
-    assistant_message_ids: set[str] = set()
-    part_text_by_message: dict[str, list[str]] = {}
-    last_assistant_message_id: str | None = None
-    last_embedded_message: str | None = None
-
-    for payload in payloads:
-        event_type = _opencode_event_type(payload)
-        message_payload = _opencode_message_payload(payload)
-        inner_type = _opencode_event_type(message_payload)
-        effective_type = event_type or inner_type
-
-        if effective_type == "message.updated":
-            if not _opencode_event_matches_session(
-                payload,
-                primary_session_id=primary_session_id,
-            ):
-                continue
-            properties_obj = message_payload.get("properties")
-            if not isinstance(properties_obj, dict):
-                continue
-            properties = cast("dict[str, object]", properties_obj)
-
-            info_obj = properties.get("info")
-            if not isinstance(info_obj, dict):
-                continue
-            info = cast("dict[str, object]", info_obj)
-
-            role = str(info.get("role", "")).strip().lower()
-            message_id = str(info.get("id", "")).strip()
-            if role == "assistant" and message_id:
-                assistant_message_ids.add(message_id)
-                last_assistant_message_id = message_id
-
-            if role != "assistant":
-                continue
-
-            parts_obj = info.get("parts")
-            if not isinstance(parts_obj, list):
-                continue
-            parts = cast("list[object]", parts_obj)
-
-            text_chunks: list[str] = []
-            for part_obj in parts:
-                if not isinstance(part_obj, dict):
-                    continue
-                part = cast("dict[str, object]", part_obj)
-                if str(part.get("type", "")).strip().lower() != "text":
-                    continue
-                text_chunks.append(str(part.get("text", "")))
-            message = "".join(chunk for chunk in text_chunks if chunk).strip()
-            if message:
-                last_embedded_message = message
-            continue
-
-        if effective_type != "message.part.updated":
-            continue
-
-        if not _opencode_event_matches_session(payload, primary_session_id=primary_session_id):
-            continue
-
-        properties_obj = message_payload.get("properties")
-        if not isinstance(properties_obj, dict):
-            continue
-        properties = cast("dict[str, object]", properties_obj)
-
-        part_obj = properties.get("part")
-        if not isinstance(part_obj, dict):
-            continue
-        part = cast("dict[str, object]", part_obj)
-        if str(part.get("type", "")).strip().lower() != "text":
-            continue
-
-        message_id = str(part.get("messageID", part.get("message_id", ""))).strip()
-        if not message_id or message_id not in assistant_message_ids:
-            continue
-
-        text = str(part.get("text", "")).strip()
-        if not text:
-            continue
-        part_text_by_message.setdefault(message_id, []).append(text)
-        last_assistant_message_id = message_id
-
-    if last_assistant_message_id:
-        chunks = part_text_by_message.get(last_assistant_message_id)
-        if chunks:
-            joined = "".join(chunks).strip()
-            if joined:
-                return joined
-
-    return last_embedded_message
-
-
-def extract_opencode_report(artifacts: ArtifactStore, spawn_id: SpawnId) -> str | None:
-    payloads = _iter_json_lines_artifact(artifacts, spawn_id, OUTPUT_FILENAME)
-    primary_session_id = _read_session_id_artifact(
-        artifacts,
-        spawn_id,
-    ) or _resolve_opencode_primary_session_id(payloads)
-    report = _extract_opencode_report_from_stream(
-        payloads,
-        primary_session_id=primary_session_id,
-    )
-    if report:
-        return report
-
-    session_id = primary_session_id or extract_session_id_from_artifacts_with_patterns(
-        artifacts,
-        spawn_id,
-        json_keys=_OPENCODE_SESSION_ID_JSON_KEYS,
-    )
-    if not session_id:
-        return None
-
-    from meridian.lib.harness.opencode_storage import resolve_opencode_session_file
-    from meridian.lib.harness.opencode_transcript import (
-        extract_last_assistant_report_from_session_path,
-    )
-
-    session_path = resolve_opencode_session_file(session_id=session_id)
-    if session_path is None:
-        return None
-    return extract_last_assistant_report_from_session_path(session_path)
-
-
 def extract_usage_from_artifacts(artifacts: ArtifactStore, spawn_id: SpawnId) -> TokenUsage:
     candidates: list[_UsageCandidate] = []
 
@@ -751,12 +525,9 @@ def extract_session_id_from_artifacts_with_patterns(
     json_keys: tuple[str, ...] = ("session_id", "sessionId"),
     text_patterns: tuple[re.Pattern[str], ...] = (),
 ) -> str | None:
-    key = ArtifactKey(f"{spawn_id}/session_id.txt")
-    if artifacts.exists(key):
-        raw = artifacts.get(key)
-        session_id = raw.decode("utf-8", errors="ignore").strip()
-        if session_id:
-            return session_id
+    session_id = read_session_id_artifact(artifacts, spawn_id)
+    if session_id:
+        return session_id
 
     history_key = ArtifactKey(f"{spawn_id}/{HISTORY_FILENAME}")
     output_key = ArtifactKey(f"{spawn_id}/{OUTPUT_FILENAME}")

--- a/src/meridian/lib/harness/common.py
+++ b/src/meridian/lib/harness/common.py
@@ -356,6 +356,55 @@ def extract_codex_thread_id(payload: dict[str, object]) -> str | None:
     return None
 
 
+def extract_opencode_session_id(payload: dict[str, object]) -> str | None:
+    """Read an OpenCode session id from an event payload."""
+
+    normalized_payload = _opencode_message_payload(payload)
+    for candidate in _opencode_session_id_candidates(normalized_payload):
+        session_id = _extract_text(candidate)
+        if session_id:
+            return session_id
+    return None
+
+
+def _opencode_session_id_candidates(payload: dict[str, object]) -> list[object]:
+    candidates: list[object] = []
+    for key in ("sessionID", "sessionId", "session_id"):
+        if key in payload:
+            candidates.append(payload[key])
+
+    properties_obj = payload.get("properties")
+    if isinstance(properties_obj, dict):
+        properties = cast("dict[str, object]", properties_obj)
+        for key in ("sessionID", "sessionId", "session_id"):
+            if key in properties:
+                candidates.append(properties[key])
+        for nested_key in ("info", "part", "message"):
+            nested_obj = properties.get(nested_key)
+            if isinstance(nested_obj, dict):
+                nested = cast("dict[str, object]", nested_obj)
+                for key in ("sessionID", "sessionId", "session_id"):
+                    if key in nested:
+                        candidates.append(nested[key])
+
+    for nested_key in ("info", "part", "message"):
+        nested_obj = payload.get(nested_key)
+        if isinstance(nested_obj, dict):
+            nested = cast("dict[str, object]", nested_obj)
+            for key in ("sessionID", "sessionId", "session_id"):
+                if key in nested:
+                    candidates.append(nested[key])
+
+    session_obj = payload.get("session")
+    if isinstance(session_obj, dict):
+        session = cast("dict[str, object]", session_obj)
+        for key in ("id", "sessionID", "sessionId", "session_id"):
+            if key in session:
+                candidates.append(session[key])
+
+    return candidates
+
+
 def _codex_item_type(payload: dict[str, object]) -> str:
     item = payload.get("item")
     if not isinstance(item, dict):
@@ -480,7 +529,60 @@ def _opencode_message_payload(payload: dict[str, object]) -> dict[str, object]:
     return payload
 
 
-def _extract_opencode_report_from_stream(payloads: list[dict[str, object]]) -> str | None:
+def _opencode_message_role(payload: dict[str, object]) -> str:
+    message_payload = _opencode_message_payload(payload)
+    properties_obj = message_payload.get("properties")
+    if not isinstance(properties_obj, dict):
+        return ""
+    properties = cast("dict[str, object]", properties_obj)
+    info_obj = properties.get("info")
+    if not isinstance(info_obj, dict):
+        return ""
+    info = cast("dict[str, object]", info_obj)
+    return str(info.get("role", "")).strip().lower()
+
+
+def _read_session_id_artifact(artifacts: ArtifactStore, spawn_id: SpawnId) -> str | None:
+    key = ArtifactKey(f"{spawn_id}/session_id.txt")
+    if not artifacts.exists(key):
+        return None
+    raw = artifacts.get(key)
+    session_id = raw.decode("utf-8", errors="ignore").strip()
+    return session_id or None
+
+
+def _resolve_opencode_primary_session_id(payloads: list[dict[str, object]]) -> str | None:
+    for payload in payloads:
+        event_type = _opencode_event_type(payload)
+        message_payload = _opencode_message_payload(payload)
+        inner_type = _opencode_event_type(message_payload)
+        effective_type = event_type or inner_type
+        if effective_type != "message.updated":
+            continue
+        if _opencode_message_role(payload) != "user":
+            continue
+        session_id = extract_opencode_session_id(payload)
+        if session_id:
+            return session_id
+    return None
+
+
+def _opencode_event_matches_session(
+    payload: dict[str, object],
+    *,
+    primary_session_id: str | None,
+) -> bool:
+    if primary_session_id is None:
+        return True
+    session_id = extract_opencode_session_id(payload)
+    return session_id == primary_session_id
+
+
+def _extract_opencode_report_from_stream(
+    payloads: list[dict[str, object]],
+    *,
+    primary_session_id: str | None = None,
+) -> str | None:
     assistant_message_ids: set[str] = set()
     part_text_by_message: dict[str, list[str]] = {}
     last_assistant_message_id: str | None = None
@@ -493,6 +595,11 @@ def _extract_opencode_report_from_stream(payloads: list[dict[str, object]]) -> s
         effective_type = event_type or inner_type
 
         if effective_type == "message.updated":
+            if not _opencode_event_matches_session(
+                payload,
+                primary_session_id=primary_session_id,
+            ):
+                continue
             properties_obj = message_payload.get("properties")
             if not isinstance(properties_obj, dict):
                 continue
@@ -533,6 +640,9 @@ def _extract_opencode_report_from_stream(payloads: list[dict[str, object]]) -> s
         if effective_type != "message.part.updated":
             continue
 
+        if not _opencode_event_matches_session(payload, primary_session_id=primary_session_id):
+            continue
+
         properties_obj = message_payload.get("properties")
         if not isinstance(properties_obj, dict):
             continue
@@ -567,11 +677,18 @@ def _extract_opencode_report_from_stream(payloads: list[dict[str, object]]) -> s
 
 def extract_opencode_report(artifacts: ArtifactStore, spawn_id: SpawnId) -> str | None:
     payloads = _iter_json_lines_artifact(artifacts, spawn_id, OUTPUT_FILENAME)
-    report = _extract_opencode_report_from_stream(payloads)
+    primary_session_id = _read_session_id_artifact(
+        artifacts,
+        spawn_id,
+    ) or _resolve_opencode_primary_session_id(payloads)
+    report = _extract_opencode_report_from_stream(
+        payloads,
+        primary_session_id=primary_session_id,
+    )
     if report:
         return report
 
-    session_id = extract_session_id_from_artifacts_with_patterns(
+    session_id = primary_session_id or extract_session_id_from_artifacts_with_patterns(
         artifacts,
         spawn_id,
         json_keys=_OPENCODE_SESSION_ID_JSON_KEYS,

--- a/src/meridian/lib/harness/connections/.context/CONTEXT.md
+++ b/src/meridian/lib/harness/connections/.context/CONTEXT.md
@@ -49,6 +49,12 @@ Required abstract methods — every subclass must implement all of these:
   this for resident-until-done structured liveness and follow-up turns;
   non-resident transports return None. This is the only public resident control
   seam — callers do not reach for adapter-specific backend objects.
+- `primary_event_scope` → `PrimaryEventScope | None`; parent-conversation identity
+  for transports whose event stream can include child work. Codex returns the main
+  turn `threadId`; OpenCode returns the launched parent `sessionID`. Drain and
+  primary-attach callers pass this into `terminal_outcome()`,
+  `activity_transition()`, and `clears_signal()` so child task events remain
+  persisted but cannot finish or report for the parent.
 - `scope_snapshot` → `ProcessScopeSnapshot | None`; managed backends expose the
   process-scope facts captured at launch so primary attach and cleanup paths do
   not reconstruct containment from PID fields.
@@ -72,8 +78,9 @@ supports the capability:
 
 `event_type` is scoped to the producing harness — it is **not globally unique**.
 Always qualify with `harness_id` before branching on `event_type`. Same-named events
-across harnesses have different semantics. See parent `.context/` for terminal event
-classification.
+across harnesses have different semantics. Terminal semantics are also parent-scope
+aware when `primary_event_scope` is present. See parent `.context/` for the full
+classification table.
 
 ### ConnectionCapabilities
 

--- a/src/meridian/lib/harness/connections/base.py
+++ b/src/meridian/lib/harness/connections/base.py
@@ -14,6 +14,7 @@ from meridian.lib.launch.launch_types import SpecT
 
 if TYPE_CHECKING:
     from meridian.lib.harness.connections.resident_backend import ResidentBackendControl
+    from meridian.lib.harness.semantics import PrimaryEventScope
     from meridian.lib.observability.debug_tracer import DebugTracer
     from meridian.lib.platform.process_scope import ProcessScopeSnapshot
 
@@ -266,6 +267,11 @@ class HarnessConnection(Generic[SpecT], ABC):
     @property
     @abstractmethod
     def session_id(self) -> str | None: ...
+
+    @property
+    def primary_event_scope(self) -> PrimaryEventScope | None:
+        """Parent scope for events that multiplex child activity on the same stream."""
+        return None
 
     @property
     @abstractmethod

--- a/src/meridian/lib/harness/connections/codex_ws.py
+++ b/src/meridian/lib/harness/connections/codex_ws.py
@@ -64,7 +64,11 @@ from meridian.lib.harness.connections.resident_backend import (
     LivenessResidentBackendControl,
     ResidentBackendControl,
 )
-from meridian.lib.harness.semantics import clears_signal
+from meridian.lib.harness.semantics import (
+    PrimaryEventScope,
+    clears_signal,
+    codex_primary_event_scope,
+)
 from meridian.lib.launch.env import inherit_child_env
 from meridian.lib.launch.launch_types import ResolvedLaunchSpec
 from meridian.lib.observability.trace_helpers import (
@@ -268,6 +272,10 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
     @property
     def main_turn_thread_id(self) -> str | None:
         return self._main_turn_thread_id
+
+    @property
+    def primary_event_scope(self) -> PrimaryEventScope | None:
+        return codex_primary_event_scope(self._main_turn_thread_id)
 
     @property
     def subprocess_pid(self) -> int | None:
@@ -1262,7 +1270,7 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
             thread_id = _extract_thread_id(payload)
             if thread_id is not None:
                 self._main_turn_thread_id = thread_id
-        if clears_signal(event, codex_main_thread_id=self._main_turn_thread_id):
+        if clears_signal(event, primary_event_scope=self.primary_event_scope):
             self._end_current_turn()
             self._signal_in_flight = False
             self._liveness.signal_request_resolved("cancel")

--- a/src/meridian/lib/harness/connections/opencode_http.py
+++ b/src/meridian/lib/harness/connections/opencode_http.py
@@ -55,7 +55,11 @@ from meridian.lib.harness.projections.project_opencode_streaming import (
     project_opencode_spec_to_session_payload as _project_opencode_spec_to_session_payload,
 )
 from meridian.lib.harness.projections.projection_errors import HarnessCapabilityMismatch
-from meridian.lib.harness.semantics import clears_signal
+from meridian.lib.harness.semantics import (
+    PrimaryEventScope,
+    clears_signal,
+    opencode_primary_event_scope,
+)
 from meridian.lib.launch.env import inherit_child_env
 from meridian.lib.launch.launch_types import ResolvedLaunchSpec
 from meridian.lib.launch.workspace_projection import OPENCODE_CONFIG_CONTENT_ENV
@@ -225,6 +229,10 @@ class OpenCodeConnection(HarnessConnection[ResolvedLaunchSpec]):
     @property
     def session_id(self) -> str | None:
         return self._session_id
+
+    @property
+    def primary_event_scope(self) -> PrimaryEventScope | None:
+        return opencode_primary_event_scope(self._session_id)
 
     @property
     def subprocess_pid(self) -> int | None:
@@ -990,7 +998,7 @@ class OpenCodeConnection(HarnessConnection[ResolvedLaunchSpec]):
             harness_id=HarnessId.OPENCODE.value,
             raw_text=raw_text,
         )
-        if clears_signal(event):
+        if clears_signal(event, primary_event_scope=self.primary_event_scope):
             self._signal_in_flight = False
             self._liveness.signal_request_resolved("cancel")
         return event

--- a/src/meridian/lib/harness/extractors/.context/CONTEXT.md
+++ b/src/meridian/lib/harness/extractors/.context/CONTEXT.md
@@ -78,6 +78,13 @@ process state. Called after the process has completed (subprocess path) or after
 drain loop exits (streaming path). `ArtifactStore` is the abstraction — do not reach
 for raw file paths.
 
+Report extraction must preserve the same parent-scope boundary as terminal
+classification. OpenCode's global event stream can include child task sessions; its
+report extractor resolves the parent session from `session_id.txt` or the first parent
+user `message.updated`, then ignores child-session assistant text. Child task output
+stays readable through `meridian session log`, but it must not become the parent
+`report.md`.
+
 ### Protocol is `@runtime_checkable`
 
 `isinstance(obj, HarnessExtractor)` works. The check tests for the presence of the

--- a/src/meridian/lib/harness/extractors/.context/CONTEXT.md
+++ b/src/meridian/lib/harness/extractors/.context/CONTEXT.md
@@ -80,10 +80,16 @@ for raw file paths.
 
 Report extraction must preserve the same parent-scope boundary as terminal
 classification. OpenCode's global event stream can include child task sessions; its
-report extractor resolves the parent session from `session_id.txt` or the first parent
-user `message.updated`, then ignores child-session assistant text. Child task output
-stays readable through `meridian session log`, but it must not become the parent
-`report.md`.
+report extractor resolves the parent session from `session_id.txt`, parent terminal
+events, or the first parent user `message.updated`, then ignores child-session
+assistant text. Child task output stays readable through `meridian session log`, but
+it must not become the parent `report.md`.
+
+OpenCode session-id/report parsing is owned by `harness/opencode_report.py`.
+`extractors/opencode.py` delegates to that module for artifact session-id detection
+and report extraction, while keeping live-event detection, usage extraction, and
+filesystem/database discovery local to the extractor. Do not reintroduce duplicate
+OpenCode event parsers in the generic `harness/common.py` helpers.
 
 ### Protocol is `@runtime_checkable`
 

--- a/src/meridian/lib/harness/extractors/opencode.py
+++ b/src/meridian/lib/harness/extractors/opencode.py
@@ -17,11 +17,13 @@ from meridian.lib.harness.common import (
     _coerce_optional_int,  # pyright: ignore[reportPrivateUsage]
     _iter_json_lines_artifact,  # pyright: ignore[reportPrivateUsage]
     coerce_optional_float,
-    extract_session_id_from_artifacts_with_patterns,
     extract_usage_from_artifacts,
 )
 from meridian.lib.harness.connections.base import HarnessEvent
-from meridian.lib.harness.opencode_report import extract_opencode_report
+from meridian.lib.harness.opencode_report import (
+    extract_opencode_report,
+    extract_opencode_session_id_from_artifacts,
+)
 from meridian.lib.harness.opencode_storage import (
     iter_opencode_session_files,
     opencode_session_id_from_path,
@@ -301,12 +303,7 @@ class OpenCodeHarnessExtractor(HarnessExtractor[ResolvedLaunchSpec]):
         return extract_usage_from_artifacts(artifacts, spawn_id)
 
     def extract_session_id(self, artifacts: ArtifactStore, spawn_id: SpawnId) -> str | None:
-        return extract_session_id_from_artifacts_with_patterns(
-            artifacts,
-            spawn_id,
-            json_keys=("session_id", "sessionId", "sessionID", "id"),
-            text_patterns=_SESSION_ID_TEXT_PATTERNS,
-        )
+        return extract_opencode_session_id_from_artifacts(artifacts, spawn_id)
 
     def extract_report(self, artifacts: ArtifactStore, spawn_id: SpawnId) -> str | None:
         return extract_opencode_report(artifacts, spawn_id)

--- a/src/meridian/lib/harness/extractors/opencode.py
+++ b/src/meridian/lib/harness/extractors/opencode.py
@@ -17,11 +17,11 @@ from meridian.lib.harness.common import (
     _coerce_optional_int,  # pyright: ignore[reportPrivateUsage]
     _iter_json_lines_artifact,  # pyright: ignore[reportPrivateUsage]
     coerce_optional_float,
-    extract_opencode_report,
     extract_session_id_from_artifacts_with_patterns,
     extract_usage_from_artifacts,
 )
 from meridian.lib.harness.connections.base import HarnessEvent
+from meridian.lib.harness.opencode_report import extract_opencode_report
 from meridian.lib.harness.opencode_storage import (
     iter_opencode_session_files,
     opencode_session_id_from_path,

--- a/src/meridian/lib/harness/opencode.py
+++ b/src/meridian/lib/harness/opencode.py
@@ -37,11 +37,13 @@ from meridian.lib.harness.bundle import (
     project_subprocess_spec,
     register_harness_bundle,
 )
-from meridian.lib.harness.common import extract_session_id_from_artifacts_with_patterns
 from meridian.lib.harness.connections.opencode_http import OpenCodeConnection
 from meridian.lib.harness.extractors.opencode import OPENCODE_EXTRACTOR
 from meridian.lib.harness.launch_types import SessionSeed
-from meridian.lib.harness.opencode_report import extract_opencode_report
+from meridian.lib.harness.opencode_report import (
+    extract_opencode_report,
+    extract_opencode_session_id_from_artifacts,
+)
 from meridian.lib.harness.opencode_storage import resolve_opencode_session_file
 from meridian.lib.harness.projections.project_opencode_streaming import (
     project_opencode_spec_to_serve_command,
@@ -526,12 +528,8 @@ class OpenCodeAdapter(BaseHarnessAdapter[ResolvedLaunchSpec]):
         return resolve_opencode_session_file(session_id=session_id)
 
     def extract_session_id(self, artifacts: ArtifactStore, spawn_id: SpawnId) -> str | None:
-        return extract_session_id_from_artifacts_with_patterns(
-            artifacts,
-            spawn_id,
-            json_keys=self.SESSION_ID_KEYS,
-            text_patterns=self.SESSION_ID_TEXT_PATTERNS,
-        )
+        _ = self
+        return extract_opencode_session_id_from_artifacts(artifacts, spawn_id)
 
     def owns_untracked_session(self, *, project_root: Path, session_ref: str) -> bool:
         return _owns_session(project_root, session_ref)

--- a/src/meridian/lib/harness/opencode.py
+++ b/src/meridian/lib/harness/opencode.py
@@ -37,13 +37,11 @@ from meridian.lib.harness.bundle import (
     project_subprocess_spec,
     register_harness_bundle,
 )
-from meridian.lib.harness.common import (
-    extract_opencode_report,
-    extract_session_id_from_artifacts_with_patterns,
-)
+from meridian.lib.harness.common import extract_session_id_from_artifacts_with_patterns
 from meridian.lib.harness.connections.opencode_http import OpenCodeConnection
 from meridian.lib.harness.extractors.opencode import OPENCODE_EXTRACTOR
 from meridian.lib.harness.launch_types import SessionSeed
+from meridian.lib.harness.opencode_report import extract_opencode_report
 from meridian.lib.harness.opencode_storage import resolve_opencode_session_file
 from meridian.lib.harness.projections.project_opencode_streaming import (
     project_opencode_spec_to_serve_command,

--- a/src/meridian/lib/harness/opencode_report.py
+++ b/src/meridian/lib/harness/opencode_report.py
@@ -110,6 +110,20 @@ def _resolve_opencode_primary_session_id(payloads: list[dict[str, object]]) -> s
     return None
 
 
+
+def _resolve_opencode_terminal_session_id(payloads: list[dict[str, object]]) -> str | None:
+    for payload in reversed(payloads):
+        event_type = _opencode_event_type(payload)
+        message_payload = _opencode_message_payload(payload)
+        inner_type = _opencode_event_type(message_payload)
+        effective_type = event_type or inner_type
+        if effective_type not in {"session.idle", "session.error"}:
+            continue
+        session_id = extract_opencode_session_id(payload)
+        if session_id:
+            return session_id
+    return None
+
 def _opencode_event_matches_session(
     payload: dict[str, object],
     *,
@@ -218,12 +232,46 @@ def _extract_opencode_report_from_stream(
     return last_embedded_message
 
 
+
+
+def extract_opencode_session_id_from_artifacts(
+    artifacts: ArtifactStore,
+    spawn_id: SpawnId,
+) -> str | None:
+    payloads = iter_json_lines_artifact(artifacts, spawn_id, OUTPUT_FILENAME)
+    return (
+        read_session_id_artifact(artifacts, spawn_id)
+        or _resolve_opencode_terminal_session_id(payloads)
+        or _resolve_opencode_primary_session_id(payloads)
+        or extract_session_id_from_artifacts_with_patterns(
+            artifacts,
+            spawn_id,
+            json_keys=_OPENCODE_SESSION_ID_JSON_KEYS,
+        )
+    )
+
+def _extract_opencode_report_from_db(session_id: str) -> str | None:
+    from meridian.lib.harness.opencode_transcript import iter_opencode_db_events
+
+    last_assistant: str | None = None
+    for event in iter_opencode_db_events(session_id=session_id):
+        role = str(event.get("role", "")).strip().lower()
+        mode = str(event.get("mode", "")).strip().lower()
+        agent = str(event.get("agent", "")).strip().lower()
+        if role != "assistant" or (mode == "compaction" and agent == "compaction"):
+            continue
+        content = extract_text(event.get("content"))
+        if content:
+            last_assistant = content
+    return last_assistant
+
 def extract_opencode_report(artifacts: ArtifactStore, spawn_id: SpawnId) -> str | None:
     payloads = iter_json_lines_artifact(artifacts, spawn_id, OUTPUT_FILENAME)
-    primary_session_id = read_session_id_artifact(
-        artifacts,
-        spawn_id,
-    ) or _resolve_opencode_primary_session_id(payloads)
+    primary_session_id = (
+        read_session_id_artifact(artifacts, spawn_id)
+        or _resolve_opencode_terminal_session_id(payloads)
+        or _resolve_opencode_primary_session_id(payloads)
+    )
     report = _extract_opencode_report_from_stream(
         payloads,
         primary_session_id=primary_session_id,
@@ -231,13 +279,16 @@ def extract_opencode_report(artifacts: ArtifactStore, spawn_id: SpawnId) -> str 
     if report:
         return report
 
-    session_id = primary_session_id or extract_session_id_from_artifacts_with_patterns(
+    session_id = primary_session_id or extract_opencode_session_id_from_artifacts(
         artifacts,
         spawn_id,
-        json_keys=_OPENCODE_SESSION_ID_JSON_KEYS,
     )
     if not session_id:
         return None
+
+    db_report = _extract_opencode_report_from_db(session_id)
+    if db_report:
+        return db_report
 
     from meridian.lib.harness.opencode_storage import resolve_opencode_session_file
     from meridian.lib.harness.opencode_transcript import (
@@ -250,4 +301,8 @@ def extract_opencode_report(artifacts: ArtifactStore, spawn_id: SpawnId) -> str 
     return extract_last_assistant_report_from_session_path(session_path)
 
 
-__all__ = ["extract_opencode_report", "extract_opencode_session_id"]
+__all__ = [
+    "extract_opencode_report",
+    "extract_opencode_session_id",
+    "extract_opencode_session_id_from_artifacts",
+]

--- a/src/meridian/lib/harness/opencode_report.py
+++ b/src/meridian/lib/harness/opencode_report.py
@@ -1,0 +1,253 @@
+"""OpenCode-owned session id and report extraction."""
+
+from __future__ import annotations
+
+from typing import cast
+
+from meridian.lib.core.types import SpawnId
+from meridian.lib.harness.adapter import ArtifactStore
+from meridian.lib.harness.common import (
+    extract_session_id_from_artifacts_with_patterns,
+    extract_text,
+    iter_json_lines_artifact,
+    read_session_id_artifact,
+)
+from meridian.lib.launch.constants import OUTPUT_FILENAME
+
+_OPENCODE_SESSION_ID_JSON_KEYS = ("session_id", "sessionId", "sessionID", "id")
+
+
+def extract_opencode_session_id(payload: dict[str, object]) -> str | None:
+    """Read an OpenCode session id from an event payload."""
+
+    normalized_payload = _opencode_message_payload(payload)
+    for candidate in _opencode_session_id_candidates(normalized_payload):
+        session_id = extract_text(candidate)
+        if session_id:
+            return session_id
+    return None
+
+
+def _opencode_session_id_candidates(payload: dict[str, object]) -> list[object]:
+    candidates: list[object] = []
+    for key in ("sessionID", "sessionId", "session_id"):
+        if key in payload:
+            candidates.append(payload[key])
+
+    properties_obj = payload.get("properties")
+    if isinstance(properties_obj, dict):
+        properties = cast("dict[str, object]", properties_obj)
+        for key in ("sessionID", "sessionId", "session_id"):
+            if key in properties:
+                candidates.append(properties[key])
+        for nested_key in ("info", "part", "message"):
+            nested_obj = properties.get(nested_key)
+            if isinstance(nested_obj, dict):
+                nested = cast("dict[str, object]", nested_obj)
+                for key in ("sessionID", "sessionId", "session_id"):
+                    if key in nested:
+                        candidates.append(nested[key])
+
+    for nested_key in ("info", "part", "message"):
+        nested_obj = payload.get(nested_key)
+        if isinstance(nested_obj, dict):
+            nested = cast("dict[str, object]", nested_obj)
+            for key in ("sessionID", "sessionId", "session_id"):
+                if key in nested:
+                    candidates.append(nested[key])
+
+    session_obj = payload.get("session")
+    if isinstance(session_obj, dict):
+        session = cast("dict[str, object]", session_obj)
+        for key in ("id", "sessionID", "sessionId", "session_id"):
+            if key in session:
+                candidates.append(session[key])
+
+    return candidates
+
+
+def _opencode_event_type(payload: dict[str, object]) -> str:
+    return (
+        str(payload.get("event_type", payload.get("event", payload.get("type", ""))))
+        .strip()
+        .lower()
+    )
+
+
+def _opencode_message_payload(payload: dict[str, object]) -> dict[str, object]:
+    nested = payload.get("payload")
+    if isinstance(nested, dict):
+        return cast("dict[str, object]", nested)
+    return payload
+
+
+def _opencode_message_role(payload: dict[str, object]) -> str:
+    message_payload = _opencode_message_payload(payload)
+    properties_obj = message_payload.get("properties")
+    if not isinstance(properties_obj, dict):
+        return ""
+    properties = cast("dict[str, object]", properties_obj)
+    info_obj = properties.get("info")
+    if not isinstance(info_obj, dict):
+        return ""
+    info = cast("dict[str, object]", info_obj)
+    return str(info.get("role", "")).strip().lower()
+
+
+def _resolve_opencode_primary_session_id(payloads: list[dict[str, object]]) -> str | None:
+    for payload in payloads:
+        event_type = _opencode_event_type(payload)
+        message_payload = _opencode_message_payload(payload)
+        inner_type = _opencode_event_type(message_payload)
+        effective_type = event_type or inner_type
+        if effective_type != "message.updated":
+            continue
+        if _opencode_message_role(payload) != "user":
+            continue
+        session_id = extract_opencode_session_id(payload)
+        if session_id:
+            return session_id
+    return None
+
+
+def _opencode_event_matches_session(
+    payload: dict[str, object],
+    *,
+    primary_session_id: str | None,
+) -> bool:
+    if primary_session_id is None:
+        return True
+    session_id = extract_opencode_session_id(payload)
+    return session_id == primary_session_id
+
+
+def _extract_opencode_report_from_stream(
+    payloads: list[dict[str, object]],
+    *,
+    primary_session_id: str | None = None,
+) -> str | None:
+    assistant_message_ids: set[str] = set()
+    part_text_by_message: dict[str, list[str]] = {}
+    last_assistant_message_id: str | None = None
+    last_embedded_message: str | None = None
+
+    for payload in payloads:
+        event_type = _opencode_event_type(payload)
+        message_payload = _opencode_message_payload(payload)
+        inner_type = _opencode_event_type(message_payload)
+        effective_type = event_type or inner_type
+
+        if effective_type == "message.updated":
+            if not _opencode_event_matches_session(
+                payload,
+                primary_session_id=primary_session_id,
+            ):
+                continue
+            properties_obj = message_payload.get("properties")
+            if not isinstance(properties_obj, dict):
+                continue
+            properties = cast("dict[str, object]", properties_obj)
+
+            info_obj = properties.get("info")
+            if not isinstance(info_obj, dict):
+                continue
+            info = cast("dict[str, object]", info_obj)
+
+            role = str(info.get("role", "")).strip().lower()
+            message_id = str(info.get("id", "")).strip()
+            if role == "assistant" and message_id:
+                assistant_message_ids.add(message_id)
+                last_assistant_message_id = message_id
+
+            if role != "assistant":
+                continue
+
+            parts_obj = info.get("parts")
+            if not isinstance(parts_obj, list):
+                continue
+            parts = cast("list[object]", parts_obj)
+
+            text_chunks: list[str] = []
+            for part_obj in parts:
+                if not isinstance(part_obj, dict):
+                    continue
+                part = cast("dict[str, object]", part_obj)
+                if str(part.get("type", "")).strip().lower() != "text":
+                    continue
+                text_chunks.append(str(part.get("text", "")))
+            message = "".join(chunk for chunk in text_chunks if chunk).strip()
+            if message:
+                last_embedded_message = message
+            continue
+
+        if effective_type != "message.part.updated":
+            continue
+
+        if not _opencode_event_matches_session(payload, primary_session_id=primary_session_id):
+            continue
+
+        properties_obj = message_payload.get("properties")
+        if not isinstance(properties_obj, dict):
+            continue
+        properties = cast("dict[str, object]", properties_obj)
+
+        part_obj = properties.get("part")
+        if not isinstance(part_obj, dict):
+            continue
+        part = cast("dict[str, object]", part_obj)
+        if str(part.get("type", "")).strip().lower() != "text":
+            continue
+
+        message_id = str(part.get("messageID", part.get("message_id", ""))).strip()
+        if not message_id or message_id not in assistant_message_ids:
+            continue
+
+        text = str(part.get("text", "")).strip()
+        if not text:
+            continue
+        part_text_by_message.setdefault(message_id, []).append(text)
+        last_assistant_message_id = message_id
+
+    if last_assistant_message_id:
+        chunks = part_text_by_message.get(last_assistant_message_id)
+        if chunks:
+            joined = "".join(chunks).strip()
+            if joined:
+                return joined
+
+    return last_embedded_message
+
+
+def extract_opencode_report(artifacts: ArtifactStore, spawn_id: SpawnId) -> str | None:
+    payloads = iter_json_lines_artifact(artifacts, spawn_id, OUTPUT_FILENAME)
+    primary_session_id = read_session_id_artifact(
+        artifacts,
+        spawn_id,
+    ) or _resolve_opencode_primary_session_id(payloads)
+    report = _extract_opencode_report_from_stream(
+        payloads,
+        primary_session_id=primary_session_id,
+    )
+    if report:
+        return report
+
+    session_id = primary_session_id or extract_session_id_from_artifacts_with_patterns(
+        artifacts,
+        spawn_id,
+        json_keys=_OPENCODE_SESSION_ID_JSON_KEYS,
+    )
+    if not session_id:
+        return None
+
+    from meridian.lib.harness.opencode_storage import resolve_opencode_session_file
+    from meridian.lib.harness.opencode_transcript import (
+        extract_last_assistant_report_from_session_path,
+    )
+
+    session_path = resolve_opencode_session_file(session_id=session_id)
+    if session_path is None:
+        return None
+    return extract_last_assistant_report_from_session_path(session_path)
+
+
+__all__ = ["extract_opencode_report", "extract_opencode_session_id"]

--- a/src/meridian/lib/harness/opencode_transcript.py
+++ b/src/meridian/lib/harness/opencode_transcript.py
@@ -213,12 +213,6 @@ def iter_opencode_db_events(
         with sqlite3.connect(
             f"file:{resolved_db_path}?mode=ro", uri=True, timeout=0.1
         ) as connection:
-            session_row = connection.execute(
-                "SELECT 1 FROM session WHERE id = ?",
-                (normalized_session_id,),
-            ).fetchone()
-            if session_row is None:
-                return
             message_rows = connection.execute(
                 """
                 SELECT id, data, time_created

--- a/src/meridian/lib/harness/opencode_transcript.py
+++ b/src/meridian/lib/harness/opencode_transcript.py
@@ -66,7 +66,7 @@ class OpenCodeStorageTranscriptProvider:
 
     def iter_events(self, path: Path) -> Iterator[dict[str, object]]:
         db_events = self._load_opencode_db_events(path)
-        if db_events:
+        if _has_interaction_events(db_events):
             yield from db_events
             return
         yield from self._iter_json_events(path)
@@ -193,6 +193,53 @@ def _message_events(
             yield from _tool_events(part)
 
 
+def _has_interaction_events(events: list[dict[str, object]]) -> bool:
+    for event in events:
+        role = str(event.get("role", "")).strip().lower()
+        if role in {"assistant", "user"} and not _is_compaction_message(event):
+            return True
+        event_type = str(event.get("event_type", "")).strip().lower()
+        item_type = str(event.get("type", "")).strip().lower()
+        if event_type == "response_item" and item_type in {
+            "function_call",
+            "function_call_output",
+        }:
+            return True
+    return False
+
+
+def _is_compaction_message(message_payload: dict[str, object]) -> bool:
+    role = str(message_payload.get("role", "")).strip().lower()
+    mode = str(message_payload.get("mode", "")).strip().lower()
+    agent = str(message_payload.get("agent", "")).strip().lower()
+    return role == "assistant" and mode == "compaction" and agent == "compaction"
+
+
+def _compaction_handoff_event(
+    *,
+    message_payload: dict[str, object],
+    parts: list[dict[str, object]],
+) -> dict[str, object]:
+    event: dict[str, object] = {
+        "role": "assistant",
+        "mode": "compaction",
+        "agent": "compaction",
+    }
+    if parts:
+        event["parts"] = parts
+    else:
+        raw_parts = message_payload.get("parts")
+        if isinstance(raw_parts, list):
+            event["parts"] = raw_parts
+        raw_part = message_payload.get("part")
+        if isinstance(raw_part, dict):
+            event["part"] = raw_part
+    content = message_payload.get("content")
+    if content is not None:
+        event["content"] = content
+    return event
+
+
 def iter_opencode_db_events(
     *,
     session_id: str,
@@ -256,6 +303,15 @@ def iter_opencode_db_events(
         if role not in {"assistant", "user", "system"}:
             continue
 
+        message_parts = parts_by_message.get(normalized_message_id, [])
+        if _is_compaction_message(message_payload):
+            yield {"part": {"type": "compaction"}}
+            yield _compaction_handoff_event(
+                message_payload=message_payload,
+                parts=message_parts,
+            )
+            continue
+
         if role == "user" and not first_user_system_seen:
             first_user_system_seen = True
             system = text_reader(message_payload.get("system"))
@@ -264,7 +320,7 @@ def iter_opencode_db_events(
 
         yield from _message_events(
             role=role,
-            parts=parts_by_message.get(normalized_message_id, []),
+            parts=message_parts,
             text_from_value=text_reader,
         )
 
@@ -288,6 +344,8 @@ def extract_last_assistant_report_from_session_path(path: Path) -> str | None:
     )
     last_assistant: str | None = None
     for event in provider.iter_events(path):
+        if _is_compaction_message(event):
+            continue
         if str(event.get("role", "")).strip().lower() != "assistant":
             continue
         content = _text_from_value(event.get("content"))

--- a/src/meridian/lib/harness/opencode_transcript.py
+++ b/src/meridian/lib/harness/opencode_transcript.py
@@ -5,9 +5,44 @@ from __future__ import annotations
 import json
 import sqlite3
 from collections import defaultdict
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Mapping
 from pathlib import Path
 from typing import cast
+
+from meridian.lib.harness.opencode_storage import resolve_opencode_storage_root
+
+
+def resolve_opencode_db_path(launch_env: Mapping[str, str] | None = None) -> Path:
+    """Resolve the OpenCode SQLite database path from the storage root."""
+
+    return resolve_opencode_storage_root(launch_env).parent / "opencode.db"
+
+
+def opencode_db_session_exists(
+    *,
+    session_id: str,
+    db_path: Path | None = None,
+) -> bool:
+    """Return whether opencode.db contains a session row for ``session_id``."""
+
+    normalized_session_id = session_id.strip()
+    if not normalized_session_id:
+        return False
+    resolved_db_path = db_path or resolve_opencode_db_path()
+    if not resolved_db_path.is_file():
+        return False
+
+    try:
+        with sqlite3.connect(
+            f"file:{resolved_db_path}?mode=ro", uri=True, timeout=0.1
+        ) as connection:
+            row = connection.execute(
+                "SELECT 1 FROM session WHERE id = ?",
+                (normalized_session_id,),
+            ).fetchone()
+    except (OSError, sqlite3.Error):
+        return False
+    return row is not None
 
 
 class OpenCodeStorageTranscriptProvider:
@@ -50,82 +85,194 @@ class OpenCodeStorageTranscriptProvider:
             return []
 
         db_path = self._opencode_db_path_for_session_file(path)
-        if db_path is None or not db_path.is_file():
+        if db_path is None:
             return []
+        return list(iter_opencode_db_events(session_id=session_id, db_path=db_path))
 
-        try:
-            with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=0.1) as connection:
-                message_rows = connection.execute(
-                    """
-                    SELECT id, data, time_created
-                    FROM message
-                    WHERE session_id = ?
-                    ORDER BY time_created ASC, id ASC
-                    """,
-                    (session_id,),
-                ).fetchall()
-                part_rows = connection.execute(
-                    """
-                    SELECT message_id, data, time_created, id
-                    FROM part
-                    WHERE session_id = ?
-                    ORDER BY time_created ASC, id ASC
-                    """,
-                    (session_id,),
-                ).fetchall()
-        except (OSError, sqlite3.Error):
-            return []
 
-        if not message_rows:
-            return []
+def _load_json_object(value: object) -> dict[str, object] | None:
+    try:
+        parsed = json.loads(str(value))
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return cast("dict[str, object]", parsed)
 
-        parts_by_message: dict[str, list[dict[str, object]]] = defaultdict(list)
-        for message_id, part_data, _time_created, _part_id in part_rows:
-            normalized_message_id = str(message_id or "").strip()
-            if not normalized_message_id:
-                continue
-            try:
-                part_obj = json.loads(str(part_data))
-            except (TypeError, ValueError):
-                continue
-            if isinstance(part_obj, dict):
-                parts_by_message[normalized_message_id].append(cast("dict[str, object]", part_obj))
 
-        events: list[dict[str, object]] = []
-        for message_id, message_data, _time_created in message_rows:
-            normalized_message_id = str(message_id or "").strip()
-            if not normalized_message_id:
-                continue
-            try:
-                message_obj = json.loads(str(message_data))
-            except (TypeError, ValueError):
-                continue
-            if not isinstance(message_obj, dict):
-                continue
+def _text_from_mapping(mapping: dict[str, object], keys: tuple[str, ...]) -> str:
+    for key in keys:
+        value = mapping.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
 
-            message_payload = cast("dict[str, object]", message_obj)
-            role = str(message_payload.get("role", "")).strip().lower()
-            if role not in {"assistant", "user", "system"}:
-                continue
 
-            text_parts: list[str] = []
-            for part in parts_by_message.get(normalized_message_id, []):
-                if str(part.get("type", "")).strip().lower() != "text":
-                    continue
-                text = self._text_from_value(part.get("text"))
-                if text:
-                    text_parts.append(text)
+def _tool_body(state: dict[str, object]) -> str:
+    raw_input = state.get("input")
+    if not isinstance(raw_input, dict):
+        return ""
+    tool_input = cast("dict[str, object]", raw_input)
+    direct = _text_from_mapping(
+        tool_input,
+        (
+            "command",
+            "filePath",
+            "file_path",
+            "path",
+            "pattern",
+            "description",
+        ),
+    )
+    if direct:
+        return direct
+    if not tool_input:
+        return ""
+    try:
+        return json.dumps(tool_input, sort_keys=True, separators=(",", ":"))
+    except TypeError:
+        return str(tool_input)
 
-            content = "\n".join(text_parts).strip()
-            if not content:
-                content = self._text_from_value(message_payload.get("content"))
-            if not content:
-                content = self._text_from_value(message_payload.get("text"))
-            if not content:
-                continue
-            events.append({"role": role, "content": content})
 
-        return events
+def _tool_output(state: dict[str, object]) -> str:
+    output = state.get("output")
+    if isinstance(output, str) and output.strip():
+        return output.strip()
+    metadata = state.get("metadata")
+    if isinstance(metadata, dict):
+        metadata_output = cast("dict[str, object]", metadata).get("output")
+        if isinstance(metadata_output, str) and metadata_output.strip():
+            return metadata_output.strip()
+    return ""
+
+
+def _tool_events(part: dict[str, object]) -> list[dict[str, object]]:
+    state = part.get("state")
+    if not isinstance(state, dict):
+        return []
+    state_payload = cast("dict[str, object]", state)
+    if str(state_payload.get("status", "")).strip().lower() != "completed":
+        return []
+
+    tool_name = str(part.get("tool", "tool")).strip() or "tool"
+    body = _tool_body(state_payload)
+    events: list[dict[str, object]] = [
+        {
+            "event_type": "response_item",
+            "type": "function_call",
+            "name": tool_name,
+            "arguments": body,
+        }
+    ]
+    output = _tool_output(state_payload)
+    if output:
+        events.append(
+            {
+                "event_type": "response_item",
+                "type": "function_call_output",
+                "output": output,
+            }
+        )
+    return events
+
+
+def _message_events(
+    *,
+    role: str,
+    parts: list[dict[str, object]],
+    text_from_value: Callable[[object], str],
+) -> Iterator[dict[str, object]]:
+    for part in parts:
+        part_type = str(part.get("type", "")).strip().lower()
+        if part_type == "text":
+            text = text_from_value(part.get("text"))
+            if text:
+                yield {"role": role, "content": text}
+            continue
+        if part_type == "tool":
+            yield from _tool_events(part)
+
+
+def iter_opencode_db_events(
+    *,
+    session_id: str,
+    db_path: Path | None = None,
+    text_from_value: Callable[[object], str] | None = None,
+) -> Iterator[dict[str, object]]:
+    """Yield transcript events for one OpenCode DB session."""
+
+    normalized_session_id = session_id.strip()
+    if not normalized_session_id:
+        return
+
+    resolved_db_path = db_path or resolve_opencode_db_path()
+    if not resolved_db_path.is_file():
+        return
+
+    try:
+        with sqlite3.connect(
+            f"file:{resolved_db_path}?mode=ro", uri=True, timeout=0.1
+        ) as connection:
+            session_row = connection.execute(
+                "SELECT 1 FROM session WHERE id = ?",
+                (normalized_session_id,),
+            ).fetchone()
+            if session_row is None:
+                return
+            message_rows = connection.execute(
+                """
+                SELECT id, data, time_created
+                FROM message
+                WHERE session_id = ?
+                ORDER BY time_created ASC, id ASC
+                """,
+                (normalized_session_id,),
+            ).fetchall()
+            part_rows = connection.execute(
+                """
+                SELECT message_id, data, time_created, id
+                FROM part
+                WHERE session_id = ?
+                ORDER BY time_created ASC, id ASC
+                """,
+                (normalized_session_id,),
+            ).fetchall()
+    except (OSError, sqlite3.Error):
+        return
+
+    parts_by_message: dict[str, list[dict[str, object]]] = defaultdict(list)
+    for message_id, part_data, _time_created, _part_id in part_rows:
+        normalized_message_id = str(message_id or "").strip()
+        if not normalized_message_id:
+            continue
+        part_obj = _load_json_object(part_data)
+        if part_obj is not None:
+            parts_by_message[normalized_message_id].append(part_obj)
+
+    first_user_system_seen = False
+    text_reader = text_from_value or _text_from_value
+    for message_id, message_data, _time_created in message_rows:
+        normalized_message_id = str(message_id or "").strip()
+        if not normalized_message_id:
+            continue
+        message_payload = _load_json_object(message_data)
+        if message_payload is None:
+            continue
+        role = str(message_payload.get("role", "")).strip().lower()
+        if role not in {"assistant", "user", "system"}:
+            continue
+
+        if role == "user" and not first_user_system_seen:
+            first_user_system_seen = True
+            system = text_reader(message_payload.get("system"))
+            if system:
+                yield {"opencode_db_setup": system}
+
+        yield from _message_events(
+            role=role,
+            parts=parts_by_message.get(normalized_message_id, []),
+            text_from_value=text_reader,
+        )
 
 
 def _text_from_value(value: object) -> str:
@@ -158,4 +305,7 @@ def extract_last_assistant_report_from_session_path(path: Path) -> str | None:
 __all__ = [
     "OpenCodeStorageTranscriptProvider",
     "extract_last_assistant_report_from_session_path",
+    "iter_opencode_db_events",
+    "opencode_db_session_exists",
+    "resolve_opencode_db_path",
 ]

--- a/src/meridian/lib/harness/semantics.py
+++ b/src/meridian/lib/harness/semantics.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Literal, cast
 
 from meridian.lib.core.domain import SpawnStatus
 from meridian.lib.core.types import HarnessId
-from meridian.lib.harness.common import extract_codex_thread_id
+from meridian.lib.harness.common import extract_codex_thread_id, extract_opencode_session_id
 
 if TYPE_CHECKING:
     from meridian.lib.harness.connections.base import HarnessEvent
@@ -22,6 +22,36 @@ class TerminalEventOutcome:
     status: SpawnStatus
     exit_code: int
     error: str | None = None
+
+
+@dataclass(frozen=True)
+class PrimaryEventScope:
+    """Primary harness event scope for parent-session classification."""
+
+    harness_id: HarnessId
+    scope_id: str
+    unscoped_events_match: bool = False
+
+
+def codex_primary_event_scope(thread_id: str | None) -> PrimaryEventScope | None:
+    normalized = (thread_id or "").strip()
+    if not normalized:
+        return None
+    return PrimaryEventScope(
+        harness_id=HarnessId.CODEX,
+        scope_id=normalized,
+        unscoped_events_match=True,
+    )
+
+
+def opencode_primary_event_scope(session_id: str | None) -> PrimaryEventScope | None:
+    normalized = (session_id or "").strip()
+    if not normalized:
+        return None
+    return PrimaryEventScope(
+        harness_id=HarnessId.OPENCODE,
+        scope_id=normalized,
+    )
 
 
 def _stringify_terminal_error(error: object) -> str | None:
@@ -38,31 +68,68 @@ def _stringify_terminal_error(error: object) -> str | None:
     return normalized or None
 
 
+def _resolve_primary_event_scope(
+    primary_event_scope: PrimaryEventScope | None,
+    *,
+    codex_main_thread_id: str | None,
+) -> PrimaryEventScope | None:
+    if primary_event_scope is not None:
+        return primary_event_scope
+    return codex_primary_event_scope(codex_main_thread_id)
+
+
+def _event_scope_id(event: HarnessEvent, scope: PrimaryEventScope) -> str | None:
+    if event.harness_id != scope.harness_id.value:
+        return None
+    if scope.harness_id is HarnessId.CODEX:
+        return extract_codex_thread_id(event.payload)
+    if scope.harness_id is HarnessId.OPENCODE:
+        return extract_opencode_session_id(event.payload)
+    return None
+
+
+def event_matches_primary_scope(
+    event: HarnessEvent,
+    *,
+    primary_event_scope: PrimaryEventScope | None,
+) -> bool:
+    if primary_event_scope is None:
+        return True
+    if event.harness_id != primary_event_scope.harness_id.value:
+        return True
+    event_scope_id = _event_scope_id(event, primary_event_scope)
+    if event_scope_id is None:
+        return primary_event_scope.unscoped_events_match
+    return event_scope_id == primary_event_scope.scope_id
+
+
 def _codex_turn_completes_session(
     event: HarnessEvent,
     *,
-    codex_main_thread_id: str | None,
+    primary_event_scope: PrimaryEventScope | None,
 ) -> bool:
-    if event.harness_id != HarnessId.CODEX.value or event.event_type != "turn/completed":
-        return False
-    if codex_main_thread_id is None:
-        return True
-    event_thread_id = extract_codex_thread_id(event.payload)
-    if event_thread_id is None:
-        return True
-    return event_thread_id == codex_main_thread_id
+    return (
+        event.harness_id == HarnessId.CODEX.value
+        and event.event_type == "turn/completed"
+        and event_matches_primary_scope(event, primary_event_scope=primary_event_scope)
+    )
 
 
 def terminal_outcome(
     event: HarnessEvent,
     *,
+    primary_event_scope: PrimaryEventScope | None = None,
     codex_main_thread_id: str | None = None,
 ) -> TerminalEventOutcome | None:
     """Classify whether a harness event completes a spawn drain."""
 
+    resolved_scope = _resolve_primary_event_scope(
+        primary_event_scope,
+        codex_main_thread_id=codex_main_thread_id,
+    )
     if _codex_turn_completes_session(
         event,
-        codex_main_thread_id=codex_main_thread_id,
+        primary_event_scope=resolved_scope,
     ):
         return TerminalEventOutcome(status="succeeded", exit_code=0)
 
@@ -120,6 +187,8 @@ def terminal_outcome(
         )
 
     if event.harness_id == HarnessId.OPENCODE.value:
+        if not event_matches_primary_scope(event, primary_event_scope=resolved_scope):
+            return None
         if event.event_type == "session.idle":
             return TerminalEventOutcome(status="succeeded", exit_code=0)
 
@@ -173,10 +242,15 @@ def terminal_outcome(
 def activity_transition(
     event: HarnessEvent,
     *,
+    primary_event_scope: PrimaryEventScope | None = None,
     codex_main_thread_id: str | None = None,
 ) -> ActivityState | None:
     """Return primary UI activity transition caused by a harness event."""
 
+    resolved_scope = _resolve_primary_event_scope(
+        primary_event_scope,
+        codex_main_thread_id=codex_main_thread_id,
+    )
     if event.event_type in {
         "turn/started",  # Codex
         "agent_message_chunk",  # OpenCode: assistant text streaming
@@ -184,15 +258,19 @@ def activity_transition(
         "tool_call",  # OpenCode: tool invocation
         "tool_call_update",  # OpenCode: tool result
     }:
+        if not event_matches_primary_scope(event, primary_event_scope=resolved_scope):
+            return None
         return "turn_active"
     if event.event_type == "turn/completed":
         if _codex_turn_completes_session(
             event,
-            codex_main_thread_id=codex_main_thread_id,
+            primary_event_scope=resolved_scope,
         ):
             return "idle"
         return None
     if event.event_type == "session.idle":
+        if not event_matches_primary_scope(event, primary_event_scope=resolved_scope):
+            return None
         return "idle"
     if event.harness_id == HarnessId.PI.value:
         if event.event_type in {
@@ -212,49 +290,87 @@ def activity_transition(
 def clears_signal(
     event: HarnessEvent,
     *,
+    primary_event_scope: PrimaryEventScope | None = None,
     codex_main_thread_id: str | None = None,
 ) -> bool:
     """Return whether an event clears a pending user signal for its harness."""
 
+    resolved_scope = _resolve_primary_event_scope(
+        primary_event_scope,
+        codex_main_thread_id=codex_main_thread_id,
+    )
     if event.harness_id in {HarnessId.CLAUDE.value, HarnessId.CURSOR.value}:
         return event.event_type == "result"
     if event.harness_id == HarnessId.CODEX.value:
         return _codex_turn_completes_session(
             event,
-            codex_main_thread_id=codex_main_thread_id,
+            primary_event_scope=resolved_scope,
         )
     if event.harness_id == HarnessId.OPENCODE.value:
-        return event.event_type in {"session.idle", "session.error"}
+        return (
+            event.event_type in {"session.idle", "session.error"}
+            and event_matches_primary_scope(event, primary_event_scope=resolved_scope)
+        )
     if event.harness_id == HarnessId.PI.value:
         return event.event_type == "agent_end"
     return False
 
 
 @dataclass
-class CodexDrainThreadTracker:
-    """Track the main Codex thread for thread-aware drain classification."""
+class PrimaryEventScopeTracker:
+    """Track the primary event scope for drain classification."""
 
-    main_thread_id: str | None = field(default=None)
+    primary_event_scope: PrimaryEventScope | None = field(default=None)
 
     def observe(self, event: HarnessEvent) -> None:
         if event.harness_id != HarnessId.CODEX.value or event.event_type != "turn/started":
             return
-        if self.main_thread_id is not None:
+        if self.primary_event_scope is not None:
             return
         thread_id = extract_codex_thread_id(event.payload)
-        if thread_id:
-            self.main_thread_id = thread_id
+        scope = codex_primary_event_scope(thread_id)
+        if scope is not None:
+            self.primary_event_scope = scope
 
     def terminal_outcome(self, event: HarnessEvent) -> TerminalEventOutcome | None:
         self.observe(event)
-        return terminal_outcome(event, codex_main_thread_id=self.main_thread_id)
+        return terminal_outcome(event, primary_event_scope=self.primary_event_scope)
+
+    def activity_transition(self, event: HarnessEvent) -> ActivityState | None:
+        self.observe(event)
+        return activity_transition(event, primary_event_scope=self.primary_event_scope)
+
+
+@dataclass
+class CodexDrainThreadTracker:
+    """Track the main Codex thread for thread-aware drain classification."""
+
+    _tracker: PrimaryEventScopeTracker = field(default_factory=PrimaryEventScopeTracker)
+
+    @property
+    def main_thread_id(self) -> str | None:
+        scope = self._tracker.primary_event_scope
+        if scope is None or scope.harness_id is not HarnessId.CODEX:
+            return None
+        return scope.scope_id
+
+    def observe(self, event: HarnessEvent) -> None:
+        self._tracker.observe(event)
+
+    def terminal_outcome(self, event: HarnessEvent) -> TerminalEventOutcome | None:
+        return self._tracker.terminal_outcome(event)
 
 
 __all__ = [
     "ActivityState",
     "CodexDrainThreadTracker",
+    "PrimaryEventScope",
+    "PrimaryEventScopeTracker",
     "TerminalEventOutcome",
     "activity_transition",
     "clears_signal",
+    "codex_primary_event_scope",
+    "event_matches_primary_scope",
+    "opencode_primary_event_scope",
     "terminal_outcome",
 ]

--- a/src/meridian/lib/harness/semantics.py
+++ b/src/meridian/lib/harness/semantics.py
@@ -69,16 +69,6 @@ def _stringify_terminal_error(error: object) -> str | None:
     return normalized or None
 
 
-def _resolve_primary_event_scope(
-    primary_event_scope: PrimaryEventScope | None,
-    *,
-    codex_main_thread_id: str | None,
-) -> PrimaryEventScope | None:
-    if primary_event_scope is not None:
-        return primary_event_scope
-    return codex_primary_event_scope(codex_main_thread_id)
-
-
 def _event_scope_id(event: HarnessEvent, scope: PrimaryEventScope) -> str | None:
     if event.harness_id != scope.harness_id.value:
         return None
@@ -120,17 +110,12 @@ def terminal_outcome(
     event: HarnessEvent,
     *,
     primary_event_scope: PrimaryEventScope | None = None,
-    codex_main_thread_id: str | None = None,
 ) -> TerminalEventOutcome | None:
     """Classify whether a harness event completes a spawn drain."""
 
-    resolved_scope = _resolve_primary_event_scope(
-        primary_event_scope,
-        codex_main_thread_id=codex_main_thread_id,
-    )
     if _codex_turn_completes_session(
         event,
-        primary_event_scope=resolved_scope,
+        primary_event_scope=primary_event_scope,
     ):
         return TerminalEventOutcome(status="succeeded", exit_code=0)
 
@@ -188,7 +173,7 @@ def terminal_outcome(
         )
 
     if event.harness_id == HarnessId.OPENCODE.value:
-        if not event_matches_primary_scope(event, primary_event_scope=resolved_scope):
+        if not event_matches_primary_scope(event, primary_event_scope=primary_event_scope):
             return None
         if event.event_type == "session.idle":
             return TerminalEventOutcome(status="succeeded", exit_code=0)
@@ -244,14 +229,9 @@ def activity_transition(
     event: HarnessEvent,
     *,
     primary_event_scope: PrimaryEventScope | None = None,
-    codex_main_thread_id: str | None = None,
 ) -> ActivityState | None:
     """Return primary UI activity transition caused by a harness event."""
 
-    resolved_scope = _resolve_primary_event_scope(
-        primary_event_scope,
-        codex_main_thread_id=codex_main_thread_id,
-    )
     if event.event_type in {
         "turn/started",  # Codex
         "agent_message_chunk",  # OpenCode: assistant text streaming
@@ -259,18 +239,18 @@ def activity_transition(
         "tool_call",  # OpenCode: tool invocation
         "tool_call_update",  # OpenCode: tool result
     }:
-        if not event_matches_primary_scope(event, primary_event_scope=resolved_scope):
+        if not event_matches_primary_scope(event, primary_event_scope=primary_event_scope):
             return None
         return "turn_active"
     if event.event_type == "turn/completed":
         if _codex_turn_completes_session(
             event,
-            primary_event_scope=resolved_scope,
+            primary_event_scope=primary_event_scope,
         ):
             return "idle"
         return None
     if event.event_type == "session.idle":
-        if not event_matches_primary_scope(event, primary_event_scope=resolved_scope):
+        if not event_matches_primary_scope(event, primary_event_scope=primary_event_scope):
             return None
         return "idle"
     if event.harness_id == HarnessId.PI.value:
@@ -292,25 +272,20 @@ def clears_signal(
     event: HarnessEvent,
     *,
     primary_event_scope: PrimaryEventScope | None = None,
-    codex_main_thread_id: str | None = None,
 ) -> bool:
     """Return whether an event clears a pending user signal for its harness."""
 
-    resolved_scope = _resolve_primary_event_scope(
-        primary_event_scope,
-        codex_main_thread_id=codex_main_thread_id,
-    )
     if event.harness_id in {HarnessId.CLAUDE.value, HarnessId.CURSOR.value}:
         return event.event_type == "result"
     if event.harness_id == HarnessId.CODEX.value:
         return _codex_turn_completes_session(
             event,
-            primary_event_scope=resolved_scope,
+            primary_event_scope=primary_event_scope,
         )
     if event.harness_id == HarnessId.OPENCODE.value:
         return (
             event.event_type in {"session.idle", "session.error"}
-            and event_matches_primary_scope(event, primary_event_scope=resolved_scope)
+            and event_matches_primary_scope(event, primary_event_scope=primary_event_scope)
         )
     if event.harness_id == HarnessId.PI.value:
         return event.event_type == "agent_end"
@@ -342,29 +317,9 @@ class PrimaryEventScopeTracker:
         return activity_transition(event, primary_event_scope=self.primary_event_scope)
 
 
-@dataclass
-class CodexDrainThreadTracker:
-    """Track the main Codex thread for thread-aware drain classification."""
-
-    _tracker: PrimaryEventScopeTracker = field(default_factory=PrimaryEventScopeTracker)
-
-    @property
-    def main_thread_id(self) -> str | None:
-        scope = self._tracker.primary_event_scope
-        if scope is None or scope.harness_id is not HarnessId.CODEX:
-            return None
-        return scope.scope_id
-
-    def observe(self, event: HarnessEvent) -> None:
-        self._tracker.observe(event)
-
-    def terminal_outcome(self, event: HarnessEvent) -> TerminalEventOutcome | None:
-        return self._tracker.terminal_outcome(event)
-
 
 __all__ = [
     "ActivityState",
-    "CodexDrainThreadTracker",
     "PrimaryEventScope",
     "PrimaryEventScopeTracker",
     "TerminalEventOutcome",

--- a/src/meridian/lib/harness/semantics.py
+++ b/src/meridian/lib/harness/semantics.py
@@ -8,7 +8,8 @@ from typing import TYPE_CHECKING, Literal, cast
 
 from meridian.lib.core.domain import SpawnStatus
 from meridian.lib.core.types import HarnessId
-from meridian.lib.harness.common import extract_codex_thread_id, extract_opencode_session_id
+from meridian.lib.harness.common import extract_codex_thread_id
+from meridian.lib.harness.opencode_report import extract_opencode_session_id
 
 if TYPE_CHECKING:
     from meridian.lib.harness.connections.base import HarnessEvent

--- a/src/meridian/lib/harness/transcript.py
+++ b/src/meridian/lib/harness/transcript.py
@@ -8,7 +8,10 @@ from pathlib import Path
 from typing import NamedTuple, Protocol, cast
 
 from meridian.lib.harness.extractors.base import normalize_harness_event_type
-from meridian.lib.harness.opencode_transcript import OpenCodeStorageTranscriptProvider
+from meridian.lib.harness.opencode_transcript import (
+    OpenCodeStorageTranscriptProvider,
+    iter_opencode_db_events,
+)
 from meridian.lib.launch.constants import HISTORY_FILENAME
 from meridian.lib.state.history import iter_history_events
 
@@ -413,7 +416,8 @@ class DefaultTranscriptEventParser(TranscriptEventParser):
             if isinstance(raw_payload, dict):
                 extracted = _extract_codex_response_item(cast("dict[str, object]", raw_payload))
                 return (extracted, is_boundary)
-            return ([], is_boundary)
+            extracted = _extract_codex_response_item(event)
+            return (extracted, is_boundary)
 
         if event_type == "item.completed":
             item = event.get("item")
@@ -526,6 +530,10 @@ def _extract_claude_system_prologue(event: dict[str, object]) -> str | None:
     if _is_claude_compaction_boundary(event):
         return None
     return text_from_value(event.get("content")) or text_from_value(event.get("text")) or None
+
+
+def _extract_opencode_db_system_prologue(event: dict[str, object]) -> str | None:
+    return text_from_value(event.get("opencode_db_setup")) or None
 
 
 def _extract_claude_boundary_handoff(event: dict[str, object]) -> str | None:
@@ -643,7 +651,10 @@ def _parse_events_with_prologues(
                 continue
 
         if segment_setups[-1] is None:
-            prologue = _extract_claude_system_prologue(normalized_event)
+            prologue = (
+                _extract_claude_system_prologue(normalized_event)
+                or _extract_opencode_db_system_prologue(normalized_event)
+            )
             if prologue:
                 segment_setups[-1] = prologue
 
@@ -699,6 +710,18 @@ def parse_transcript_file_with_prologues(
     return _parse_events_with_prologues(iter_transcript_events(path), parser=resolved_parser)
 
 
+def parse_opencode_db_transcript_with_prologues(
+    session_id: str,
+    *,
+    parser: TranscriptEventParser | None = None,
+) -> TranscriptParseResult:
+    resolved_parser = parser or DefaultTranscriptEventParser()
+    return _parse_events_with_prologues(
+        iter_opencode_db_events(session_id=session_id, text_from_value=text_from_value),
+        parser=resolved_parser,
+    )
+
+
 __all__ = [
     "DefaultTranscriptEventParser",
     "HistoryJsonlTranscriptProvider",
@@ -711,6 +734,7 @@ __all__ = [
     "TranscriptProvider",
     "_text_from_value",
     "iter_transcript_events",
+    "parse_opencode_db_transcript_with_prologues",
     "parse_transcript_events",
     "parse_transcript_events_with_prologues",
     "parse_transcript_file",

--- a/src/meridian/lib/launch/process/primary_attach.py
+++ b/src/meridian/lib/launch/process/primary_attach.py
@@ -14,14 +14,14 @@ from contextlib import suppress
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from threading import Lock
-from typing import Any
+from typing import Any, cast
 
 import psutil
 
 from meridian.lib.core.types import HarnessId, SpawnId
 from meridian.lib.harness.connections.base import ConnectionConfig, HarnessConnection, HarnessEvent
 from meridian.lib.harness.connections.errors import PortBindError
-from meridian.lib.harness.semantics import activity_transition
+from meridian.lib.harness.semantics import PrimaryEventScope, activity_transition
 from meridian.lib.launch.launch_types import ResolvedLaunchSpec
 from meridian.lib.platform.process_scope import terminate_scope_sync
 from meridian.lib.platform.process_scope.base import (
@@ -167,6 +167,12 @@ def _startup_phase_message(connection: HarnessConnection[Any]) -> str:
     if connection.harness_id is HarnessId.CODEX:
         return f"Starting {harness_label} app-server..."
     return f"Starting {harness_label} managed session..."
+
+
+def _primary_event_scope(connection: object) -> PrimaryEventScope | None:
+    """Read the connection's primary event scope when it exposes one."""
+
+    return cast("PrimaryEventScope | None", getattr(connection, "primary_event_scope", None))
 
 
 class PrimaryAttachLauncher:
@@ -369,7 +375,7 @@ class PrimaryAttachLauncher:
 
         activity = activity_transition(
             event,
-            primary_event_scope=self._connection.primary_event_scope,
+            primary_event_scope=_primary_event_scope(self._connection),
         )
         if activity is not None:
             self._set_activity(activity)

--- a/src/meridian/lib/launch/process/primary_attach.py
+++ b/src/meridian/lib/launch/process/primary_attach.py
@@ -14,14 +14,14 @@ from contextlib import suppress
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from threading import Lock
-from typing import Any, cast
+from typing import Any
 
 import psutil
 
 from meridian.lib.core.types import HarnessId, SpawnId
 from meridian.lib.harness.connections.base import ConnectionConfig, HarnessConnection, HarnessEvent
 from meridian.lib.harness.connections.errors import PortBindError
-from meridian.lib.harness.semantics import PrimaryEventScope, activity_transition
+from meridian.lib.harness.semantics import activity_transition
 from meridian.lib.launch.launch_types import ResolvedLaunchSpec
 from meridian.lib.platform.process_scope import terminate_scope_sync
 from meridian.lib.platform.process_scope.base import (
@@ -167,12 +167,6 @@ def _startup_phase_message(connection: HarnessConnection[Any]) -> str:
     if connection.harness_id is HarnessId.CODEX:
         return f"Starting {harness_label} app-server..."
     return f"Starting {harness_label} managed session..."
-
-
-def _primary_event_scope(connection: object) -> PrimaryEventScope | None:
-    """Read the connection's primary event scope when it exposes one."""
-
-    return cast("PrimaryEventScope | None", getattr(connection, "primary_event_scope", None))
 
 
 class PrimaryAttachLauncher:
@@ -375,7 +369,7 @@ class PrimaryAttachLauncher:
 
         activity = activity_transition(
             event,
-            primary_event_scope=_primary_event_scope(self._connection),
+            primary_event_scope=self._connection.primary_event_scope,
         )
         if activity is not None:
             self._set_activity(activity)

--- a/src/meridian/lib/launch/process/primary_attach.py
+++ b/src/meridian/lib/launch/process/primary_attach.py
@@ -367,11 +367,10 @@ class PrimaryAttachLauncher:
     def _update_activity_from_event(self, event: HarnessEvent) -> None:
         """Update activity state based on connection events."""
 
-        main_thread_id = getattr(self._connection, "main_turn_thread_id", None)
-        codex_main_thread_id = (
-            main_thread_id if isinstance(main_thread_id, str) and main_thread_id.strip() else None
+        activity = activity_transition(
+            event,
+            primary_event_scope=self._connection.primary_event_scope,
         )
-        activity = activity_transition(event, codex_main_thread_id=codex_main_thread_id)
         if activity is not None:
             self._set_activity(activity)
 

--- a/src/meridian/lib/launch/streaming_runner.py
+++ b/src/meridian/lib/launch/streaming_runner.py
@@ -30,7 +30,8 @@ from meridian.lib.harness.common import parse_json_stream_event, unwrap_event_pa
 from meridian.lib.harness.connections.base import ConnectionConfig, HarnessConnection
 from meridian.lib.harness.extractor import StreamingExtractor
 from meridian.lib.harness.semantics import (
-    CodexDrainThreadTracker,
+    PrimaryEventScope,
+    PrimaryEventScopeTracker,
     TerminalEventOutcome,
     terminal_outcome,
 )
@@ -382,7 +383,7 @@ async def _consume_subscriber_events(
     event_observer: Callable[[StreamEvent], None] | None,
     stream_stdout_to_terminal: bool,
     terminal_event_future: asyncio.Future[TerminalEventOutcome] | None = None,
-    codex_thread_tracker: CodexDrainThreadTracker | None = None,
+    primary_scope_tracker: PrimaryEventScopeTracker | None = None,
 ) -> None:
     while True:
         event = await subscriber.get()
@@ -399,8 +400,8 @@ async def _consume_subscriber_events(
                 budget_signal.set()
 
         if terminal_event_future is not None and not terminal_event_future.done():
-            if codex_thread_tracker is not None:
-                event_outcome = codex_thread_tracker.terminal_outcome(event)
+            if primary_scope_tracker is not None:
+                event_outcome = primary_scope_tracker.terminal_outcome(event)
             else:
                 event_outcome = terminal_outcome(event)
             if event_outcome is not None:
@@ -444,6 +445,14 @@ async def _report_watchdog(
         grace_seconds=grace_seconds,
     )
     return True
+
+
+def _connection_primary_event_scope(
+    connection: HarnessConnection[Any] | None,
+) -> PrimaryEventScope | None:
+    if connection is None:
+        return None
+    return connection.primary_event_scope
 
 
 async def run_streaming_spawn(
@@ -498,7 +507,7 @@ async def run_streaming_spawn(
         runtime_root,
     )
     try:
-        await manager.start_spawn(config, run_spec)
+        connection = await manager.start_spawn(config, run_spec)
         if on_control_endpoint_ready is not None:
             endpoint = manager.control_endpoint(spawn_id)
             if endpoint is not None:
@@ -521,9 +530,11 @@ async def run_streaming_spawn(
             if manager.raw_terminal_frames_are_authoritative(spawn_id)
             else None
         )
-        codex_thread_tracker = (
-            CodexDrainThreadTracker()
-            if config.harness_id == HarnessId.CODEX and terminal_event_capture is not None
+        primary_scope_tracker = (
+            PrimaryEventScopeTracker(
+                primary_event_scope=_connection_primary_event_scope(connection)
+            )
+            if terminal_event_capture is not None
             else None
         )
         completion_task = asyncio.create_task(manager.wait_for_completion(spawn_id))
@@ -536,7 +547,7 @@ async def run_streaming_spawn(
                 event_observer=None,
                 stream_stdout_to_terminal=stream_to_terminal,
                 terminal_event_future=terminal_event_capture,
-                codex_thread_tracker=codex_thread_tracker,
+                primary_scope_tracker=primary_scope_tracker,
             )
         )
         signal_task = asyncio.create_task(shutdown_event.wait())
@@ -623,7 +634,7 @@ async def _run_streaming_attempt(
         asyncio.get_running_loop().create_future()
     )
     terminal_event_capture: asyncio.Future[TerminalEventOutcome] | None = None
-    codex_thread_tracker: CodexDrainThreadTracker | None = None
+    primary_scope_tracker: PrimaryEventScopeTracker | None = None
     subscriber: asyncio.Queue[HarnessEvent | None] | None = None
     connection: HarnessConnection[Any] | None = None
     drain_exit_code = DEFAULT_INFRA_EXIT_CODE
@@ -640,9 +651,11 @@ async def _run_streaming_attempt(
             if manager.raw_terminal_frames_are_authoritative(run.spawn_id)
             else None
         )
-        codex_thread_tracker = (
-            CodexDrainThreadTracker()
-            if config.harness_id == HarnessId.CODEX and terminal_event_capture is not None
+        primary_scope_tracker = (
+            PrimaryEventScopeTracker(
+                primary_event_scope=_connection_primary_event_scope(connection)
+            )
+            if terminal_event_capture is not None
             else None
         )
         await manager.start_heartbeat(run.spawn_id)
@@ -666,7 +679,7 @@ async def _run_streaming_attempt(
                 event_observer=event_observer,
                 stream_stdout_to_terminal=stream_stdout_to_terminal,
                 terminal_event_future=terminal_event_capture,
-                codex_thread_tracker=codex_thread_tracker,
+                primary_scope_tracker=primary_scope_tracker,
             )
         )
         signal_task = asyncio.create_task(signal_event.wait())

--- a/src/meridian/lib/launch/streaming_runner.py
+++ b/src/meridian/lib/launch/streaming_runner.py
@@ -452,7 +452,7 @@ def _connection_primary_event_scope(
 ) -> PrimaryEventScope | None:
     if connection is None:
         return None
-    return connection.primary_event_scope
+    return cast("PrimaryEventScope | None", getattr(connection, "primary_event_scope", None))
 
 
 async def run_streaming_spawn(

--- a/src/meridian/lib/launch/streaming_runner.py
+++ b/src/meridian/lib/launch/streaming_runner.py
@@ -30,7 +30,6 @@ from meridian.lib.harness.common import parse_json_stream_event, unwrap_event_pa
 from meridian.lib.harness.connections.base import ConnectionConfig, HarnessConnection
 from meridian.lib.harness.extractor import StreamingExtractor
 from meridian.lib.harness.semantics import (
-    PrimaryEventScope,
     PrimaryEventScopeTracker,
     TerminalEventOutcome,
     terminal_outcome,
@@ -447,14 +446,6 @@ async def _report_watchdog(
     return True
 
 
-def _connection_primary_event_scope(
-    connection: HarnessConnection[Any] | None,
-) -> PrimaryEventScope | None:
-    if connection is None:
-        return None
-    return cast("PrimaryEventScope | None", getattr(connection, "primary_event_scope", None))
-
-
 async def run_streaming_spawn(
     *,
     config: ConnectionConfig,
@@ -532,7 +523,7 @@ async def run_streaming_spawn(
         )
         primary_scope_tracker = (
             PrimaryEventScopeTracker(
-                primary_event_scope=_connection_primary_event_scope(connection)
+                primary_event_scope=connection.primary_event_scope
             )
             if terminal_event_capture is not None
             else None
@@ -653,7 +644,7 @@ async def _run_streaming_attempt(
         )
         primary_scope_tracker = (
             PrimaryEventScopeTracker(
-                primary_event_scope=_connection_primary_event_scope(connection)
+                primary_event_scope=connection.primary_event_scope
             )
             if terminal_event_capture is not None
             else None

--- a/src/meridian/lib/ops/.context/CONTEXT.md
+++ b/src/meridian/lib/ops/.context/CONTEXT.md
@@ -172,6 +172,27 @@ if present, else delegates to `ensure_temporary_worktree()`. When `ensure=False`
 returns status-only response (no-op) if path already exists. When work_id is empty
 and no active work item, uses temporary worktree path.
 
+### session_target.py / session_transcript.py — Ordered Transcript Sources
+
+Session-log target resolution builds an ordered source plan once, then parsing walks
+that plan. Do not implement fallback by recursively re-entering
+`resolve_session_log_target()` or by fabricating placeholder files for non-file
+sources. `SessionLogTarget.sources` is the durable plan; each `TranscriptSource`
+identifies its kind (`file`, `opencode_db`, or `spawn_history`), session id,
+harness, label, and optional path.
+
+OpenCode completed-session precedence is:
+
+1. `opencode.db` when a matching `session.id` exists;
+2. native transcript file (`storage/session_diff/...` / legacy JSON) when present;
+3. Meridian spawn `history.jsonl` as fallback/debug/live output.
+
+`parse_session_target()` tries sources in order and stops at the first source with
+usable user/assistant interaction content. This preserves the completed-session
+preference for OpenCode DB while still allowing native-file or spawn-history fallback
+when a DB row exists but contains no conversation rows. Spawn history is a fallback
+source, not the preferred completed OpenCode transcript.
+
 ### session_log_render.py — Session Log Rendering
 
 Pure rendering module with no IO. Sits at the end of the session-read pipeline:

--- a/src/meridian/lib/ops/session_log_render.py
+++ b/src/meridian/lib/ops/session_log_render.py
@@ -10,9 +10,12 @@ from meridian.lib.harness.transcript import ToolCall
 
 _CONTENT_PREVIEW_MAX_LINES = 80
 _CONTENT_PREVIEW_MAX_CHARS = 8000
+_TOOL_RESULT_PREVIEW_MAX_CHARS = 240
 _TOOL_RESULT_HINT = "Use --no-truncate to expand tool outputs"
 _TOOL_RESULT_PREFIX = "[tool_result]"  # Text marker prefix for tool results
 _ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+_TASK_STATE_RE = re.compile(r"<task\b[^>]*\bstate=[\"'](?P<state>[^\"']+)[\"']", re.IGNORECASE)
+_TASK_RESULT_RE = re.compile(r"<task_result>(?P<body>.*?)</task_result>", re.DOTALL | re.IGNORECASE)
 _COMMAND_BLOCK_RE = re.compile(
     r"(?:\s*<command-(?:name|args|message)>.*?</command-(?:name|args|message)>\s*)+",
     re.DOTALL,
@@ -347,6 +350,33 @@ def _tool_failed_reason(result_body: str) -> str | None:
     return None
 
 
+def _preview_first_line(content: str) -> str:
+    for line in clean_content(content).splitlines():
+        compact = " ".join(line.split())
+        if not compact:
+            continue
+        if len(compact) <= _TOOL_RESULT_PREVIEW_MAX_CHARS:
+            return compact
+        return f"{compact[: _TOOL_RESULT_PREVIEW_MAX_CHARS - 3].rstrip()}..."
+    return ""
+
+
+def _task_result_summary(result_body: str) -> str | None:
+    state_match = _TASK_STATE_RE.search(result_body)
+    state = state_match.group("state").strip() if state_match is not None else ""
+    task_result_match = _TASK_RESULT_RE.search(result_body)
+    task_result = task_result_match.group("body") if task_result_match is not None else result_body
+    preview = _preview_first_line(task_result)
+
+    if state and preview:
+        return f"({state}) {preview}"
+    if state:
+        return f"({state})"
+    if preview:
+        return f"(result) {preview}"
+    return None
+
+
 def _render_collapsed_tools(
     messages: Sequence[SessionLogRenderableMessage],
 ) -> tuple[list[str], bool]:
@@ -370,6 +400,12 @@ def _render_collapsed_tools(
                         rendered.append(f"  (failed: {failure})")
                     else:
                         rendered.append("  (failed)")
+                index += 2
+                continue
+            if result_body is not None and tc.name == "task":
+                summary = _task_result_summary(result_body)
+                if summary is not None:
+                    rendered.append(f"  {summary}")
                 index += 2
                 continue
             if result_body is not None:

--- a/src/meridian/lib/ops/session_repair.py
+++ b/src/meridian/lib/ops/session_repair.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, ConfigDict
 from meridian.lib.config.project_root import resolve_project_root_resolution
 from meridian.lib.core.util import FormatContext
 from meridian.lib.ops.runtime import async_from_sync, resolve_runtime_root_for_read
-from meridian.lib.ops.session_target import resolve_session_repair_target
+from meridian.lib.ops.session_repair_target import resolve_session_repair_target
 from meridian.lib.ops.spawn.query import (
     read_latest_primary_spawn_for_chat_read_only,
     read_spawn_row_read_only,

--- a/src/meridian/lib/ops/session_repair_target.py
+++ b/src/meridian/lib/ops/session_repair_target.py
@@ -1,0 +1,270 @@
+"""Session-reference repair target resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import NamedTuple
+
+from meridian.lib.harness.session_detection import infer_harness_from_untracked_session_ref
+from meridian.lib.ops.session_target import (
+    _detect_primary_session_id,
+    _is_chat_ref,
+    _is_spawn_ref,
+    _latest_harness_session_id,
+    _primary_spawn_for_chat,
+    _primary_transcript_unavailable_message,
+    _read_chat_session_record,
+    _resolve_harness_transcript_target_or_none,
+    _resolve_transcript_from_candidates,
+)
+from meridian.lib.ops.spawn.query import read_spawn_row_read_only
+from meridian.lib.state.primary_meta import read_primary_harness_session_id
+
+
+class SessionRepairTarget(NamedTuple):
+    detected_harness_session_id: str | None
+    source: str | None
+    reason: str | None = None
+
+
+def _repair_target_from_detected_session_id(
+    *,
+    project_root: Path,
+    harness: str | None,
+    detected_session_id: str,
+    invalid_reason: str,
+    unavailable_reason: str,
+) -> SessionRepairTarget:
+    if _is_spawn_ref(detected_session_id):
+        return SessionRepairTarget(
+            detected_harness_session_id=None,
+            source=None,
+            reason=invalid_reason,
+        )
+
+    transcript_target = _resolve_harness_transcript_target_or_none(
+        project_root=project_root,
+        session_id=detected_session_id,
+        harness=harness,
+    )
+    if transcript_target is not None:
+        return SessionRepairTarget(
+            detected_harness_session_id=transcript_target.session_id,
+            source=transcript_target.source,
+        )
+
+    return SessionRepairTarget(
+        detected_harness_session_id=detected_session_id,
+        source=f"{harness or 'primary'} detected session id",
+        reason=unavailable_reason,
+    )
+
+
+
+
+def _resolve_repair_from_chat_id(
+    *,
+    project_root: Path,
+    runtime_root: Path,
+    chat_id: str,
+) -> SessionRepairTarget:
+    session_record = _read_chat_session_record(runtime_root, chat_id)
+    if session_record is None:
+        raise ValueError(f"Chat '{chat_id}' not found")
+
+    primary_spawn = _primary_spawn_for_chat(project_root, runtime_root, chat_id)
+    harness = session_record.harness.strip() or None
+    if harness is None and primary_spawn is not None:
+        harness = (primary_spawn.harness or "").strip() or None
+
+    transcript_target = _resolve_transcript_from_candidates(
+        project_root=project_root,
+        harness=harness,
+        candidate_ids=[
+            _latest_harness_session_id(session_record),
+            (
+                read_primary_harness_session_id(runtime_root, primary_spawn.id)
+                if primary_spawn is not None
+                else None
+            ),
+        ],
+    )
+    if transcript_target is not None:
+        return SessionRepairTarget(
+            detected_harness_session_id=transcript_target.session_id,
+            source=transcript_target.source,
+        )
+
+    detected_session_id = _detect_primary_session_id(
+        project_root=project_root,
+        runtime_root=runtime_root,
+        spawn_row=primary_spawn,
+        harness=harness,
+    )
+    if detected_session_id is not None:
+        return _repair_target_from_detected_session_id(
+            project_root=project_root,
+            harness=harness,
+            detected_session_id=detected_session_id,
+            invalid_reason=(
+                f"Detected session id '{detected_session_id}' for chat '{chat_id}' "
+                "looks like a spawn id; refusing repair."
+            ),
+            unavailable_reason=(
+                f"Detected harness session id '{detected_session_id}' for chat '{chat_id}' "
+                "but transcript file is not available yet."
+            ),
+        )
+
+    return SessionRepairTarget(
+        detected_harness_session_id=None,
+        source=None,
+        reason=_primary_transcript_unavailable_message(chat_id),
+    )
+
+
+def _resolve_repair_from_spawn_id(
+    *,
+    project_root: Path,
+    runtime_root: Path,
+    spawn_id: str,
+) -> SessionRepairTarget:
+    row = read_spawn_row_read_only(project_root, spawn_id, runtime_root=runtime_root)
+    if row is None:
+        raise ValueError(f"Spawn '{spawn_id}' not found")
+
+    harness = (row.harness or "").strip() or None
+    row_session_id = (row.harness_session_id or "").strip()
+    transcript_target = _resolve_transcript_from_candidates(
+        project_root=project_root,
+        harness=harness,
+        candidate_ids=[row_session_id if not _is_spawn_ref(row_session_id) else None],
+    )
+    if transcript_target is not None:
+        return SessionRepairTarget(
+            detected_harness_session_id=transcript_target.session_id,
+            source=transcript_target.source,
+        )
+
+    if row.kind != "primary":
+        return SessionRepairTarget(
+            detected_harness_session_id=None,
+            source=None,
+            reason=(
+                f"Spawn '{spawn_id}' has no detected harness session id to repair "
+                "(non-primary spawns may only have output fallback)."
+            ),
+        )
+
+    if row.chat_id:
+        chat_record = _read_chat_session_record(runtime_root, row.chat_id)
+        if chat_record is not None:
+            if harness is None:
+                harness = chat_record.harness.strip() or None
+            transcript_target = _resolve_transcript_from_candidates(
+                project_root=project_root,
+                harness=harness,
+                candidate_ids=[_latest_harness_session_id(chat_record)],
+            )
+            if transcript_target is not None:
+                return SessionRepairTarget(
+                    detected_harness_session_id=transcript_target.session_id,
+                    source=transcript_target.source,
+                )
+
+    transcript_target = _resolve_transcript_from_candidates(
+        project_root=project_root,
+        harness=harness,
+        candidate_ids=[
+            (
+                read_primary_harness_session_id(runtime_root, spawn_id)
+                if row.kind == "primary"
+                else None
+            )
+        ],
+    )
+    if transcript_target is not None:
+        return SessionRepairTarget(
+            detected_harness_session_id=transcript_target.session_id,
+            source=transcript_target.source,
+        )
+
+    detected_session_id = _detect_primary_session_id(
+        project_root=project_root,
+        runtime_root=runtime_root,
+        spawn_row=row,
+        harness=harness,
+    )
+    if detected_session_id is None:
+        return SessionRepairTarget(
+            detected_harness_session_id=None,
+            source=None,
+            reason=(
+                f"Spawn '{spawn_id}' has no detected harness session id to repair "
+                "(no harness transcript available yet)."
+            ),
+        )
+
+    return _repair_target_from_detected_session_id(
+        project_root=project_root,
+        harness=harness,
+        detected_session_id=detected_session_id,
+        invalid_reason=(
+            f"Detected session id '{detected_session_id}' for spawn "
+            f"'{spawn_id}' looks like a spawn id; refusing repair."
+        ),
+        unavailable_reason=(
+            f"Detected harness session id '{detected_session_id}' for "
+            f"spawn '{spawn_id}' but transcript file is not available yet."
+        ),
+    )
+
+
+def _resolve_repair_from_session_ref(
+    *,
+    project_root: Path,
+    session_ref: str,
+) -> SessionRepairTarget:
+    inferred = infer_harness_from_untracked_session_ref(project_root, session_ref)
+    harness = str(inferred) if inferred is not None else None
+    transcript_target = _resolve_harness_transcript_target_or_none(
+        project_root=project_root,
+        session_id=session_ref,
+        harness=harness,
+    )
+    if transcript_target is not None:
+        return SessionRepairTarget(
+            detected_harness_session_id=transcript_target.session_id,
+            source=transcript_target.source,
+        )
+    raise FileNotFoundError(f"Session file for '{session_ref}' not found")
+
+
+def resolve_session_repair_target(
+    *,
+    ref: str,
+    project_root: Path,
+    runtime_root: Path,
+) -> SessionRepairTarget:
+    normalized_ref = ref.strip()
+    if not normalized_ref:
+        raise ValueError("Session reference is required")
+    if _is_chat_ref(runtime_root, normalized_ref):
+        return _resolve_repair_from_chat_id(
+            project_root=project_root,
+            runtime_root=runtime_root,
+            chat_id=normalized_ref,
+        )
+    if _is_spawn_ref(normalized_ref):
+        return _resolve_repair_from_spawn_id(
+            project_root=project_root,
+            runtime_root=runtime_root,
+            spawn_id=normalized_ref,
+        )
+    return _resolve_repair_from_session_ref(
+        project_root=project_root,
+        session_ref=normalized_ref,
+    )
+
+
+__all__ = ["SessionRepairTarget", "resolve_session_repair_target"]

--- a/src/meridian/lib/ops/session_repair_target.py
+++ b/src/meridian/lib/ops/session_repair_target.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+# pyright: reportPrivateUsage=false
 from pathlib import Path
 from typing import NamedTuple
 

--- a/src/meridian/lib/ops/session_target.py
+++ b/src/meridian/lib/ops/session_target.py
@@ -10,9 +10,10 @@ from __future__ import annotations
 import re
 from datetime import datetime
 from pathlib import Path
-from typing import NamedTuple
+from typing import Literal, NamedTuple
 
 from meridian.lib.core.types import HarnessId
+from meridian.lib.harness.opencode_transcript import opencode_db_session_exists
 from meridian.lib.harness.pi_paths import resolve_pi_spawn_session_root
 from meridian.lib.harness.registry import get_default_harness_registry
 from meridian.lib.harness.session_detection import infer_harness_from_untracked_session_ref
@@ -41,8 +42,9 @@ _PRIMARY_TRANSCRIPT_UNAVAILABLE_SUFFIX = (
 class SessionLogTarget(NamedTuple):
     session_id: str
     harness: str | None
-    file_path: Path
+    file_path: Path | None
     source: str
+    transcript_source: Literal["file", "opencode_db"] = "file"
 
 
 class SessionRepairTarget(NamedTuple):
@@ -101,6 +103,17 @@ def _resolve_harness_session_file(
     registry = get_default_harness_registry()
     normalized_harness = (harness or "").strip().lower() or None
     if normalized_harness is not None:
+        if (
+            normalized_harness == HarnessId.OPENCODE.value
+            and opencode_db_session_exists(session_id=normalized_session_id)
+        ):
+            return SessionLogTarget(
+                session_id=normalized_session_id,
+                harness=HarnessId.OPENCODE.value,
+                file_path=None,
+                source="opencode transcript",
+                transcript_source="opencode_db",
+            )
         try:
             harness_id = HarnessId(normalized_harness)
             adapter = registry.get_subprocess_harness(harness_id)
@@ -132,6 +145,17 @@ def _resolve_harness_session_file(
         except TypeError:
             continue
         checked_harnesses.append(str(harness_id))
+        if (
+            harness_id == HarnessId.OPENCODE
+            and opencode_db_session_exists(session_id=normalized_session_id)
+        ):
+            return SessionLogTarget(
+                session_id=normalized_session_id,
+                harness=str(harness_id),
+                file_path=None,
+                source=f"{harness_id} transcript",
+                transcript_source="opencode_db",
+            )
         candidate = adapter.resolve_session_file(
             project_root=project_root,
             session_id=normalized_session_id,

--- a/src/meridian/lib/ops/session_target.py
+++ b/src/meridian/lib/ops/session_target.py
@@ -40,19 +40,20 @@ _PRIMARY_TRANSCRIPT_UNAVAILABLE_SUFFIX = (
 )
 
 
+class TranscriptSource(NamedTuple):
+    kind: Literal["file", "opencode_db", "spawn_history"]
+    session_id: str
+    harness: str | None
+    source_label: str
+    path: Path | None = None
+
+
 class SessionLogTarget(NamedTuple):
     session_id: str
     harness: str | None
     file_path: Path | None
     source: str
-    transcript_source: Literal["file", "opencode_db"] = "file"
-    fallback_targets: tuple[SessionLogTarget, ...] = ()
-
-
-class SessionRepairTarget(NamedTuple):
-    detected_harness_session_id: str | None
-    source: str | None
-    reason: str | None = None
+    sources: tuple[TranscriptSource, ...]
 
 
 def _is_chat_ref(runtime_root: Path, value: str) -> bool:
@@ -72,6 +73,43 @@ def _extract_session_id_from_path(path: Path) -> str:
     return path.name
 
 
+def _target_from_source(source: TranscriptSource) -> SessionLogTarget:
+    return SessionLogTarget(
+        session_id=source.session_id,
+        harness=source.harness,
+        file_path=source.path,
+        source=source.source_label,
+        sources=(source,),
+    )
+
+
+def _source_key(source: TranscriptSource) -> tuple[str, str, str | None, str]:
+    return (
+        source.kind,
+        source.session_id,
+        source.path.as_posix() if source.path is not None else None,
+        source.source_label,
+    )
+
+
+def _with_sources(
+    target: SessionLogTarget,
+    *additional_targets: SessionLogTarget | None,
+) -> SessionLogTarget:
+    sources = list(target.sources)
+    seen = {_source_key(source) for source in sources}
+    for additional_target in additional_targets:
+        if additional_target is None:
+            continue
+        for source in additional_target.sources:
+            key = _source_key(source)
+            if key in seen:
+                continue
+            sources.append(source)
+            seen.add(key)
+    return target._replace(sources=tuple(sources))
+
+
 def _resolve_file_target(file_path: str) -> SessionLogTarget:
     resolved = Path(file_path).expanduser().resolve()
     if not resolved.is_file():
@@ -84,11 +122,14 @@ def _resolve_file_target(file_path: str) -> SessionLogTarget:
     elif ".codex" in parts:
         harness = "codex"
 
-    return SessionLogTarget(
-        session_id=_extract_session_id_from_path(resolved),
-        harness=harness,
-        file_path=resolved,
-        source="file",
+    return _target_from_source(
+        TranscriptSource(
+            kind="file",
+            session_id=_extract_session_id_from_path(resolved),
+            harness=harness,
+            path=resolved,
+            source_label="file",
+        )
     )
 
 
@@ -105,26 +146,25 @@ def _resolve_adapter_file_target(
     )
     if candidate is None or not candidate.is_file():
         return None
-    return SessionLogTarget(
-        session_id=session_id,
-        harness=str(harness_id),
-        file_path=candidate,
-        source=f"{harness_id} transcript",
+    return _target_from_source(
+        TranscriptSource(
+            kind="file",
+            session_id=session_id,
+            harness=str(harness_id),
+            path=candidate,
+            source_label=f"{harness_id} transcript",
+        )
     )
 
 
-def _opencode_db_target(
-    *,
-    session_id: str,
-    fallback_targets: tuple[SessionLogTarget, ...] = (),
-) -> SessionLogTarget:
-    return SessionLogTarget(
-        session_id=session_id,
-        harness=HarnessId.OPENCODE.value,
-        file_path=None,
-        source="opencode transcript",
-        transcript_source="opencode_db",
-        fallback_targets=fallback_targets,
+def _opencode_db_target(*, session_id: str) -> SessionLogTarget:
+    return _target_from_source(
+        TranscriptSource(
+            kind="opencode_db",
+            session_id=session_id,
+            harness=HarnessId.OPENCODE.value,
+            source_label="opencode transcript",
+        )
     )
 
 
@@ -160,9 +200,9 @@ def _resolve_harness_session_file(
             harness_id == HarnessId.OPENCODE
             and opencode_db_session_exists(session_id=normalized_session_id)
         ):
-            return _opencode_db_target(
-                session_id=normalized_session_id,
-                fallback_targets=(file_target,) if file_target is not None else (),
+            return _with_sources(
+                _opencode_db_target(session_id=normalized_session_id),
+                file_target,
             )
         if file_target is not None:
             return file_target
@@ -187,9 +227,9 @@ def _resolve_harness_session_file(
             harness_id == HarnessId.OPENCODE
             and opencode_db_session_exists(session_id=normalized_session_id)
         ):
-            return _opencode_db_target(
-                session_id=normalized_session_id,
-                fallback_targets=(file_target,) if file_target is not None else (),
+            return _with_sources(
+                _opencode_db_target(session_id=normalized_session_id),
+                file_target,
             )
         if file_target is not None:
             return file_target
@@ -314,47 +354,15 @@ def _target_from_spawn_output(
     output_path = spawn_output_path_for_target(runtime_root, spawn_id, live_first=live_first)
     if output_path is None:
         return None
-    return SessionLogTarget(
-        session_id=display_id,
-        harness=None,
-        file_path=output_path,
-        source=source or f"spawn {spawn_id} output",
+    return _target_from_source(
+        TranscriptSource(
+            kind="spawn_history",
+            session_id=display_id,
+            harness=None,
+            path=output_path,
+            source_label=source or f"spawn {spawn_id} output",
+        )
     )
-
-
-def _target_key(target: SessionLogTarget) -> tuple[str, str, str | None, str]:
-    return (
-        target.transcript_source,
-        target.session_id,
-        target.file_path.as_posix() if target.file_path is not None else None,
-        target.source,
-    )
-
-
-def _with_fallback_targets(
-    target: SessionLogTarget,
-    *fallback_targets: SessionLogTarget | None,
-) -> SessionLogTarget:
-    existing = list(target.fallback_targets)
-    seen = {_target_key(target), *(_target_key(fallback) for fallback in existing)}
-    for fallback in fallback_targets:
-        if fallback is None:
-            continue
-        key = _target_key(fallback)
-        if key in seen:
-            continue
-        existing.append(fallback)
-        seen.add(key)
-    return target._replace(fallback_targets=tuple(existing))
-
-
-def _with_opencode_fallback_targets(
-    target: SessionLogTarget,
-    *fallback_targets: SessionLogTarget | None,
-) -> SessionLogTarget:
-    if target.transcript_source != "opencode_db":
-        return target
-    return _with_fallback_targets(target, *fallback_targets)
 
 
 def _managed_primary_output_target(
@@ -619,39 +627,6 @@ def _skip_primary_default_root_detection(
     return configured_session_dir != default_session_dir
 
 
-def _repair_target_from_detected_session_id(
-    *,
-    project_root: Path,
-    harness: str | None,
-    detected_session_id: str,
-    invalid_reason: str,
-    unavailable_reason: str,
-) -> SessionRepairTarget:
-    if _is_spawn_ref(detected_session_id):
-        return SessionRepairTarget(
-            detected_harness_session_id=None,
-            source=None,
-            reason=invalid_reason,
-        )
-
-    transcript_target = _resolve_harness_transcript_target_or_none(
-        project_root=project_root,
-        session_id=detected_session_id,
-        harness=harness,
-    )
-    if transcript_target is not None:
-        return SessionRepairTarget(
-            detected_harness_session_id=transcript_target.session_id,
-            source=transcript_target.source,
-        )
-
-    return SessionRepairTarget(
-        detected_harness_session_id=detected_session_id,
-        source=f"{harness or 'primary'} detected session id",
-        reason=unavailable_reason,
-    )
-
-
 def _resolve_from_chat_id(
     *,
     project_root: Path,
@@ -711,7 +686,7 @@ def _resolve_from_chat_id(
             chat_id=chat_id,
             primary_spawn=primary_spawn,
         )
-        return _with_opencode_fallback_targets(transcript_target, output_target)
+        return _with_sources(transcript_target, output_target)
 
     detected_session_id = _detect_primary_session_id(
         project_root=project_root,
@@ -732,7 +707,7 @@ def _resolve_from_chat_id(
                 chat_id=chat_id,
                 primary_spawn=primary_spawn,
             )
-            return _with_opencode_fallback_targets(transcript_target, output_target)
+            return _with_sources(transcript_target, output_target)
 
     if primary_spawn is not None:
         output_target = _managed_primary_output_target(
@@ -877,7 +852,7 @@ def _resolve_from_spawn_id(
             is_managed_backend_primary=is_managed_backend_primary,
             harness=harness,
         )
-        return _with_opencode_fallback_targets(transcript_target, output_target)
+        return _with_sources(transcript_target, output_target)
 
     if is_primary_spawn:
         detected_session_id = _detect_primary_session_id(
@@ -901,7 +876,7 @@ def _resolve_from_spawn_id(
                     is_managed_backend_primary=is_managed_backend_primary,
                     harness=harness,
                 )
-                return _with_opencode_fallback_targets(transcript_target, output_target)
+                return _with_sources(transcript_target, output_target)
 
     if is_primary_spawn:
         if is_managed_backend_primary:
@@ -955,7 +930,7 @@ def _resolve_from_session_ref(
             display_id=session_id,
             record=record,
         )
-        return _with_opencode_fallback_targets(target, output_target)
+        return _with_sources(target, output_target)
 
     inferred = infer_harness_from_untracked_session_ref(project_root, session_ref)
     inferred_name = str(inferred) if inferred is not None else None
@@ -969,212 +944,7 @@ def _resolve_from_session_ref(
         display_id=session_ref,
         harness_session_id=session_ref,
     )
-    return _with_opencode_fallback_targets(target, output_target)
-
-
-def _resolve_repair_from_chat_id(
-    *,
-    project_root: Path,
-    runtime_root: Path,
-    chat_id: str,
-) -> SessionRepairTarget:
-    session_record = _read_chat_session_record(runtime_root, chat_id)
-    if session_record is None:
-        raise ValueError(f"Chat '{chat_id}' not found")
-
-    primary_spawn = _primary_spawn_for_chat(project_root, runtime_root, chat_id)
-    harness = session_record.harness.strip() or None
-    if harness is None and primary_spawn is not None:
-        harness = (primary_spawn.harness or "").strip() or None
-
-    transcript_target = _resolve_transcript_from_candidates(
-        project_root=project_root,
-        harness=harness,
-        candidate_ids=[
-            _latest_harness_session_id(session_record),
-            (
-                read_primary_harness_session_id(runtime_root, primary_spawn.id)
-                if primary_spawn is not None
-                else None
-            ),
-        ],
-    )
-    if transcript_target is not None:
-        return SessionRepairTarget(
-            detected_harness_session_id=transcript_target.session_id,
-            source=transcript_target.source,
-        )
-
-    detected_session_id = _detect_primary_session_id(
-        project_root=project_root,
-        runtime_root=runtime_root,
-        spawn_row=primary_spawn,
-        harness=harness,
-    )
-    if detected_session_id is not None:
-        return _repair_target_from_detected_session_id(
-            project_root=project_root,
-            harness=harness,
-            detected_session_id=detected_session_id,
-            invalid_reason=(
-                f"Detected session id '{detected_session_id}' for chat '{chat_id}' "
-                "looks like a spawn id; refusing repair."
-            ),
-            unavailable_reason=(
-                f"Detected harness session id '{detected_session_id}' for chat '{chat_id}' "
-                "but transcript file is not available yet."
-            ),
-        )
-
-    return SessionRepairTarget(
-        detected_harness_session_id=None,
-        source=None,
-        reason=_primary_transcript_unavailable_message(chat_id),
-    )
-
-
-def _resolve_repair_from_spawn_id(
-    *,
-    project_root: Path,
-    runtime_root: Path,
-    spawn_id: str,
-) -> SessionRepairTarget:
-    row = read_spawn_row_read_only(project_root, spawn_id, runtime_root=runtime_root)
-    if row is None:
-        raise ValueError(f"Spawn '{spawn_id}' not found")
-
-    harness = (row.harness or "").strip() or None
-    row_session_id = (row.harness_session_id or "").strip()
-    transcript_target = _resolve_transcript_from_candidates(
-        project_root=project_root,
-        harness=harness,
-        candidate_ids=[row_session_id if not _is_spawn_ref(row_session_id) else None],
-    )
-    if transcript_target is not None:
-        return SessionRepairTarget(
-            detected_harness_session_id=transcript_target.session_id,
-            source=transcript_target.source,
-        )
-
-    if row.kind != "primary":
-        return SessionRepairTarget(
-            detected_harness_session_id=None,
-            source=None,
-            reason=(
-                f"Spawn '{spawn_id}' has no detected harness session id to repair "
-                "(non-primary spawns may only have output fallback)."
-            ),
-        )
-
-    if row.chat_id:
-        chat_record = _read_chat_session_record(runtime_root, row.chat_id)
-        if chat_record is not None:
-            if harness is None:
-                harness = chat_record.harness.strip() or None
-            transcript_target = _resolve_transcript_from_candidates(
-                project_root=project_root,
-                harness=harness,
-                candidate_ids=[_latest_harness_session_id(chat_record)],
-            )
-            if transcript_target is not None:
-                return SessionRepairTarget(
-                    detected_harness_session_id=transcript_target.session_id,
-                    source=transcript_target.source,
-                )
-
-    transcript_target = _resolve_transcript_from_candidates(
-        project_root=project_root,
-        harness=harness,
-        candidate_ids=[
-            (
-                read_primary_harness_session_id(runtime_root, spawn_id)
-                if row.kind == "primary"
-                else None
-            )
-        ],
-    )
-    if transcript_target is not None:
-        return SessionRepairTarget(
-            detected_harness_session_id=transcript_target.session_id,
-            source=transcript_target.source,
-        )
-
-    detected_session_id = _detect_primary_session_id(
-        project_root=project_root,
-        runtime_root=runtime_root,
-        spawn_row=row,
-        harness=harness,
-    )
-    if detected_session_id is None:
-        return SessionRepairTarget(
-            detected_harness_session_id=None,
-            source=None,
-            reason=(
-                f"Spawn '{spawn_id}' has no detected harness session id to repair "
-                "(no harness transcript available yet)."
-            ),
-        )
-
-    return _repair_target_from_detected_session_id(
-        project_root=project_root,
-        harness=harness,
-        detected_session_id=detected_session_id,
-        invalid_reason=(
-            f"Detected session id '{detected_session_id}' for spawn "
-            f"'{spawn_id}' looks like a spawn id; refusing repair."
-        ),
-        unavailable_reason=(
-            f"Detected harness session id '{detected_session_id}' for "
-            f"spawn '{spawn_id}' but transcript file is not available yet."
-        ),
-    )
-
-
-def _resolve_repair_from_session_ref(
-    *,
-    project_root: Path,
-    session_ref: str,
-) -> SessionRepairTarget:
-    inferred = infer_harness_from_untracked_session_ref(project_root, session_ref)
-    harness = str(inferred) if inferred is not None else None
-    transcript_target = _resolve_harness_transcript_target_or_none(
-        project_root=project_root,
-        session_id=session_ref,
-        harness=harness,
-    )
-    if transcript_target is not None:
-        return SessionRepairTarget(
-            detected_harness_session_id=transcript_target.session_id,
-            source=transcript_target.source,
-        )
-    raise FileNotFoundError(f"Session file for '{session_ref}' not found")
-
-
-def resolve_session_repair_target(
-    *,
-    ref: str,
-    project_root: Path,
-    runtime_root: Path,
-) -> SessionRepairTarget:
-    normalized_ref = ref.strip()
-    if not normalized_ref:
-        raise ValueError("Session reference is required")
-    if _is_chat_ref(runtime_root, normalized_ref):
-        return _resolve_repair_from_chat_id(
-            project_root=project_root,
-            runtime_root=runtime_root,
-            chat_id=normalized_ref,
-        )
-    if _is_spawn_ref(normalized_ref):
-        return _resolve_repair_from_spawn_id(
-            project_root=project_root,
-            runtime_root=runtime_root,
-            spawn_id=normalized_ref,
-        )
-    return _resolve_repair_from_session_ref(
-        project_root=project_root,
-        session_ref=normalized_ref,
-    )
+    return _with_sources(target, output_target)
 
 
 def resolve_session_log_target(
@@ -1214,8 +984,6 @@ def resolve_session_log_target(
 
 __all__ = [
     "SessionLogTarget",
-    "SessionRepairTarget",
     "resolve_session_log_target",
-    "resolve_session_repair_target",
     "spawn_output_path_for_target",
 ]

--- a/src/meridian/lib/ops/session_target.py
+++ b/src/meridian/lib/ops/session_target.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Literal, NamedTuple
 
 from meridian.lib.core.types import HarnessId
+from meridian.lib.harness.adapter import SubprocessHarness
 from meridian.lib.harness.opencode_transcript import opencode_db_session_exists
 from meridian.lib.harness.pi_paths import resolve_pi_spawn_session_root
 from meridian.lib.harness.registry import get_default_harness_registry
@@ -22,7 +23,7 @@ from meridian.lib.ops.spawn.query import (
     read_latest_primary_spawn_for_chat_read_only,
     read_spawn_row_read_only,
 )
-from meridian.lib.state import session_identity, session_store
+from meridian.lib.state import session_identity, session_store, spawn_store
 from meridian.lib.state.paths import spawn_output_path
 from meridian.lib.state.primary_meta import (
     is_managed_primary,
@@ -45,6 +46,7 @@ class SessionLogTarget(NamedTuple):
     file_path: Path | None
     source: str
     transcript_source: Literal["file", "opencode_db"] = "file"
+    fallback_targets: tuple[SessionLogTarget, ...] = ()
 
 
 class SessionRepairTarget(NamedTuple):
@@ -90,6 +92,42 @@ def _resolve_file_target(file_path: str) -> SessionLogTarget:
     )
 
 
+def _resolve_adapter_file_target(
+    *,
+    project_root: Path,
+    session_id: str,
+    harness_id: HarnessId,
+    adapter: SubprocessHarness,
+) -> SessionLogTarget | None:
+    candidate = adapter.resolve_session_file(
+        project_root=project_root,
+        session_id=session_id,
+    )
+    if candidate is None or not candidate.is_file():
+        return None
+    return SessionLogTarget(
+        session_id=session_id,
+        harness=str(harness_id),
+        file_path=candidate,
+        source=f"{harness_id} transcript",
+    )
+
+
+def _opencode_db_target(
+    *,
+    session_id: str,
+    fallback_targets: tuple[SessionLogTarget, ...] = (),
+) -> SessionLogTarget:
+    return SessionLogTarget(
+        session_id=session_id,
+        harness=HarnessId.OPENCODE.value,
+        file_path=None,
+        source="opencode transcript",
+        transcript_source="opencode_db",
+        fallback_targets=fallback_targets,
+    )
+
+
 def _resolve_harness_session_file(
     *,
     project_root: Path,
@@ -103,17 +141,6 @@ def _resolve_harness_session_file(
     registry = get_default_harness_registry()
     normalized_harness = (harness or "").strip().lower() or None
     if normalized_harness is not None:
-        if (
-            normalized_harness == HarnessId.OPENCODE.value
-            and opencode_db_session_exists(session_id=normalized_session_id)
-        ):
-            return SessionLogTarget(
-                session_id=normalized_session_id,
-                harness=HarnessId.OPENCODE.value,
-                file_path=None,
-                source="opencode transcript",
-                transcript_source="opencode_db",
-            )
         try:
             harness_id = HarnessId(normalized_harness)
             adapter = registry.get_subprocess_harness(harness_id)
@@ -123,17 +150,22 @@ def _resolve_harness_session_file(
                 f"(harness={normalized_harness}) not found"
             ) from exc
 
-        candidate = adapter.resolve_session_file(
+        file_target = _resolve_adapter_file_target(
             project_root=project_root,
             session_id=normalized_session_id,
+            harness_id=harness_id,
+            adapter=adapter,
         )
-        if candidate is not None and candidate.is_file():
-            return SessionLogTarget(
+        if (
+            harness_id == HarnessId.OPENCODE
+            and opencode_db_session_exists(session_id=normalized_session_id)
+        ):
+            return _opencode_db_target(
                 session_id=normalized_session_id,
-                harness=str(harness_id),
-                file_path=candidate,
-                source=f"{harness_id} transcript",
+                fallback_targets=(file_target,) if file_target is not None else (),
             )
+        if file_target is not None:
+            return file_target
         raise FileNotFoundError(
             f"Session file for '{normalized_session_id}' (harness={normalized_harness}) not found"
         )
@@ -145,28 +177,22 @@ def _resolve_harness_session_file(
         except TypeError:
             continue
         checked_harnesses.append(str(harness_id))
+        file_target = _resolve_adapter_file_target(
+            project_root=project_root,
+            session_id=normalized_session_id,
+            harness_id=harness_id,
+            adapter=adapter,
+        )
         if (
             harness_id == HarnessId.OPENCODE
             and opencode_db_session_exists(session_id=normalized_session_id)
         ):
-            return SessionLogTarget(
+            return _opencode_db_target(
                 session_id=normalized_session_id,
-                harness=str(harness_id),
-                file_path=None,
-                source=f"{harness_id} transcript",
-                transcript_source="opencode_db",
+                fallback_targets=(file_target,) if file_target is not None else (),
             )
-        candidate = adapter.resolve_session_file(
-            project_root=project_root,
-            session_id=normalized_session_id,
-        )
-        if candidate is not None and candidate.is_file():
-            return SessionLogTarget(
-                session_id=normalized_session_id,
-                harness=str(harness_id),
-                file_path=candidate,
-                source=f"{harness_id} transcript",
-            )
+        if file_target is not None:
+            return file_target
 
     checked = ", ".join(checked_harnesses) if checked_harnesses else "<none>"
     raise FileNotFoundError(
@@ -296,6 +322,41 @@ def _target_from_spawn_output(
     )
 
 
+def _target_key(target: SessionLogTarget) -> tuple[str, str, str | None, str]:
+    return (
+        target.transcript_source,
+        target.session_id,
+        target.file_path.as_posix() if target.file_path is not None else None,
+        target.source,
+    )
+
+
+def _with_fallback_targets(
+    target: SessionLogTarget,
+    *fallback_targets: SessionLogTarget | None,
+) -> SessionLogTarget:
+    existing = list(target.fallback_targets)
+    seen = {_target_key(target), *(_target_key(fallback) for fallback in existing)}
+    for fallback in fallback_targets:
+        if fallback is None:
+            continue
+        key = _target_key(fallback)
+        if key in seen:
+            continue
+        existing.append(fallback)
+        seen.add(key)
+    return target._replace(fallback_targets=tuple(existing))
+
+
+def _with_opencode_fallback_targets(
+    target: SessionLogTarget,
+    *fallback_targets: SessionLogTarget | None,
+) -> SessionLogTarget:
+    if target.transcript_source != "opencode_db":
+        return target
+    return _with_fallback_targets(target, *fallback_targets)
+
+
 def _managed_primary_output_target(
     runtime_root: Path,
     *,
@@ -336,6 +397,113 @@ def _running_managed_primary_output_target(
         spawn_id=spawn_row.id,
         live_first=True,
     )
+
+
+def _resolved_spawn_output_fallback_target(
+    *,
+    runtime_root: Path,
+    row: SpawnRecord,
+    display_id: str,
+    is_primary_spawn: bool,
+    is_managed_backend_primary: bool,
+    harness: str | None,
+) -> SessionLogTarget | None:
+    if is_primary_spawn:
+        if not is_managed_backend_primary:
+            return None
+        return _managed_primary_output_target(
+            runtime_root,
+            spawn_row=row,
+            display_id=display_id,
+            harness=harness,
+        )
+    return _target_from_spawn_output(
+        runtime_root,
+        display_id=display_id,
+        spawn_id=row.id,
+        live_first=(row.status == "running"),
+    )
+
+
+def _spawn_history_fallback_for_session_ref(
+    *,
+    project_root: Path,
+    runtime_root: Path,
+    display_id: str,
+    record: session_store.SessionRecord,
+) -> SessionLogTarget | None:
+    spawn_id = (record.spawn_id or "").strip()
+    if spawn_id:
+        row = read_spawn_row_read_only(project_root, spawn_id, runtime_root=runtime_root)
+        if row is not None:
+            output_target = _target_from_spawn_output(
+                runtime_root,
+                display_id=display_id,
+                spawn_id=row.id,
+                live_first=(row.status == "running"),
+            )
+            if output_target is not None:
+                return output_target
+
+    return _spawn_history_fallback_for_harness_session_id(
+        runtime_root=runtime_root,
+        display_id=display_id,
+        harness_session_id=record.harness_session_id,
+    )
+
+
+def _spawn_history_fallback_for_harness_session_id(
+    *,
+    runtime_root: Path,
+    display_id: str,
+    harness_session_id: str,
+) -> SessionLogTarget | None:
+    normalized_session_id = harness_session_id.strip()
+    if not normalized_session_id:
+        return None
+    for row in reversed(spawn_store.list_spawns(runtime_root)):
+        if (row.harness_session_id or "").strip() != normalized_session_id:
+            continue
+        output_target = _target_from_spawn_output(
+            runtime_root,
+            display_id=display_id,
+            spawn_id=row.id,
+            live_first=(row.status == "running"),
+        )
+        if output_target is not None:
+            return output_target
+    return None
+
+
+def _spawn_history_fallback_for_chat_ref(
+    *,
+    runtime_root: Path,
+    display_id: str,
+    chat_id: str,
+    primary_spawn: SpawnRecord | None,
+) -> SessionLogTarget | None:
+    candidates: list[SpawnRecord] = []
+    if primary_spawn is not None:
+        candidates.append(primary_spawn)
+    candidates.extend(
+        reversed(session_identity.list_spawns_for_exact_session(runtime_root, chat_id))
+    )
+    candidates.extend(reversed(session_identity.list_spawns_for_owner_chat(runtime_root, chat_id)))
+
+    seen: set[str] = set()
+    for row in candidates:
+        if row.id in seen:
+            continue
+        seen.add(row.id)
+        output_target = _target_from_spawn_output(
+            runtime_root,
+            display_id=display_id,
+            spawn_id=row.id,
+            live_first=(row.status == "running"),
+        )
+        if output_target is not None:
+            return output_target
+    return None
 
 
 def _primary_spawn_for_chat(
@@ -537,7 +705,13 @@ def _resolve_from_chat_id(
         candidate_ids=[normalized_session_id],
     )
     if transcript_target is not None:
-        return transcript_target
+        output_target = _spawn_history_fallback_for_chat_ref(
+            runtime_root=runtime_root,
+            display_id=chat_id,
+            chat_id=chat_id,
+            primary_spawn=primary_spawn,
+        )
+        return _with_opencode_fallback_targets(transcript_target, output_target)
 
     detected_session_id = _detect_primary_session_id(
         project_root=project_root,
@@ -552,7 +726,13 @@ def _resolve_from_chat_id(
             candidate_ids=[detected_session_id],
         )
         if transcript_target is not None:
-            return transcript_target
+            output_target = _spawn_history_fallback_for_chat_ref(
+                runtime_root=runtime_root,
+                display_id=chat_id,
+                chat_id=chat_id,
+                primary_spawn=primary_spawn,
+            )
+            return _with_opencode_fallback_targets(transcript_target, output_target)
 
     if primary_spawn is not None:
         output_target = _managed_primary_output_target(
@@ -689,7 +869,15 @@ def _resolve_from_spawn_id(
         candidate_ids=[session_id],
     )
     if transcript_target is not None:
-        return transcript_target
+        output_target = _resolved_spawn_output_fallback_target(
+            runtime_root=runtime_root,
+            row=row,
+            display_id=spawn_id,
+            is_primary_spawn=is_primary_spawn,
+            is_managed_backend_primary=is_managed_backend_primary,
+            harness=harness,
+        )
+        return _with_opencode_fallback_targets(transcript_target, output_target)
 
     if is_primary_spawn:
         detected_session_id = _detect_primary_session_id(
@@ -705,7 +893,15 @@ def _resolve_from_spawn_id(
                 candidate_ids=[detected_session_id],
             )
             if transcript_target is not None:
-                return transcript_target
+                output_target = _resolved_spawn_output_fallback_target(
+                    runtime_root=runtime_root,
+                    row=row,
+                    display_id=spawn_id,
+                    is_primary_spawn=is_primary_spawn,
+                    is_managed_backend_primary=is_managed_backend_primary,
+                    harness=harness,
+                )
+                return _with_opencode_fallback_targets(transcript_target, output_target)
 
     if is_primary_spawn:
         if is_managed_backend_primary:
@@ -748,19 +944,32 @@ def _resolve_from_session_ref(
     if record is not None:
         session_id = record.harness_session_id.strip() or session_ref
         harness = record.harness.strip() or None
-        return _resolve_harness_session_file(
+        target = _resolve_harness_session_file(
             project_root=project_root,
             session_id=session_id,
             harness=harness,
         )
+        output_target = _spawn_history_fallback_for_session_ref(
+            project_root=project_root,
+            runtime_root=runtime_root,
+            display_id=session_id,
+            record=record,
+        )
+        return _with_opencode_fallback_targets(target, output_target)
 
     inferred = infer_harness_from_untracked_session_ref(project_root, session_ref)
     inferred_name = str(inferred) if inferred is not None else None
-    return _resolve_harness_session_file(
+    target = _resolve_harness_session_file(
         project_root=project_root,
         session_id=session_ref,
         harness=inferred_name,
     )
+    output_target = _spawn_history_fallback_for_harness_session_id(
+        runtime_root=runtime_root,
+        display_id=session_ref,
+        harness_session_id=session_ref,
+    )
+    return _with_opencode_fallback_targets(target, output_target)
 
 
 def _resolve_repair_from_chat_id(

--- a/src/meridian/lib/ops/session_target.py
+++ b/src/meridian/lib/ops/session_target.py
@@ -968,7 +968,7 @@ def resolve_session_log_target(
             chat_id=normalized_ref,
         )
 
-    if normalized_ref.startswith("p") and normalized_ref[1:].isdigit():
+    if _is_spawn_ref(normalized_ref):
         return _resolve_from_spawn_id(
             project_root=project_root,
             runtime_root=runtime_root,

--- a/src/meridian/lib/ops/session_transcript.py
+++ b/src/meridian/lib/ops/session_transcript.py
@@ -14,7 +14,11 @@ from meridian.lib.harness.transcript import (
     parse_transcript_file_with_prologues,
 )
 from meridian.lib.ops.runtime import resolve_runtime_authority_for_read
-from meridian.lib.ops.session_target import SessionLogTarget, resolve_session_log_target
+from meridian.lib.ops.session_target import (
+    SessionLogTarget,
+    TranscriptSource,
+    resolve_session_log_target,
+)
 
 _PROLOGUE_PLACEHOLDER = "[prologue slot reserved: no extractable system prompt]"
 _HANDOFF_PLACEHOLDER = "[compaction handoff slot reserved: no extractable handoff]"
@@ -262,12 +266,21 @@ def route_for_corpus_target(target: SessionLogTarget) -> SessionLogRoute:
     return SessionLogRoute(mode="file", value=str(target.file_path))
 
 
-def _parse_target_source(target: SessionLogTarget) -> TranscriptParseResult:
-    if target.transcript_source == "opencode_db":
-        return parse_opencode_db_transcript_with_prologues(target.session_id)
-    if target.file_path is None:
-        raise FileNotFoundError(f"Session file for '{target.session_id}' not found")
-    return parse_transcript_file_with_prologues(target.file_path)
+def _parse_transcript_source(source: TranscriptSource) -> TranscriptParseResult:
+    if source.kind == "opencode_db":
+        return parse_opencode_db_transcript_with_prologues(source.session_id)
+    if source.path is None:
+        raise FileNotFoundError(f"Session file for '{source.session_id}' not found")
+    return parse_transcript_file_with_prologues(source.path)
+
+
+def _target_for_source(target: SessionLogTarget, source: TranscriptSource) -> SessionLogTarget:
+    return target._replace(
+        session_id=source.session_id,
+        harness=source.harness,
+        file_path=source.path,
+        source=source.source_label,
+    )
 
 
 def _has_usable_interaction_content(parsed: TranscriptParseResult) -> bool:
@@ -285,17 +298,17 @@ def parse_session_target(
     target: SessionLogTarget,
     route: SessionLogRoute,
 ) -> ParsedSessionTranscript:
-    parsed = _parse_target_source(target)
-    if target.transcript_source == "opencode_db" and not _has_usable_interaction_content(parsed):
-        for fallback_target in target.fallback_targets:
-            fallback = parse_session_target(
-                project_root=project_root,
-                runtime_root=runtime_root,
-                target=fallback_target,
-                route=route,
-            )
-            if fallback.entries:
-                return fallback
+    parsed: TranscriptParseResult | None = None
+    resolved_target = target
+    for source in target.sources:
+        candidate = _parse_transcript_source(source)
+        parsed = candidate
+        resolved_target = _target_for_source(target, source)
+        if _has_usable_interaction_content(candidate):
+            break
+    if parsed is None:
+        raise FileNotFoundError(f"Session file for '{target.session_id}' not found")
+
     flattened = flatten_transcript_segments(parsed.segments)
     interaction_entries = group_transcript_entries(flattened)
     segment_entries = build_segment_entries(
@@ -310,7 +323,7 @@ def parse_session_target(
     return ParsedSessionTranscript(
         project_root=project_root,
         runtime_root=runtime_root,
-        target=target,
+        target=resolved_target,
         route=route,
         segments=parsed.segments,
         total_compactions=parsed.total_compactions,

--- a/src/meridian/lib/ops/session_transcript.py
+++ b/src/meridian/lib/ops/session_transcript.py
@@ -9,6 +9,7 @@ from meridian.lib.core.command_strings import format_command_for_display
 from meridian.lib.harness.transcript import (
     ToolCall,
     TranscriptMessage,
+    parse_opencode_db_transcript_with_prologues,
     parse_transcript_file_with_prologues,
 )
 from meridian.lib.ops.runtime import resolve_runtime_authority_for_read
@@ -255,6 +256,8 @@ def _route_from_request(
 
 
 def route_for_corpus_target(target: SessionLogTarget) -> SessionLogRoute:
+    if target.file_path is None:
+        return SessionLogRoute(mode="ref", value=target.session_id)
     return SessionLogRoute(mode="file", value=str(target.file_path))
 
 
@@ -265,7 +268,12 @@ def parse_session_target(
     target: SessionLogTarget,
     route: SessionLogRoute,
 ) -> ParsedSessionTranscript:
-    parsed = parse_transcript_file_with_prologues(target.file_path)
+    if target.transcript_source == "opencode_db":
+        parsed = parse_opencode_db_transcript_with_prologues(target.session_id)
+    else:
+        if target.file_path is None:
+            raise FileNotFoundError(f"Session file for '{target.session_id}' not found")
+        parsed = parse_transcript_file_with_prologues(target.file_path)
     flattened = flatten_transcript_segments(parsed.segments)
     interaction_entries = group_transcript_entries(flattened)
     segment_entries = build_segment_entries(

--- a/src/meridian/lib/ops/session_transcript.py
+++ b/src/meridian/lib/ops/session_transcript.py
@@ -9,6 +9,7 @@ from meridian.lib.core.command_strings import format_command_for_display
 from meridian.lib.harness.transcript import (
     ToolCall,
     TranscriptMessage,
+    TranscriptParseResult,
     parse_opencode_db_transcript_with_prologues,
     parse_transcript_file_with_prologues,
 )
@@ -261,6 +262,22 @@ def route_for_corpus_target(target: SessionLogTarget) -> SessionLogRoute:
     return SessionLogRoute(mode="file", value=str(target.file_path))
 
 
+def _parse_target_source(target: SessionLogTarget) -> TranscriptParseResult:
+    if target.transcript_source == "opencode_db":
+        return parse_opencode_db_transcript_with_prologues(target.session_id)
+    if target.file_path is None:
+        raise FileNotFoundError(f"Session file for '{target.session_id}' not found")
+    return parse_transcript_file_with_prologues(target.file_path)
+
+
+def _has_usable_interaction_content(parsed: TranscriptParseResult) -> bool:
+    return any(
+        message.role in {"assistant", "user"} and message.content.strip()
+        for segment in parsed.segments
+        for message in segment
+    )
+
+
 def parse_session_target(
     *,
     project_root: Path,
@@ -268,12 +285,17 @@ def parse_session_target(
     target: SessionLogTarget,
     route: SessionLogRoute,
 ) -> ParsedSessionTranscript:
-    if target.transcript_source == "opencode_db":
-        parsed = parse_opencode_db_transcript_with_prologues(target.session_id)
-    else:
-        if target.file_path is None:
-            raise FileNotFoundError(f"Session file for '{target.session_id}' not found")
-        parsed = parse_transcript_file_with_prologues(target.file_path)
+    parsed = _parse_target_source(target)
+    if target.transcript_source == "opencode_db" and not _has_usable_interaction_content(parsed):
+        for fallback_target in target.fallback_targets:
+            fallback = parse_session_target(
+                project_root=project_root,
+                runtime_root=runtime_root,
+                target=fallback_target,
+                route=route,
+            )
+            if fallback.entries:
+                return fallback
     flattened = flatten_transcript_segments(parsed.segments)
     interaction_entries = group_transcript_entries(flattened)
     segment_entries = build_segment_entries(

--- a/src/meridian/lib/streaming/.context/CONTEXT.md
+++ b/src/meridian/lib/streaming/.context/CONTEXT.md
@@ -78,6 +78,8 @@ configuration belongs in `DrainPlan`, not in coordinator methods.
 Scope filtering happens before coordinator terminal handling. A child OpenCode
 `session.idle` / `session.error` produces no `TerminalEventOutcome` for the parent,
 so resident and plain drain paths never see it as a parent completion candidate.
+`PrimaryEventScope` is the only scope contract passed through the drain stack; do
+not preserve or add compatibility side channels such as a Codex-only thread-id path.
 
 ### DrainOutcome Priority
 

--- a/src/meridian/lib/streaming/.context/CONTEXT.md
+++ b/src/meridian/lib/streaming/.context/CONTEXT.md
@@ -56,6 +56,13 @@ Persistence is synchronous and happens before any notification. 10 consecutive
 write failures abort the loop with a `failed` outcome. Do not reorder these stages
 — observers and the subscriber must only see events that are durably written.
 
+Terminal classification happens after persistence. The drain loop passes
+`connection.primary_event_scope` into the harness semantic helpers when a connection
+provides one. This matters for multiplexed streams: child Codex threads and child
+OpenCode task sessions are still written to `history.jsonl` and sent to observers,
+but their terminal events do not complete/fail the parent, clear parent signals, or
+drive parent activity transitions.
+
 ### DrainPlan Selection
 
 `SpawnManager._select_drain_plan()` returns the whole drain-loop configuration for
@@ -67,6 +74,10 @@ no-op coordinator class — absence of a coordinator is the plain path.
 `DrainCoordinator` stays narrow: it observes events, handles terminal events,
 provides timeouts, classifies stream close, and handles stream exit. Constant
 configuration belongs in `DrainPlan`, not in coordinator methods.
+
+Scope filtering happens before coordinator terminal handling. A child OpenCode
+`session.idle` / `session.error` produces no `TerminalEventOutcome` for the parent,
+so resident and plain drain paths never see it as a parent completion candidate.
 
 ### DrainOutcome Priority
 

--- a/src/meridian/lib/streaming/AGENTS.md
+++ b/src/meridian/lib/streaming/AGENTS.md
@@ -32,6 +32,11 @@ steps 1 and 2 could leave observers with data the persistence layer never record
 starting, stopping, injecting messages, subscribing to events, and tracking heartbeats.
 Do not bypass it to reach a connection or subscriber directly.
 
+`connection.primary_event_scope` is part of terminal classification for multiplexed
+streams. The drain loop still persists and broadcasts child Codex/OpenCode events,
+but semantic helpers must receive the scope so child terminal frames cannot finish,
+fail, or clear signals for the parent.
+
 ## Key Rules
 
 **Never call `connection.send_user_message()` directly.** Always use

--- a/src/meridian/lib/streaming/spawn_drain_loop.py
+++ b/src/meridian/lib/streaming/spawn_drain_loop.py
@@ -31,7 +31,7 @@ from meridian.lib.streaming.spawn_session import DrainOutcome, SpawnSession
 
 if TYPE_CHECKING:
     from meridian.lib.harness.connections.base import HarnessConnection
-    from meridian.lib.harness.semantics import TerminalEventOutcome
+    from meridian.lib.harness.semantics import PrimaryEventScope, TerminalEventOutcome
     from meridian.lib.observability.debug_tracer import DebugTracer
 
 logger = logging.getLogger(__name__)
@@ -129,7 +129,7 @@ class SpawnDrainLoop:
 
                 transition = activity_transition(
                     event,
-                    codex_main_thread_id=_codex_main_thread_id(receiver),
+                    primary_event_scope=_primary_event_scope(receiver),
                 )
                 duplicate_canonical_event = await _observe_event(
                     coordinator,
@@ -196,7 +196,7 @@ class SpawnDrainLoop:
 
                 event_outcome = terminal_outcome(
                     event,
-                    codex_main_thread_id=_codex_main_thread_id(receiver),
+                    primary_event_scope=_primary_event_scope(receiver),
                 )
                 self._fan_out_event(spawn_id, event)
                 persisted_event_decision = _note_event_persisted(coordinator, event)
@@ -313,14 +313,14 @@ class SpawnDrainLoop:
                         continue
 
 
-def _codex_main_thread_id(connection: object) -> str | None:
-    """Read the tracked main Codex thread id when the connection exposes it."""
+def _primary_event_scope(connection: object) -> PrimaryEventScope | None:
+    """Read the connection's primary event scope when it exposes one."""
 
     try:
-        thread_id = cast("Any", connection).main_turn_thread_id
+        scope = cast("Any", connection).primary_event_scope
     except Exception:
         return None
-    return thread_id if isinstance(thread_id, str) and thread_id.strip() else None
+    return cast("PrimaryEventScope | None", scope)
 
 
 class _NoAuxWake:

--- a/src/meridian/lib/streaming/spawn_drain_loop.py
+++ b/src/meridian/lib/streaming/spawn_drain_loop.py
@@ -31,7 +31,7 @@ from meridian.lib.streaming.spawn_session import DrainOutcome, SpawnSession
 
 if TYPE_CHECKING:
     from meridian.lib.harness.connections.base import HarnessConnection
-    from meridian.lib.harness.semantics import PrimaryEventScope, TerminalEventOutcome
+    from meridian.lib.harness.semantics import TerminalEventOutcome
     from meridian.lib.observability.debug_tracer import DebugTracer
 
 logger = logging.getLogger(__name__)
@@ -129,7 +129,7 @@ class SpawnDrainLoop:
 
                 transition = activity_transition(
                     event,
-                    primary_event_scope=_primary_event_scope(receiver),
+                    primary_event_scope=receiver.primary_event_scope,
                 )
                 duplicate_canonical_event = await _observe_event(
                     coordinator,
@@ -196,7 +196,7 @@ class SpawnDrainLoop:
 
                 event_outcome = terminal_outcome(
                     event,
-                    primary_event_scope=_primary_event_scope(receiver),
+                    primary_event_scope=receiver.primary_event_scope,
                 )
                 self._fan_out_event(spawn_id, event)
                 persisted_event_decision = _note_event_persisted(coordinator, event)
@@ -311,16 +311,6 @@ class SpawnDrainLoop:
                         with suppress(asyncio.QueueEmpty):
                             session.subscriber.get_nowait()
                         continue
-
-
-def _primary_event_scope(connection: object) -> PrimaryEventScope | None:
-    """Read the connection's primary event scope when it exposes one."""
-
-    try:
-        scope = cast("Any", connection).primary_event_scope
-    except Exception:
-        return None
-    return cast("PrimaryEventScope | None", scope)
 
 
 class _NoAuxWake:

--- a/tests/integration/launch/streaming_runner_support.py
+++ b/tests/integration/launch/streaming_runner_support.py
@@ -21,6 +21,11 @@ from meridian.lib.harness.connections.base import (
 )
 from meridian.lib.harness.launch_spec import ResolvedLaunchSpec
 from meridian.lib.harness.registry import HarnessRegistry
+from meridian.lib.harness.semantics import (
+    PrimaryEventScope,
+    codex_primary_event_scope,
+    opencode_primary_event_scope,
+)
 from meridian.lib.launch.context import build_launch_context
 from meridian.lib.launch.request import (
     LaunchArgvIntent,
@@ -98,6 +103,10 @@ class _ReportThenHangConnection:
     @property
     def subprocess_pid(self) -> int | None:
         return 4242
+
+    @property
+    def primary_event_scope(self) -> None:
+        return None
 
     @property
     def resident_backend(self) -> object:
@@ -196,6 +205,14 @@ class _OpenCodeTerminalWithScopeConnection:
     @property
     def subprocess_pid(self) -> int | None:
         return self._scope_snapshot.root_pid if self._scope_snapshot is not None else None
+
+    @property
+    def primary_event_scope(self) -> PrimaryEventScope | None:
+        if self.harness is HarnessId.CODEX:
+            return codex_primary_event_scope(self._session_id)
+        if self.harness is HarnessId.OPENCODE:
+            return opencode_primary_event_scope(self._session_id)
+        return None
 
     @property
     def resident_backend(self) -> object:
@@ -309,6 +326,10 @@ class _ResidentDeadlineConnection:
         return 8282
 
     @property
+    def primary_event_scope(self) -> None:
+        return None
+
+    @property
     def resident_backend(self) -> object:
         return self._resident_backend
 
@@ -403,6 +424,10 @@ class _ScriptedRetryOpenCodeConnection:
     @property
     def subprocess_pid(self) -> int | None:
         return type(self).subprocess_pid_value
+
+    @property
+    def primary_event_scope(self) -> PrimaryEventScope | None:
+        return opencode_primary_event_scope(type(self).session_id_value)
 
     @property
     def resident_backend(self) -> object:

--- a/tests/integration/launch/test_primary_attach.py
+++ b/tests/integration/launch/test_primary_attach.py
@@ -110,6 +110,10 @@ class FakeManagedConnection:
         return self._subprocess_pid
 
     @property
+    def primary_event_scope(self) -> None:
+        return None
+
+    @property
     def managed_backend(self) -> None:
         return None
 

--- a/tests/integration/launch/test_signals.py
+++ b/tests/integration/launch/test_signals.py
@@ -93,6 +93,10 @@ async def test_streaming_runner_signal_cancel_invokes_send_cancel_once(
             return None
 
         @property
+        def primary_event_scope(self) -> None:
+            return None
+
+        @property
         def resident_backend(self) -> None:
             return None
 

--- a/tests/integration/launch/test_spawn_manager_hitl.py
+++ b/tests/integration/launch/test_spawn_manager_hitl.py
@@ -112,6 +112,10 @@ async def test_spawn_manager_codex_hitl_requests_auto_rejected_for_spawned_agent
             return None
 
         @property
+        def primary_event_scope(self) -> None:
+            return None
+
+        @property
         def resident_backend(self) -> None:
             return None
 
@@ -252,6 +256,10 @@ async def test_spawn_manager_retryable_permission_send_failure_resolves_not_fail
 
         @property
         def subprocess_pid(self) -> int | None:
+            return None
+
+        @property
+        def primary_event_scope(self) -> None:
             return None
 
         @property

--- a/tests/integration/launch/test_spawn_manager_lifecycle.py
+++ b/tests/integration/launch/test_spawn_manager_lifecycle.py
@@ -115,6 +115,10 @@ async def test_wait_for_completion_survives_cleanup_without_private_hooks(
             return 7373
 
         @property
+        def primary_event_scope(self) -> None:
+            return None
+
+        @property
         def resident_backend(self) -> None:
             return None
 
@@ -392,6 +396,10 @@ async def test_spawn_manager_serializes_control_actions_and_persists_transitions
 
         @property
         def subprocess_pid(self) -> int | None:
+            return None
+
+        @property
+        def primary_event_scope(self) -> None:
             return None
 
         @property

--- a/tests/integration/launch/test_streaming_runner_retry_policy.py
+++ b/tests/integration/launch/test_streaming_runner_retry_policy.py
@@ -136,7 +136,11 @@ async def test_execute_with_streaming_does_not_retry_authoritative_terminal_fail
             HarnessEvent(
                 event_type="session.error",
                 harness_id="opencode",
-                payload={"type": "session.error", "error": "connection reset by peer"},
+                payload={
+                    "type": "session.error",
+                    "error": "connection reset by peer",
+                    "sessionID": "session-retryable-opencode",
+                },
             ),
         ),
         session_id="session-retryable-opencode",

--- a/tests/integration/launch/test_streaming_runner_seed.py
+++ b/tests/integration/launch/test_streaming_runner_seed.py
@@ -66,6 +66,10 @@ class _ClaudeSeedPersistenceConnection:
         return 5252
 
     @property
+    def primary_event_scope(self) -> None:
+        return None
+
+    @property
     def resident_backend(self) -> None:
         return None
 
@@ -128,6 +132,10 @@ class _OpenCodeSeedPortConnection:
     @property
     def subprocess_pid(self) -> int | None:
         return 6262
+
+    @property
+    def primary_event_scope(self) -> None:
+        return None
 
     @property
     def resident_backend(self) -> None:
@@ -193,6 +201,10 @@ class _OpenCodeConnectSessionConnection:
     @property
     def subprocess_pid(self) -> int | None:
         return 7272
+
+    @property
+    def primary_event_scope(self) -> None:
+        return None
 
     @property
     def resident_backend(self) -> None:

--- a/tests/integration/ops/test_session_log_harness_retrieval.py
+++ b/tests/integration/ops/test_session_log_harness_retrieval.py
@@ -7,9 +7,9 @@ each harness type (opencode, codex, claude) using env-var overrides.
 """
 
 import json
-import sqlite3
 from pathlib import Path
 
+import pytest
 from pytest import MonkeyPatch
 
 from meridian.lib.harness.claude import project_slug
@@ -17,6 +17,10 @@ from meridian.lib.launch.constants import HISTORY_FILENAME
 from meridian.lib.ops.session_log import SessionLogInput, session_log_sync
 from meridian.lib.state import session_store, spawn_store
 from meridian.lib.state.paths import resolve_project_runtime_root
+from tests.support.opencode_db import (
+    write_opencode_db_session,
+    write_opencode_db_session_with_parts,
+)
 
 
 def _write_codex_rollout(
@@ -84,139 +88,6 @@ def _write_claude_session(
     return session_path
 
 
-def _write_opencode_db_session(
-    *,
-    db_path: Path,
-    session_id: str,
-    messages: list[tuple[str, str]],
-) -> None:
-    db_path.parent.mkdir(parents=True, exist_ok=True)
-    with sqlite3.connect(db_path) as connection:
-        connection.executescript(
-            """
-            CREATE TABLE session (
-                id TEXT PRIMARY KEY,
-                time_created INTEGER NOT NULL,
-                time_updated INTEGER NOT NULL
-            );
-            CREATE TABLE message (
-                id TEXT PRIMARY KEY,
-                session_id TEXT NOT NULL,
-                time_created INTEGER NOT NULL,
-                time_updated INTEGER NOT NULL,
-                data TEXT NOT NULL
-            );
-            CREATE TABLE part (
-                id TEXT PRIMARY KEY,
-                message_id TEXT NOT NULL,
-                session_id TEXT NOT NULL,
-                time_created INTEGER NOT NULL,
-                time_updated INTEGER NOT NULL,
-                data TEXT NOT NULL
-            );
-            """
-        )
-        now = 1_778_945_817_030
-        connection.execute(
-            "INSERT INTO session (id, time_created, time_updated) VALUES (?, ?, ?)",
-            (session_id, now, now),
-        )
-        for index, (role, text) in enumerate(messages):
-            timestamp = now + index
-            message_id = f"msg_{index}"
-            part_id = f"prt_{index}"
-            connection.execute(
-                "INSERT INTO message "
-                "(id, session_id, time_created, time_updated, data) "
-                "VALUES (?, ?, ?, ?, ?)",
-                (
-                    message_id,
-                    session_id,
-                    timestamp,
-                    timestamp,
-                    json.dumps({"role": role, "time": {"created": timestamp}}),
-                ),
-            )
-            connection.execute(
-                "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) "
-                "VALUES (?, ?, ?, ?, ?, ?)",
-                (
-                    part_id,
-                    message_id,
-                    session_id,
-                    timestamp,
-                    timestamp,
-                    json.dumps({"type": "text", "text": text}),
-                ),
-            )
-        connection.commit()
-
-
-def _write_opencode_db_session_with_parts(
-    *,
-    db_path: Path,
-    session_id: str,
-    messages: list[tuple[str, dict[str, object], list[dict[str, object]]]],
-) -> None:
-    db_path.parent.mkdir(parents=True, exist_ok=True)
-    with sqlite3.connect(db_path) as connection:
-        connection.executescript(
-            """
-            CREATE TABLE session (
-                id TEXT PRIMARY KEY,
-                time_created INTEGER NOT NULL,
-                time_updated INTEGER NOT NULL
-            );
-            CREATE TABLE message (
-                id TEXT PRIMARY KEY,
-                session_id TEXT NOT NULL,
-                time_created INTEGER NOT NULL,
-                time_updated INTEGER NOT NULL,
-                data TEXT NOT NULL
-            );
-            CREATE TABLE part (
-                id TEXT PRIMARY KEY,
-                message_id TEXT NOT NULL,
-                session_id TEXT NOT NULL,
-                time_created INTEGER NOT NULL,
-                time_updated INTEGER NOT NULL,
-                data TEXT NOT NULL
-            );
-            """
-        )
-        now = 1_778_945_817_030
-        connection.execute(
-            "INSERT INTO session (id, time_created, time_updated) VALUES (?, ?, ?)",
-            (session_id, now, now),
-        )
-        for message_index, (role, message_data, parts) in enumerate(messages):
-            timestamp = now + (message_index * 100)
-            message_id = f"msg_{message_index}"
-            payload = {"role": role, "time": {"created": timestamp}, **message_data}
-            connection.execute(
-                "INSERT INTO message "
-                "(id, session_id, time_created, time_updated, data) "
-                "VALUES (?, ?, ?, ?, ?)",
-                (message_id, session_id, timestamp, timestamp, json.dumps(payload)),
-            )
-            for part_index, part in enumerate(parts):
-                part_timestamp = timestamp + part_index + 1
-                connection.execute(
-                    "INSERT INTO part "
-                    "(id, message_id, session_id, time_created, time_updated, data) "
-                    "VALUES (?, ?, ?, ?, ?, ?)",
-                    (
-                        f"prt_{message_index}_{part_index}",
-                        message_id,
-                        session_id,
-                        part_timestamp,
-                        part_timestamp,
-                        json.dumps(part),
-                    ),
-                )
-        connection.commit()
-
-
 def test_session_log_resolves_opencode_db_transcript_when_session_diff_is_empty(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -231,7 +102,7 @@ def test_session_log_resolves_opencode_db_transcript_when_session_diff_is_empty(
     session_file = xdg_data_home / "opencode" / "storage" / "session_diff" / f"{session_id}.json"
     session_file.parent.mkdir(parents=True)
     session_file.write_text("[]\n", encoding="utf-8")
-    _write_opencode_db_session(
+    write_opencode_db_session(
         db_path=xdg_data_home / "opencode" / "opencode.db",
         session_id=session_id,
         messages=[
@@ -280,7 +151,7 @@ def test_session_log_resolves_opencode_db_without_legacy_session_file(
 
     xdg_data_home = tmp_path / "xdg-data"
     session_id = "ses_fixture_db_only_12345"
-    _write_opencode_db_session_with_parts(
+    write_opencode_db_session_with_parts(
         db_path=xdg_data_home / "opencode" / "opencode.db",
         session_id=session_id,
         messages=[
@@ -345,7 +216,7 @@ def test_session_log_renders_opencode_db_completed_tool_parts(
     xdg_data_home = tmp_path / "xdg-data"
     session_id = "ses_fixture_db_tool_12345"
     target_path = "/tmp/opencode-write.txt"
-    _write_opencode_db_session_with_parts(
+    write_opencode_db_session_with_parts(
         db_path=xdg_data_home / "opencode" / "opencode.db",
         session_id=session_id,
         messages=[
@@ -415,7 +286,7 @@ def test_session_log_default_render_shows_completed_opencode_task_result(
 
     xdg_data_home = tmp_path / "xdg-data"
     session_id = "ses_fixture_db_task_12345"
-    _write_opencode_db_session_with_parts(
+    write_opencode_db_session_with_parts(
         db_path=xdg_data_home / "opencode" / "opencode.db",
         session_id=session_id,
         messages=[
@@ -483,7 +354,7 @@ def test_session_log_renders_opencode_db_compaction_as_segment_handoff(
 
     xdg_data_home = tmp_path / "xdg-data"
     session_id = "ses_fixture_db_compaction_12345"
-    _write_opencode_db_session_with_parts(
+    write_opencode_db_session_with_parts(
         db_path=xdg_data_home / "opencode" / "opencode.db",
         session_id=session_id,
         messages=[
@@ -547,7 +418,7 @@ def test_session_log_falls_back_to_legacy_opencode_json_when_db_has_no_messages(
         json.dumps({"role": "assistant", "content": "legacy JSON transcript"}) + "\n",
         encoding="utf-8",
     )
-    _write_opencode_db_session_with_parts(
+    write_opencode_db_session_with_parts(
         db_path=xdg_data_home / "opencode" / "opencode.db",
         session_id=session_id,
         messages=[],
@@ -581,9 +452,47 @@ def test_session_log_falls_back_to_legacy_opencode_json_when_db_has_no_messages(
     ]
 
 
+def _write_spawn_history(runtime_root: Path, spawn_id: str, text: str) -> None:
+    history_path = runtime_root / "spawns" / spawn_id / HISTORY_FILENAME
+    history_path.write_text(
+        json.dumps(
+            {
+                "event_type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": text}],
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize(
+    ("ref_kind", "ref", "track_session", "expected_session_id", "history_text"),
+    [
+        ("spawn", "p1", False, "p1", "spawn history transcript"),
+        ("chat", "c1", True, "c1", "chat ref spawn history transcript"),
+        ("raw", "session", True, "session", "raw ref spawn history transcript"),
+        (
+            "raw-untracked",
+            "session",
+            False,
+            "session",
+            "untracked raw ref spawn history transcript",
+        ),
+    ],
+)
 def test_session_log_falls_back_to_spawn_history_when_opencode_db_has_no_messages(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
+    ref_kind: str,
+    ref: str,
+    track_session: bool,
+    expected_session_id: str,
+    history_text: str,
 ) -> None:
     project_root = tmp_path / "repo"
     project_root.mkdir()
@@ -591,14 +500,23 @@ def test_session_log_falls_back_to_spawn_history_when_opencode_db_has_no_message
     runtime_root.mkdir(parents=True, exist_ok=True)
 
     xdg_data_home = tmp_path / "xdg-data"
-    session_id = "ses_fixture_empty_db_spawn_history_12345"
-    _write_opencode_db_session_with_parts(
+    session_id = f"ses_fixture_empty_db_{ref_kind}_history_12345"
+    write_opencode_db_session_with_parts(
         db_path=xdg_data_home / "opencode" / "opencode.db",
         session_id=session_id,
         messages=[],
     )
     monkeypatch.setenv("XDG_DATA_HOME", xdg_data_home.as_posix())
 
+    if track_session:
+        session_store.start_session(
+            runtime_root,
+            harness="opencode",
+            harness_session_id=session_id,
+            model="gpt-5.3-codex",
+            chat_id="c1",
+            spawn_id="p1",
+        )
     spawn_store.start_spawn(
         runtime_root,
         chat_id="c1",
@@ -610,240 +528,20 @@ def test_session_log_falls_back_to_spawn_history_when_opencode_db_has_no_message
         harness_session_id=session_id,
         started_at="2026-04-11T00:00:00Z",
     )
-    history_path = runtime_root / "spawns" / "p1" / HISTORY_FILENAME
-    history_path.write_text(
-        json.dumps(
-            {
-                "event_type": "response_item",
-                "payload": {
-                    "type": "message",
-                    "role": "assistant",
-                    "content": [
-                        {"type": "output_text", "text": "spawn history transcript"}
-                    ],
-                },
-            }
-        )
-        + "\n",
-        encoding="utf-8",
-    )
+    _write_spawn_history(runtime_root, "p1", history_text)
 
+    resolved_ref = session_id if ref == "session" else ref
     output = session_log_sync(
-        SessionLogInput(
-            ref="p1",
-            project_root=project_root.as_posix(),
-            full=True,
-        )
+        SessionLogInput(ref=resolved_ref, project_root=project_root.as_posix(), full=True)
     )
 
-    assert output.session_id == "p1"
+    expected_output_session_id = (
+        session_id if expected_session_id == "session" else expected_session_id
+    )
+    assert output.session_id == expected_output_session_id
     assert output.source == "spawn p1 output"
     assert [(message.role, message.content) for message in output.messages] == [
-        ("assistant", "spawn history transcript")
-    ]
-
-
-def test_session_log_chat_id_falls_back_to_spawn_history_when_opencode_db_has_no_messages(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
-) -> None:
-    project_root = tmp_path / "repo"
-    project_root.mkdir()
-    runtime_root = resolve_project_runtime_root(project_root)
-    runtime_root.mkdir(parents=True, exist_ok=True)
-
-    xdg_data_home = tmp_path / "xdg-data"
-    session_id = "ses_fixture_empty_db_chat_history_12345"
-    _write_opencode_db_session_with_parts(
-        db_path=xdg_data_home / "opencode" / "opencode.db",
-        session_id=session_id,
-        messages=[],
-    )
-    monkeypatch.setenv("XDG_DATA_HOME", xdg_data_home.as_posix())
-
-    session_store.start_session(
-        runtime_root,
-        harness="opencode",
-        harness_session_id=session_id,
-        model="gpt-5.3-codex",
-        chat_id="c1",
-    )
-    spawn_store.start_spawn(
-        runtime_root,
-        chat_id="c1",
-        model="gpt-5.3-codex",
-        agent="coder",
-        harness="opencode",
-        prompt="hello",
-        spawn_id="p1",
-        harness_session_id=session_id,
-        started_at="2026-04-11T00:00:00Z",
-    )
-    history_path = runtime_root / "spawns" / "p1" / HISTORY_FILENAME
-    history_path.write_text(
-        json.dumps(
-            {
-                "event_type": "response_item",
-                "payload": {
-                    "type": "message",
-                    "role": "assistant",
-                    "content": [
-                        {"type": "output_text", "text": "chat ref spawn history transcript"}
-                    ],
-                },
-            }
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-
-    output = session_log_sync(
-        SessionLogInput(
-            ref="c1",
-            project_root=project_root.as_posix(),
-            full=True,
-        )
-    )
-
-    assert output.session_id == "c1"
-    assert output.source == "spawn p1 output"
-    assert [(message.role, message.content) for message in output.messages] == [
-        ("assistant", "chat ref spawn history transcript")
-    ]
-
-
-def test_session_log_raw_session_id_falls_back_to_spawn_history_when_opencode_db_has_no_messages(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
-) -> None:
-    project_root = tmp_path / "repo"
-    project_root.mkdir()
-    runtime_root = resolve_project_runtime_root(project_root)
-    runtime_root.mkdir(parents=True, exist_ok=True)
-
-    xdg_data_home = tmp_path / "xdg-data"
-    session_id = "ses_fixture_empty_db_raw_ref_history_12345"
-    _write_opencode_db_session_with_parts(
-        db_path=xdg_data_home / "opencode" / "opencode.db",
-        session_id=session_id,
-        messages=[],
-    )
-    monkeypatch.setenv("XDG_DATA_HOME", xdg_data_home.as_posix())
-
-    session_store.start_session(
-        runtime_root,
-        harness="opencode",
-        harness_session_id=session_id,
-        model="gpt-5.3-codex",
-        chat_id="c1",
-        spawn_id="p1",
-    )
-    spawn_store.start_spawn(
-        runtime_root,
-        chat_id="c1",
-        model="gpt-5.3-codex",
-        agent="coder",
-        harness="opencode",
-        prompt="hello",
-        spawn_id="p1",
-        harness_session_id=session_id,
-        started_at="2026-04-11T00:00:00Z",
-    )
-    history_path = runtime_root / "spawns" / "p1" / HISTORY_FILENAME
-    history_path.write_text(
-        json.dumps(
-            {
-                "event_type": "response_item",
-                "payload": {
-                    "type": "message",
-                    "role": "assistant",
-                    "content": [
-                        {"type": "output_text", "text": "raw ref spawn history transcript"}
-                    ],
-                },
-            }
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-
-    output = session_log_sync(
-        SessionLogInput(
-            ref=session_id,
-            project_root=project_root.as_posix(),
-            full=True,
-        )
-    )
-
-    assert output.session_id == session_id
-    assert output.source == "spawn p1 output"
-    assert [(message.role, message.content) for message in output.messages] == [
-        ("assistant", "raw ref spawn history transcript")
-    ]
-
-
-def test_session_log_untracked_raw_session_id_falls_back_to_spawn_history_when_db_is_empty(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
-) -> None:
-    project_root = tmp_path / "repo"
-    project_root.mkdir()
-    runtime_root = resolve_project_runtime_root(project_root)
-    runtime_root.mkdir(parents=True, exist_ok=True)
-
-    xdg_data_home = tmp_path / "xdg-data"
-    session_id = "ses_fixture_empty_db_untracked_raw_history_12345"
-    _write_opencode_db_session_with_parts(
-        db_path=xdg_data_home / "opencode" / "opencode.db",
-        session_id=session_id,
-        messages=[],
-    )
-    monkeypatch.setenv("XDG_DATA_HOME", xdg_data_home.as_posix())
-
-    spawn_store.start_spawn(
-        runtime_root,
-        chat_id="c1",
-        model="gpt-5.3-codex",
-        agent="coder",
-        harness="opencode",
-        prompt="hello",
-        spawn_id="p1",
-        harness_session_id=session_id,
-        started_at="2026-04-11T00:00:00Z",
-    )
-    history_path = runtime_root / "spawns" / "p1" / HISTORY_FILENAME
-    history_path.write_text(
-        json.dumps(
-            {
-                "event_type": "response_item",
-                "payload": {
-                    "type": "message",
-                    "role": "assistant",
-                    "content": [
-                        {
-                            "type": "output_text",
-                            "text": "untracked raw ref spawn history transcript",
-                        }
-                    ],
-                },
-            }
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-
-    output = session_log_sync(
-        SessionLogInput(
-            ref=session_id,
-            project_root=project_root.as_posix(),
-            full=True,
-        )
-    )
-
-    assert output.session_id == session_id
-    assert output.source == "spawn p1 output"
-    assert [(message.role, message.content) for message in output.messages] == [
-        ("assistant", "untracked raw ref spawn history transcript")
+        ("assistant", history_text)
     ]
 
 

--- a/tests/integration/ops/test_session_log_harness_retrieval.py
+++ b/tests/integration/ops/test_session_log_harness_retrieval.py
@@ -10,7 +10,10 @@ import json
 import sqlite3
 from pathlib import Path
 
+from pytest import MonkeyPatch
+
 from meridian.lib.harness.claude import project_slug
+from meridian.lib.launch.constants import HISTORY_FILENAME
 from meridian.lib.ops.session_log import SessionLogInput, session_log_sync
 from meridian.lib.state import session_store, spawn_store
 from meridian.lib.state.paths import resolve_project_runtime_root
@@ -216,7 +219,7 @@ def _write_opencode_db_session_with_parts(
 
 def test_session_log_resolves_opencode_db_transcript_when_session_diff_is_empty(
     tmp_path: Path,
-    monkeypatch,
+    monkeypatch: MonkeyPatch,
 ) -> None:
     project_root = tmp_path / "repo"
     project_root.mkdir()
@@ -268,7 +271,7 @@ def test_session_log_resolves_opencode_db_transcript_when_session_diff_is_empty(
 
 def test_session_log_resolves_opencode_db_without_legacy_session_file(
     tmp_path: Path,
-    monkeypatch,
+    monkeypatch: MonkeyPatch,
 ) -> None:
     project_root = tmp_path / "repo"
     project_root.mkdir()
@@ -332,7 +335,7 @@ def test_session_log_resolves_opencode_db_without_legacy_session_file(
 
 def test_session_log_renders_opencode_db_completed_tool_parts(
     tmp_path: Path,
-    monkeypatch,
+    monkeypatch: MonkeyPatch,
 ) -> None:
     project_root = tmp_path / "repo"
     project_root.mkdir()
@@ -401,9 +404,384 @@ def test_session_log_renders_opencode_db_completed_tool_parts(
     assert output.messages[2].is_tool_result is True
 
 
+def test_session_log_renders_opencode_db_compaction_as_segment_handoff(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    runtime_root = resolve_project_runtime_root(project_root)
+    runtime_root.mkdir(parents=True, exist_ok=True)
+
+    xdg_data_home = tmp_path / "xdg-data"
+    session_id = "ses_fixture_db_compaction_12345"
+    _write_opencode_db_session_with_parts(
+        db_path=xdg_data_home / "opencode" / "opencode.db",
+        session_id=session_id,
+        messages=[
+            ("user", {}, [{"type": "text", "text": "segment zero user"}]),
+            ("assistant", {}, [{"type": "text", "text": "segment zero assistant"}]),
+            (
+                "assistant",
+                {"mode": "compaction", "agent": "compaction"},
+                [{"type": "text", "text": "handoff into segment one"}],
+            ),
+            ("user", {}, [{"type": "text", "text": "segment one user"}]),
+            ("assistant", {}, [{"type": "text", "text": "segment one assistant"}]),
+        ],
+    )
+    monkeypatch.setenv("XDG_DATA_HOME", xdg_data_home.as_posix())
+
+    spawn_store.start_spawn(
+        runtime_root,
+        chat_id="c1",
+        model="gpt-5.3-codex",
+        agent="coder",
+        harness="opencode",
+        prompt="hello",
+        spawn_id="p1",
+        harness_session_id=session_id,
+        started_at="2026-04-11T00:00:00Z",
+    )
+
+    output = session_log_sync(
+        SessionLogInput(
+            ref="p1",
+            project_root=project_root.as_posix(),
+            full=True,
+        )
+    )
+
+    assert output.total_segments == 2
+    assert output.segment_index == 1
+    assert output.entries[0].role == "system"
+    assert output.entries[0].content == "handoff into segment one"
+    assert [(message.role, message.content) for message in output.messages] == [
+        ("user", "segment one user"),
+        ("assistant", "segment one assistant"),
+    ]
+
+
+def test_session_log_falls_back_to_legacy_opencode_json_when_db_has_no_messages(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    runtime_root = resolve_project_runtime_root(project_root)
+    runtime_root.mkdir(parents=True, exist_ok=True)
+
+    xdg_data_home = tmp_path / "xdg-data"
+    session_id = "ses_fixture_empty_db_legacy_json_12345"
+    session_file = xdg_data_home / "opencode" / "storage" / "session_diff" / f"{session_id}.json"
+    session_file.parent.mkdir(parents=True, exist_ok=True)
+    session_file.write_text(
+        json.dumps({"role": "assistant", "content": "legacy JSON transcript"}) + "\n",
+        encoding="utf-8",
+    )
+    _write_opencode_db_session_with_parts(
+        db_path=xdg_data_home / "opencode" / "opencode.db",
+        session_id=session_id,
+        messages=[],
+    )
+    monkeypatch.setenv("XDG_DATA_HOME", xdg_data_home.as_posix())
+
+    spawn_store.start_spawn(
+        runtime_root,
+        chat_id="c1",
+        model="gpt-5.3-codex",
+        agent="coder",
+        harness="opencode",
+        prompt="hello",
+        spawn_id="p1",
+        harness_session_id=session_id,
+        started_at="2026-04-11T00:00:00Z",
+    )
+
+    output = session_log_sync(
+        SessionLogInput(
+            ref="p1",
+            project_root=project_root.as_posix(),
+            full=True,
+        )
+    )
+
+    assert output.session_id == session_id
+    assert output.source == "opencode transcript"
+    assert [(message.role, message.content) for message in output.messages] == [
+        ("assistant", "legacy JSON transcript")
+    ]
+
+
+def test_session_log_falls_back_to_spawn_history_when_opencode_db_has_no_messages(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    runtime_root = resolve_project_runtime_root(project_root)
+    runtime_root.mkdir(parents=True, exist_ok=True)
+
+    xdg_data_home = tmp_path / "xdg-data"
+    session_id = "ses_fixture_empty_db_spawn_history_12345"
+    _write_opencode_db_session_with_parts(
+        db_path=xdg_data_home / "opencode" / "opencode.db",
+        session_id=session_id,
+        messages=[],
+    )
+    monkeypatch.setenv("XDG_DATA_HOME", xdg_data_home.as_posix())
+
+    spawn_store.start_spawn(
+        runtime_root,
+        chat_id="c1",
+        model="gpt-5.3-codex",
+        agent="coder",
+        harness="opencode",
+        prompt="hello",
+        spawn_id="p1",
+        harness_session_id=session_id,
+        started_at="2026-04-11T00:00:00Z",
+    )
+    history_path = runtime_root / "spawns" / "p1" / HISTORY_FILENAME
+    history_path.write_text(
+        json.dumps(
+            {
+                "event_type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {"type": "output_text", "text": "spawn history transcript"}
+                    ],
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    output = session_log_sync(
+        SessionLogInput(
+            ref="p1",
+            project_root=project_root.as_posix(),
+            full=True,
+        )
+    )
+
+    assert output.session_id == "p1"
+    assert output.source == "spawn p1 output"
+    assert [(message.role, message.content) for message in output.messages] == [
+        ("assistant", "spawn history transcript")
+    ]
+
+
+def test_session_log_chat_id_falls_back_to_spawn_history_when_opencode_db_has_no_messages(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    runtime_root = resolve_project_runtime_root(project_root)
+    runtime_root.mkdir(parents=True, exist_ok=True)
+
+    xdg_data_home = tmp_path / "xdg-data"
+    session_id = "ses_fixture_empty_db_chat_history_12345"
+    _write_opencode_db_session_with_parts(
+        db_path=xdg_data_home / "opencode" / "opencode.db",
+        session_id=session_id,
+        messages=[],
+    )
+    monkeypatch.setenv("XDG_DATA_HOME", xdg_data_home.as_posix())
+
+    session_store.start_session(
+        runtime_root,
+        harness="opencode",
+        harness_session_id=session_id,
+        model="gpt-5.3-codex",
+        chat_id="c1",
+    )
+    spawn_store.start_spawn(
+        runtime_root,
+        chat_id="c1",
+        model="gpt-5.3-codex",
+        agent="coder",
+        harness="opencode",
+        prompt="hello",
+        spawn_id="p1",
+        harness_session_id=session_id,
+        started_at="2026-04-11T00:00:00Z",
+    )
+    history_path = runtime_root / "spawns" / "p1" / HISTORY_FILENAME
+    history_path.write_text(
+        json.dumps(
+            {
+                "event_type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {"type": "output_text", "text": "chat ref spawn history transcript"}
+                    ],
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    output = session_log_sync(
+        SessionLogInput(
+            ref="c1",
+            project_root=project_root.as_posix(),
+            full=True,
+        )
+    )
+
+    assert output.session_id == "c1"
+    assert output.source == "spawn p1 output"
+    assert [(message.role, message.content) for message in output.messages] == [
+        ("assistant", "chat ref spawn history transcript")
+    ]
+
+
+def test_session_log_raw_session_id_falls_back_to_spawn_history_when_opencode_db_has_no_messages(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    runtime_root = resolve_project_runtime_root(project_root)
+    runtime_root.mkdir(parents=True, exist_ok=True)
+
+    xdg_data_home = tmp_path / "xdg-data"
+    session_id = "ses_fixture_empty_db_raw_ref_history_12345"
+    _write_opencode_db_session_with_parts(
+        db_path=xdg_data_home / "opencode" / "opencode.db",
+        session_id=session_id,
+        messages=[],
+    )
+    monkeypatch.setenv("XDG_DATA_HOME", xdg_data_home.as_posix())
+
+    session_store.start_session(
+        runtime_root,
+        harness="opencode",
+        harness_session_id=session_id,
+        model="gpt-5.3-codex",
+        chat_id="c1",
+        spawn_id="p1",
+    )
+    spawn_store.start_spawn(
+        runtime_root,
+        chat_id="c1",
+        model="gpt-5.3-codex",
+        agent="coder",
+        harness="opencode",
+        prompt="hello",
+        spawn_id="p1",
+        harness_session_id=session_id,
+        started_at="2026-04-11T00:00:00Z",
+    )
+    history_path = runtime_root / "spawns" / "p1" / HISTORY_FILENAME
+    history_path.write_text(
+        json.dumps(
+            {
+                "event_type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {"type": "output_text", "text": "raw ref spawn history transcript"}
+                    ],
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    output = session_log_sync(
+        SessionLogInput(
+            ref=session_id,
+            project_root=project_root.as_posix(),
+            full=True,
+        )
+    )
+
+    assert output.session_id == session_id
+    assert output.source == "spawn p1 output"
+    assert [(message.role, message.content) for message in output.messages] == [
+        ("assistant", "raw ref spawn history transcript")
+    ]
+
+
+def test_session_log_untracked_raw_session_id_falls_back_to_spawn_history_when_db_is_empty(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    runtime_root = resolve_project_runtime_root(project_root)
+    runtime_root.mkdir(parents=True, exist_ok=True)
+
+    xdg_data_home = tmp_path / "xdg-data"
+    session_id = "ses_fixture_empty_db_untracked_raw_history_12345"
+    _write_opencode_db_session_with_parts(
+        db_path=xdg_data_home / "opencode" / "opencode.db",
+        session_id=session_id,
+        messages=[],
+    )
+    monkeypatch.setenv("XDG_DATA_HOME", xdg_data_home.as_posix())
+
+    spawn_store.start_spawn(
+        runtime_root,
+        chat_id="c1",
+        model="gpt-5.3-codex",
+        agent="coder",
+        harness="opencode",
+        prompt="hello",
+        spawn_id="p1",
+        harness_session_id=session_id,
+        started_at="2026-04-11T00:00:00Z",
+    )
+    history_path = runtime_root / "spawns" / "p1" / HISTORY_FILENAME
+    history_path.write_text(
+        json.dumps(
+            {
+                "event_type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "untracked raw ref spawn history transcript",
+                        }
+                    ],
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    output = session_log_sync(
+        SessionLogInput(
+            ref=session_id,
+            project_root=project_root.as_posix(),
+            full=True,
+        )
+    )
+
+    assert output.session_id == session_id
+    assert output.source == "spawn p1 output"
+    assert [(message.role, message.content) for message in output.messages] == [
+        ("assistant", "untracked raw ref spawn history transcript")
+    ]
+
+
 def test_session_log_resolves_codex_session_file_from_codex_home_env(
     tmp_path: Path,
-    monkeypatch,
+    monkeypatch: MonkeyPatch,
 ) -> None:
     project_root = tmp_path / "repo"
     project_root.mkdir()
@@ -449,7 +827,7 @@ def test_session_log_resolves_codex_session_file_from_codex_home_env(
 
 def test_session_log_resolves_claude_session_file_from_claude_config_dir_env(
     tmp_path: Path,
-    monkeypatch,
+    monkeypatch: MonkeyPatch,
 ) -> None:
     project_root = tmp_path / "repo"
     project_root.mkdir()

--- a/tests/integration/ops/test_session_log_harness_retrieval.py
+++ b/tests/integration/ops/test_session_log_harness_retrieval.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 from meridian.lib.harness.claude import project_slug
 from meridian.lib.ops.session_log import SessionLogInput, session_log_sync
-from meridian.lib.state import spawn_store
+from meridian.lib.state import session_store, spawn_store
 from meridian.lib.state.paths import resolve_project_runtime_root
 
 
@@ -149,6 +149,71 @@ def _write_opencode_db_session(
         connection.commit()
 
 
+def _write_opencode_db_session_with_parts(
+    *,
+    db_path: Path,
+    session_id: str,
+    messages: list[tuple[str, dict[str, object], list[dict[str, object]]]],
+) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as connection:
+        connection.executescript(
+            """
+            CREATE TABLE session (
+                id TEXT PRIMARY KEY,
+                time_created INTEGER NOT NULL,
+                time_updated INTEGER NOT NULL
+            );
+            CREATE TABLE message (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                time_created INTEGER NOT NULL,
+                time_updated INTEGER NOT NULL,
+                data TEXT NOT NULL
+            );
+            CREATE TABLE part (
+                id TEXT PRIMARY KEY,
+                message_id TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                time_created INTEGER NOT NULL,
+                time_updated INTEGER NOT NULL,
+                data TEXT NOT NULL
+            );
+            """
+        )
+        now = 1_778_945_817_030
+        connection.execute(
+            "INSERT INTO session (id, time_created, time_updated) VALUES (?, ?, ?)",
+            (session_id, now, now),
+        )
+        for message_index, (role, message_data, parts) in enumerate(messages):
+            timestamp = now + (message_index * 100)
+            message_id = f"msg_{message_index}"
+            payload = {"role": role, "time": {"created": timestamp}, **message_data}
+            connection.execute(
+                "INSERT INTO message "
+                "(id, session_id, time_created, time_updated, data) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (message_id, session_id, timestamp, timestamp, json.dumps(payload)),
+            )
+            for part_index, part in enumerate(parts):
+                part_timestamp = timestamp + part_index + 1
+                connection.execute(
+                    "INSERT INTO part "
+                    "(id, message_id, session_id, time_created, time_updated, data) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    (
+                        f"prt_{message_index}_{part_index}",
+                        message_id,
+                        session_id,
+                        part_timestamp,
+                        part_timestamp,
+                        json.dumps(part),
+                    ),
+                )
+        connection.commit()
+
+
 def test_session_log_resolves_opencode_db_transcript_when_session_diff_is_empty(
     tmp_path: Path,
     monkeypatch,
@@ -199,6 +264,141 @@ def test_session_log_resolves_opencode_db_transcript_when_session_diff_is_empty(
         ("user", "show transcript please"),
         ("assistant", "here is your transcript"),
     ]
+
+
+def test_session_log_resolves_opencode_db_without_legacy_session_file(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    runtime_root = resolve_project_runtime_root(project_root)
+    runtime_root.mkdir(parents=True, exist_ok=True)
+
+    xdg_data_home = tmp_path / "xdg-data"
+    session_id = "ses_fixture_db_only_12345"
+    _write_opencode_db_session_with_parts(
+        db_path=xdg_data_home / "opencode" / "opencode.db",
+        session_id=session_id,
+        messages=[
+            (
+                "user",
+                {"system": "OpenCode DB setup"},
+                [{"type": "text", "text": "show transcript please"}],
+            ),
+            ("assistant", {}, [{"type": "text", "text": "here is your transcript"}]),
+        ],
+    )
+    monkeypatch.setenv("XDG_DATA_HOME", xdg_data_home.as_posix())
+
+    chat_id = "c1"
+    session_store.start_session(
+        runtime_root,
+        harness="opencode",
+        harness_session_id=session_id,
+        model="gpt-5.3-codex",
+        chat_id=chat_id,
+    )
+    spawn_store.start_spawn(
+        runtime_root,
+        chat_id=chat_id,
+        model="gpt-5.3-codex",
+        agent="coder",
+        harness="opencode",
+        prompt="hello",
+        spawn_id="p1",
+        harness_session_id=session_id,
+        started_at="2026-04-11T00:00:00Z",
+    )
+
+    for ref in ("p1", chat_id, session_id):
+        output = session_log_sync(
+            SessionLogInput(
+                ref=ref,
+                project_root=project_root.as_posix(),
+                full=True,
+            )
+        )
+
+        assert output.session_id == session_id
+        assert output.source == "opencode transcript"
+        assert output.entries[0].role == "system"
+        assert output.entries[0].content == "OpenCode DB setup"
+        assert [(message.role, message.content) for message in output.messages] == [
+            ("user", "show transcript please"),
+            ("assistant", "here is your transcript"),
+        ]
+
+
+def test_session_log_renders_opencode_db_completed_tool_parts(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    runtime_root = resolve_project_runtime_root(project_root)
+    runtime_root.mkdir(parents=True, exist_ok=True)
+
+    xdg_data_home = tmp_path / "xdg-data"
+    session_id = "ses_fixture_db_tool_12345"
+    target_path = "/tmp/opencode-write.txt"
+    _write_opencode_db_session_with_parts(
+        db_path=xdg_data_home / "opencode" / "opencode.db",
+        session_id=session_id,
+        messages=[
+            ("user", {}, [{"type": "text", "text": "write the file"}]),
+            (
+                "assistant",
+                {},
+                [
+                    {"type": "reasoning", "text": "hidden"},
+                    {
+                        "type": "tool",
+                        "tool": "write",
+                        "state": {
+                            "status": "completed",
+                            "input": {"filePath": target_path, "content": "OK\n"},
+                            "output": "Wrote file successfully.",
+                        },
+                    },
+                ],
+            ),
+            ("assistant", {}, [{"type": "text", "text": "File written."}]),
+        ],
+    )
+    monkeypatch.setenv("XDG_DATA_HOME", xdg_data_home.as_posix())
+
+    spawn_store.start_spawn(
+        runtime_root,
+        chat_id="c1",
+        model="gpt-5.3-codex",
+        agent="coder",
+        harness="opencode",
+        prompt="hello",
+        spawn_id="p1",
+        harness_session_id=session_id,
+        started_at="2026-04-11T00:00:00Z",
+    )
+
+    output = session_log_sync(
+        SessionLogInput(
+            ref="p1",
+            project_root=project_root.as_posix(),
+            full=True,
+            truncate=False,
+        )
+    )
+
+    assert [(message.role, message.content) for message in output.messages] == [
+        ("user", "write the file"),
+        ("assistant", f"[tool: write {target_path}]"),
+        ("user", "[tool_result] Wrote file successfully."),
+        ("assistant", "File written."),
+    ]
+    assert output.messages[1].tool_call is not None
+    assert output.messages[1].tool_call.name == "write"
+    assert output.messages[1].tool_call.body == target_path
+    assert output.messages[2].is_tool_result is True
 
 
 def test_session_log_resolves_codex_session_file_from_codex_home_env(

--- a/tests/integration/ops/test_session_log_harness_retrieval.py
+++ b/tests/integration/ops/test_session_log_harness_retrieval.py
@@ -404,6 +404,74 @@ def test_session_log_renders_opencode_db_completed_tool_parts(
     assert output.messages[2].is_tool_result is True
 
 
+def test_session_log_default_render_shows_completed_opencode_task_result(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    runtime_root = resolve_project_runtime_root(project_root)
+    runtime_root.mkdir(parents=True, exist_ok=True)
+
+    xdg_data_home = tmp_path / "xdg-data"
+    session_id = "ses_fixture_db_task_12345"
+    _write_opencode_db_session_with_parts(
+        db_path=xdg_data_home / "opencode" / "opencode.db",
+        session_id=session_id,
+        messages=[
+            ("user", {}, [{"type": "text", "text": "find KB links"}]),
+            (
+                "assistant",
+                {},
+                [
+                    {"type": "text", "text": "Let me now search for contradictions."},
+                    {
+                        "type": "tool",
+                        "tool": "task",
+                        "state": {
+                            "status": "completed",
+                            "input": {"description": "Search code repo for KB links"},
+                            "output": (
+                                '<task id="ses_child" state="completed">\n'
+                                "<task_result>\n"
+                                "Here is the complete report of all matches found.\n"
+                                "</task_result>\n"
+                                "</task>"
+                            ),
+                        },
+                    },
+                ],
+            ),
+        ],
+    )
+    monkeypatch.setenv("XDG_DATA_HOME", xdg_data_home.as_posix())
+
+    spawn_store.start_spawn(
+        runtime_root,
+        chat_id="c1",
+        model="gpt-5.3-codex",
+        agent="coder",
+        harness="opencode",
+        prompt="hello",
+        spawn_id="p1",
+        harness_session_id=session_id,
+        started_at="2026-04-11T00:00:00Z",
+    )
+
+    output = session_log_sync(
+        SessionLogInput(
+            ref="p1",
+            project_root=project_root.as_posix(),
+            from_ordinal=1,
+            limit=1,
+        )
+    )
+    rendered = output.format_text()
+
+    assert "task: Search code repo for KB links" in rendered
+    assert "(completed) Here is the complete report of all matches found." in rendered
+
+
 def test_session_log_renders_opencode_db_compaction_as_segment_handoff(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,

--- a/tests/support/opencode_db.py
+++ b/tests/support/opencode_db.py
@@ -1,0 +1,89 @@
+"""Reusable OpenCode SQLite transcript fixtures for tests."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+OpenCodeDbMessage = tuple[str, dict[str, object], list[dict[str, object]]]
+
+
+def write_opencode_db_session(
+    *,
+    db_path: Path,
+    session_id: str,
+    messages: list[tuple[str, str]],
+) -> None:
+    write_opencode_db_session_with_parts(
+        db_path=db_path,
+        session_id=session_id,
+        messages=[
+            (role, {}, [{"type": "text", "text": text}]) for role, text in messages
+        ],
+    )
+
+
+def write_opencode_db_session_with_parts(
+    *,
+    db_path: Path,
+    session_id: str,
+    messages: list[OpenCodeDbMessage],
+) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as connection:
+        connection.executescript(
+            """
+            CREATE TABLE session (
+                id TEXT PRIMARY KEY,
+                time_created INTEGER NOT NULL,
+                time_updated INTEGER NOT NULL
+            );
+            CREATE TABLE message (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                time_created INTEGER NOT NULL,
+                time_updated INTEGER NOT NULL,
+                data TEXT NOT NULL
+            );
+            CREATE TABLE part (
+                id TEXT PRIMARY KEY,
+                message_id TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                time_created INTEGER NOT NULL,
+                time_updated INTEGER NOT NULL,
+                data TEXT NOT NULL
+            );
+            """
+        )
+        now = 1_778_945_817_030
+        connection.execute(
+            "INSERT INTO session (id, time_created, time_updated) VALUES (?, ?, ?)",
+            (session_id, now, now),
+        )
+        for message_index, (role, message_data, parts) in enumerate(messages):
+            timestamp = now + (message_index * 100)
+            message_id = f"msg_{message_index}"
+            payload = {"role": role, "time": {"created": timestamp}, **message_data}
+            connection.execute(
+                "INSERT INTO message "
+                "(id, session_id, time_created, time_updated, data) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (message_id, session_id, timestamp, timestamp, json.dumps(payload)),
+            )
+            for part_index, part in enumerate(parts):
+                part_timestamp = timestamp + part_index + 1
+                connection.execute(
+                    "INSERT INTO part "
+                    "(id, message_id, session_id, time_created, time_updated, data) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    (
+                        f"prt_{message_index}_{part_index}",
+                        message_id,
+                        session_id,
+                        part_timestamp,
+                        part_timestamp,
+                        json.dumps(part),
+                    ),
+                )
+        connection.commit()

--- a/tests/support/opencode_db.py
+++ b/tests/support/opencode_db.py
@@ -34,19 +34,19 @@ def write_opencode_db_session_with_parts(
     with sqlite3.connect(db_path) as connection:
         connection.executescript(
             """
-            CREATE TABLE session (
+            CREATE TABLE IF NOT EXISTS session (
                 id TEXT PRIMARY KEY,
                 time_created INTEGER NOT NULL,
                 time_updated INTEGER NOT NULL
             );
-            CREATE TABLE message (
+            CREATE TABLE IF NOT EXISTS message (
                 id TEXT PRIMARY KEY,
                 session_id TEXT NOT NULL,
                 time_created INTEGER NOT NULL,
                 time_updated INTEGER NOT NULL,
                 data TEXT NOT NULL
             );
-            CREATE TABLE part (
+            CREATE TABLE IF NOT EXISTS part (
                 id TEXT PRIMARY KEY,
                 message_id TEXT NOT NULL,
                 session_id TEXT NOT NULL,
@@ -58,12 +58,15 @@ def write_opencode_db_session_with_parts(
         )
         now = 1_778_945_817_030
         connection.execute(
-            "INSERT INTO session (id, time_created, time_updated) VALUES (?, ?, ?)",
+            "INSERT OR REPLACE INTO session (id, time_created, time_updated) VALUES (?, ?, ?)",
             (session_id, now, now),
+        )
+        id_prefix = "".join(
+            character if character.isalnum() else "_" for character in session_id
         )
         for message_index, (role, message_data, parts) in enumerate(messages):
             timestamp = now + (message_index * 100)
-            message_id = f"msg_{message_index}"
+            message_id = f"{id_prefix}_msg_{message_index}"
             payload = {"role": role, "time": {"created": timestamp}, **message_data}
             connection.execute(
                 "INSERT INTO message "
@@ -78,7 +81,7 @@ def write_opencode_db_session_with_parts(
                     "(id, message_id, session_id, time_created, time_updated, data) "
                     "VALUES (?, ?, ?, ?, ?, ?)",
                     (
-                        f"prt_{message_index}_{part_index}",
+                        f"{id_prefix}_prt_{message_index}_{part_index}",
                         message_id,
                         session_id,
                         part_timestamp,

--- a/tests/unit/harness/test_codex_thread_termination.py
+++ b/tests/unit/harness/test_codex_thread_termination.py
@@ -8,6 +8,7 @@ from meridian.lib.harness.semantics import (
     CodexDrainThreadTracker,
     activity_transition,
     clears_signal,
+    opencode_primary_event_scope,
     terminal_outcome,
 )
 from meridian.lib.state.artifact_store import LocalStore
@@ -21,6 +22,17 @@ def _codex_event(event_type: str, payload: dict[str, object]) -> HarnessEvent:
         event_type=event_type,
         payload=payload,
         harness_id="codex",
+    )
+
+
+def _opencode_event(event_type: str, session_id: str | None) -> HarnessEvent:
+    properties: dict[str, object] = {}
+    if session_id is not None:
+        properties["sessionID"] = session_id
+    return HarnessEvent(
+        event_type=event_type,
+        payload={"type": event_type, "properties": properties},
+        harness_id="opencode",
     )
 
 
@@ -59,6 +71,34 @@ def test_single_thread_turn_completed_stays_terminal_without_thread_id() -> None
     outcome = terminal_outcome(event)
     assert outcome is not None
     assert outcome.status == "succeeded"
+
+
+def test_opencode_child_session_terminal_events_do_not_complete_parent_scope() -> None:
+    parent_scope = opencode_primary_event_scope("ses_parent")
+    child_idle = _opencode_event("session.idle", "ses_child")
+    child_error = _opencode_event("session.error", "ses_child")
+    parent_idle = _opencode_event("session.idle", "ses_parent")
+
+    assert terminal_outcome(child_idle, primary_event_scope=parent_scope) is None
+    assert terminal_outcome(child_error, primary_event_scope=parent_scope) is None
+    assert clears_signal(child_idle, primary_event_scope=parent_scope) is False
+    assert activity_transition(child_idle, primary_event_scope=parent_scope) is None
+
+    outcome = terminal_outcome(parent_idle, primary_event_scope=parent_scope)
+    assert outcome is not None
+    assert outcome.status == "succeeded"
+    assert clears_signal(parent_idle, primary_event_scope=parent_scope) is True
+    assert activity_transition(parent_idle, primary_event_scope=parent_scope) == "idle"
+
+
+def test_opencode_unscoped_terminal_event_only_counts_without_parent_scope() -> None:
+    unscoped_idle = _opencode_event("session.idle", None)
+
+    assert terminal_outcome(unscoped_idle) is not None
+    assert terminal_outcome(
+        unscoped_idle,
+        primary_event_scope=opencode_primary_event_scope("ses_parent"),
+    ) is None
 
 
 def test_extract_codex_report_uses_main_thread_agent_message(tmp_path: Path) -> None:

--- a/tests/unit/harness/test_codex_thread_termination.py
+++ b/tests/unit/harness/test_codex_thread_termination.py
@@ -5,9 +5,10 @@ from meridian.lib.core.types import ArtifactKey, SpawnId
 from meridian.lib.harness.common import extract_codex_report
 from meridian.lib.harness.connections.base import HarnessEvent
 from meridian.lib.harness.semantics import (
-    CodexDrainThreadTracker,
+    PrimaryEventScopeTracker,
     activity_transition,
     clears_signal,
+    codex_primary_event_scope,
     opencode_primary_event_scope,
     terminal_outcome,
 )
@@ -37,7 +38,7 @@ def _opencode_event(event_type: str, session_id: str | None) -> HarnessEvent:
 
 
 def test_subagent_turn_completed_is_not_terminal_before_main_thread() -> None:
-    tracker = CodexDrainThreadTracker()
+    tracker = PrimaryEventScopeTracker()
     started = _codex_event(
         "turn/started",
         {"threadId": MAIN_THREAD, "turnId": "turn-main"},
@@ -51,19 +52,21 @@ def test_subagent_turn_completed_is_not_terminal_before_main_thread() -> None:
         {"threadId": MAIN_THREAD, "turnId": "turn-main"},
     )
 
+    main_scope = codex_primary_event_scope(MAIN_THREAD)
+
     assert tracker.terminal_outcome(started) is None
-    assert tracker.main_thread_id == MAIN_THREAD
+    assert tracker.primary_event_scope == main_scope
     assert tracker.terminal_outcome(subagent_completed) is None
-    assert terminal_outcome(subagent_completed, codex_main_thread_id=MAIN_THREAD) is None
-    assert clears_signal(subagent_completed, codex_main_thread_id=MAIN_THREAD) is False
-    assert activity_transition(subagent_completed, codex_main_thread_id=MAIN_THREAD) is None
+    assert terminal_outcome(subagent_completed, primary_event_scope=main_scope) is None
+    assert clears_signal(subagent_completed, primary_event_scope=main_scope) is False
+    assert activity_transition(subagent_completed, primary_event_scope=main_scope) is None
 
     outcome = tracker.terminal_outcome(main_completed)
     assert outcome is not None
     assert outcome.status == "succeeded"
     assert outcome.exit_code == 0
-    assert clears_signal(main_completed, codex_main_thread_id=MAIN_THREAD) is True
-    assert activity_transition(main_completed, codex_main_thread_id=MAIN_THREAD) == "idle"
+    assert clears_signal(main_completed, primary_event_scope=main_scope) is True
+    assert activity_transition(main_completed, primary_event_scope=main_scope) == "idle"
 
 
 def test_single_thread_turn_completed_stays_terminal_without_thread_id() -> None:

--- a/tests/unit/harness/test_extract_opencode_report.py
+++ b/tests/unit/harness/test_extract_opencode_report.py
@@ -336,3 +336,109 @@ def test_extract_opencode_report_falls_back_to_opencode_db_session(
     store._payloads[f"{spawn_id}/session_id.txt"] = session_id.encode("utf-8")
 
     assert extract_opencode_report(store, spawn_id) == "LIVE_OK"
+
+
+def test_extract_opencode_report_ignores_opencode_db_compaction_handoff(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    session_id = "ses_fixture_report_db_compaction"
+    spawn_id = SpawnId("p-opencode-db-compaction")
+    storage_root = tmp_path / "opencode" / "storage"
+    session_file = storage_root / "session_diff" / f"{session_id}.json"
+    session_file.parent.mkdir(parents=True, exist_ok=True)
+    session_file.write_text("[]\n", encoding="utf-8")
+
+    db_path = tmp_path / "opencode" / "opencode.db"
+    with sqlite3.connect(db_path) as connection:
+        connection.executescript(
+            """
+            CREATE TABLE message (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                time_created INTEGER NOT NULL,
+                time_updated INTEGER NOT NULL,
+                data TEXT NOT NULL
+            );
+            CREATE TABLE part (
+                id TEXT PRIMARY KEY,
+                message_id TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                time_created INTEGER NOT NULL,
+                time_updated INTEGER NOT NULL,
+                data TEXT NOT NULL
+            );
+            """
+        )
+        connection.execute(
+            "INSERT INTO message "
+            "(id, session_id, time_created, time_updated, data) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("msg_1", session_id, 1, 1, json.dumps({"role": "assistant"})),
+        )
+        connection.execute(
+            "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                "prt_1",
+                "msg_1",
+                session_id,
+                1,
+                1,
+                json.dumps({"type": "text", "text": "FINAL_OK"}),
+            ),
+        )
+        connection.execute(
+            "INSERT INTO message "
+            "(id, session_id, time_created, time_updated, data) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (
+                "msg_2",
+                session_id,
+                2,
+                2,
+                json.dumps(
+                    {
+                        "role": "assistant",
+                        "mode": "compaction",
+                        "agent": "compaction",
+                    }
+                ),
+            ),
+        )
+        connection.execute(
+            "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                "prt_2",
+                "msg_2",
+                session_id,
+                2,
+                2,
+                json.dumps({"type": "text", "text": "handoff only"}),
+            ),
+        )
+        connection.commit()
+
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    assert resolve_opencode_storage_root() == storage_root
+
+    store = _artifact_store_from_history_lines(
+        spawn_id,
+        [
+            {
+                "byte_offset": 0,
+                "event_type": "session.idle",
+                "harness_id": "opencode",
+                "payload": {
+                    "id": "evt_idle",
+                    "type": "session.idle",
+                    "properties": {"sessionID": session_id},
+                },
+                "seq": 1,
+            }
+        ],
+    )
+    store._payloads[f"{spawn_id}/session_id.txt"] = session_id.encode("utf-8")
+
+    assert extract_opencode_report(store, spawn_id) == "FINAL_OK"

--- a/tests/unit/harness/test_extract_opencode_report.py
+++ b/tests/unit/harness/test_extract_opencode_report.py
@@ -237,6 +237,151 @@ def test_extract_opencode_report_reads_assistant_text_from_message_part_updated(
     assert extract_opencode_report(store, spawn_id) == "LIVE_OK"
 
 
+def test_extract_opencode_report_ignores_child_session_assistant_text() -> None:
+    spawn_id = SpawnId("p-opencode-parent-scope")
+    child_message_id = "msg_child_assistant"
+    parent_message_id = "msg_parent_assistant"
+    store = _artifact_store_from_history_lines(
+        spawn_id,
+        [
+            {
+                "event_type": "message.updated",
+                "harness_id": "opencode",
+                "payload": {
+                    "type": "message.updated",
+                    "properties": {
+                        "info": {
+                            "id": "msg_parent_user",
+                            "role": "user",
+                            "sessionID": "ses_parent",
+                            "parts": [{"type": "text", "text": "Parent task"}],
+                        }
+                    },
+                },
+            },
+            {
+                "event_type": "message.updated",
+                "harness_id": "opencode",
+                "payload": {
+                    "type": "message.updated",
+                    "properties": {
+                        "info": {
+                            "id": "msg_child_user",
+                            "role": "user",
+                            "sessionID": "ses_child",
+                            "parts": [{"type": "text", "text": "Child task"}],
+                        }
+                    },
+                },
+            },
+            {
+                "event_type": "message.updated",
+                "harness_id": "opencode",
+                "payload": {
+                    "type": "message.updated",
+                    "properties": {
+                        "info": {
+                            "id": child_message_id,
+                            "role": "assistant",
+                            "sessionID": "ses_child",
+                        }
+                    },
+                },
+            },
+            {
+                "event_type": "message.part.updated",
+                "harness_id": "opencode",
+                "payload": {
+                    "type": "message.part.updated",
+                    "properties": {
+                        "sessionID": "ses_child",
+                        "part": {
+                            "messageID": child_message_id,
+                            "sessionID": "ses_child",
+                            "type": "text",
+                            "text": "Child report must not be parent report.",
+                        },
+                    },
+                },
+            },
+            {
+                "event_type": "message.updated",
+                "harness_id": "opencode",
+                "payload": {
+                    "type": "message.updated",
+                    "properties": {
+                        "info": {
+                            "id": parent_message_id,
+                            "role": "assistant",
+                            "sessionID": "ses_parent",
+                        }
+                    },
+                },
+            },
+            {
+                "event_type": "message.part.updated",
+                "harness_id": "opencode",
+                "payload": {
+                    "type": "message.part.updated",
+                    "properties": {
+                        "sessionID": "ses_parent",
+                        "part": {
+                            "messageID": parent_message_id,
+                            "sessionID": "ses_parent",
+                            "type": "text",
+                            "text": "Parent report.",
+                        },
+                    },
+                },
+            },
+        ],
+    )
+
+    assert extract_opencode_report(store, spawn_id) == "Parent report."
+
+
+def test_extract_opencode_report_returns_none_when_only_child_session_reports() -> None:
+    spawn_id = SpawnId("p-opencode-child-only")
+    child_message_id = "msg_child_assistant"
+    store = _artifact_store_from_history_lines(
+        spawn_id,
+        [
+            {
+                "event_type": "message.updated",
+                "harness_id": "opencode",
+                "payload": {
+                    "type": "message.updated",
+                    "properties": {
+                        "info": {
+                            "id": "msg_parent_user",
+                            "role": "user",
+                            "sessionID": "ses_parent",
+                            "parts": [{"type": "text", "text": "Parent task"}],
+                        }
+                    },
+                },
+            },
+            {
+                "event_type": "message.updated",
+                "harness_id": "opencode",
+                "payload": {
+                    "type": "message.updated",
+                    "properties": {
+                        "info": {
+                            "id": child_message_id,
+                            "role": "assistant",
+                            "sessionID": "ses_child",
+                            "parts": [{"type": "text", "text": "Child finished."}],
+                        }
+                    },
+                },
+            },
+        ],
+    )
+
+    assert extract_opencode_report(store, spawn_id) is None
+
+
 def test_extract_or_fallback_report_never_returns_session_idle_envelope() -> None:
     spawn_id = SpawnId("p-opencode-fallback-idle")
     store = _artifact_store_from_history_lines(

--- a/tests/unit/harness/test_extract_opencode_report.py
+++ b/tests/unit/harness/test_extract_opencode_report.py
@@ -7,8 +7,8 @@ import sqlite3
 from pathlib import Path
 
 from meridian.lib.core.types import ArtifactKey, SpawnId
-from meridian.lib.harness.common import extract_opencode_report
 from meridian.lib.harness.extractors.opencode import OPENCODE_EXTRACTOR
+from meridian.lib.harness.opencode_report import extract_opencode_report
 from meridian.lib.harness.opencode_storage import resolve_opencode_storage_root
 from meridian.lib.launch.constants import HISTORY_FILENAME
 from meridian.lib.launch.report import extract_or_fallback_report

--- a/tests/unit/harness/test_extract_opencode_report.py
+++ b/tests/unit/harness/test_extract_opencode_report.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import sqlite3
 from pathlib import Path
 
 from meridian.lib.core.types import ArtifactKey, SpawnId
@@ -12,6 +11,7 @@ from meridian.lib.harness.opencode_report import extract_opencode_report
 from meridian.lib.harness.opencode_storage import resolve_opencode_storage_root
 from meridian.lib.launch.constants import HISTORY_FILENAME
 from meridian.lib.launch.report import extract_or_fallback_report
+from tests.support.opencode_db import write_opencode_db_session_with_parts
 
 
 class _MemoryArtifactStore:
@@ -418,47 +418,13 @@ def test_extract_opencode_report_falls_back_to_opencode_db_session(
     session_file.parent.mkdir(parents=True, exist_ok=True)
     session_file.write_text("[]\n", encoding="utf-8")
 
-    db_path = tmp_path / "opencode" / "opencode.db"
-    with sqlite3.connect(db_path) as connection:
-        connection.executescript(
-            """
-            CREATE TABLE message (
-                id TEXT PRIMARY KEY,
-                session_id TEXT NOT NULL,
-                time_created INTEGER NOT NULL,
-                time_updated INTEGER NOT NULL,
-                data TEXT NOT NULL
-            );
-            CREATE TABLE part (
-                id TEXT PRIMARY KEY,
-                message_id TEXT NOT NULL,
-                session_id TEXT NOT NULL,
-                time_created INTEGER NOT NULL,
-                time_updated INTEGER NOT NULL,
-                data TEXT NOT NULL
-            );
-            """
-        )
-        connection.execute(
-            "INSERT INTO message "
-            "(id, session_id, time_created, time_updated, data) "
-            "VALUES (?, ?, ?, ?, ?)",
-            ("msg_1", session_id, 1, 1, json.dumps({"role": "assistant"})),
-        )
-        connection.execute(
-            "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
-            (
-                "prt_1",
-                "msg_1",
-                session_id,
-                1,
-                1,
-                json.dumps({"type": "text", "text": "LIVE_OK"}),
-            ),
-        )
-        connection.commit()
-
+    write_opencode_db_session_with_parts(
+        db_path=tmp_path / "opencode" / "opencode.db",
+        session_id=session_id,
+        messages=[
+            ("assistant", {}, [{"type": "text", "text": "LIVE_OK"}]),
+        ],
+    )
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
     assert resolve_opencode_storage_root() == storage_root
 
@@ -494,77 +460,18 @@ def test_extract_opencode_report_ignores_opencode_db_compaction_handoff(
     session_file.parent.mkdir(parents=True, exist_ok=True)
     session_file.write_text("[]\n", encoding="utf-8")
 
-    db_path = tmp_path / "opencode" / "opencode.db"
-    with sqlite3.connect(db_path) as connection:
-        connection.executescript(
-            """
-            CREATE TABLE message (
-                id TEXT PRIMARY KEY,
-                session_id TEXT NOT NULL,
-                time_created INTEGER NOT NULL,
-                time_updated INTEGER NOT NULL,
-                data TEXT NOT NULL
-            );
-            CREATE TABLE part (
-                id TEXT PRIMARY KEY,
-                message_id TEXT NOT NULL,
-                session_id TEXT NOT NULL,
-                time_created INTEGER NOT NULL,
-                time_updated INTEGER NOT NULL,
-                data TEXT NOT NULL
-            );
-            """
-        )
-        connection.execute(
-            "INSERT INTO message "
-            "(id, session_id, time_created, time_updated, data) "
-            "VALUES (?, ?, ?, ?, ?)",
-            ("msg_1", session_id, 1, 1, json.dumps({"role": "assistant"})),
-        )
-        connection.execute(
-            "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
+    write_opencode_db_session_with_parts(
+        db_path=tmp_path / "opencode" / "opencode.db",
+        session_id=session_id,
+        messages=[
+            ("assistant", {}, [{"type": "text", "text": "FINAL_OK"}]),
             (
-                "prt_1",
-                "msg_1",
-                session_id,
-                1,
-                1,
-                json.dumps({"type": "text", "text": "FINAL_OK"}),
+                "assistant",
+                {"mode": "compaction", "agent": "compaction"},
+                [{"type": "text", "text": "handoff only"}],
             ),
-        )
-        connection.execute(
-            "INSERT INTO message "
-            "(id, session_id, time_created, time_updated, data) "
-            "VALUES (?, ?, ?, ?, ?)",
-            (
-                "msg_2",
-                session_id,
-                2,
-                2,
-                json.dumps(
-                    {
-                        "role": "assistant",
-                        "mode": "compaction",
-                        "agent": "compaction",
-                    }
-                ),
-            ),
-        )
-        connection.execute(
-            "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
-            (
-                "prt_2",
-                "msg_2",
-                session_id,
-                2,
-                2,
-                json.dumps({"type": "text", "text": "handoff only"}),
-            ),
-        )
-        connection.commit()
-
+        ],
+    )
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
     assert resolve_opencode_storage_root() == storage_root
 

--- a/tests/unit/harness/test_extract_opencode_report.py
+++ b/tests/unit/harness/test_extract_opencode_report.py
@@ -337,6 +337,79 @@ def test_extract_opencode_report_ignores_child_session_assistant_text() -> None:
         ],
     )
 
+    assert OPENCODE_EXTRACTOR.extract_session_id(store, spawn_id) == "ses_parent"
+    assert extract_opencode_report(store, spawn_id) == "Parent report."
+
+
+
+def test_extract_opencode_report_uses_terminal_parent_scope_without_artifact() -> None:
+    spawn_id = SpawnId("p-opencode-terminal-scope")
+    child_message_id = "msg_child_assistant"
+    parent_message_id = "msg_parent_assistant"
+    store = _artifact_store_from_history_lines(
+        spawn_id,
+        [
+            {
+                "event_type": "message.updated",
+                "payload": {
+                    "type": "message.updated",
+                    "properties": {
+                        "info": {
+                            "id": child_message_id,
+                            "role": "assistant",
+                            "sessionID": "ses_child",
+                        }
+                    },
+                },
+            },
+            {
+                "event_type": "message.part.updated",
+                "payload": {
+                    "type": "message.part.updated",
+                    "properties": {
+                        "part": {
+                            "type": "text",
+                            "messageID": child_message_id,
+                            "sessionID": "ses_child",
+                            "text": "Child report.",
+                        }
+                    },
+                },
+            },
+            {
+                "event_type": "message.updated",
+                "payload": {
+                    "type": "message.updated",
+                    "properties": {
+                        "info": {
+                            "id": parent_message_id,
+                            "role": "assistant",
+                            "sessionID": "ses_parent",
+                        }
+                    },
+                },
+            },
+            {
+                "event_type": "message.part.updated",
+                "payload": {
+                    "type": "message.part.updated",
+                    "properties": {
+                        "part": {
+                            "type": "text",
+                            "messageID": parent_message_id,
+                            "sessionID": "ses_parent",
+                            "text": "Parent report.",
+                        }
+                    },
+                },
+            },
+            {
+                "event_type": "session.idle",
+                "payload": {"type": "session.idle", "properties": {"sessionID": "ses_parent"}},
+            },
+        ],
+    )
+
     assert extract_opencode_report(store, spawn_id) == "Parent report."
 
 
@@ -447,6 +520,42 @@ def test_extract_opencode_report_falls_back_to_opencode_db_session(
     store._payloads[f"{spawn_id}/session_id.txt"] = session_id.encode("utf-8")
 
     assert extract_opencode_report(store, spawn_id) == "LIVE_OK"
+
+
+
+def test_extract_opencode_report_reads_opencode_db_without_legacy_session_file(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    session_id = "ses_fixture_report_db_only"
+    spawn_id = SpawnId("p-opencode-db-only")
+    storage_root = tmp_path / "opencode" / "storage"
+    write_opencode_db_session_with_parts(
+        db_path=tmp_path / "opencode" / "opencode.db",
+        session_id=session_id,
+        messages=[
+            ("assistant", {}, [{"type": "text", "text": "DB_ONLY_OK"}]),
+        ],
+    )
+
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    assert resolve_opencode_storage_root() == storage_root
+
+    store = _artifact_store_from_history_lines(
+        spawn_id,
+        [
+            {
+                "event_type": "session.idle",
+                "harness_id": "opencode",
+                "payload": {
+                    "type": "session.idle",
+                    "properties": {"sessionID": session_id},
+                },
+            }
+        ],
+    )
+
+    assert extract_opencode_report(store, spawn_id) == "DB_ONLY_OK"
 
 
 def test_extract_opencode_report_ignores_opencode_db_compaction_handoff(

--- a/tests/unit/ops/test_session_log_render.py
+++ b/tests/unit/ops/test_session_log_render.py
@@ -60,6 +60,15 @@ def _tool_result(msg_idx: int, content: str) -> SessionLogEntryMessage:
     )
 
 
+def _task_call(msg_idx: int, description: str) -> SessionLogEntryMessage:
+    return SessionLogEntryMessage(
+        segment_message=msg_idx,
+        role="assistant",
+        content=f"[tool: task {description}]",
+        tool_call=ToolCall(name="task", body=description),
+    )
+
+
 def test_clean_content_strips_known_wrappers() -> None:
     cleaned = clean_content(
         "<local-command-caveat>meta</local-command-caveat>"
@@ -150,6 +159,29 @@ def test_codex_exec_command_failed() -> None:
     )
     rendered = _output(entries=(entry,)).format_text()
     assert "(failed: exit 1)" in rendered
+
+
+def test_completed_task_call_shows_collapsed_result_preview() -> None:
+    entry = _entry(
+        index=1,
+        role="mixed",
+        messages=(
+            _task_call(1, "Search code repo for KB links"),
+            _tool_result(
+                2,
+                '<task id="ses_child" state="completed">\n'
+                "<task_result>\n"
+                "Here is the complete report of all matches found.\n"
+                "</task_result>\n"
+                "</task>",
+            ),
+        ),
+    )
+
+    rendered = _output(entries=(entry,)).format_text()
+
+    assert "  task: Search code repo for KB links" in rendered
+    assert "  (completed) Here is the complete report of all matches found." in rendered
 
 
 def test_orphan_tool_call() -> None:

--- a/tests/unit/ops/test_session_transcript_command_rendering.py
+++ b/tests/unit/ops/test_session_transcript_command_rendering.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import cast
 
 from meridian.lib.core import command_strings
-from meridian.lib.ops.session_target import SessionLogTarget
+from meridian.lib.ops.session_target import SessionLogTarget, TranscriptSource
 from meridian.lib.ops.session_transcript import (
     SessionLogRoute,
     build_session_log_command,
@@ -62,11 +62,21 @@ def test_route_for_corpus_target_uses_native_path_string() -> None:
         def as_posix(self) -> str:
             return "C:/Users/Jane Doe/logs/session&(1).jsonl"
 
+    file_path = cast("Path", _WindowsLikePath())
     target = SessionLogTarget(
         session_id="session-1",
         harness="codex",
-        file_path=cast("Path", _WindowsLikePath()),
+        file_path=file_path,
         source="codex transcript",
+        sources=(
+            TranscriptSource(
+                kind="file",
+                session_id="session-1",
+                harness="codex",
+                path=file_path,
+                source_label="codex transcript",
+            ),
+        ),
     )
 
     route = route_for_corpus_target(target)

--- a/tests/unit/streaming/resident_drain_test_helpers.py
+++ b/tests/unit/streaming/resident_drain_test_helpers.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+from meridian.lib.core.types import HarnessId, SpawnId
+from meridian.lib.harness.connections.base import (
+    ConnectionCapabilities,
+    ConnectionConfig,
+    ConnectionState,
+    HarnessConnection,
+    HarnessEvent,
+    StopProgressCallback,
+    StopResult,
+)
+from meridian.lib.harness.connections.liveness import LivenessDecision
+from meridian.lib.harness.connections.resident_backend import ResidentBackendControl
+from meridian.lib.harness.semantics import (
+    PrimaryEventScope,
+    TerminalEventOutcome,
+    opencode_primary_event_scope,
+)
+from meridian.lib.launch.launch_types import ResolvedLaunchSpec
+from meridian.lib.safety.permissions import UnsafeNoOpPermissionResolver
+from meridian.lib.state import spawn_store
+from meridian.lib.streaming.drain_policy import TURN_BOUNDARY_EVENT_TYPE, DrainPolicy
+from meridian.lib.streaming.resident_drain import ResidentDrainCoordinator
+from meridian.lib.streaming.spawn_manager import SpawnManager
+from tests.support.fakes import FakeClock
+from tests.unit.streaming.pi_quiescence_test_helpers import NoopControlServer
+
+
+class FakeResidentBackendControl:
+    def __init__(self) -> None:
+        self.awaiting_done_values: list[bool] = []
+        self.status: LivenessDecision = LivenessDecision.CONTINUE
+        self.injected_messages: list[str] = []
+        self.fail_inject: bool = False
+
+    def health_status(self) -> LivenessDecision:
+        return self.status
+
+    def set_awaiting_done(self, awaiting: bool) -> None:
+        self.awaiting_done_values.append(awaiting)
+
+    async def begin_followup_turn(self, message: str) -> None:
+        if self.fail_inject:
+            raise RuntimeError("inject failed")
+        self.injected_messages.append(message)
+
+
+class FakeResidentConnection(HarnessConnection[ResolvedLaunchSpec]):
+    def __init__(self, harness_id: HarnessId) -> None:
+        self._harness_id = harness_id
+        self._spawn_id = SpawnId("")
+        self._state: ConnectionState = "created"
+        self.resident_events: asyncio.Queue[HarnessEvent | None] = asyncio.Queue()
+        self._resident_backend = FakeResidentBackendControl()
+        self.stop_reasons: list[str | None] = []
+
+    @property
+    def state(self) -> ConnectionState:
+        return self._state
+
+    @property
+    def harness_id(self) -> HarnessId:
+        return self._harness_id
+
+    @property
+    def spawn_id(self) -> SpawnId:
+        return self._spawn_id
+
+    @property
+    def capabilities(self) -> ConnectionCapabilities:
+        return ConnectionCapabilities(
+            mid_turn_injection="queue",
+            supports_steer=True,
+            supports_cancel=True,
+            runtime_model_switch=False,
+            structured_reasoning=True,
+        )
+
+    @property
+    def session_id(self) -> str | None:
+        return "ses-resident"
+
+    @property
+    def primary_event_scope(self) -> PrimaryEventScope | None:
+        if self._harness_id is HarnessId.OPENCODE:
+            return opencode_primary_event_scope(self.session_id)
+        return None
+
+    @property
+    def subprocess_pid(self) -> int | None:
+        return 4242
+
+    @property
+    def fake_resident_backend(self) -> FakeResidentBackendControl:
+        return self._resident_backend
+
+    @property
+    def resident_backend(self) -> ResidentBackendControl:
+        return self._resident_backend
+
+    async def start(self, config: ConnectionConfig, spec: ResolvedLaunchSpec) -> None:
+        _ = spec
+        self._spawn_id = config.spawn_id
+        self._state = "connected"
+
+    async def stop(
+        self,
+        *,
+        reason: str | None = None,
+        progress: StopProgressCallback | None = None,
+    ) -> StopResult:
+        _ = progress
+        self.stop_reasons.append(reason)
+        self._state = "stopped"
+        return StopResult()
+
+    def health(self) -> bool:
+        return self._state == "connected"
+
+    async def send_user_message(self, text: str) -> None:
+        _ = text
+
+    async def send_cancel(self) -> None:
+        return None
+
+    async def events(self) -> AsyncIterator[HarnessEvent]:
+        while True:
+            event = await self.resident_events.get()
+            if event is None:
+                return
+            yield event
+
+    def emit(self, event: HarnessEvent) -> None:
+        self.resident_events.put_nowait(event)
+
+    def close_stream(self) -> None:
+        self.resident_events.put_nowait(None)
+
+    def mark_failed(self) -> None:
+        self._state = "failed"
+        self._resident_backend.status = LivenessDecision.BACKEND_DEAD
+
+    def mark_stalled(self) -> None:
+        self._resident_backend.status = LivenessDecision.STREAM_STALLED
+
+
+def awaiting_done_coordinator(
+    tmp_path: Path,
+    connection: HarnessConnection[Any],
+) -> ResidentDrainCoordinator:
+    resident_backend = connection.resident_backend
+    assert resident_backend is not None
+    coordinator = ResidentDrainCoordinator.for_connection(
+        project_root=tmp_path,
+        runtime_root=tmp_path,
+        spawn_id=SpawnId("p1"),
+        receiver=connection,
+        resident_backend=resident_backend,
+        deadline_seconds=30.0,
+        poll_seconds=0.01,
+    )
+    coordinator.pending_outcome = TerminalEventOutcome(status="succeeded", exit_code=0)
+    coordinator.deadline_monotonic = time.monotonic() + coordinator.deadline_seconds
+    return coordinator
+
+
+def resident_event(
+    harness_id: HarnessId,
+    event_type: str,
+    payload: dict[str, object],
+) -> HarnessEvent:
+    if harness_id is HarnessId.OPENCODE and "properties" not in payload:
+        payload = {
+            **payload,
+            "type": event_type,
+            "properties": {"sessionID": "ses-resident"},
+        }
+    return HarnessEvent(event_type=event_type, harness_id=harness_id.value, payload=payload)
+
+
+async def next_turn_boundary(
+    subscriber: asyncio.Queue[HarnessEvent | None],
+) -> HarnessEvent:
+    while True:
+        event = await asyncio.wait_for(subscriber.get(), timeout=0.5)
+        assert event is not None
+        if event.event_type == TURN_BOUNDARY_EVENT_TYPE:
+            return event
+
+
+def start_row(
+    runtime_root: Path,
+    spawn_id: str,
+    harness: HarnessId,
+    parent_id: str | None,
+) -> None:
+    spawn_store.start_spawn(
+        runtime_root,
+        spawn_id=SpawnId(spawn_id),
+        chat_id=spawn_id,
+        parent_id=parent_id,
+        model="test-model",
+        agent="test-agent",
+        harness=harness.value,
+        prompt="hello",
+        status="running",
+    )
+
+
+async def start_manager(
+    tmp_path: Path,
+    connection: FakeResidentConnection,
+    *,
+    spawn_id: SpawnId,
+    project_root: Path | None = None,
+    resident_deadline_seconds: float = 30.0,
+    resident_poll_seconds: float = 0.01,
+    drain_policy: DrainPolicy | None = None,
+) -> SpawnManager:
+    async def _start_connection(
+        config: ConnectionConfig,
+        spec: ResolvedLaunchSpec,
+    ) -> HarnessConnection[Any]:
+        await connection.start(config, spec)
+        return connection
+
+    manager = SpawnManager(
+        runtime_root=tmp_path,
+        project_root=project_root or tmp_path,
+        start_connection=_start_connection,
+        control_server_factory=lambda _spawn_id, _socket_path, _manager: NoopControlServer(),
+    )
+    await manager.start_spawn(
+        ConnectionConfig(
+            spawn_id=spawn_id,
+            harness_id=connection.harness_id,
+            prompt="hello",
+            control_root=tmp_path,
+            env_overrides={},
+            resident_deadline_seconds=resident_deadline_seconds,
+            resident_poll_seconds=resident_poll_seconds,
+        ),
+        ResolvedLaunchSpec(
+            harness=connection.harness_id.value,
+            prompt="hello",
+            permission_resolver=UnsafeNoOpPermissionResolver(_suppress_warning=True),
+        ),
+        drain_policy=drain_policy,
+    )
+    return manager
+
+
+def coordinator_with_clock(
+    tmp_path: Path,
+    connection: FakeResidentConnection,
+    clock: FakeClock,
+    *,
+    deadline_seconds: float = 3300.0,
+    poll_seconds: float = 5.0,
+) -> ResidentDrainCoordinator:
+    coordinator = ResidentDrainCoordinator.for_connection(
+        project_root=tmp_path,
+        runtime_root=tmp_path,
+        spawn_id=SpawnId("p1"),
+        receiver=connection,
+        resident_backend=connection.resident_backend,
+        deadline_seconds=deadline_seconds,
+        poll_seconds=poll_seconds,
+    )
+    coordinator.pending_outcome = TerminalEventOutcome(status="succeeded", exit_code=0)
+    coordinator.deadline_monotonic = clock.monotonic() + deadline_seconds
+    coordinator._set_awaiting_done(True)
+    return coordinator
+

--- a/tests/unit/streaming/test_resident_drain.py
+++ b/tests/unit/streaming/test_resident_drain.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-import time
-from collections.abc import AsyncIterator
 from pathlib import Path
-from typing import Any
 
 import pytest
 
@@ -13,258 +10,22 @@ from meridian.lib.bootstrap.services import prepare_for_runtime_write
 from meridian.lib.core.context import RuntimeContext
 from meridian.lib.core.types import HarnessId, SpawnId
 from meridian.lib.harness.common import extract_codex_report
-from meridian.lib.harness.connections.base import (
-    ConnectionCapabilities,
-    ConnectionConfig,
-    ConnectionState,
-    HarnessConnection,
-    HarnessEvent,
-    StopProgressCallback,
-    StopResult,
-)
-from meridian.lib.harness.connections.liveness import LivenessDecision
-from meridian.lib.harness.connections.resident_backend import (
-    ResidentBackendControl,
-)
-from meridian.lib.harness.semantics import (
-    PrimaryEventScope,
-    TerminalEventOutcome,
-    opencode_primary_event_scope,
-)
-from meridian.lib.launch.launch_types import ResolvedLaunchSpec
 from meridian.lib.ops.spawn.models import SpawnSignalInput
-from meridian.lib.safety.permissions import UnsafeNoOpPermissionResolver
 from meridian.lib.state import spawn_store
 from meridian.lib.state.artifact_store import LocalStore
 from meridian.lib.streaming.drain_policy import (
-    TURN_BOUNDARY_EVENT_TYPE,
-    DrainPolicy,
     PersistentDrainPolicy,
 )
-from meridian.lib.streaming.resident_drain import ResidentDrainCoordinator
-from meridian.lib.streaming.spawn_manager import SpawnManager
 from tests.support.fakes import FakeClock
-from tests.unit.streaming.pi_quiescence_test_helpers import NoopControlServer
-
-
-class _FakeResidentBackendControl:
-    def __init__(self) -> None:
-        self.awaiting_done_values: list[bool] = []
-        self.status: LivenessDecision = LivenessDecision.CONTINUE
-        self.injected_messages: list[str] = []
-        self.fail_inject: bool = False
-
-    def health_status(self) -> LivenessDecision:
-        return self.status
-
-    def set_awaiting_done(self, awaiting: bool) -> None:
-        self.awaiting_done_values.append(awaiting)
-
-    async def begin_followup_turn(self, message: str) -> None:
-        if self.fail_inject:
-            raise RuntimeError("inject failed")
-        self.injected_messages.append(message)
-
-
-class _FakeResidentConnection(HarnessConnection[ResolvedLaunchSpec]):
-    def __init__(self, harness_id: HarnessId) -> None:
-        self._harness_id = harness_id
-        self._spawn_id = SpawnId("")
-        self._state: ConnectionState = "created"
-        self._events: asyncio.Queue[HarnessEvent | None] = asyncio.Queue()
-        self._resident_backend = _FakeResidentBackendControl()
-        self.stop_reasons: list[str | None] = []
-
-    @property
-    def state(self) -> ConnectionState:
-        return self._state
-
-    @property
-    def harness_id(self) -> HarnessId:
-        return self._harness_id
-
-    @property
-    def spawn_id(self) -> SpawnId:
-        return self._spawn_id
-
-    @property
-    def capabilities(self) -> ConnectionCapabilities:
-        return ConnectionCapabilities(
-            mid_turn_injection="queue",
-            supports_steer=True,
-            supports_cancel=True,
-            runtime_model_switch=False,
-            structured_reasoning=True,
-        )
-
-    @property
-    def session_id(self) -> str | None:
-        return "ses-resident"
-
-    @property
-    def primary_event_scope(self) -> PrimaryEventScope | None:
-        if self._harness_id is HarnessId.OPENCODE:
-            return opencode_primary_event_scope(self.session_id)
-        return None
-
-    @property
-    def subprocess_pid(self) -> int | None:
-        return 4242
-
-    @property
-    def fake_resident_backend(self) -> _FakeResidentBackendControl:
-        return self._resident_backend
-
-    @property
-    def resident_backend(self) -> ResidentBackendControl:
-        return self._resident_backend
-
-    async def start(self, config: ConnectionConfig, spec: ResolvedLaunchSpec) -> None:
-        _ = spec
-        self._spawn_id = config.spawn_id
-        self._state = "connected"
-
-    async def stop(
-        self,
-        *,
-        reason: str | None = None,
-        progress: StopProgressCallback | None = None,
-    ) -> StopResult:
-        _ = progress
-        self.stop_reasons.append(reason)
-        self._state = "stopped"
-        return StopResult()
-
-    def health(self) -> bool:
-        return self._state == "connected"
-
-    async def send_user_message(self, text: str) -> None:
-        _ = text
-
-    async def send_cancel(self) -> None:
-        return None
-
-    async def events(self) -> AsyncIterator[HarnessEvent]:
-        while True:
-            event = await self._events.get()
-            if event is None:
-                return
-            yield event
-
-    def emit(self, event: HarnessEvent) -> None:
-        self._events.put_nowait(event)
-
-    def close_stream(self) -> None:
-        self._events.put_nowait(None)
-
-    def mark_failed(self) -> None:
-        self._state = "failed"
-        self._resident_backend.status = LivenessDecision.BACKEND_DEAD
-
-    def mark_stalled(self) -> None:
-        self._resident_backend.status = LivenessDecision.STREAM_STALLED
-
-
-def _awaiting_done_coordinator(
-    tmp_path: Path,
-    connection: HarnessConnection[Any],
-) -> ResidentDrainCoordinator:
-    resident_backend = connection.resident_backend
-    assert resident_backend is not None
-    coordinator = ResidentDrainCoordinator.for_connection(
-        project_root=tmp_path,
-        runtime_root=tmp_path,
-        spawn_id=SpawnId("p1"),
-        receiver=connection,
-        resident_backend=resident_backend,
-        deadline_seconds=30.0,
-        poll_seconds=0.01,
-    )
-    coordinator.pending_outcome = TerminalEventOutcome(status="succeeded", exit_code=0)
-    coordinator.deadline_monotonic = time.monotonic() + coordinator.deadline_seconds
-    return coordinator
-
-
-def _event(harness_id: HarnessId, event_type: str, payload: dict[str, object]) -> HarnessEvent:
-    if harness_id is HarnessId.OPENCODE and "properties" not in payload:
-        payload = {
-            **payload,
-            "type": event_type,
-            "properties": {"sessionID": "ses-resident"},
-        }
-    return HarnessEvent(event_type=event_type, harness_id=harness_id.value, payload=payload)
-
-
-async def _next_turn_boundary(
-    subscriber: asyncio.Queue[HarnessEvent | None],
-) -> HarnessEvent:
-    while True:
-        event = await asyncio.wait_for(subscriber.get(), timeout=0.5)
-        assert event is not None
-        if event.event_type == TURN_BOUNDARY_EVENT_TYPE:
-            return event
-
-
-def _start_row(
-    runtime_root: Path,
-    spawn_id: str,
-    harness: HarnessId,
-    parent_id: str | None,
-) -> None:
-    spawn_store.start_spawn(
-        runtime_root,
-        spawn_id=SpawnId(spawn_id),
-        chat_id=spawn_id,
-        parent_id=parent_id,
-        model="test-model",
-        agent="test-agent",
-        harness=harness.value,
-        prompt="hello",
-        status="running",
-    )
-
-
-async def _start_manager(
-    tmp_path: Path,
-    connection: _FakeResidentConnection,
-    *,
-    spawn_id: SpawnId,
-    project_root: Path | None = None,
-    resident_deadline_seconds: float = 30.0,
-    resident_poll_seconds: float = 0.01,
-    drain_policy: DrainPolicy | None = None,
-) -> SpawnManager:
-    async def _start_connection(
-        config: ConnectionConfig,
-        spec: ResolvedLaunchSpec,
-    ) -> HarnessConnection[Any]:
-        await connection.start(config, spec)
-        return connection
-
-    manager = SpawnManager(
-        runtime_root=tmp_path,
-        project_root=project_root or tmp_path,
-        start_connection=_start_connection,
-        control_server_factory=lambda _spawn_id, _socket_path, _manager: NoopControlServer(),
-    )
-    await manager.start_spawn(
-        ConnectionConfig(
-            spawn_id=spawn_id,
-            harness_id=connection.harness_id,
-            prompt="hello",
-            control_root=tmp_path,
-            env_overrides={},
-            resident_deadline_seconds=resident_deadline_seconds,
-            resident_poll_seconds=resident_poll_seconds,
-        ),
-        ResolvedLaunchSpec(
-            harness=connection.harness_id.value,
-            prompt="hello",
-            permission_resolver=UnsafeNoOpPermissionResolver(_suppress_warning=True),
-        ),
-        drain_policy=drain_policy,
-    )
-    return manager
+from tests.unit.streaming.resident_drain_test_helpers import (
+    FakeResidentConnection,
+    awaiting_done_coordinator,
+    coordinator_with_clock,
+    next_turn_boundary,
+    resident_event,
+    start_manager,
+    start_row,
+)
 
 
 @pytest.mark.asyncio
@@ -272,11 +33,11 @@ async def test_codex_terminal_success_without_live_children_finalizes_immediatel
     tmp_path: Path,
 ) -> None:
     spawn_id = SpawnId("p1")
-    _start_row(tmp_path, str(spawn_id), HarnessId.CODEX, None)
-    connection = _FakeResidentConnection(HarnessId.CODEX)
-    manager = await _start_manager(tmp_path, connection, spawn_id=spawn_id)
+    start_row(tmp_path, str(spawn_id), HarnessId.CODEX, None)
+    connection = FakeResidentConnection(HarnessId.CODEX)
+    manager = await start_manager(tmp_path, connection, spawn_id=spawn_id)
 
-    connection.emit(_event(HarnessId.CODEX, "turn/completed", {}))
+    connection.emit(resident_event(HarnessId.CODEX, "turn/completed", {}))
 
     try:
         outcome = await asyncio.wait_for(manager.wait_for_completion(spawn_id), timeout=0.5)
@@ -292,11 +53,11 @@ async def test_opencode_terminal_success_without_live_children_finalizes_immedia
     tmp_path: Path,
 ) -> None:
     spawn_id = SpawnId("p1")
-    _start_row(tmp_path, str(spawn_id), HarnessId.OPENCODE, None)
-    connection = _FakeResidentConnection(HarnessId.OPENCODE)
-    manager = await _start_manager(tmp_path, connection, spawn_id=spawn_id)
+    start_row(tmp_path, str(spawn_id), HarnessId.OPENCODE, None)
+    connection = FakeResidentConnection(HarnessId.OPENCODE)
+    manager = await start_manager(tmp_path, connection, spawn_id=spawn_id)
 
-    connection.emit(_event(HarnessId.OPENCODE, "session.idle", {}))
+    connection.emit(resident_event(HarnessId.OPENCODE, "session.idle", {}))
 
     try:
         outcome = await asyncio.wait_for(manager.wait_for_completion(spawn_id), timeout=0.5)
@@ -312,13 +73,13 @@ async def test_opencode_child_session_idle_does_not_finalize_parent(
     tmp_path: Path,
 ) -> None:
     spawn_id = SpawnId("p1")
-    _start_row(tmp_path, str(spawn_id), HarnessId.OPENCODE, None)
-    connection = _FakeResidentConnection(HarnessId.OPENCODE)
-    manager = await _start_manager(tmp_path, connection, spawn_id=spawn_id)
+    start_row(tmp_path, str(spawn_id), HarnessId.OPENCODE, None)
+    connection = FakeResidentConnection(HarnessId.OPENCODE)
+    manager = await start_manager(tmp_path, connection, spawn_id=spawn_id)
     subscriber = manager.subscribe(spawn_id)
     assert subscriber is not None
 
-    child_idle = _event(
+    child_idle = resident_event(
         HarnessId.OPENCODE,
         "session.idle",
         {"type": "session.idle", "properties": {"sessionID": "ses-child"}},
@@ -335,7 +96,7 @@ async def test_opencode_child_session_idle_does_not_finalize_parent(
             )
 
         connection.emit(
-            _event(
+            resident_event(
                 HarnessId.OPENCODE,
                 "session.idle",
                 {"type": "session.idle", "properties": {"sessionID": "ses-resident"}},
@@ -353,12 +114,12 @@ async def test_opencode_child_session_error_does_not_fail_parent(
     tmp_path: Path,
 ) -> None:
     spawn_id = SpawnId("p1")
-    _start_row(tmp_path, str(spawn_id), HarnessId.OPENCODE, None)
-    connection = _FakeResidentConnection(HarnessId.OPENCODE)
-    manager = await _start_manager(tmp_path, connection, spawn_id=spawn_id)
+    start_row(tmp_path, str(spawn_id), HarnessId.OPENCODE, None)
+    connection = FakeResidentConnection(HarnessId.OPENCODE)
+    manager = await start_manager(tmp_path, connection, spawn_id=spawn_id)
 
     connection.emit(
-        _event(
+        resident_event(
             HarnessId.OPENCODE,
             "session.error",
             {"type": "session.error", "properties": {"sessionID": "ses-child"}},
@@ -373,7 +134,7 @@ async def test_opencode_child_session_error_does_not_fail_parent(
             )
 
         connection.emit(
-            _event(
+            resident_event(
                 HarnessId.OPENCODE,
                 "session.idle",
                 {"type": "session.idle", "properties": {"sessionID": "ses-resident"}},
@@ -400,9 +161,9 @@ async def test_resident_persistent_policy_emits_boundary_and_stays_alive(
     event_type: str,
 ) -> None:
     spawn_id = SpawnId("p1")
-    _start_row(tmp_path, str(spawn_id), harness_id, None)
-    connection = _FakeResidentConnection(harness_id)
-    manager = await _start_manager(
+    start_row(tmp_path, str(spawn_id), harness_id, None)
+    connection = FakeResidentConnection(harness_id)
+    manager = await start_manager(
         tmp_path,
         connection,
         spawn_id=spawn_id,
@@ -411,10 +172,10 @@ async def test_resident_persistent_policy_emits_boundary_and_stays_alive(
     subscriber = manager.subscribe(spawn_id)
     assert subscriber is not None
 
-    connection.emit(_event(harness_id, event_type, {}))
+    connection.emit(resident_event(harness_id, event_type, {}))
 
     try:
-        await _next_turn_boundary(subscriber)
+        await next_turn_boundary(subscriber)
         with pytest.raises(asyncio.TimeoutError):
             await asyncio.wait_for(
                 asyncio.shield(manager.wait_for_completion(spawn_id)),
@@ -432,12 +193,12 @@ async def test_opencode_terminal_success_resides_until_child_finishes(
 ) -> None:
     spawn_id = SpawnId("p1")
     child_id = SpawnId("p2")
-    _start_row(tmp_path, str(spawn_id), HarnessId.OPENCODE, None)
-    _start_row(tmp_path, str(child_id), HarnessId.CODEX, str(spawn_id))
-    connection = _FakeResidentConnection(HarnessId.OPENCODE)
-    manager = await _start_manager(tmp_path, connection, spawn_id=spawn_id)
+    start_row(tmp_path, str(spawn_id), HarnessId.OPENCODE, None)
+    start_row(tmp_path, str(child_id), HarnessId.CODEX, str(spawn_id))
+    connection = FakeResidentConnection(HarnessId.OPENCODE)
+    manager = await start_manager(tmp_path, connection, spawn_id=spawn_id)
 
-    connection.emit(_event(HarnessId.OPENCODE, "session.idle", {}))
+    connection.emit(resident_event(HarnessId.OPENCODE, "session.idle", {}))
 
     try:
         with pytest.raises(asyncio.TimeoutError):
@@ -469,17 +230,17 @@ async def test_resident_reconciles_finalizing_child_with_durable_report_as_done(
 ) -> None:
     spawn_id = SpawnId("p1")
     child_id = SpawnId("p2")
-    _start_row(tmp_path, str(spawn_id), HarnessId.OPENCODE, None)
-    _start_row(tmp_path, str(child_id), HarnessId.CODEX, str(spawn_id))
+    start_row(tmp_path, str(spawn_id), HarnessId.OPENCODE, None)
+    start_row(tmp_path, str(child_id), HarnessId.CODEX, str(spawn_id))
     spawn_store.mark_finalizing(tmp_path, child_id)
     (tmp_path / "spawns" / str(child_id) / "report.md").write_text(
         "# Report\n\nChild completed.\n",
         encoding="utf-8",
     )
-    connection = _FakeResidentConnection(HarnessId.OPENCODE)
-    manager = await _start_manager(tmp_path, connection, spawn_id=spawn_id)
+    connection = FakeResidentConnection(HarnessId.OPENCODE)
+    manager = await start_manager(tmp_path, connection, spawn_id=spawn_id)
 
-    connection.emit(_event(HarnessId.OPENCODE, "session.idle", {}))
+    connection.emit(resident_event(HarnessId.OPENCODE, "session.idle", {}))
 
     try:
         outcome = await asyncio.wait_for(manager.wait_for_completion(spawn_id), timeout=0.5)
@@ -496,13 +257,13 @@ async def test_resident_still_waits_on_genuinely_active_finalizing_child(
 ) -> None:
     spawn_id = SpawnId("p1")
     child_id = SpawnId("p2")
-    _start_row(tmp_path, str(spawn_id), HarnessId.OPENCODE, None)
-    _start_row(tmp_path, str(child_id), HarnessId.CODEX, str(spawn_id))
+    start_row(tmp_path, str(spawn_id), HarnessId.OPENCODE, None)
+    start_row(tmp_path, str(child_id), HarnessId.CODEX, str(spawn_id))
     spawn_store.mark_finalizing(tmp_path, child_id)
-    connection = _FakeResidentConnection(HarnessId.OPENCODE)
-    manager = await _start_manager(tmp_path, connection, spawn_id=spawn_id)
+    connection = FakeResidentConnection(HarnessId.OPENCODE)
+    manager = await start_manager(tmp_path, connection, spawn_id=spawn_id)
 
-    connection.emit(_event(HarnessId.OPENCODE, "session.idle", {}))
+    connection.emit(resident_event(HarnessId.OPENCODE, "session.idle", {}))
 
     try:
         with pytest.raises(asyncio.TimeoutError):
@@ -517,20 +278,20 @@ async def test_resident_still_waits_on_genuinely_active_finalizing_child(
 
 
 @pytest.mark.asyncio
-async def test_done_signal_at_terminal_event_wins_over_outstanding_child(
+async def test_done_signal_at_terminalresident_event_wins_over_outstanding_child(
     tmp_path: Path,
 ) -> None:
     from meridian.lib.state.spawn_signals import write_spawn_signal
 
     spawn_id = SpawnId("p1")
-    _start_row(tmp_path, str(spawn_id), HarnessId.OPENCODE, None)
-    _start_row(tmp_path, "p2", HarnessId.CODEX, str(spawn_id))
+    start_row(tmp_path, str(spawn_id), HarnessId.OPENCODE, None)
+    start_row(tmp_path, "p2", HarnessId.CODEX, str(spawn_id))
     write_spawn_signal(tmp_path, spawn_id, "done")
     write_spawn_signal(tmp_path, spawn_id, "rearm")
-    connection = _FakeResidentConnection(HarnessId.OPENCODE)
-    manager = await _start_manager(tmp_path, connection, spawn_id=spawn_id)
+    connection = FakeResidentConnection(HarnessId.OPENCODE)
+    manager = await start_manager(tmp_path, connection, spawn_id=spawn_id)
 
-    connection.emit(_event(HarnessId.OPENCODE, "session.idle", {}))
+    connection.emit(resident_event(HarnessId.OPENCODE, "session.idle", {}))
 
     try:
         outcome = await asyncio.wait_for(manager.wait_for_completion(spawn_id), timeout=0.5)
@@ -552,17 +313,17 @@ async def test_spawn_done_op_releases_resident_wait_via_environment_default(
     runtime_root = prepared.runtime_root
     assert runtime_root is not None
     spawn_id = SpawnId("p1")
-    _start_row(runtime_root, str(spawn_id), HarnessId.OPENCODE, None)
-    _start_row(runtime_root, "p2", HarnessId.CODEX, str(spawn_id))
-    connection = _FakeResidentConnection(HarnessId.OPENCODE)
-    manager = await _start_manager(
+    start_row(runtime_root, str(spawn_id), HarnessId.OPENCODE, None)
+    start_row(runtime_root, "p2", HarnessId.CODEX, str(spawn_id))
+    connection = FakeResidentConnection(HarnessId.OPENCODE)
+    manager = await start_manager(
         runtime_root,
         connection,
         spawn_id=spawn_id,
         project_root=project_root,
     )
 
-    connection.emit(_event(HarnessId.OPENCODE, "session.idle", {}))
+    connection.emit(resident_event(HarnessId.OPENCODE, "session.idle", {}))
     completion_task = asyncio.create_task(manager.wait_for_completion(spawn_id))
 
     try:
@@ -591,10 +352,10 @@ async def test_spawn_rearm_op_extends_resident_deadline(
     runtime_root = prepared.runtime_root
     assert runtime_root is not None
     spawn_id = SpawnId("p1")
-    _start_row(runtime_root, str(spawn_id), HarnessId.CODEX, None)
-    _start_row(runtime_root, "p2", HarnessId.CODEX, str(spawn_id))
-    connection = _FakeResidentConnection(HarnessId.CODEX)
-    manager = await _start_manager(
+    start_row(runtime_root, str(spawn_id), HarnessId.CODEX, None)
+    start_row(runtime_root, "p2", HarnessId.CODEX, str(spawn_id))
+    connection = FakeResidentConnection(HarnessId.CODEX)
+    manager = await start_manager(
         runtime_root,
         connection,
         spawn_id=spawn_id,
@@ -603,7 +364,7 @@ async def test_spawn_rearm_op_extends_resident_deadline(
         resident_poll_seconds=0.01,
     )
 
-    connection.emit(_event(HarnessId.CODEX, "turn/completed", {}))
+    connection.emit(resident_event(HarnessId.CODEX, "turn/completed", {}))
     completion_task = asyncio.create_task(manager.wait_for_completion(spawn_id))
 
     try:
@@ -635,17 +396,17 @@ async def test_spawn_rearm_op_extends_resident_deadline(
 @pytest.mark.asyncio
 async def test_resident_wait_fans_out_turn_boundary_to_subscriber(tmp_path: Path) -> None:
     spawn_id = SpawnId("p1")
-    _start_row(tmp_path, str(spawn_id), HarnessId.CODEX, None)
-    _start_row(tmp_path, "p2", HarnessId.OPENCODE, str(spawn_id))
-    connection = _FakeResidentConnection(HarnessId.CODEX)
-    manager = await _start_manager(tmp_path, connection, spawn_id=spawn_id)
+    start_row(tmp_path, str(spawn_id), HarnessId.CODEX, None)
+    start_row(tmp_path, "p2", HarnessId.OPENCODE, str(spawn_id))
+    connection = FakeResidentConnection(HarnessId.CODEX)
+    manager = await start_manager(tmp_path, connection, spawn_id=spawn_id)
     subscriber = manager.subscribe(spawn_id)
     assert subscriber is not None
 
-    connection.emit(_event(HarnessId.CODEX, "turn/completed", {}))
+    connection.emit(resident_event(HarnessId.CODEX, "turn/completed", {}))
 
     try:
-        boundary = await _next_turn_boundary(subscriber)
+        boundary = await next_turn_boundary(subscriber)
         assert boundary.payload["status"] == "succeeded"
         with pytest.raises(asyncio.TimeoutError):
             await asyncio.wait_for(
@@ -657,17 +418,17 @@ async def test_resident_wait_fans_out_turn_boundary_to_subscriber(tmp_path: Path
 
 
 @pytest.mark.asyncio
-async def test_child_written_before_terminal_event_is_processed_prevents_early_finalize(
+async def test_child_written_before_terminalresident_event_is_processed_prevents_early_finalize(
     tmp_path: Path,
 ) -> None:
     spawn_id = SpawnId("p1")
     child_id = SpawnId("p2")
-    _start_row(tmp_path, str(spawn_id), HarnessId.CODEX, None)
-    connection = _FakeResidentConnection(HarnessId.CODEX)
-    manager = await _start_manager(tmp_path, connection, spawn_id=spawn_id)
+    start_row(tmp_path, str(spawn_id), HarnessId.CODEX, None)
+    connection = FakeResidentConnection(HarnessId.CODEX)
+    manager = await start_manager(tmp_path, connection, spawn_id=spawn_id)
 
-    connection.emit(_event(HarnessId.CODEX, "turn/completed", {}))
-    _start_row(tmp_path, str(child_id), HarnessId.OPENCODE, str(spawn_id))
+    connection.emit(resident_event(HarnessId.CODEX, "turn/completed", {}))
+    start_row(tmp_path, str(child_id), HarnessId.OPENCODE, str(spawn_id))
 
     try:
         with pytest.raises(asyncio.TimeoutError):
@@ -688,12 +449,12 @@ async def test_resident_stream_close_with_dead_backend_fails_while_child_running
     tmp_path: Path,
 ) -> None:
     spawn_id = SpawnId("p1")
-    _start_row(tmp_path, str(spawn_id), HarnessId.OPENCODE, None)
-    _start_row(tmp_path, "p2", HarnessId.CODEX, str(spawn_id))
-    connection = _FakeResidentConnection(HarnessId.OPENCODE)
-    manager = await _start_manager(tmp_path, connection, spawn_id=spawn_id)
+    start_row(tmp_path, str(spawn_id), HarnessId.OPENCODE, None)
+    start_row(tmp_path, "p2", HarnessId.CODEX, str(spawn_id))
+    connection = FakeResidentConnection(HarnessId.OPENCODE)
+    manager = await start_manager(tmp_path, connection, spawn_id=spawn_id)
 
-    connection.emit(_event(HarnessId.OPENCODE, "session.idle", {}))
+    connection.emit(resident_event(HarnessId.OPENCODE, "session.idle", {}))
 
     try:
         with pytest.raises(asyncio.TimeoutError):
@@ -717,12 +478,12 @@ async def test_resident_stream_close_with_stalled_backend_is_not_dead_outcome(
     tmp_path: Path,
 ) -> None:
     spawn_id = SpawnId("p1")
-    _start_row(tmp_path, str(spawn_id), HarnessId.OPENCODE, None)
-    _start_row(tmp_path, "p2", HarnessId.CODEX, str(spawn_id))
-    connection = _FakeResidentConnection(HarnessId.OPENCODE)
-    manager = await _start_manager(tmp_path, connection, spawn_id=spawn_id)
+    start_row(tmp_path, str(spawn_id), HarnessId.OPENCODE, None)
+    start_row(tmp_path, "p2", HarnessId.CODEX, str(spawn_id))
+    connection = FakeResidentConnection(HarnessId.OPENCODE)
+    manager = await start_manager(tmp_path, connection, spawn_id=spawn_id)
 
-    connection.emit(_event(HarnessId.OPENCODE, "session.idle", {}))
+    connection.emit(resident_event(HarnessId.OPENCODE, "session.idle", {}))
 
     try:
         with pytest.raises(asyncio.TimeoutError):
@@ -747,8 +508,8 @@ async def test_codex_resident_deadline_waits_then_reaps_live_child(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     spawn_id = SpawnId("p1")
-    _start_row(tmp_path, str(spawn_id), HarnessId.CODEX, None)
-    _start_row(tmp_path, "p2", HarnessId.CODEX, str(spawn_id))
+    start_row(tmp_path, str(spawn_id), HarnessId.CODEX, None)
+    start_row(tmp_path, "p2", HarnessId.CODEX, str(spawn_id))
     from meridian.lib.bootstrap import services as bootstrap_services
     from meridian.lib.state.spawn_tree import active_descendants
 
@@ -775,8 +536,8 @@ async def test_codex_resident_deadline_waits_then_reaps_live_child(
         "build_spawn_application_service_from_roots",
         lambda _project_root, _runtime_root: _FakeService(),
     )
-    connection = _FakeResidentConnection(HarnessId.CODEX)
-    manager = await _start_manager(
+    connection = FakeResidentConnection(HarnessId.CODEX)
+    manager = await start_manager(
         tmp_path,
         connection,
         spawn_id=spawn_id,
@@ -784,7 +545,7 @@ async def test_codex_resident_deadline_waits_then_reaps_live_child(
         resident_poll_seconds=0.01,
     )
 
-    connection.emit(_event(HarnessId.CODEX, "turn/completed", {}))
+    connection.emit(resident_event(HarnessId.CODEX, "turn/completed", {}))
     completion_task = asyncio.create_task(manager.wait_for_completion(spawn_id))
 
     try:
@@ -808,19 +569,19 @@ async def test_codex_resident_deadline_waits_then_reaps_live_child(
 async def test_codex_resident_finalization_preserves_artifact_report(tmp_path: Path) -> None:
     spawn_id = SpawnId("p1")
     child_id = SpawnId("p2")
-    _start_row(tmp_path, str(spawn_id), HarnessId.CODEX, None)
-    _start_row(tmp_path, str(child_id), HarnessId.OPENCODE, str(spawn_id))
-    connection = _FakeResidentConnection(HarnessId.CODEX)
-    manager = await _start_manager(tmp_path, connection, spawn_id=spawn_id)
+    start_row(tmp_path, str(spawn_id), HarnessId.CODEX, None)
+    start_row(tmp_path, str(child_id), HarnessId.OPENCODE, str(spawn_id))
+    connection = FakeResidentConnection(HarnessId.CODEX)
+    manager = await start_manager(tmp_path, connection, spawn_id=spawn_id)
 
     connection.emit(
-        _event(
+        resident_event(
             HarnessId.CODEX,
             "item/completed",
             {"item": {"type": "agentMessage", "text": "Resident report."}},
         )
     )
-    connection.emit(_event(HarnessId.CODEX, "turn/completed", {}))
+    connection.emit(resident_event(HarnessId.CODEX, "turn/completed", {}))
 
     try:
         with pytest.raises(asyncio.TimeoutError):
@@ -845,27 +606,6 @@ async def test_codex_resident_finalization_preserves_artifact_report(tmp_path: P
         await manager.stop_spawn(spawn_id)
 
 
-def _coordinator_with_clock(
-    tmp_path: Path,
-    connection: _FakeResidentConnection,
-    clock: FakeClock,
-    *,
-    deadline_seconds: float = 3300.0,
-    poll_seconds: float = 5.0,
-) -> ResidentDrainCoordinator:
-    coordinator = ResidentDrainCoordinator.for_connection(
-        project_root=tmp_path,
-        runtime_root=tmp_path,
-        spawn_id=SpawnId("p1"),
-        receiver=connection,
-        resident_backend=connection.resident_backend,
-        deadline_seconds=deadline_seconds,
-        poll_seconds=poll_seconds,
-    )
-    coordinator.pending_outcome = TerminalEventOutcome(status="succeeded", exit_code=0)
-    coordinator.deadline_monotonic = clock.monotonic() + deadline_seconds
-    coordinator._set_awaiting_done(True)
-    return coordinator
 
 
 @pytest.mark.asyncio
@@ -878,9 +618,9 @@ async def test_rearm_signal_extends_deadline_and_injects_only_after_cadence(
 
     clock = FakeClock(start=100.0)
     monkeypatch.setattr(resident_drain_module.time, "monotonic", clock.monotonic)
-    _start_row(tmp_path, "p1", HarnessId.CODEX, None)
-    connection = _FakeResidentConnection(HarnessId.CODEX)
-    coordinator = _coordinator_with_clock(tmp_path, connection, clock, deadline_seconds=3300.0)
+    start_row(tmp_path, "p1", HarnessId.CODEX, None)
+    connection = FakeResidentConnection(HarnessId.CODEX)
+    coordinator = coordinator_with_clock(tmp_path, connection, clock, deadline_seconds=3300.0)
 
     clock.advance(10.0)
     write_spawn_signal(tmp_path, "p1", "rearm")
@@ -922,9 +662,9 @@ async def test_active_followup_turn_stays_resident_honors_done_and_defers_poll(
 
     clock = FakeClock(start=100.0)
     monkeypatch.setattr(resident_drain_module.time, "monotonic", clock.monotonic)
-    _start_row(tmp_path, "p1", HarnessId.CODEX, None)
-    connection = _FakeResidentConnection(HarnessId.CODEX)
-    coordinator = _coordinator_with_clock(tmp_path, connection, clock, deadline_seconds=300.0)
+    start_row(tmp_path, "p1", HarnessId.CODEX, None)
+    connection = FakeResidentConnection(HarnessId.CODEX)
+    coordinator = coordinator_with_clock(tmp_path, connection, clock, deadline_seconds=300.0)
     coordinator.resident_requested = True
     coordinator.next_inject_monotonic = clock.monotonic()
 
@@ -955,9 +695,9 @@ async def test_active_followup_turn_still_enforces_deadline(
 
     clock = FakeClock(start=0.0)
     monkeypatch.setattr(resident_drain_module.time, "monotonic", clock.monotonic)
-    _start_row(tmp_path, "p1", HarnessId.CODEX, None)
-    connection = _FakeResidentConnection(HarnessId.CODEX)
-    coordinator = _coordinator_with_clock(tmp_path, connection, clock, deadline_seconds=10.0)
+    start_row(tmp_path, "p1", HarnessId.CODEX, None)
+    connection = FakeResidentConnection(HarnessId.CODEX)
+    coordinator = coordinator_with_clock(tmp_path, connection, clock, deadline_seconds=10.0)
     coordinator.observe_activity_transition("turn_active")
 
     clock.advance(10.0)
@@ -978,9 +718,9 @@ async def test_deadline_returns_timed_out_when_descendant_reap_fails(
 
     clock = FakeClock(start=0.0)
     monkeypatch.setattr(resident_drain_module.time, "monotonic", clock.monotonic)
-    _start_row(tmp_path, "p1", HarnessId.CODEX, None)
-    connection = _FakeResidentConnection(HarnessId.CODEX)
-    coordinator = _coordinator_with_clock(tmp_path, connection, clock, deadline_seconds=10.0)
+    start_row(tmp_path, "p1", HarnessId.CODEX, None)
+    connection = FakeResidentConnection(HarnessId.CODEX)
+    coordinator = coordinator_with_clock(tmp_path, connection, clock, deadline_seconds=10.0)
 
     class _FailingService:
         async def cancel_descendants(self, root_id: SpawnId) -> set[str]:
@@ -1012,12 +752,12 @@ async def test_deadline_reap_cancels_active_descendant_cli_spawns(
 
     clock = FakeClock(start=0.0)
     monkeypatch.setattr(resident_drain_module.time, "monotonic", clock.monotonic)
-    _start_row(tmp_path, "p1", HarnessId.CODEX, None)
-    _start_row(tmp_path, "p2", HarnessId.OPENCODE, "p1")
-    _start_row(tmp_path, "p3", HarnessId.OPENCODE, "p1")
+    start_row(tmp_path, "p1", HarnessId.CODEX, None)
+    start_row(tmp_path, "p2", HarnessId.OPENCODE, "p1")
+    start_row(tmp_path, "p3", HarnessId.OPENCODE, "p1")
     spawn_store.finalize_spawn(tmp_path, SpawnId("p3"), "succeeded", 0, origin="runner")
-    connection = _FakeResidentConnection(HarnessId.CODEX)
-    coordinator = _coordinator_with_clock(tmp_path, connection, clock, deadline_seconds=10.0)
+    connection = FakeResidentConnection(HarnessId.CODEX)
+    coordinator = coordinator_with_clock(tmp_path, connection, clock, deadline_seconds=10.0)
     cancelled: list[str] = []
 
     class _FakeService:
@@ -1062,10 +802,10 @@ async def test_done_signal_is_honored_with_tracked_child_outstanding(
 ) -> None:
     from meridian.lib.state.spawn_signals import write_spawn_signal
 
-    _start_row(tmp_path, "p1", HarnessId.OPENCODE, None)
-    _start_row(tmp_path, "p2", HarnessId.CODEX, "p1")
-    connection = _FakeResidentConnection(HarnessId.OPENCODE)
-    coordinator = _awaiting_done_coordinator(tmp_path, connection)
+    start_row(tmp_path, "p1", HarnessId.OPENCODE, None)
+    start_row(tmp_path, "p2", HarnessId.CODEX, "p1")
+    connection = FakeResidentConnection(HarnessId.OPENCODE)
+    coordinator = awaiting_done_coordinator(tmp_path, connection)
 
     write_spawn_signal(tmp_path, "p1", "done")
     decision = await coordinator.handle_timeout()

--- a/tests/unit/streaming/test_resident_drain.py
+++ b/tests/unit/streaming/test_resident_drain.py
@@ -26,7 +26,11 @@ from meridian.lib.harness.connections.liveness import LivenessDecision
 from meridian.lib.harness.connections.resident_backend import (
     ResidentBackendControl,
 )
-from meridian.lib.harness.semantics import TerminalEventOutcome
+from meridian.lib.harness.semantics import (
+    PrimaryEventScope,
+    TerminalEventOutcome,
+    opencode_primary_event_scope,
+)
 from meridian.lib.launch.launch_types import ResolvedLaunchSpec
 from meridian.lib.ops.spawn.models import SpawnSignalInput
 from meridian.lib.safety.permissions import UnsafeNoOpPermissionResolver
@@ -96,6 +100,12 @@ class _FakeResidentConnection(HarnessConnection[ResolvedLaunchSpec]):
     @property
     def session_id(self) -> str | None:
         return "ses-resident"
+
+    @property
+    def primary_event_scope(self) -> PrimaryEventScope | None:
+        if self._harness_id is HarnessId.OPENCODE:
+            return opencode_primary_event_scope(self.session_id)
+        return None
 
     @property
     def subprocess_pid(self) -> int | None:
@@ -176,6 +186,12 @@ def _awaiting_done_coordinator(
 
 
 def _event(harness_id: HarnessId, event_type: str, payload: dict[str, object]) -> HarnessEvent:
+    if harness_id is HarnessId.OPENCODE and "properties" not in payload:
+        payload = {
+            **payload,
+            "type": event_type,
+            "properties": {"sessionID": "ses-resident"},
+        }
     return HarnessEvent(event_type=event_type, harness_id=harness_id.value, payload=payload)
 
 
@@ -287,6 +303,85 @@ async def test_opencode_terminal_success_without_live_children_finalizes_immedia
         assert outcome is not None
         assert outcome.status == "succeeded"
         assert True not in connection.fake_resident_backend.awaiting_done_values
+    finally:
+        await manager.stop_spawn(spawn_id)
+
+
+@pytest.mark.asyncio
+async def test_opencode_child_session_idle_does_not_finalize_parent(
+    tmp_path: Path,
+) -> None:
+    spawn_id = SpawnId("p1")
+    _start_row(tmp_path, str(spawn_id), HarnessId.OPENCODE, None)
+    connection = _FakeResidentConnection(HarnessId.OPENCODE)
+    manager = await _start_manager(tmp_path, connection, spawn_id=spawn_id)
+    subscriber = manager.subscribe(spawn_id)
+    assert subscriber is not None
+
+    child_idle = _event(
+        HarnessId.OPENCODE,
+        "session.idle",
+        {"type": "session.idle", "properties": {"sessionID": "ses-child"}},
+    )
+    connection.emit(child_idle)
+
+    try:
+        observed = await asyncio.wait_for(subscriber.get(), timeout=0.5)
+        assert observed == child_idle
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(
+                asyncio.shield(manager.wait_for_completion(spawn_id)),
+                timeout=0.05,
+            )
+
+        connection.emit(
+            _event(
+                HarnessId.OPENCODE,
+                "session.idle",
+                {"type": "session.idle", "properties": {"sessionID": "ses-resident"}},
+            )
+        )
+        outcome = await asyncio.wait_for(manager.wait_for_completion(spawn_id), timeout=0.5)
+        assert outcome is not None
+        assert outcome.status == "succeeded"
+    finally:
+        await manager.stop_spawn(spawn_id)
+
+
+@pytest.mark.asyncio
+async def test_opencode_child_session_error_does_not_fail_parent(
+    tmp_path: Path,
+) -> None:
+    spawn_id = SpawnId("p1")
+    _start_row(tmp_path, str(spawn_id), HarnessId.OPENCODE, None)
+    connection = _FakeResidentConnection(HarnessId.OPENCODE)
+    manager = await _start_manager(tmp_path, connection, spawn_id=spawn_id)
+
+    connection.emit(
+        _event(
+            HarnessId.OPENCODE,
+            "session.error",
+            {"type": "session.error", "properties": {"sessionID": "ses-child"}},
+        )
+    )
+
+    try:
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(
+                asyncio.shield(manager.wait_for_completion(spawn_id)),
+                timeout=0.05,
+            )
+
+        connection.emit(
+            _event(
+                HarnessId.OPENCODE,
+                "session.idle",
+                {"type": "session.idle", "properties": {"sessionID": "ses-resident"}},
+            )
+        )
+        outcome = await asyncio.wait_for(manager.wait_for_completion(spawn_id), timeout=0.5)
+        assert outcome is not None
+        assert outcome.status == "succeeded"
     finally:
         await manager.stop_spawn(spawn_id)
 


### PR DESCRIPTION
## Why

OpenCode session logs were incomplete or misleading in two related ways:

- completed OpenCode sessions now live primarily in `opencode.db`, while Meridian still depended on legacy transcript files or raw spawn history
- OpenCode child task sessions share the same event stream as the parent, so a child `session.idle` could falsely complete the parent spawn and child output could become the parent report

## Goal

Make OpenCode completed-session logs readable from the durable OpenCode DB source, and make OpenCode parent completion/reporting as scope-safe as Codex main-thread completion.

## Summary

- Read completed OpenCode transcripts from `opencode.db` before legacy JSON or spawn-history fallback.
- Replaced recursive session-log fallback targets with an ordered transcript-source plan.
- Render OpenCode DB messages, setup text, compactions, and completed task previews in `meridian session log`.
- Moved OpenCode report/session extraction into an OpenCode-owned module.
- Made `HarnessConnection.primary_event_scope` the drain contract for Codex/OpenCode parent scope.
- Scope OpenCode terminal events, signal clearing, activity transitions, report extraction, and session-id artifact fallback to the parent `sessionID`.
- Split resident-drain test helpers and reusable OpenCode DB fixtures.

## Resulting Behavior

- `meridian session log p...`, `meridian session log c...`, and raw `ses_...` refs can show completed OpenCode transcripts from `opencode.db`.
- If an OpenCode DB source exists but has no usable interaction content, session log tries the next ordered source: native JSON, then spawn history where applicable.
- Completed OpenCode `task` tool output shows a concise `(completed)` preview by default.
- OpenCode parent agents can spawn child tasks, wait for them, continue work, and only complete when the parent session completes.
- Codex retains the same parent-child behavior through its main-thread scope.

## Changes

- Added `TranscriptSource` source ordering for session-log resolution and moved source fallback to the transcript read boundary.
- Split session repair target resolution out of `session_target.py`; `session_target.py` is now 989 lines.
- Added `src/meridian/lib/harness/opencode_report.py` for OpenCode session-id/report extraction and DB-native report fallback.
- Removed `codex_main_thread_id` compatibility parameters and `CodexDrainThreadTracker`.
- Updated drain, streaming runner, primary attach, and test fakes to use `connection.primary_event_scope` directly.
- Added reusable `tests/support/opencode_db.py`; `tests/unit/streaming/test_resident_drain.py` is now 815 lines.
- Reviewer follow-up fixed DB-only OpenCode report fallback, missing-`session_id.txt` parent scoping, and multi-session DB fixture IDs.

## Work Item

`opencode-db-session-log`

## Verification

Targeted:

- `uv run pytest tests/integration/ops/test_session_log_harness_retrieval.py -q` — `12 passed`
- `uv run pytest tests/unit/harness/test_extract_opencode_report.py tests/unit/harness/test_codex_thread_termination.py -q` — `15 passed`
- `uv run pytest tests/unit/streaming -q` — `79 passed`

Full:

- `uv run ruff check .` — passed
- `uv run --extra dev python -m pyright` — `0 errors, 0 warnings`
- `uv run pytest -x -q` — `1421 passed, 2 skipped`
- pre-push hook passed: ruff, pyright, full pytest, `uv build --no-sources`

Runtime probes:

- Prior live OpenCode parent-child probe `p4302` succeeded; parent wrote `PARENT_CONTINUED_AFTER_CHILD` after child task completed.
- Prior live Codex parent-child regression probe `p4303` succeeded; parent wrote `CODEX_PARENT_CONTINUED_AFTER_CHILD` after child task completed.
- Cleanup prober `p4313` ran no-credit local runtime probes: CLI launch/dry-run, fake OpenCode child terminal events, DB preference, and DB fallthrough to JSON/spawn history. Live model probes were not rerun to avoid external credits.

## Knowledge Updates

- Code docs/context updated earlier in this PR:
  - `src/meridian/lib/harness/AGENTS.md`
  - `src/meridian/lib/harness/.context/CONTEXT.md`
  - `src/meridian/lib/harness/connections/.context/CONTEXT.md`
  - `src/meridian/lib/harness/extractors/.context/CONTEXT.md`
  - `src/meridian/lib/streaming/AGENTS.md`
  - `src/meridian/lib/streaming/.context/CONTEXT.md`
  - `docs/harness-integration.md`
- KB updated separately in `haowjy/meridian-cli-kb` commit `d573b50 docs: capture primary event scope`.
- Cleanup refactor did not require additional docs beyond this PR body.

## Spawn Trace

- `p4274` gpt-dev — implemented OpenCode DB session-log support
- `p4275` reviewer — reviewed completed task rendering
- `p4276` prober — verified completed task rendering
- `p4278` investigator — diagnosed p2016 false-success root cause
- `p4284` gpt-dev — implemented primary event scope change; cancelled after finalization stall, diff salvaged
- `p4289` reviewer — approved primary event scope implementation
- `p4290` prober — verified primary event scope behavior
- `p4295` kb-lead — captured docs/KB updates
- `p4302` OpenCode runtime probe — parent-child continuation passed
- `p4303` Codex runtime probe — parent-child regression passed
- `p4304` gpt-dev — fixed pre-push primary attach fake-connection regression
- `p4312` reviewer — reviewed cleanup refactor; findings fixed in `0907eded`
- `p4313` prober — no-credit runtime probe of cleanup behavior

## Release Label Guide

Set one `release:*` label on this PR:

- `release:patch` / `release:stable` — next stable **patch** release after merge
- `release:minor` — next stable **minor** release
- `release:major` — next stable **major** release
- `release:rc` — next **prerelease (RC)** after merge
- `release:skip` — no release for this merge

No `release:*` label defaults to a prerelease (RC). Unknown `release:*` labels also default to RC.

## Post-Merge Automation

After merge to `main`, CI (`.github/workflows/release-on-merge.yml`) will:

1. Read the PR release label
2. Skip only when `release:skip` is present (no label defaults to RC)
3. Compute the next stable or RC version from existing `v*` tags
4. Update `src/meridian/__init__.py` + promote `CHANGELOG.md` `[Unreleased]`
5. Commit `Release X.Y.Z`, create/push `vX.Y.Z`
6. Run `.github/workflows/publish-pypi.yml`

## Cleanup

After merge, clean merged worktrees with:

```bash
scripts/prune-worktrees.sh
```
