### PR TITLE
fix(spawn): reserve durable row before prep to close the pre-init crash window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- A spawn launcher killed (SIGKILL) during prep — before the spawn row was written — left nothing on disk: invisible to `spawn list/status/wait`, the reconciler, and `doctor --kill-orphans` (the c2076 double-background incident). The durable `queued` row is now reserved before prep, so a killed-mid-prep launch is recovered by the existing reaper (`failed`/`missing_runner_pid`). Reserve/announce is two-phase: work-item creation and lifecycle events (`spawn.created`, telemetry, subrun start) are deferred until prep succeeds, so graceful prep failures remain side-effect-free as before — only the kill path changes.
+
+### Changed
+- `meridian.spawn.execute` reserves the spawn row up front via a shared `_reserve_then_prepare` helper (removes two duplicated post-prep `update_spawn` blocks); a single `resolve_spawn_work_id` resolver replaces the divergent work_id precedence (`execute_init._resolve_work_id` deleted); `remove_spawn_events` now removes the full reserved spawn dir.
+
 ## [0.3.9] - 2026-06-13
 
 ### Fixed

--- a/src/meridian/lib/core/lifecycle.py
+++ b/src/meridian/lib/core/lifecycle.py
@@ -256,8 +256,9 @@ class SpawnLifecycleService:
         status: SpawnStatus = "running",
         started_at: str | None = None,
         clock: Clock | None = None,
+        dispatch_events: bool = True,
     ) -> str:
-        """Start a new spawn and dispatch spawn.created."""
+        """Start a new spawn and optionally dispatch spawn.created."""
         with bind_lifecycle_correlation(self._correlation(operation="start", spawn_id=spawn_id)):
             # Authoritative transition write still happens in _spawn_store().
             result_id = _spawn_store().start_spawn(
@@ -293,12 +294,28 @@ class SpawnLifecycleService:
             allocate_spawn_sequence(str(result_id))
             record = _spawn_store().get_spawn(self._runtime_root, result_id)
             self._record = record
-            event = self._build_event("spawn.created", self._record, spawn_id=str(result_id))
-            self._dispatch(event)
-            self._emit_telemetry_event("spawn.queued", self._record)
-            if status == "running":
-                self._emit_telemetry_event("spawn.running", self._record)
+            if dispatch_events:
+                self._dispatch_spawn_started_events(status=status, spawn_id=str(result_id))
             return str(result_id)
+
+    def announce_started(self, spawn_id: str) -> None:
+        """Dispatch spawn.created and initial telemetry for an existing row."""
+        with bind_lifecycle_correlation(
+            self._correlation(operation="announce_started", spawn_id=spawn_id)
+        ):
+            record = _spawn_store().get_spawn(self._runtime_root, spawn_id)
+            if record is None:
+                raise ValueError(f"spawn row not found: {spawn_id}")
+            self._record = record
+            self._dispatch_spawn_started_events(status=record.status, spawn_id=spawn_id)
+
+    def _dispatch_spawn_started_events(self, *, status: SpawnStatus, spawn_id: str) -> None:
+        assert self._record is not None
+        event = self._build_event("spawn.created", self._record, spawn_id=spawn_id)
+        self._dispatch(event)
+        self._emit_telemetry_event("spawn.queued", self._record)
+        if status == "running":
+            self._emit_telemetry_event("spawn.running", self._record)
 
     def mark_running(
         self,

--- a/src/meridian/lib/ops/spawn/execute.py
+++ b/src/meridian/lib/ops/spawn/execute.py
@@ -17,6 +17,7 @@ from meridian.lib.core.context import RuntimeContext
 from meridian.lib.launch.context import PreparedLaunchSurface
 from meridian.lib.launch.cwd import resolve_task_cwd
 from meridian.lib.launch.request import LaunchArgvIntent, SpawnRequest
+from meridian.lib.ops.work_attachment import ensure_explicit_work_item
 from meridian.lib.platform import IS_WINDOWS
 from meridian.lib.state import spawn_store
 from meridian.lib.state.launch_boundary import (
@@ -25,7 +26,11 @@ from meridian.lib.state.launch_boundary import (
     EVENT_PARENT_LAUNCH_SPAWNED,
 )
 from meridian.lib.state.paths import resolve_project_paths, resolve_spawn_log_dir
-from meridian.lib.state.spawn.model import BACKGROUND_LAUNCH_MODE, FOREGROUND_LAUNCH_MODE
+from meridian.lib.state.spawn.model import (
+    BACKGROUND_LAUNCH_MODE,
+    FOREGROUND_LAUNCH_MODE,
+    LaunchMode,
+)
 
 from ..runtime import OperationRuntime, runtime_context
 from .execute_bg import (
@@ -39,13 +44,16 @@ from .execute_bg import (
     _record_launch_boundary_observation,
 )
 from .execute_init import (
+    _announce_reserved_spawn,
     _emit_subrun_event,
     _init_spawn,
     _spawn_background_worker_env,
+    _SpawnContext,
     _write_params_json,
     build_spawn_mars_runtime,
     depth_exceeded_output,
     depth_limits,
+    resolve_spawn_work_id,
 )
 from .execute_runner import launch_prepared_spawn
 from .failure_policy import finalize_launch_failure_sync
@@ -102,7 +110,7 @@ def _resolve_execution_contract(
     request: SpawnRequest,
     project_paths: Any,
     payload: SpawnCreateInput,
-    ambient_work_id: str | None,
+    ctx: RuntimeContext,
 ) -> SpawnExecutionContract:
     request_control_root = (request.authority_root or "").strip()
     control_root = (
@@ -120,17 +128,11 @@ def _resolve_execution_contract(
             project_state_dir=resolve_project_paths(project_paths.project_root).root_dir,
             explicit_task_dir=payload.task_dir,
             explicit_work_id=explicit_work_id,
-            ambient_work_id=None if explicit_work_id else ambient_work_id,
+            ambient_work_id=None if explicit_work_id else ctx.work_id,
             caller_cwd=payload.caller_cwd,
         ).task_cwd
 
-    work_id = (
-        (request.task_cwd_work_item or "").strip()
-        or (request.work_id_hint or "").strip()
-        or payload.work.strip()
-        or (ambient_work_id or "").strip()
-        or None
-    )
+    work_id = resolve_spawn_work_id(payload, request, ctx=ctx)
     execution_cwd_str = execution_cwd.as_posix()
     return SpawnExecutionContract(
         control_root=control_root,
@@ -161,7 +163,7 @@ def _prepare_spawn_execution(
                 request=request,
                 project_paths=project_paths,
                 payload=payload,
-                ambient_work_id=resolved_context.work_id,
+                ctx=resolved_context,
             )
             return SpawnExecutionPreparation(
                 resolved_context=resolved_context,
@@ -174,13 +176,46 @@ def _prepare_spawn_execution(
     return run_pre_init_boundary(payload=payload, request=request, operation=_operation)
 
 
-def execute_spawn_background(
+def _persist_execution_contract(
+    context: _SpawnContext,
+    execution_contract: SpawnExecutionContract,
+) -> None:
+    execution_cwd_str = execution_contract.execution_cwd.as_posix()
+    spawn_store.update_spawn(
+        context.runtime_root,
+        context.spawn.spawn_id,
+        control_root=execution_contract.control_root.as_posix(),
+        task_cwd=_task_cwd_from_execution(
+            control_root=execution_contract.control_root,
+            execution_cwd=execution_cwd_str,
+        ),
+        execution_cwd=execution_cwd_str,
+    )
+
+
+def _reserve_then_prepare(
     *,
     payload: SpawnCreateInput,
     request: SpawnRequest,
     runtime: OperationRuntime,
-    ctx: RuntimeContext | None = None,
-) -> SpawnActionOutput:
+    ctx: RuntimeContext | None,
+    launch_mode: LaunchMode,
+    runner_pid: int | None = None,
+) -> tuple[_SpawnContext, SpawnExecutionPreparation] | SpawnActionOutput:
+    resolved_context = runtime_context(ctx)
+    context = _init_spawn(
+        payload=payload,
+        request=request,
+        runtime=runtime,
+        desc=payload.desc,
+        work_id=resolve_spawn_work_id(payload, request, ctx=resolved_context),
+        status="queued",
+        launch_mode=launch_mode,
+        runner_pid=runner_pid,
+        launch_policy_snapshot=request.launch_policy_snapshot,
+        ctx=resolved_context,
+        announce=False,
+    )
     preparation = _prepare_spawn_execution(
         payload=payload,
         request=request,
@@ -188,45 +223,62 @@ def execute_spawn_background(
         ctx=ctx,
     )
     if isinstance(preparation, SpawnActionOutput):
+        spawn_store.remove_spawn_events(context.runtime_root, context.spawn.spawn_id)
         return preparation
-    resolved_context = preparation.resolved_context
+
+    project_paths = preparation.project_paths
+    final_work_id = context.work_id
+    if (payload.work or "").strip():
+        from typing import cast
+
+        project_local_root = resolve_project_paths(project_paths.project_root).root_dir
+        final_work_id = cast("str", final_work_id)
+        final_work_id = ensure_explicit_work_item(project_local_root, final_work_id)
+        if final_work_id != context.work_id:
+            spawn_store.update_spawn(
+                context.runtime_root,
+                context.spawn.spawn_id,
+                work_id=final_work_id,
+            )
+    context = context.model_copy(update={"work_id": final_work_id})
+
+    _persist_execution_contract(context, preparation.execution_contract)
+    _announce_reserved_spawn(
+        context=context,
+        request=request,
+        runtime=runtime,
+        project_root=project_paths.project_root,
+        ctx=resolved_context,
+    )
+    return context, preparation
+
+
+def execute_spawn_background(
+    *,
+    payload: SpawnCreateInput,
+    request: SpawnRequest,
+    runtime: OperationRuntime,
+    ctx: RuntimeContext | None = None,
+) -> SpawnActionOutput:
+    reserved = _reserve_then_prepare(
+        payload=payload,
+        request=request,
+        runtime=runtime,
+        ctx=ctx,
+        launch_mode=BACKGROUND_LAUNCH_MODE,
+    )
+    if isinstance(reserved, SpawnActionOutput):
+        return reserved
+    context, preparation = reserved
     project_paths = preparation.project_paths
     execution_contract = preparation.execution_contract
 
     initial_execution_cwd = execution_contract.execution_cwd.as_posix()
-    initial_task_cwd = execution_contract.task_cwd
     if payload.stream:
         logger.warning("--stream requires --foreground; output goes to spawn log files.")
-    context = _init_spawn(
-        payload=payload,
-        request=request,
-        runtime=runtime,
-        desc=payload.desc,
-        work_id=execution_contract.work_id,
-        status="queued",
-        launch_mode=BACKGROUND_LAUNCH_MODE,
-        control_root=execution_contract.control_root.as_posix(),
-        task_cwd=initial_task_cwd,
-        execution_cwd=initial_execution_cwd,
-        launch_policy_snapshot=request.launch_policy_snapshot,
-        ctx=resolved_context,
-    )
     spawn_id_text = str(context.spawn.spawn_id)
     execution_cwd_str = initial_execution_cwd
     parent_launch_cwd_str = execution_contract.control_root.as_posix()
-    task_cwd_str = _task_cwd_from_execution(
-        control_root=execution_contract.control_root,
-        execution_cwd=execution_cwd_str,
-    )
-    # Record resolved execution_cwd immediately so it's correct even if
-    # the background worker dies before runner.py's authoritative update.
-    spawn_store.update_spawn(
-        context.runtime_root,
-        context.spawn.spawn_id,
-        control_root=execution_contract.control_root.as_posix(),
-        task_cwd=task_cwd_str,
-        execution_cwd=execution_cwd_str,
-    )
     log_dir = resolve_spawn_log_dir(project_paths.project_root, context.spawn.spawn_id)
     log_dir.mkdir(parents=True, exist_ok=True)
     try:
@@ -437,35 +489,22 @@ def execute_spawn_blocking(
     prepared: PreparedLaunchSurface | None = None,
     on_spawn_id: Callable[[str], None] | None = None,
 ) -> SpawnActionOutput:
-    preparation = _prepare_spawn_execution(
+    reserved = _reserve_then_prepare(
         payload=payload,
         request=request,
         runtime=runtime,
         ctx=ctx,
+        launch_mode=FOREGROUND_LAUNCH_MODE,
+        runner_pid=os.getpid(),
     )
-    if isinstance(preparation, SpawnActionOutput):
-        return preparation
+    if isinstance(reserved, SpawnActionOutput):
+        return reserved
+    context, preparation = reserved
     resolved_context = preparation.resolved_context
     project_paths = preparation.project_paths
     execution_contract = preparation.execution_contract
 
     initial_execution_cwd = execution_contract.execution_cwd.as_posix()
-    initial_task_cwd = execution_contract.task_cwd
-    context = _init_spawn(
-        payload=payload,
-        request=request,
-        runtime=runtime,
-        desc=payload.desc,
-        work_id=execution_contract.work_id,
-        status="queued",
-        launch_mode=FOREGROUND_LAUNCH_MODE,
-        runner_pid=os.getpid(),
-        control_root=execution_contract.control_root.as_posix(),
-        task_cwd=initial_task_cwd,
-        execution_cwd=initial_execution_cwd,
-        launch_policy_snapshot=request.launch_policy_snapshot,
-        ctx=resolved_context,
-    )
     spawn = context.spawn
     spawn_id_text = str(spawn.spawn_id)
     if on_spawn_id is not None:
@@ -476,17 +515,6 @@ def execute_spawn_blocking(
 
     try:
         execution_cwd_str = initial_execution_cwd
-        # Reflect selected task_cwd before launch_prepared_spawn.
-        spawn_store.update_spawn(
-            context.runtime_root,
-            spawn.spawn_id,
-            control_root=execution_contract.control_root.as_posix(),
-            task_cwd=_task_cwd_from_execution(
-                control_root=execution_contract.control_root,
-                execution_cwd=execution_cwd_str,
-            ),
-            execution_cwd=execution_cwd_str,
-        )
         try:
             _write_params_json(
                 project_paths,

--- a/src/meridian/lib/ops/spawn/execute_init.py
+++ b/src/meridian/lib/ops/spawn/execute_init.py
@@ -135,20 +135,19 @@ def _spawn_background_worker_env(
     return child_env
 
 
-def _resolve_work_id(
-    *,
+def resolve_spawn_work_id(
     payload: SpawnCreateInput,
-    runtime_context: RuntimeContext,
-    runtime_root: Path,
-    work_id: str | None = None,
+    request: SpawnRequest,
+    ctx: RuntimeContext | None = None,
 ) -> str | None:
-    requested_work_id = (work_id or payload.work).strip()
-    if requested_work_id:
-        return requested_work_id
-    inherited_work_id = (runtime_context.work_id or "").strip()
-    if inherited_work_id:
-        return inherited_work_id
-    return None
+    resolved_context = runtime_context(ctx)
+    return (
+        (request.task_cwd_work_item or "").strip()
+        or (request.work_id_hint or "").strip()
+        or payload.work.strip()
+        or (resolved_context.work_id or "").strip()
+        or None
+    )
 
 
 def _init_spawn(
@@ -166,20 +165,16 @@ def _init_spawn(
     task_cwd: str | None = None,
     execution_cwd: str | None = None,
     ctx: RuntimeContext | None = None,
+    announce: bool = True,
 ) -> _SpawnContext:
-    from typing import cast
-
     resolved_context = runtime_context(ctx)
     project_paths = resolve_project_config_paths(project_root=runtime.project_root)
-    project_local_root = resolve_project_paths(project_paths.project_root).root_dir
     runtime_root = resolve_runtime_root(project_paths.project_root)
-    resolved_work_id = _resolve_work_id(
-        payload=payload,
-        runtime_context=resolved_context,
-        runtime_root=runtime_root,
-        work_id=work_id,
-    )
-    if (payload.work or "").strip():
+    resolved_work_id = work_id
+    if announce and (payload.work or "").strip():
+        from typing import cast
+
+        project_local_root = resolve_project_paths(project_paths.project_root).root_dir
         resolved_work_id = cast("str", resolved_work_id)
         resolved_work_id = ensure_explicit_work_item(project_local_root, resolved_work_id)
     resolved_desc = (desc if desc is not None else payload.desc).strip() or None
@@ -215,6 +210,7 @@ def _init_spawn(
         runner_pid=runner_pid,
         launch_policy_snapshot=launch_policy_snapshot or request.launch_policy_snapshot,
         status=status,
+        dispatch_events=announce,
     )
     spawn = Spawn(
         spawn_id=SpawnId(spawn_id),
@@ -223,20 +219,57 @@ def _init_spawn(
         status=status,
     )
     current_depth = resolved_context.depth
-    run_start_event: dict[str, Any] = {
-        "t": "meridian.spawn.start",
-        "id": str(spawn.spawn_id),
-        "model": request.model or "",
-        "d": current_depth,
-    }
-    if request.agent is not None:
-        run_start_event["agent"] = request.agent
-    _emit_subrun_event(run_start_event, sink=runtime.sink, ctx=resolved_context)
+    if announce:
+        _emit_spawn_start_subrun_event(
+            spawn_id=str(spawn.spawn_id),
+            request=request,
+            current_depth=current_depth,
+            sink=runtime.sink,
+            ctx=resolved_context,
+        )
     return _SpawnContext(
         spawn=spawn,
         runtime_root=runtime_root,
         current_depth=current_depth,
         work_id=resolved_work_id,
+    )
+
+
+def _emit_spawn_start_subrun_event(
+    *,
+    spawn_id: str,
+    request: SpawnRequest,
+    current_depth: int,
+    sink: OutputSink,
+    ctx: RuntimeContext | None = None,
+) -> None:
+    run_start_event: dict[str, Any] = {
+        "t": "meridian.spawn.start",
+        "id": spawn_id,
+        "model": request.model or "",
+        "d": current_depth,
+    }
+    if request.agent is not None:
+        run_start_event["agent"] = request.agent
+    _emit_subrun_event(run_start_event, sink=sink, ctx=ctx)
+
+
+def _announce_reserved_spawn(
+    *,
+    context: _SpawnContext,
+    request: SpawnRequest,
+    runtime: OperationRuntime,
+    project_root: Path,
+    ctx: RuntimeContext | None = None,
+) -> None:
+    service = build_spawn_lifecycle_service_from_roots(project_root, context.runtime_root)
+    service.announce_started(str(context.spawn.spawn_id))
+    _emit_spawn_start_subrun_event(
+        spawn_id=str(context.spawn.spawn_id),
+        request=request,
+        current_depth=context.current_depth,
+        sink=runtime.sink,
+        ctx=ctx,
     )
 
 
@@ -277,6 +310,7 @@ def _write_params_json(
 __all__ = [
     "LaunchUserInputError",
     "_SpawnContext",
+    "_announce_reserved_spawn",
     "_emit_subrun_event",
     "_init_spawn",
     "_spawn_background_worker_env",
@@ -285,4 +319,5 @@ __all__ = [
     "build_spawn_mars_runtime",
     "depth_exceeded_output",
     "depth_limits",
+    "resolve_spawn_work_id",
 ]

--- a/src/meridian/lib/state/spawn_store.py
+++ b/src/meridian/lib/state/spawn_store.py
@@ -6,6 +6,7 @@ Also includes file-backed ID generation for spawns and sessions.
 from __future__ import annotations
 
 import os
+import shutil
 from collections.abc import Mapping
 from contextlib import suppress
 from datetime import UTC, datetime
@@ -381,9 +382,9 @@ def remove_spawn_events(
     """
 
     paths = RuntimePaths.from_root_dir(runtime_root)
-    state_path = paths.spawns_dir / str(spawn_id) / "state.json"
+    spawn_dir = paths.spawns_dir / str(spawn_id)
     with suppress(FileNotFoundError):
-        state_path.unlink()
+        shutil.rmtree(spawn_dir)
 
 
 def update_spawn(

--- a/tests/integration/ops/test_spawn_execute_report_output.py
+++ b/tests/integration/ops/test_spawn_execute_report_output.py
@@ -6,7 +6,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 import meridian.lib.ops.spawn.execute as execute_module
+import meridian.lib.ops.spawn.execute_init as execute_init_module
 from meridian.lib.config.settings import load_config
+from meridian.lib.core.context import RuntimeContext
+from meridian.lib.core.lifecycle import LifecycleEvent, SpawnLifecycleService
+from meridian.lib.core.sink import OutputSink
 from meridian.lib.launch.request import SpawnRequest
 from meridian.lib.ops.runtime import (
     OperationRuntime,
@@ -14,7 +18,8 @@ from meridian.lib.ops.runtime import (
     resolve_runtime_authority_for_write,
 )
 from meridian.lib.ops.spawn.models import SpawnCreateInput
-from meridian.lib.state import spawn_store
+from meridian.lib.state import spawn_store, work_store
+from meridian.lib.state.paths import resolve_project_paths
 
 if TYPE_CHECKING:
     import pytest
@@ -22,7 +27,43 @@ if TYPE_CHECKING:
 # qa-validated: spawn-return-report
 
 
-def _build_test_runtime(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> OperationRuntime:
+class RecordingOutputSink:
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    def result(self, payload: Any) -> None:
+        _ = payload
+
+    def status(self, message: str) -> None:
+        _ = message
+
+    def warning(self, message: str) -> None:
+        _ = message
+
+    def error(self, message: str, exit_code: int = 1) -> None:
+        _ = (message, exit_code)
+
+    def heartbeat(self, message: str) -> None:
+        _ = message
+
+    def event(self, payload: dict[str, Any]) -> None:
+        self.events.append(payload)
+
+
+class LifecycleEventHook:
+    def __init__(self) -> None:
+        self.event_types: list[str] = []
+
+    def on_event(self, event: LifecycleEvent) -> None:
+        self.event_types.append(event.event_type)
+
+
+def _build_test_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    sink: OutputSink | None = None,
+) -> OperationRuntime:
     project_root = tmp_path / "repo"
     project_root.mkdir()
     monkeypatch.setenv("MERIDIAN_HOME", (tmp_path / "home").as_posix())
@@ -33,6 +74,7 @@ def _build_test_runtime(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Oper
         project_root,
         config,
         authority=authority,
+        sink=sink,
     )
 
 
@@ -127,11 +169,7 @@ def test_execute_spawn_blocking_pre_init_failure_returns_failed_output(
     def _raise_project_paths(**kwargs: object) -> object:
         raise ValueError("harness binary not found")
 
-    def _fail_init(**kwargs: object) -> object:
-        raise AssertionError("_init_spawn should not be called")
-
     monkeypatch.setattr(execute_module, "resolve_project_config_paths", _raise_project_paths)
-    monkeypatch.setattr(execute_module, "_init_spawn", _fail_init)
 
     result = execute_module.execute_spawn_blocking(
         payload=SpawnCreateInput(prompt="run"),
@@ -160,6 +198,182 @@ def test_execute_spawn_blocking_pre_init_failure_returns_failed_output(
     assert result.to_wire()["harness_id"] == "opencode"
     assert result.to_wire()["task_cwd_source"] == "explicit-task-dir"
     assert result.to_wire()["task_cwd_work_item"] == "browser-investigation"
+    authority = resolve_runtime_authority_for_write(tmp_path / "repo")
+    assert authority.runtime_root is not None
+    assert not list((authority.runtime_root / "spawns").glob("*/state.json"))
+
+
+def test_reserve_then_prepare_graceful_prep_failure_leaks_nothing_with_work(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hook = LifecycleEventHook()
+    sink = RecordingOutputSink()
+    runtime = _build_test_runtime(tmp_path, monkeypatch, sink=sink)
+    project_root = tmp_path / "repo"
+    project_state_dir = resolve_project_paths(project_root).root_dir
+    authority = resolve_runtime_authority_for_write(project_root)
+    assert authority.runtime_root is not None
+
+    original_factory = execute_init_module.build_spawn_lifecycle_service_from_roots
+
+    def _service_with_hook(project_root_arg: Path, runtime_root: Path) -> SpawnLifecycleService:
+        service = original_factory(project_root_arg, runtime_root)
+        service._hooks = [*service._hooks, hook]
+        return service
+
+    monkeypatch.setattr(
+        execute_init_module,
+        "build_spawn_lifecycle_service_from_roots",
+        _service_with_hook,
+    )
+
+    def _raise_project_paths(**kwargs: object) -> object:
+        raise ValueError("harness binary not found")
+
+    monkeypatch.setattr(execute_module, "resolve_project_config_paths", _raise_project_paths)
+
+    assert work_store.get_work_item(project_state_dir, "new-work-item") is None
+
+    result = execute_module.execute_spawn_blocking(
+        payload=SpawnCreateInput(prompt="run", work="new-work-item"),
+        request=SpawnRequest(
+            prompt="run",
+            model="gpt-5.4",
+            harness="codex",
+        ),
+        runtime=runtime,
+        ctx=RuntimeContext(depth=1, spawn_id="p-parent"),
+    )
+
+    assert result.status == "failed"
+    assert result.spawn_id is None
+    assert result.error == "pre_init_failed"
+    assert not list((authority.runtime_root / "spawns").glob("*/state.json"))
+    assert work_store.get_work_item(project_state_dir, "new-work-item") is None
+    assert hook.event_types == []
+    assert [event.get("t") for event in sink.events] == []
+
+
+def test_reserve_then_prepare_happy_path_announces_once_with_normalized_work_id(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hook = LifecycleEventHook()
+    sink = RecordingOutputSink()
+    runtime = _build_test_runtime(tmp_path, monkeypatch, sink=sink)
+    project_root = tmp_path / "repo"
+    project_state_dir = resolve_project_paths(project_root).root_dir
+    authority = resolve_runtime_authority_for_write(project_root)
+    assert authority.runtime_root is not None
+
+    original_factory = execute_init_module.build_spawn_lifecycle_service_from_roots
+
+    def _service_with_hook(project_root_arg: Path, runtime_root: Path) -> SpawnLifecycleService:
+        service = original_factory(project_root_arg, runtime_root)
+        service._hooks = [*service._hooks, hook]
+        return service
+
+    monkeypatch.setattr(
+        execute_init_module,
+        "build_spawn_lifecycle_service_from_roots",
+        _service_with_hook,
+    )
+
+    async def _fake_launch_prepared_spawn(**kwargs: object) -> int:
+        spawn = cast("Any", kwargs["spawn"])
+        spawn_store.finalize_spawn(
+            authority.runtime_root,
+            str(spawn.spawn_id),
+            "succeeded",
+            0,
+            origin="runner",
+        )
+        return 0
+
+    monkeypatch.setattr(execute_module, "launch_prepared_spawn", _fake_launch_prepared_spawn)
+    monkeypatch.setattr(
+        execute_module,
+        "read_spawn_row",
+        lambda _project_root, spawn_id, **_kwargs: spawn_store.get_spawn(
+            authority.runtime_root,
+            spawn_id,
+        ),
+    )
+
+    result = execute_module.execute_spawn_blocking(
+        payload=SpawnCreateInput(prompt="run", work="new-work-item"),
+        request=SpawnRequest(
+            prompt="run",
+            model="gpt-5.4",
+            harness="codex",
+            agent="coder",
+        ),
+        runtime=runtime,
+        ctx=RuntimeContext(depth=1, spawn_id="p-parent"),
+    )
+
+    assert result.status == "succeeded"
+    assert result.spawn_id is not None
+    row = spawn_store.get_spawn(authority.runtime_root, result.spawn_id)
+    assert row is not None
+    assert row.work_id == "new-work-item"
+    assert work_store.get_work_item(project_state_dir, "new-work-item") is not None
+    assert hook.event_types == ["spawn.created"]
+    start_events = [event for event in sink.events if event.get("t") == "meridian.spawn.start"]
+    assert len(start_events) == 1
+    assert start_events[0]["id"] == result.spawn_id
+
+
+def test_execute_spawn_blocking_persists_unified_work_id_precedence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from meridian.lib.core.context import RuntimeContext
+
+    runtime = _build_test_runtime(tmp_path, monkeypatch)
+    authority = resolve_runtime_authority_for_write(tmp_path / "repo")
+    assert authority.runtime_root is not None
+
+    async def _fake_launch_prepared_spawn(**kwargs: object) -> int:
+        spawn = cast("Any", kwargs["spawn"])
+        spawn_store.finalize_spawn(
+            authority.runtime_root,
+            str(spawn.spawn_id),
+            "succeeded",
+            0,
+            origin="runner",
+        )
+        return 0
+
+    monkeypatch.setattr(execute_module, "launch_prepared_spawn", _fake_launch_prepared_spawn)
+    monkeypatch.setattr(
+        execute_module,
+        "read_spawn_row",
+        lambda _project_root, spawn_id, **_kwargs: spawn_store.get_spawn(
+            authority.runtime_root,
+            spawn_id,
+        ),
+    )
+
+    result = execute_module.execute_spawn_blocking(
+        payload=SpawnCreateInput(prompt="run", work="from-payload"),
+        request=SpawnRequest(
+            prompt="run",
+            model="gpt-5.4",
+            harness="codex",
+            task_cwd_work_item="from-request",
+            work_id_hint="from-hint",
+        ),
+        runtime=runtime,
+        ctx=RuntimeContext(work_id="ambient-work"),
+    )
+
+    assert result.status == "succeeded"
+    assert result.spawn_id is not None
+    row = spawn_store.get_spawn(authority.runtime_root, result.spawn_id)
+    assert row is not None
+    assert row.work_id == "from-request"
 
 
 def test_execute_spawn_background_pre_init_failure_returns_failed_output(
@@ -171,11 +385,7 @@ def test_execute_spawn_background_pre_init_failure_returns_failed_output(
     def _raise_project_paths(**kwargs: object) -> object:
         raise PermissionError("permission denied resolving project")
 
-    def _fail_init(**kwargs: object) -> object:
-        raise AssertionError("_init_spawn should not be called")
-
     monkeypatch.setattr(execute_module, "resolve_project_config_paths", _raise_project_paths)
-    monkeypatch.setattr(execute_module, "_init_spawn", _fail_init)
 
     result = execute_module.execute_spawn_background(
         payload=SpawnCreateInput(prompt="run", background=True),
@@ -204,3 +414,6 @@ def test_execute_spawn_background_pre_init_failure_returns_failed_output(
     assert result.to_wire()["harness_id"] == "opencode"
     assert result.to_wire()["task_cwd_source"] == "explicit-task-dir"
     assert result.to_wire()["task_cwd_work_item"] == "browser-investigation"
+    authority = resolve_runtime_authority_for_write(tmp_path / "repo")
+    assert authority.runtime_root is not None
+    assert not list((authority.runtime_root / "spawns").glob("*/state.json"))

--- a/tests/integration/state/test_reaper_reconciliation.py
+++ b/tests/integration/state/test_reaper_reconciliation.py
@@ -461,3 +461,107 @@ def test_reconcile_active_spawn_durable_report_wins_over_cancelled_runner_exit(
     assert latest.status == "succeeded"
     assert latest.exit_code == 0
     assert latest.error is None
+
+
+class _MidPrepKillSimulation(Exception):
+    """Simulates abrupt launcher death during prep (no cleanup)."""
+
+
+def test_reserve_then_prepare_mid_prep_kill_leaves_queued_row_reconciled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import meridian.lib.ops.spawn.execute as execute_module
+    from meridian.lib.config.settings import load_config
+    from meridian.lib.core.context import RuntimeContext
+    from meridian.lib.core.sink import OutputSink
+    from meridian.lib.launch.request import SpawnRequest
+    from meridian.lib.ops.runtime import (
+        build_runtime_from_root_and_config,
+        resolve_runtime_authority_for_write,
+    )
+    from meridian.lib.ops.spawn.models import SpawnCreateInput
+    from meridian.lib.state import work_store
+    from meridian.lib.state.paths import resolve_project_paths
+    from meridian.lib.state.spawn.model import BACKGROUND_LAUNCH_MODE
+    from meridian.lib.state.spawn.repository import scan_spawn_ids, write_state_locked
+
+    class _RecordingSink:
+        def __init__(self) -> None:
+            self.events: list[dict[str, object]] = []
+
+        def result(self, payload: object) -> None:
+            _ = payload
+
+        def status(self, message: str) -> None:
+            _ = message
+
+        def warning(self, message: str) -> None:
+            _ = message
+
+        def error(self, message: str, exit_code: int = 1) -> None:
+            _ = (message, exit_code)
+
+        def heartbeat(self, message: str) -> None:
+            _ = message
+
+        def event(self, payload: dict[str, object]) -> None:
+            self.events.append(payload)
+
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    monkeypatch.setenv("MERIDIAN_HOME", (tmp_path / "home").as_posix())
+    authority = resolve_runtime_authority_for_write(project_root)
+    assert authority.runtime_root is not None
+    config = load_config(project_root, authority=authority)
+    sink: OutputSink = _RecordingSink()
+    runtime = build_runtime_from_root_and_config(
+        project_root,
+        config,
+        authority=authority,
+        sink=sink,
+    )
+    runtime_root = authority.runtime_root
+    project_state_dir = resolve_project_paths(project_root).root_dir
+    assert work_store.get_work_item(project_state_dir, "new-work-item") is None
+
+    def _prep_kill(**kwargs: object) -> object:
+        spawn_ids = scan_spawn_ids(runtime_root / "spawns")
+        assert len(spawn_ids) == 1
+        record = spawn_store.get_spawn(runtime_root, spawn_ids[0])
+        assert record is not None
+        assert record.status == "queued"
+        assert record.runner_pid is None
+        raise _MidPrepKillSimulation()
+
+    monkeypatch.setattr(execute_module, "_prepare_spawn_execution", _prep_kill)
+
+    with pytest.raises(_MidPrepKillSimulation):
+        execute_module._reserve_then_prepare(
+            payload=SpawnCreateInput(prompt="run", work="new-work-item"),
+            request=SpawnRequest(prompt="run", model="gpt-5.4", harness="codex"),
+            runtime=runtime,
+            ctx=RuntimeContext(depth=1, spawn_id="p-parent"),
+            launch_mode=BACKGROUND_LAUNCH_MODE,
+        )
+
+    spawn_ids = scan_spawn_ids(runtime_root / "spawns")
+    assert len(spawn_ids) == 1
+    spawn_id = spawn_ids[0]
+    assert work_store.get_work_item(project_state_dir, "new-work-item") is None
+    assert [event.get("t") for event in sink.events] == []
+    write_state_locked(
+        runtime_root / "spawns",
+        spawn_id,
+        lambda current: current.model_copy(update={"started_at": _OLD_STARTED_AT}),
+    )
+    record = _get_spawn(runtime_root, spawn_id)
+
+    reconciled = _reconcile(project_root, runtime_root, record)
+
+    assert reconciled.status == "failed"
+    assert reconciled.exit_code == 1
+    assert reconciled.error == "missing_runner_pid"
+    latest = _get_spawn(runtime_root, spawn_id)
+    assert latest.status == "failed"
+    assert latest.error == "missing_runner_pid"

--- a/tests/unit/core/test_lifecycle.py
+++ b/tests/unit/core/test_lifecycle.py
@@ -40,6 +40,16 @@ class StoreSnapshotHook:
         )
 
 
+class EventTypeHook:
+    """Captures lifecycle event types for assertions."""
+
+    def __init__(self) -> None:
+        self.event_types: list[str] = []
+
+    def on_event(self, event: LifecycleEvent) -> None:
+        self.event_types.append(event.event_type)
+
+
 def _make_service(
     runtime_root: Path,
     hooks: list[Any] | None = None,
@@ -202,6 +212,32 @@ def test_start_accepts_typed_metadata_and_persists_goal(tmp_path: Path) -> None:
     assert record.desc == "goal metadata"
     assert record.work_id == "w-lifecycle"
     assert record.goal == "finish migration"
+
+
+def test_start_without_dispatch_events_defers_hook_until_announce_started(tmp_path: Path) -> None:
+    hook = EventTypeHook()
+    service = _make_service(tmp_path, hooks=[hook])
+
+    spawn_id = service.start(
+        chat_id="c1",
+        session_metadata=PrimarySessionMetadata(
+            harness="codex",
+            model="gpt-5.4",
+            agent="coder",
+            agent_path="",
+            skills=(),
+            skill_paths=(),
+        ),
+        prompt="run it",
+        status="queued",
+        dispatch_events=False,
+    )
+
+    assert hook.event_types == []
+
+    service.announce_started(spawn_id)
+
+    assert hook.event_types == ["spawn.created"]
 
 
 def test_owner_mark_running_clears_stale_runner_created_epoch_when_pid_replaced(


### PR DESCRIPTION
## Why

A spawn launcher killed by SIGKILL during `_prepare_spawn_execution` — before `_init_spawn` wrote `state.json` — left nothing on disk. The spawn was invisible to `spawn list/status/wait`, the reconciler, and `doctor --kill-orphans`: the only forever-invisible spawn failure mode. This is the root of the c2076 incident (a `meridian spawn --bg` double-backgrounded through Claude Code's `run_in_background`, then torn down by auto-compaction inside the ~2s startup window). The companion usage fix (always-injected spawn contract, PR #328) tells the model not to double-background, but that's model-controlled; this makes a killed launch safe regardless.

## Goal

A launcher killed at any point leaves a recoverable, visible row — delivering the crash-only principle for the one window where it wasn't true — without changing behavior on any non-kill path.

## Summary

Reserve the durable `queued` spawn row before prep instead of after. A killed-mid-prep launch now leaves a `queued` row with no `runner_pid` that the existing reaper reconciles to `failed`/`missing_runner_pid`. To keep every non-kill path behavior-preserving, reserve and announce are split: the reserve writes only the row; work-item creation and lifecycle/telemetry/subrun events are deferred to an announce step that runs only after prep succeeds.

## Resulting Behavior

- Kill a `meridian spawn` launcher mid-prep → the spawn shows up in `meridian spawn list`/`status` and reconciles to `failed` (was: silently gone).
- Graceful prep failure (bad model/config/typo) → unchanged: synchronous error, no durable row, **no created work item, no emitted events**.
- Happy path → unchanged net side effects (work item + `spawn.created`/subrun start emitted exactly once), just with the row written earlier.

## Changes

- `ops/spawn/execute.py`: new shared `_reserve_then_prepare` helper owns reserve → prep → (on success) ensure-work-item + persist-contract + announce. Both execute paths use it; the two duplicated post-prep `update_spawn` blocks are deleted.
- `ops/spawn/execute_init.py`: `_init_spawn(announce=...)` — reserve mode writes the row only (skips work-item create, subrun event, `dispatch_events=False`). Single `resolve_spawn_work_id` resolver with full precedence; `_resolve_work_id` deleted (had one caller).
- `core/lifecycle.py`: `LifecycleService.start(dispatch_events=False)` + `announce_started()` cleanly split the row write from event dispatch.
- `state/spawn_store.py`: `remove_spawn_events` now rmtree's the reserved spawn dir.
- No reaper changes, no schema changes, no new states. Source net ≈ flat.

## Work Item

spawn-row-before-prep

## Verification

- `uv run ruff check .` clean; `uv run --extra dev python -m pyright` 0 errors.
- Broad suite: `1413 passed` (full `tests/unit tests/integration tests/contract`).
- New coverage: kill-mid-prep leaves a reconcilable `queued` row with no work item / no start events; graceful prep failure leaks nothing (row, work item, and events all absent); happy path announces exactly once; work_id precedence parity vs prior behavior; lifecycle `dispatch_events=False` defers events until `announce_started`.
- Adversarial correctness review (p4356) caught that the initial reorder leaked work-item creation + start events on graceful failure (the design assumed `_init_spawn` was side-effect-free for reserve); the two-phase split fixes it. Re-verified.

## Knowledge Updates

CHANGELOG.md `[Unreleased]` updated. The design doc (`work/spawn-row-before-prep/design.md`) recorded the two-phase correction as a gap vs the original "simple reorder" premise.

## Spawn Trace

- p4349 coder — initial reserve-before-prep reorder
- p4356 reviewer — correctness review (found the graceful-failure side-effect leak)
- p4363 coder — two-phase reserve/announce fix

## Release Label Guide

`release:patch` — bug fix, no API change.

## Post-Merge Automation

Standard.

## Cleanup

`scripts/prune-worktrees.sh` after merge.
