### PR TITLE
fix: silence two misleading noises on a successful spawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- A successful `meridian spawn` no longer emits two pieces of misleading noise. (1) The git-autosync divergence check pre-resolves `@{upstream}`; a clone with no upstream (detached HEAD / no tracking branch) is now a benign debug skip (`git_autosync_divergence_check_skipped`, `skip_reason="no_upstream"`) instead of a `[warning] git_autosync_divergence_check_failed ... no such branch: 'HEAD...'`. Genuine divergence failures still warn; the happy path is unchanged. (2) The Codex websocket reader treats a normal close (`ConnectionClosedOK`, or `ConnectionClosedError` with close code 1000) as clean shutdown, and the liveness cleanup awaits/retrieves the child task on cancellation — eliminating the GC-time `Task exception was never retrieved` / `ConnectionClosedError` traceback. Abnormal closes still surface.
+
 ## [0.3.15] - 2026-06-22
 
 ### Fixed

--- a/src/meridian/lib/harness/connections/codex_ws.py
+++ b/src/meridian/lib/harness/connections/codex_ws.py
@@ -129,6 +129,25 @@ def _ws_is_open(ws: object) -> bool:
     return False
 
 
+def _is_clean_websocket_close(exc: BaseException) -> bool:
+    """Return whether a websocket close exception represents normal closure."""
+
+    exceptions_module = getattr(_WEBSOCKETS_MODULE, "exceptions", None)
+    connection_closed_ok = getattr(exceptions_module, "ConnectionClosedOK", None)
+    if connection_closed_ok is not None and isinstance(exc, connection_closed_ok):
+        return True
+
+    connection_closed_error = getattr(exceptions_module, "ConnectionClosedError", None)
+    if connection_closed_error is None or not isinstance(exc, connection_closed_error):
+        return False
+
+    for attr in ("rcvd", "sent"):
+        close_frame = getattr(exc, attr, None)
+        if getattr(close_frame, "code", None) == 1000:
+            return True
+    return False
+
+
 class _AiohttpWebSocketCompat:
     """Compatibility layer matching the subset of the websockets API we use."""
 
@@ -723,6 +742,10 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
                             )
                         )
                     return
+                except Exception as exc:
+                    if _is_clean_websocket_close(exc):
+                        return
+                    raise
                 self._liveness.mark_activity()
                 raw_text = _coerce_text(raw_message)
                 if self._tracer is not None:

--- a/src/meridian/lib/harness/connections/liveness.py
+++ b/src/meridian/lib/harness/connections/liveness.py
@@ -137,8 +137,8 @@ class BackendLivenessPolicy:
         except BaseException:
             if not task.done():
                 task.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await task
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task
             raise
 
     def _silence_expired(self) -> bool:

--- a/src/meridian/lib/hooks/builtin/git_autosync.py
+++ b/src/meridian/lib/hooks/builtin/git_autosync.py
@@ -82,6 +82,19 @@ def _git_subprocess_env() -> dict[str, str]:
     return env
 
 
+def _is_no_upstream_error(message: str) -> bool:
+    """Return whether git reported that @{upstream} cannot be resolved."""
+
+    normalized = message.lower()
+    return (
+        "no upstream configured" in normalized
+        or "no upstream branch" in normalized
+        or "no such branch: 'head...'" in normalized
+        or "no such branch: 'head'" in normalized
+        or ("upstream" in normalized and "unknown revision" in normalized)
+    )
+
+
 @dataclass(frozen=True)
 class _SyncOutcome:
     outcome: HookOutcome
@@ -1131,9 +1144,33 @@ class GitAutosync:
     ) -> tuple[int, int] | None:
         """Check commits ahead/behind upstream. Returns (ahead, behind).
 
-        When rev-list fails, logs a warning and attempts fallback. Returns None
-        when divergence cannot be determined.
+        Repositories without a configured upstream are a benign local-only
+        state for divergence purposes. When an upstream exists but rev-list
+        fails, logs a warning and attempts fallback. Returns None when
+        divergence cannot be determined.
         """
+
+        upstream = self._run_git(
+            clone_path,
+            ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
+            timeout=_DIFF_TIMEOUT_SECS,
+        )
+        if upstream.returncode != 0:
+            error_msg = (upstream.stderr or upstream.stdout or "").strip()
+            if _is_no_upstream_error(error_msg):
+                logger.debug(
+                    "git_autosync_divergence_check_skipped",
+                    clone_path=clone_path,
+                    skip_reason="no_upstream",
+                    error=error_msg,
+                )
+            else:
+                logger.warning(
+                    "git_autosync_divergence_check_failed",
+                    clone_path=clone_path,
+                    error=error_msg,
+                )
+            return None
 
         result = self._run_git(
             clone_path,

--- a/tests/unit/harness/connections/test_codex_ws_clean_close.py
+++ b/tests/unit/harness/connections/test_codex_ws_clean_close.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from websockets.exceptions import ConnectionClosedError
+from websockets.frames import Close, CloseCode
+
+from meridian.lib.harness.connections.codex_ws import CodexConnection
+
+
+class _ClosingWebSocket:
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+
+    def __aiter__(self) -> _ClosingWebSocket:
+        return self
+
+    async def __anext__(self) -> Any:
+        raise self._exc
+
+
+@pytest.mark.asyncio
+async def test_codex_reader_treats_normal_close_error_as_clean_shutdown() -> None:
+    connection = CodexConnection()
+    connection._state = "connected"
+    connection._ws = _ClosingWebSocket(
+        ConnectionClosedError(
+            None,
+            Close(CloseCode.NORMAL_CLOSURE, ""),
+            None,
+        )
+    )
+
+    task = asyncio.create_task(connection._read_messages_loop())
+    await task
+
+    assert task.exception() is None
+    assert await connection._event_queue.get() is None
+
+
+@pytest.mark.asyncio
+async def test_codex_reader_reports_abnormal_close() -> None:
+    connection = CodexConnection()
+    connection._state = "connected"
+    connection._ws = _ClosingWebSocket(
+        ConnectionClosedError(
+            Close(CloseCode.INTERNAL_ERROR, "boom"),
+            None,
+            None,
+        )
+    )
+
+    await connection._read_messages_loop()
+
+    event = await connection._event_queue.get()
+    assert event is not None
+    assert event.event_type == "error/connectionClosed"
+    assert "1011" in str(event.payload["message"])
+    assert await connection._event_queue.get() is None

--- a/tests/unit/harness/test_backend_liveness_policy.py
+++ b/tests/unit/harness/test_backend_liveness_policy.py
@@ -266,3 +266,33 @@ async def test_wait_for_activity_raises_on_backend_dead(
 
     with pytest.raises(EventStreamLivenessTimeout):
         await policy.wait_for_activity(blocked())
+
+
+@pytest.mark.asyncio
+async def test_wait_for_activity_retrieves_child_exception_when_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    policy = BackendLivenessPolicy(
+        timeout_seconds=lambda: 10.0,
+        now=time.monotonic,
+        backend_pid=lambda: 4242,
+        backend_birth_time=lambda: 0.0,
+    )
+    policy.mark_activity()
+    loop = asyncio.get_running_loop()
+    child: asyncio.Future[None] = loop.create_future()
+
+    async def fake_wait(
+        fs: set[asyncio.Future[None]],
+        timeout: float | None = None,
+    ) -> tuple[set[asyncio.Future[None]], set[asyncio.Future[None]]]:
+        _ = fs, timeout
+        child.set_exception(RuntimeError("normal close raced with teardown"))
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(liveness_module.asyncio, "wait", fake_wait)
+
+    with pytest.raises(asyncio.CancelledError):
+        await policy.wait_for_activity(child)
+
+    assert child._log_traceback is False

--- a/tests/unit/hooks/builtin/test_git_autosync.py
+++ b/tests/unit/hooks/builtin/test_git_autosync.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+from meridian.lib.hooks.builtin.git_autosync import GitAutosync
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def _completed() -> subprocess.CompletedProcess[str]:
+    result: subprocess.CompletedProcess[str] = MagicMock(spec=subprocess.CompletedProcess)
+    result.stdout = ""
+    result.stderr = ""
+    result.returncode = 0
+    return result
+
+
+def _git_result(
+    returncode: int,
+    *,
+    stdout: str = "",
+    stderr: str = "",
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=["git"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def test_run_git_strips_repo_scoped_git_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GIT_DIR", "/tmp/real-checkout/.git")
+    monkeypatch.setenv("GIT_WORK_TREE", "/tmp/real-checkout")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", "/tmp/test-gitconfig")
+
+    with patch("subprocess.run", return_value=_completed()) as mock_run:
+        GitAutosync()._run_git("/tmp/work", ["status"], timeout=5)
+
+    call_env = mock_run.call_args.kwargs["env"]
+    assert "GIT_DIR" not in call_env
+    assert "GIT_WORK_TREE" not in call_env
+    assert call_env["GIT_CONFIG_GLOBAL"] == "/tmp/test-gitconfig"
+    assert call_env["LC_ALL"] == "C"
+
+
+def test_check_divergence_no_upstream_is_debug_skip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    autosync = GitAutosync()
+
+    def fake_run_git(
+        work_dir: str,
+        args: list[str],
+        *,
+        timeout: int,
+    ) -> subprocess.CompletedProcess[str]:
+        _ = work_dir, timeout
+        assert args == ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"]
+        return _git_result(
+            128,
+            stderr="fatal: no upstream configured for branch 'main'",
+        )
+
+    monkeypatch.setattr(autosync, "_run_git", fake_run_git)
+
+    with patch("meridian.lib.hooks.builtin.git_autosync.logger") as mock_logger:
+        assert autosync._check_divergence("/tmp/clone") is None
+
+    mock_logger.debug.assert_called_once()
+    assert mock_logger.debug.call_args.args == ("git_autosync_divergence_check_skipped",)
+    assert mock_logger.debug.call_args.kwargs["skip_reason"] == "no_upstream"
+    mock_logger.warning.assert_not_called()
+
+
+def test_check_divergence_with_upstream_computes_ahead_behind(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    autosync = GitAutosync()
+    calls: list[list[str]] = []
+
+    def fake_run_git(
+        work_dir: str,
+        args: list[str],
+        *,
+        timeout: int,
+    ) -> subprocess.CompletedProcess[str]:
+        _ = work_dir, timeout
+        calls.append(args)
+        if args == ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"]:
+            return _git_result(0, stdout="origin/main\n")
+        if args == ["rev-list", "--left-right", "--count", "HEAD...@{upstream}"]:
+            return _git_result(0, stdout="2\t3\n")
+        raise AssertionError(f"unexpected git args: {args}")
+
+    monkeypatch.setattr(autosync, "_run_git", fake_run_git)
+
+    with patch("meridian.lib.hooks.builtin.git_autosync.logger") as mock_logger:
+        assert autosync._check_divergence("/tmp/clone", "main") == (2, 3)
+
+    assert calls == [
+        ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
+        ["rev-list", "--left-right", "--count", "HEAD...@{upstream}"],
+    ]
+    mock_logger.warning.assert_not_called()


### PR DESCRIPTION
## Why

A trivial, **successful** `meridian spawn -m gpt-5.4-mini -p "hi"` printed two pieces of scary, misleading output:
1. `[warning] git_autosync_divergence_check_failed ... error="fatal: no such branch: 'HEAD...'"` on `spawn.finalized`.
2. An asyncio `Task exception was never retrieved` traceback ending in `websockets ... ConnectionClosedError: sent 1000 (OK); no close frame received`.

Both are pre-existing latent bugs (the code predates and is untouched by the spawn-capability work — `git_autosync.py` and `harness/connections/` are byte-identical to main on that branch). The spawn itself succeeded; this is pure output-hygiene noise that makes a clean run look broken.

## Goal

A successful spawn produces no traceback and no misleading warning, without suppressing genuine failures.

## Summary

- **autosync divergence**: pre-resolve `@{upstream}`; a clone with no upstream (detached HEAD / no tracking branch) is a benign debug skip, not a warning.
- **codex websocket**: treat a normal close (code 1000 / `ConnectionClosedOK`) as clean shutdown in the reader, and retrieve the child task's exception during liveness cleanup so nothing is GC'd unretrieved.

## Resulting Behavior

- `meridian spawn -m gpt-5.4-mini -p "hi"` → succeeds with **no** traceback and **no** divergence warning (verified live).
- A clone with no upstream → `git_autosync_divergence_check_skipped` at **debug** (`skip_reason="no_upstream"`); a clone with an upstream still computes ahead/behind exactly as before.
- An **abnormal** websocket close still surfaces through existing error handling.

## Changes

- `lib/hooks/builtin/git_autosync.py`: `_check_divergence` pre-resolves `@{upstream}` via `git rev-parse`; new `_is_no_upstream_error` classifies the benign case → debug skip; genuine errors still `git_autosync_divergence_check_failed` (warning). Happy path unchanged (`rev-list --left-right --count HEAD...@{upstream}`).
- `lib/harness/connections/codex_ws.py`: `_is_clean_websocket_close` (ConnectionClosedOK or ConnectionClosedError with rcvd/sent code 1000); reader returns cleanly on a clean close, re-raises otherwise.
- `lib/harness/connections/liveness.py`: cleanup awaits/retrieves the child awaitable even on cancellation, so its clean-close exception isn't left unretrieved.

## Work Item

(none — standalone output-hygiene fix off main)

## Verification

- `uv run ruff check .` clean; `uv run --extra dev python -m pyright src/meridian` → 0 errors, 0 warnings.
- `uv run pytest-llm tests/unit` → 772 passed; focused autosync + connection/liveness tests → 20 passed.
- New/updated tests: autosync no-upstream debug-skip + upstream happy path; codex reader clean-close vs abnormal-close; liveness cancellation retrieves child exceptions.
- Live repro: `meridian spawn -m gpt-5.4-mini -p "hi"` → succeeded, no traceback, no warning.

## Knowledge Updates

CHANGELOG.md `[Unreleased]` (Fixed). No KB/docs surface.

## Spawn Trace

p4402 coder (diagnosis + fix + tests); tech-lead review + commit.

## Release Label

`release:patch` — output-hygiene bug fixes; no behavior change on the happy path, no real users affected.

## Cleanup

`scripts/prune-worktrees.sh` after merge (removes the `spawn-output-noise` worktree).
