### PR TITLE
docs: reconcile stale work/context layout after launch-surface refactor

### DIFF
--- a/docs/codex-tui-passthrough.md
+++ b/docs/codex-tui-passthrough.md
@@ -33,7 +33,7 @@ Roots are deduplicated and resolved to absolute paths before projection. Paths t
 
 Managed primary sessions surface approval requests instead of auto-accepting or rejecting them.
 
-In the managed architecture Meridian is the websocket client connected to the Codex app-server. When Codex issues a `*/requestApproval` or `item/tool/requestUserInput` JSON-RPC server request, it goes to Meridian — not to the TUI. Meridian dispatches these through an interactive handler (`ManagedPrimaryRequestHandler`) that records them as `request/opened` events in the spawn's harness history. A controller — CLI, chat frontend, or API — can then answer via `respond_request()` or `respond_user_input()`.
+In the managed architecture Meridian is the websocket client connected to the Codex app-server. When Codex issues a `*/requestApproval` or `item/tool/requestUserInput` JSON-RPC server request, it goes to Meridian — not to the TUI. Meridian dispatches these through an interactive handler (`ManagedPrimaryRequestHandler`) that records them as `request/opened` events in the spawn's harness history. A controller (CLI or API) can then answer via `respond_request()` or `respond_user_input()`.
 
 Key properties:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -545,8 +545,8 @@ path   = "project/strategy"
 | --- | ---- | ------- | ------- |
 | `source` | str | `"local"` | `"local"` or `"git"` |
 | `remote` | str | — | Git remote URL (required when `source = "git"`) |
-| `path` | str | `".meridian/work"` | Path to the work directory, relative to repo or clone root |
-| `archive` | str | `".meridian/archive/work"` | Path to the work archive directory |
+| `path` | str | `"{user_home}/context/{project}/work"` | Path to the work directory (see path resolution below) |
+| `archive` | str | `"{user_home}/context/{project}/archive/work"` | Path to the work archive directory |
 
 #### `[context.kb]`
 
@@ -554,7 +554,7 @@ path   = "project/strategy"
 | --- | ---- | ------- | ------- |
 | `source` | str | `"local"` | `"local"` or `"git"` |
 | `remote` | str | — | Git remote URL (required when `source = "git"`) |
-| `path` | str | `".meridian/kb"` | Path to the knowledge base directory |
+| `path` | str | `"{user_home}/context/{project}/kb"` | Path to the knowledge base directory (see path resolution below) |
 
 #### `[context.NAME]`
 
@@ -567,6 +567,24 @@ Arbitrary named context tables are allowed alongside the built-in `work` and `kb
 | `path` | str | — | Path to the context directory, relative to repo or clone root |
 
 When `source = "git"`, Meridian clones the remote into a local cache and resolves paths relative to the clone root. Use `meridian context` to inspect the resolved paths.
+
+#### Path resolution
+
+`path` values support two placeholders:
+
+- `{user_home}` — the Meridian user home (e.g. `~/.meridian`).
+- `{project}` — the project ID from `.meridian/id`.
+
+For `source = "git"`, `path` is resolved relative to the clone root. For
+`source = "local"`, absolute paths (including expanded placeholders) are used as
+given; a relative `path` resolves against the project root.
+
+The built-in defaults are user-scoped (`{user_home}/context/{project}/...`), so
+work and KB live **outside** the project repo. As a fallback only, when a `path`
+contains `{project}` but no project ID can be resolved (no `.meridian/id`),
+Meridian uses the project-local `.meridian/` equivalents (`.meridian/work`,
+`.meridian/kb`, `.meridian/archive/work`). A normally initialized project never
+hits this fallback.
 
 ## Model Catalog
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,9 +66,7 @@ Meridian splits state across two roots: repo-tracked files that belong in versio
   .meridian/
     .gitignore               # committed — controls what else is tracked
     id                       # committed — project UUID (stable across renames)
-    kb/                      # committed — knowledge base directory
-    work/                    # committed — active work-item scratch dirs
-    archive/work/            # committed — scratch for completed work items
+    kb/                      # committed — KB fallback (used only when no project ID)
 ```
 
 Read-only commands (`meridian spawn list`, `meridian config show`, etc.) do not create `.meridian/id` or any runtime state. `meridian doctor` skips bootstrap at startup but calls `ensure_runtime_state_bootstrap_sync` internally, so it **does** create the UUID and runtime dir when run.
@@ -95,7 +93,7 @@ High-churn runtime state lives outside the repo, keyed by project UUID so the re
 
 The UUID is stored in `.meridian/id` (committed project identity — tracked in version control). Because state is keyed by UUID rather than path, renaming or moving the repo does not orphan runtime state.
 
-By default, `work/` and `archive/work/` stay repo-side so work-item scratch files are visible to all collaborators and survive across machines.
+`work/` and `archive/work/` directories no longer live here by default. Work items resolve under `[context.work]` (default `{user_home}/context/{project}/work/`). The `.meridian/` equivalents are used only as a fallback when no project ID is available — a normally initialized project never hits this path.
 
 ## `meridian.toml` Keys
 

--- a/src/meridian/lib/context/AGENTS.md
+++ b/src/meridian/lib/context/AGENTS.md
@@ -29,13 +29,17 @@ intended for terminal output. Use the default `check_env=True` for human-readabl
 `_resolve_path()` only derives the expected path from `resolve_clone_path(remote)`.
 Actual cloning is handled by git-autosync hooks at a different layer.
 
-**Fresh projects always produce valid `ResolvedContextPaths`.** When `{project}` cannot
-resolve, fallbacks kick in:
+Paths resolve via `[context.work]` and `[context.kb]` configuration. Defaults are user-scoped:
+- `work_root` → `{user_home}/context/{project}/work`
+- `kb_root` → `{user_home}/context/{project}/kb`
+
+When `{project}` cannot resolve (no `.meridian/id`), fallbacks kick in:
 - `work_root` → `<project_root>/.meridian/work`
 - `kb_root` → `<project_root>/.meridian/kb`
 - Extra contexts requiring `{project}` → silently skipped
 
-Callers can assume a non-null result but must not assume the paths exist on disk.
+A normally initialized project never hits the fallback. Callers can assume a non-null
+result but must not assume the paths exist on disk.
 
 ## Entry Points
 

--- a/src/meridian/lib/state/AGENTS.md
+++ b/src/meridian/lib/state/AGENTS.md
@@ -3,14 +3,13 @@
 File-backed authority for all Meridian runtime state. No database, no service,
 no in-memory objects that survive process death. If it's not on disk, it doesn't exist.
 
-## Dual-Root Layout
+## Roots
 
-State splits across two roots — understand which goes where before writing anything:
+State splits across distinct roots — understand which goes where before writing anything:
 
 ```
 .meridian/                          ← repo-local, committed scaffolding
   id                                — project UUID / three-word ID
-  work-items/<slug>.json            — mutable JSON per work item
 
 ~/.meridian/projects/<id>/          ← user runtime, never committed
   sessions.jsonl                    — session events (append-only)
@@ -19,10 +18,20 @@ State splits across two roots — understand which goes where before writing any
     state.lock                      — per-spawn lock for external writers
     history.jsonl                   — primary output artifact
     heartbeat · report.md · stderr.log · params.json · tokens.json
+
+<context.work root>/<slug>/         ← context-resolved, NOT repo-local
+  __status.json                     — mutable per-work-item metadata
+  prompts/ handoffs/ …              — work artifacts
 ```
 
 The project UUID in `.meridian/id` keys into `~/.meridian/projects/<id>/`. Projects
 can move or be renamed without losing runtime history.
+
+Work items live under the `[context.work]` root (default
+`{user_home}/context/<id>/work/<slug>/`), resolved by `work_scope.py` /
+`work_store.py` — **never** the project repo. The legacy
+`.meridian/work-items/<slug>.json` layout is gone; see `docs/configuration.md`
+for context-path resolution.
 
 ## Spawn State: V2 Per-Spawn Files
 


### PR DESCRIPTION
## Why

After the inheritable task-dir + work-scope work (#335 and the follow-on
named-work fix), several knowledge-layer docs still described the **old** model:
repo-local `.meridian/work-items/` / `.meridian/work` as the default work
location, and the deleted `meridian chat` frontend. Stale knowledge rots agents'
mental models and contradicts shipped behavior.

## Goal

The durable knowledge layers (`AGENTS.md`, `.context/`, `docs/`) describe current
truth: named work items resolve under `[context.work]` (user-scoped by default),
never the project repo; the `chat` feature is gone.

## Summary

Per the `/knowledge-layers` framework (current truth over history, surgical,
colocated):

- `src/meridian/lib/state/AGENTS.md` — drop the `.meridian/work-items/<slug>.json`
  line; add the `[context.work]`-resolved work-item root; note legacy layout removed.
- `docs/configuration.md` — fix `[context.work]`/`[context.kb]` default paths
  (`{user_home}/context/{project}/...`, not `.meridian/*`); add a **Path
  resolution** subsection (placeholders, git clone-root, `.meridian/` no-id
  fallback); repo-layout tree no longer lists `work/`/`archive/work/` as committed
  repo-side dirs.
- `src/meridian/lib/context/AGENTS.md` — show user-scoped defaults before the
  `.meridian/` no-id fallback (was documented as fallback-only).
- `docs/codex-tui-passthrough.md` — drop the deleted "chat frontend" from the
  controller list.

## Resulting Behavior

Docs/AGENTS/.context match shipped behavior: work items live under
`[context.work]`; `.meridian/work*` is a no-project-id fallback only; no
references to the removed chat feature (the `c123` session/chat **id** ref is
preserved — it still exists).

## Changes

Knowledge layers only — no code, tests, or `CHANGELOG.md` touched.
`state/AGENTS.md`, `context/AGENTS.md`, `docs/configuration.md`,
`docs/codex-tui-passthrough.md`.

**Verified against code, left intact:** the managed-worktree lifecycle
(`work_store.py` `WorktreeMetadata` / `provision_for_start()`) is current, so the
launch `.context/CONTEXT.md` worktree section is accurate; `spawn subagents`
naming and project-root walk-up removal were already consistent.

## Work Item

`inheritable-launch-surface`

## Verification

- Scope check: only `AGENTS.md` / `.context` / `docs/` changed.
- Each stale claim reconciled against current code (`context_config.py` defaults,
  `work_scope.py`/`work_store.py` resolution, `resolver.py` fallback).

## Knowledge Updates

This PR *is* the knowledge update. Cross-repo KB not touched (out of scope; none flagged).

## Spawn Trace

- p4678 kb-lead — swept AGENTS.md/.context/docs for obsoleted work/chat concepts,
  reconciled against code.

## Release Label Guide

`release:skip` — documentation only; no runtime behavior change.