### PR TITLE
fix: tool-level commands run without an established project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Fixed
-- `meridian doctor` no longer hard-fails in a clean shell with no project — runs diagnostics and reports bare-cwd resolution instead of exiting before checks.
+- Tool-level commands no longer require a Meridian project — `meridian doctor`, the content linters (`kg check`/`graph`, `qi check`/`list`, `mermaid check`), config readers (`config show`/`get`), and `ext list`/`commands` now run from any cwd instead of hard-failing with "No Meridian project found". Project-scoped commands (`spawn`, `work`, `telemetry`, …) still require one.
 
 ## [0.3.11] - 2026-06-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Fixed
-- Tool-level commands no longer require a Meridian project — `meridian doctor`, the content linters (`kg check`/`graph`, `qi check`/`list`, `mermaid check`), config readers (`config show`/`get`), and `ext list`/`commands` now run from any cwd instead of hard-failing with "No Meridian project found". Project-scoped commands (`spawn`, `work`, `telemetry`, …) still require one.
+- Tool-level commands no longer require a Meridian project — `meridian doctor`, the content linters (`kg check`/`graph`, `qi`/`qi check`/`list`, `mermaid check`), config readers (`config show`/`get`), and `ext list`/`commands` now run from any cwd instead of hard-failing with "No Meridian project found". Project-scoped commands (`spawn`, `work`, `telemetry`, …) still require one.
 - `python -m meridian` now routes through the same entrypoint as the `meridian` console script — gains the Windows UTF-8 stdout reconfigure, so glyph output (e.g. `mermaid check`) no longer crashes under cp1252.
 
 ## [0.3.11] - 2026-06-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- `meridian doctor` no longer hard-fails in a clean shell with no project — runs diagnostics and reports bare-cwd resolution instead of exiting before checks.
+
 ## [0.3.11] - 2026-06-21
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - Tool-level commands no longer require a Meridian project — `meridian doctor`, the content linters (`kg check`/`graph`, `qi check`/`list`, `mermaid check`), config readers (`config show`/`get`), and `ext list`/`commands` now run from any cwd instead of hard-failing with "No Meridian project found". Project-scoped commands (`spawn`, `work`, `telemetry`, …) still require one.
+- `python -m meridian` now routes through the same entrypoint as the `meridian` console script — gains the Windows UTF-8 stdout reconfigure, so glyph output (e.g. `mermaid check`) no longer crashes under cp1252.
 
 ## [0.3.11] - 2026-06-21
 

--- a/src/meridian/__main__.py
+++ b/src/meridian/__main__.py
@@ -1,6 +1,12 @@
-"""python -m meridian entry point."""
+"""python -m meridian entry point.
 
-from meridian.cli.main import main
+Routes through ``cli.entrypoint.main`` (the same target as the ``meridian``
+console script) so ``python -m meridian`` gets the trivial fast paths and the
+Windows UTF-8 stdout reconfigure — not ``cli.main.main`` directly, which skips
+them and crashes on glyph output (e.g. ``mermaid check``'s ``✓``) under cp1252.
+"""
+
+from meridian.cli.entrypoint import main
 
 if __name__ == "__main__":
     main()

--- a/src/meridian/cli/AGENTS.md
+++ b/src/meridian/cli/AGENTS.md
@@ -9,8 +9,8 @@ argv
   └── normalize_optional_value_flags()  ← pre-Cyclopts: rewrites bare --fork/--from
         └── classify_invocation()       ← longest-prefix match against COMMAND_CATALOG
               └── CommandDescriptor     ← routing information for this invocation
-                    ├── startup_class   → which bootstrap function to call
-                    ├── state_requirement
+                    ├── startup_class   → telemetry mode + primary-launch handling
+                    ├── state_requirement → bootstrap/state preparation
                     ├── telemetry_mode
                     ├── lazy_target     → import path string (deferred import)
                     └── redirect        → optional redirect (e.g. models list → mars models list)
@@ -23,23 +23,26 @@ argv
 - **Lazy imports everywhere.** `_register_commands_for_invocation()` imports only the module group matching the first positional token. Full registration fires only for `--help`. `make_lazy_command("module.path:function")` in `lazy_dispatch.py` registers a Cyclopts handler without importing it.
 - **`app_tree.py` breaks the circular import.** It defines top-level Cyclopts app objects (`spawn_app`, `session_app`, etc.) without importing any command implementations. If you import command implementations from `app_tree.py`, the lazy strategy collapses.
 - **`to_cli_output()` dispatch, not `isinstance` in `main.py`.** Command handlers return typed result objects. Each implements `to_cli_output()`. Adding result types does not require editing `main.py`.
-- **Read-only invocation classes install no telemetry, create no filesystem state.** `READ_PROJECT` and `READ_RUNTIME` classes never write UUIDs, create directories, or spawn writer threads.
+- **Read-only invocation classes install no telemetry, create no filesystem state.** `READ_ROOTLESS`, `READ_PROJECT`, and `READ_RUNTIME` classes never write UUIDs, create directories, or spawn writer threads.
 - **`root_source = RootSource.ARGV`** commands (e.g. `meridian init [path]`) defer bootstrap until after argument parsing. They call `prepare_for_project_write(arg_derived_root)` themselves — they don't receive a pre-prepared context.
 - **`validate_fork_mode()` is the single place for fork/from/continue conflict checks.** `spawn.py` and `primary_launch.py` both call it and consume `ForkModeResolution`. Do not re-implement conflict logic or ref resolution in handlers.
 - **`normalize_optional_value_flags()` runs before everything.** It rewrites bare `--fork`/`--fork-fresh`/`--from` to `--fork __SELF__` so Cyclopts always receives a value. Never call Cyclopts on raw argv containing these flags.
 
 ## Invocation Classes
 
-| Class | Examples | Bootstrap |
+| Class | Examples | State prep (`state_requirement`) |
 |---|---|---|
 | `TRIVIAL` | `--help`, `--version` | none |
-| `READ_PROJECT` | `config show`, `work current` | `prepare_for_project_read()` |
+| `READ_ROOTLESS` | `doctor`, `qi`, `kg check`, `config show` | none |
+| `READ_PROJECT` | `context`, `hooks list` | `prepare_for_project_read()` |
 | `READ_RUNTIME` | `spawn list`, `session log` | `prepare_for_runtime_read()` |
 | `WRITE_PROJECT` | `config init` | `prepare_for_project_write()` |
 | `WRITE_RUNTIME` | `spawn create`, `work start` | `prepare_for_runtime_write()` |
 | `PRIMARY_LAUNCH` | bare `meridian` | `prepare_for_runtime_write()` |
 | `SERVICE_ROOTLESS` | `serve` | none |
 | `SERVICE_RUNTIME` | `streaming serve` | `prepare_for_runtime_write()` |
+
+`startup_class` drives telemetry installation and primary-launch background repairs — not bootstrap. Bootstrap is selected solely by `state_requirement`.
 
 ## Entry Points
 

--- a/src/meridian/cli/bootstrap.py
+++ b/src/meridian/cli/bootstrap.py
@@ -336,20 +336,26 @@ def maybe_bootstrap_runtime_state(
 
     if is_agent_render_mode(render_mode):
         return None
+
+    requirement = state_requirement or _state_requirement_for_argv(argv)
+    if requirement in {None, StateRequirement.NONE}:
+        return None
+
+    from meridian.cli.utils import exit_no_established_project, resolve_cli_project_root
+
+    resolution = resolve_cli_project_root()
+    if not resolution.established or resolution.project_root is None:
+        exit_no_established_project()
+    assert resolution.project_root is not None
+    project_root = resolution.project_root
+
     try:
-        from meridian.cli.utils import require_established_project_root
         from meridian.lib.bootstrap.services import (
             prepare_for_project_read,
             prepare_for_project_write,
             prepare_for_runtime_read,
             prepare_for_runtime_write,
         )
-
-        requirement = state_requirement or _state_requirement_for_argv(argv)
-        if requirement in {None, StateRequirement.NONE}:
-            return None
-
-        project_root = require_established_project_root()
 
         if requirement == StateRequirement.PROJECT_READ:
             prepare_for_project_read(project_root)

--- a/src/meridian/cli/config_cmd.py
+++ b/src/meridian/cli/config_cmd.py
@@ -7,7 +7,7 @@ from typing import Any
 from cyclopts import App
 
 from meridian.cli.ext_registration import register_extension_cli_group
-from meridian.cli.utils import cli_project_root_posix
+from meridian.cli.utils import cli_project_root_posix, optional_cli_project_root_posix
 from meridian.lib.extensions.registry import get_first_party_registry
 from meridian.lib.ops.config import (
     ConfigGetInput,
@@ -27,7 +27,11 @@ def _config_set(emit: Emitter, key: str, value: str) -> None:
 
 
 def _config_get(emit: Emitter, key: str) -> None:
-    emit(config_get_sync(ConfigGetInput(key=key, project_root=cli_project_root_posix())))
+    emit(
+        config_get_sync(
+            ConfigGetInput(key=key, project_root=optional_cli_project_root_posix())
+        )
+    )
 
 
 def _config_reset(emit: Emitter, key: str) -> None:

--- a/src/meridian/cli/ext_registration.py
+++ b/src/meridian/cli/ext_registration.py
@@ -43,9 +43,12 @@ def _make_auto_handler_from_spec(
             return None
 
     def auto_handler() -> None:
-        from meridian.cli.utils import cli_project_root_posix
+        from meridian.cli.utils import optional_cli_project_root_posix
 
-        emit(sync_handler({"project_root": cli_project_root_posix()}))
+        payload: dict[str, object] = {}
+        if "project_root" in spec.args_schema.model_fields:
+            payload["project_root"] = optional_cli_project_root_posix()
+        emit(sync_handler(payload))
 
     return auto_handler
 

--- a/src/meridian/cli/main.py
+++ b/src/meridian/cli/main.py
@@ -1104,7 +1104,7 @@ def _main_impl(argv: Sequence[str] | None = None) -> None:
     # and reject invalid --dry-run combinations before any startup writes.
     if _bootstrap_setup_requested(cleaned_args):
         state_requirement = StateRequirement.NONE
-    # Install options early so require_established_project_root() sees project_root
+    # Install options early so resolve_cli_project_root() sees project_root
     # from -C / --directory during bootstrap resolution.
     _pre_bootstrap_token = _GLOBAL_OPTIONS.set(options)
     bootstrap_project_root = None

--- a/src/meridian/cli/qi_cmd.py
+++ b/src/meridian/cli/qi_cmd.py
@@ -69,6 +69,30 @@ def cmd_qi_graph(
     raise SystemExit(0)
 
 
+@qi_app.command(name="list")
+def cmd_qi_list(
+    path: Annotated[
+        Path,
+        Parameter(help="Directory to list (default: cwd)."),
+    ] = Path("."),
+) -> None:
+    """List all inline knowledge locations under a directory."""
+    from meridian.lib.ops.qi import discover_knowledge_points
+
+    resolved = path.resolve()
+    if not resolved.exists():
+        print(f"Error: path not found: {path}", file=sys.stderr)
+        raise SystemExit(2)
+    if not resolved.is_dir():
+        print(f"Error: not a directory: {path}", file=sys.stderr)
+        raise SystemExit(2)
+
+    points = discover_knowledge_points(resolved)
+    for point in sorted(points, key=lambda item: (item.kind, item.rel_path)):
+        print(f"{point.kind}\t{point.rel_path}")
+    raise SystemExit(0)
+
+
 @qi_app.command(name="check")
 def cmd_qi_check(
     path: Annotated[
@@ -107,5 +131,6 @@ def cmd_qi_check(
 __all__ = [
     "cmd_qi_check",
     "cmd_qi_graph",
+    "cmd_qi_list",
     "cmd_qi_root",
 ]

--- a/src/meridian/cli/startup/catalog.py
+++ b/src/meridian/cli/startup/catalog.py
@@ -373,7 +373,15 @@ _COMMAND_DESCRIPTORS: tuple[CommandDescriptor, ...] = (
         ("config", "reset"), "Reset config value.", extension_ref="meridian.config.reset"
     ),
     _read_project(("context",), "Show context paths.", extension_ref="meridian.context.context"),
-    _read_runtime(("doctor",), "Run doctor checks.", extension_ref="meridian.doctor.doctor"),
+    _descriptor(
+        ("doctor",),
+        StartupClass.READ_RUNTIME,
+        StateRequirement.NONE,
+        TelemetryMode.NONE,
+        "text",
+        "Run doctor checks.",
+        extension_ref="meridian.doctor.doctor",
+    ),
     _read_runtime(("telemetry", "status"), "Show telemetry status."),
     _read_runtime(("telemetry", "tail"), "Tail telemetry events."),
     _read_runtime(("telemetry", "query"), "Query telemetry events."),

--- a/src/meridian/cli/startup/catalog.py
+++ b/src/meridian/cli/startup/catalog.py
@@ -123,7 +123,7 @@ def _read_rootless(
     path: tuple[str, ...],
     summary: str,
     *,
-    startup_class: StartupClass = StartupClass.READ_PROJECT,
+    startup_class: StartupClass = StartupClass.READ_ROOTLESS,
     default_output_mode: str = "text",
     extension_ref: str | None = None,
 ) -> CommandDescriptor:
@@ -397,7 +397,6 @@ _COMMAND_DESCRIPTORS: tuple[CommandDescriptor, ...] = (
     _read_rootless(
         ("doctor",),
         "Run doctor checks.",
-        startup_class=StartupClass.READ_RUNTIME,
         extension_ref="meridian.doctor.doctor",
     ),
     _read_runtime(("telemetry", "status"), "Show telemetry status."),
@@ -409,13 +408,11 @@ _COMMAND_DESCRIPTORS: tuple[CommandDescriptor, ...] = (
     _read_rootless(
         ("ext", "list"),
         "List extensions.",
-        startup_class=StartupClass.READ_RUNTIME,
     ),
     _read_runtime(("ext", "show"), "Show extension."),
     _read_rootless(
         ("ext", "commands"),
         "List extension commands.",
-        startup_class=StartupClass.READ_RUNTIME,
     ),
     _read_runtime(("ext", "run"), "Run extension command."),
     _read_project(("hooks", "list"), "List hooks.", extension_ref="meridian.hooks.list"),
@@ -450,7 +447,7 @@ _COMMAND_DESCRIPTORS: tuple[CommandDescriptor, ...] = (
     _read_rootless(("kg", "graph"), "Render knowledge graph."),
     _read_rootless(("kg", "check"), "Check knowledge graph links."),
     _read_rootless(("mermaid", "check"), "Check Mermaid diagrams."),
-    _read_project(("qi",), "Show inline knowledge for current path."),
+    _read_rootless(("qi",), "Show inline knowledge for current path."),
     _read_rootless(("qi", "list"), "List all inline knowledge locations."),
     _read_rootless(("qi", "check"), "Check inline knowledge health."),
     _write_runtime(("streaming", "test"), "Run streaming test."),

--- a/src/meridian/cli/startup/catalog.py
+++ b/src/meridian/cli/startup/catalog.py
@@ -119,6 +119,27 @@ def _read_project(
     )
 
 
+def _read_rootless(
+    path: tuple[str, ...],
+    summary: str,
+    *,
+    startup_class: StartupClass = StartupClass.READ_PROJECT,
+    default_output_mode: str = "text",
+    extension_ref: str | None = None,
+) -> CommandDescriptor:
+    """Path- or user-level read commands that do not require a Meridian project."""
+
+    return _descriptor(
+        path,
+        startup_class,
+        StateRequirement.NONE,
+        TelemetryMode.NONE,
+        default_output_mode,
+        summary,
+        extension_ref=extension_ref,
+    )
+
+
 def _write_project(
     path: tuple[str, ...],
     summary: str,
@@ -363,23 +384,20 @@ _COMMAND_DESCRIPTORS: tuple[CommandDescriptor, ...] = (
         "Print or set the active work item's source-code edit directory.",
         extension_ref="meridian.work.task-dir",
     ),
-    _read_project(
+    _read_rootless(
         ("config", "show"), "Show resolved config.", extension_ref="meridian.config.show"
     ),
-    _read_project(("config", "get"), "Get config value.", extension_ref="meridian.config.get"),
+    _read_rootless(("config", "get"), "Get config value.", extension_ref="meridian.config.get"),
     _write_project(("config", "init"), "Initialize config.", extension_ref="meridian.config.init"),
     _write_project(("config", "set"), "Set config value.", extension_ref="meridian.config.set"),
     _write_project(
         ("config", "reset"), "Reset config value.", extension_ref="meridian.config.reset"
     ),
     _read_project(("context",), "Show context paths.", extension_ref="meridian.context.context"),
-    _descriptor(
+    _read_rootless(
         ("doctor",),
-        StartupClass.READ_RUNTIME,
-        StateRequirement.NONE,
-        TelemetryMode.NONE,
-        "text",
         "Run doctor checks.",
+        startup_class=StartupClass.READ_RUNTIME,
         extension_ref="meridian.doctor.doctor",
     ),
     _read_runtime(("telemetry", "status"), "Show telemetry status."),
@@ -388,9 +406,17 @@ _COMMAND_DESCRIPTORS: tuple[CommandDescriptor, ...] = (
     _write_project(("init",), "Initialize meridian in a project.", root_source=RootSource.ARGV),
     _write_project(("migrate",), "Migrate project ID from UUID to three-word format."),
     _read_runtime(("ext",), "List extension commands."),
-    _read_runtime(("ext", "list"), "List extensions."),
+    _read_rootless(
+        ("ext", "list"),
+        "List extensions.",
+        startup_class=StartupClass.READ_RUNTIME,
+    ),
     _read_runtime(("ext", "show"), "Show extension."),
-    _read_runtime(("ext", "commands"), "List extension commands."),
+    _read_rootless(
+        ("ext", "commands"),
+        "List extension commands.",
+        startup_class=StartupClass.READ_RUNTIME,
+    ),
     _read_runtime(("ext", "run"), "Run extension command."),
     _read_project(("hooks", "list"), "List hooks.", extension_ref="meridian.hooks.list"),
     _read_project(
@@ -421,12 +447,12 @@ _COMMAND_DESCRIPTORS: tuple[CommandDescriptor, ...] = (
         "Initialize workspace config.",
         extension_ref="meridian.workspace.init",
     ),
-    _read_project(("kg", "graph"), "Render knowledge graph."),
-    _read_project(("kg", "check"), "Check knowledge graph links."),
-    _read_project(("mermaid", "check"), "Check Mermaid diagrams."),
+    _read_rootless(("kg", "graph"), "Render knowledge graph."),
+    _read_rootless(("kg", "check"), "Check knowledge graph links."),
+    _read_rootless(("mermaid", "check"), "Check Mermaid diagrams."),
     _read_project(("qi",), "Show inline knowledge for current path."),
-    _read_project(("qi", "list"), "List all inline knowledge locations."),
-    _read_project(("qi", "check"), "Check inline knowledge health."),
+    _read_rootless(("qi", "list"), "List all inline knowledge locations."),
+    _read_rootless(("qi", "check"), "Check inline knowledge health."),
     _write_runtime(("streaming", "test"), "Run streaming test."),
     _descriptor(
         ("streaming", "serve"),

--- a/src/meridian/cli/startup/policy.py
+++ b/src/meridian/cli/startup/policy.py
@@ -7,6 +7,7 @@ class StartupClass(StrEnum):
     """High-level startup tier for a CLI invocation."""
 
     TRIVIAL = "trivial"
+    READ_ROOTLESS = "read_rootless"
     READ_PROJECT = "read_project"
     READ_RUNTIME = "read_runtime"
     WRITE_PROJECT = "write_project"

--- a/src/meridian/cli/utils.py
+++ b/src/meridian/cli/utils.py
@@ -30,6 +30,25 @@ def require_established_project_root() -> Path:
 
 
 
+def optional_cli_project_root_posix() -> str | None:
+    """Return an established project root when explicitly targeted, else None.
+
+    Unlike ``require_established_project_root()``, bare CWD resolution returns
+    None so read-only config/inspection callers can degrade to user defaults.
+    """
+
+    from meridian.cli.main import get_global_options
+    from meridian.lib.config.project_root import resolve_project_root_resolution
+
+    opts = get_global_options()
+    if opts.project_root is not None:
+        return opts.project_root.as_posix()
+    resolution = resolve_project_root_resolution(execution_cwd=Path.cwd())
+    if resolution.source == "cwd":
+        return None
+    return resolution.project_root.as_posix()
+
+
 def cli_project_root_posix() -> str:
     """Return the established CLI project root as a POSIX string."""
 

--- a/src/meridian/cli/utils.py
+++ b/src/meridian/cli/utils.py
@@ -1,50 +1,70 @@
 """Shared CLI-local parsing and validation helpers."""
 
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, overload
 
+from meridian.lib.config.project_root import ProjectRootSource
 
-def require_established_project_root() -> Path:
-    """Resolve project root from GlobalOptions or env, erroring if only bare CWD.
+NO_ESTABLISHED_PROJECT_MSG = (
+    "No Meridian project found. Run from the project root or pass -C <path>."
+)
 
-    Reads opts.project_root first (set from -C / --directory flag), then falls
-    back to env/CWD resolution via resolve_project_root_resolution. Raises
-    SystemExit(1) when resolution falls back to bare CWD without explicit or
-    inherited project targeting.
-    """
+
+@dataclass(frozen=True)
+class CliProjectRoot:
+    """CLI project root resolution with established-project semantics."""
+
+    project_root: Path | None
+    source: ProjectRootSource
+    established: bool
+
+
+def resolve_cli_project_root() -> CliProjectRoot:
+    """Resolve project root from GlobalOptions and env/CWD without raising."""
+
     from meridian.cli.main import get_global_options
     from meridian.lib.config.project_root import resolve_project_root_resolution
 
     opts = get_global_options()
     if opts.project_root is not None:
-        return opts.project_root
-    resolution = resolve_project_root_resolution(execution_cwd=Path.cwd())
-    if resolution.source == "cwd":
-        print(
-            "No Meridian project found. Run from the project root or pass -C <path>.",
-            file=sys.stderr,
+        return CliProjectRoot(
+            project_root=opts.project_root,
+            source="explicit",
+            established=True,
         )
-        raise SystemExit(1)
+    resolution = resolve_project_root_resolution(execution_cwd=Path.cwd())
+    established = resolution.source != "cwd"
+    return CliProjectRoot(
+        project_root=resolution.project_root if established else None,
+        source=resolution.source,
+        established=established,
+    )
+
+
+def exit_no_established_project() -> None:
+    """Exit with the standard no-project error message."""
+
+    print(NO_ESTABLISHED_PROJECT_MSG, file=sys.stderr)
+    raise SystemExit(1)
+
+
+def require_established_project_root() -> Path:
+    """Resolve an established project root or exit with a user-facing error."""
+
+    resolution = resolve_cli_project_root()
+    if not resolution.established or resolution.project_root is None:
+        exit_no_established_project()
+    assert resolution.project_root is not None
     return resolution.project_root
 
 
-
 def optional_cli_project_root_posix() -> str | None:
-    """Return an established project root when explicitly targeted, else None.
+    """Return an established project root when explicitly targeted, else None."""
 
-    Unlike ``require_established_project_root()``, bare CWD resolution returns
-    None so read-only config/inspection callers can degrade to user defaults.
-    """
-
-    from meridian.cli.main import get_global_options
-    from meridian.lib.config.project_root import resolve_project_root_resolution
-
-    opts = get_global_options()
-    if opts.project_root is not None:
-        return opts.project_root.as_posix()
-    resolution = resolve_project_root_resolution(execution_cwd=Path.cwd())
-    if resolution.source == "cwd":
+    resolution = resolve_cli_project_root()
+    if not resolution.established or resolution.project_root is None:
         return None
     return resolution.project_root.as_posix()
 

--- a/src/meridian/cli/utils.py
+++ b/src/meridian/cli/utils.py
@@ -34,8 +34,13 @@ def resolve_cli_project_root() -> CliProjectRoot:
             source="explicit",
             established=True,
         )
+    from meridian.lib.config.project_root import cwd_has_project_id
+
     resolution = resolve_project_root_resolution(execution_cwd=Path.cwd())
-    established = resolution.source != "cwd"
+    if resolution.source == "cwd":
+        established = cwd_has_project_id(resolution.project_root)
+    else:
+        established = True
     return CliProjectRoot(
         project_root=resolution.project_root if established else None,
         source=resolution.source,

--- a/src/meridian/lib/config/project_root.py
+++ b/src/meridian/lib/config/project_root.py
@@ -20,6 +20,12 @@ class ProjectRootResolution(BaseModel):
     source: ProjectRootSource
 
 
+def cwd_has_project_id(cwd: Path) -> bool:
+    """Return True when the literal cwd contains its own `.meridian/id` marker."""
+
+    return (cwd / ".meridian" / "id").is_file()
+
+
 def resolve_project_root_resolution(
     explicit: Path | None = None,
     *,

--- a/tests/integration/cli/test_cwd_project_resolution.py
+++ b/tests/integration/cli/test_cwd_project_resolution.py
@@ -1,0 +1,106 @@
+"""CLI integration: cwd with .meridian/id establishes a project."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+NO_PROJECT_MSG = "No Meridian project found. Run from the project root or pass -C <path>."
+
+
+def _run_meridian(
+    args: list[str],
+    *,
+    cwd: Path,
+    meridian_home: Path,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    for key in tuple(env):
+        if key.upper().startswith("MERIDIAN_"):
+            env.pop(key, None)
+    env["MERIDIAN_HOME"] = meridian_home.as_posix()
+    return subprocess.run(
+        [sys.executable, "-m", "meridian", *args],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.fixture
+def meridian_home(tmp_path: Path) -> Path:
+    home = tmp_path / "meridian-home"
+    home.mkdir()
+    return home
+
+
+@pytest.fixture
+def cwd_with_project_id(tmp_path: Path) -> Path:
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    (project_root / ".meridian").mkdir()
+    (project_root / ".meridian" / "id").write_text("proj-cwd-integration", encoding="utf-8")
+    return project_root
+
+
+@pytest.fixture
+def cwd_without_project_id(tmp_path: Path) -> Path:
+    bare_cwd = tmp_path / "no-project"
+    bare_cwd.mkdir()
+    return bare_cwd
+
+
+@pytest.mark.integration
+def test_spawn_list_succeeds_from_cwd_with_project_id(
+    cwd_with_project_id: Path,
+    meridian_home: Path,
+) -> None:
+    result = _run_meridian(["spawn", "list"], cwd=cwd_with_project_id, meridian_home=meridian_home)
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert NO_PROJECT_MSG not in (result.stdout + result.stderr)
+
+
+@pytest.mark.integration
+def test_spawn_list_fails_from_cwd_without_project_id(
+    cwd_without_project_id: Path,
+    meridian_home: Path,
+) -> None:
+    result = _run_meridian(
+        ["spawn", "list"],
+        cwd=cwd_without_project_id,
+        meridian_home=meridian_home,
+    )
+
+    assert result.returncode == 1
+    assert NO_PROJECT_MSG in (result.stdout + result.stderr)
+
+
+@pytest.mark.integration
+def test_doctor_runs_from_cwd_with_project_id(
+    cwd_with_project_id: Path,
+    meridian_home: Path,
+) -> None:
+    result = _run_meridian(["doctor"], cwd=cwd_with_project_id, meridian_home=meridian_home)
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert NO_PROJECT_MSG not in (result.stdout + result.stderr)
+    assert "project_root:" in result.stdout
+
+
+@pytest.mark.integration
+def test_doctor_runs_from_cwd_without_project_id(
+    cwd_without_project_id: Path,
+    meridian_home: Path,
+) -> None:
+    result = _run_meridian(["doctor"], cwd=cwd_without_project_id, meridian_home=meridian_home)
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert NO_PROJECT_MSG not in (result.stdout + result.stderr)
+    assert "project_root:" in result.stdout

--- a/tests/integration/cli/test_doctor_cli.py
+++ b/tests/integration/cli/test_doctor_cli.py
@@ -1,0 +1,36 @@
+"""CLI integration tests for meridian doctor startup policy."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+def test_doctor_runs_without_established_project(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Regression: clean env + bare cwd must not hit require_established_project_root."""
+    bare_cwd = tmp_path / "no-project"
+    bare_cwd.mkdir()
+    user_home = tmp_path / "user-home"
+    user_home.mkdir()
+
+    for key in list(os.environ):
+        if key.upper().startswith("MERIDIAN"):
+            monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("MERIDIAN_HOME", user_home.as_posix())
+    monkeypatch.chdir(bare_cwd)
+
+    from meridian.cli.main import main
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(["doctor"])
+
+    assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    assert "project_root:" in captured.out
+    assert "No Meridian project found" not in captured.err

--- a/tests/integration/cli/test_rootless_tool_commands.py
+++ b/tests/integration/cli/test_rootless_tool_commands.py
@@ -55,6 +55,15 @@ def meridian_home(tmp_path: Path) -> Path:
 
 
 @pytest.mark.integration
+def test_qi_root_without_project(
+    no_project_workspace: Path,
+    meridian_home: Path,
+) -> None:
+    result = _run_meridian(["qi"], cwd=no_project_workspace, meridian_home=meridian_home)
+    _assert_rootless_success(result)
+
+
+@pytest.mark.integration
 def test_kg_check_without_project(
     no_project_workspace: Path,
     meridian_home: Path,

--- a/tests/integration/cli/test_rootless_tool_commands.py
+++ b/tests/integration/cli/test_rootless_tool_commands.py
@@ -1,0 +1,156 @@
+"""CLI integration: tool-level commands run without a Meridian project."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+NO_PROJECT_MSG = "No Meridian project found"
+
+
+def _run_meridian(
+    args: list[str],
+    *,
+    cwd: Path,
+    meridian_home: Path,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    for key in tuple(env):
+        if key.upper().startswith("MERIDIAN_"):
+            env.pop(key, None)
+    env["MERIDIAN_HOME"] = meridian_home.as_posix()
+    return subprocess.run(
+        [sys.executable, "-m", "meridian", *args],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _assert_rootless_success(result: subprocess.CompletedProcess[str]) -> None:
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert NO_PROJECT_MSG not in (result.stdout + result.stderr)
+
+
+@pytest.fixture
+def no_project_workspace(tmp_path: Path) -> Path:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "readme.md").write_text("# hello\n", encoding="utf-8")
+    (workspace / "AGENTS.md").write_text("# agents\n", encoding="utf-8")
+    return workspace
+
+
+@pytest.fixture
+def meridian_home(tmp_path: Path) -> Path:
+    home = tmp_path / "meridian-home"
+    home.mkdir()
+    return home
+
+
+@pytest.mark.integration
+def test_kg_check_without_project(
+    no_project_workspace: Path,
+    meridian_home: Path,
+) -> None:
+    result = _run_meridian(["kg", "check"], cwd=no_project_workspace, meridian_home=meridian_home)
+    _assert_rootless_success(result)
+
+
+@pytest.mark.integration
+def test_kg_graph_without_project(
+    no_project_workspace: Path,
+    meridian_home: Path,
+) -> None:
+    result = _run_meridian(["kg", "graph"], cwd=no_project_workspace, meridian_home=meridian_home)
+    _assert_rootless_success(result)
+
+
+@pytest.mark.integration
+def test_qi_check_without_project(
+    no_project_workspace: Path,
+    meridian_home: Path,
+) -> None:
+    result = _run_meridian(["qi", "check"], cwd=no_project_workspace, meridian_home=meridian_home)
+    _assert_rootless_success(result)
+
+
+@pytest.mark.integration
+def test_qi_list_without_project(
+    no_project_workspace: Path,
+    meridian_home: Path,
+) -> None:
+    result = _run_meridian(["qi", "list"], cwd=no_project_workspace, meridian_home=meridian_home)
+    _assert_rootless_success(result)
+    assert "agents\tAGENTS.md" in result.stdout
+
+
+@pytest.mark.integration
+def test_mermaid_check_without_project(
+    no_project_workspace: Path,
+    meridian_home: Path,
+) -> None:
+    result = _run_meridian(
+        ["mermaid", "check"],
+        cwd=no_project_workspace,
+        meridian_home=meridian_home,
+    )
+    _assert_rootless_success(result)
+
+
+@pytest.mark.integration
+def test_config_show_without_project(
+    no_project_workspace: Path,
+    meridian_home: Path,
+) -> None:
+    result = _run_meridian(
+        ["config", "show"],
+        cwd=no_project_workspace,
+        meridian_home=meridian_home,
+    )
+    _assert_rootless_success(result)
+    assert "project_root:" in result.stdout
+
+
+@pytest.mark.integration
+def test_config_get_without_project(
+    no_project_workspace: Path,
+    meridian_home: Path,
+) -> None:
+    result = _run_meridian(
+        ["config", "get", "defaults.max_depth"],
+        cwd=no_project_workspace,
+        meridian_home=meridian_home,
+    )
+    _assert_rootless_success(result)
+    assert "defaults.max_depth:" in result.stdout
+
+
+@pytest.mark.integration
+def test_ext_list_without_project(
+    no_project_workspace: Path,
+    meridian_home: Path,
+) -> None:
+    result = _run_meridian(["ext", "list"], cwd=no_project_workspace, meridian_home=meridian_home)
+    _assert_rootless_success(result)
+    assert "meridian.config" in result.stdout
+
+
+@pytest.mark.integration
+def test_ext_commands_without_project(
+    no_project_workspace: Path,
+    meridian_home: Path,
+) -> None:
+    result = _run_meridian(
+        ["ext", "commands"],
+        cwd=no_project_workspace,
+        meridian_home=meridian_home,
+    )
+    _assert_rootless_success(result)
+    assert "meridian.config.get:" in result.stdout

--- a/tests/unit/cli/test_cli_project_root.py
+++ b/tests/unit/cli/test_cli_project_root.py
@@ -1,0 +1,100 @@
+"""Unit tests for CLI established-project resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from meridian.cli.utils import resolve_cli_project_root
+from meridian.lib.config.project_root import (
+    cwd_has_project_id,
+    resolve_project_root_resolution,
+)
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def test_cwd_has_project_id_true_when_id_file_present(tmp_path: Path) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    (project_root / ".meridian").mkdir()
+    (project_root / ".meridian" / "id").write_text("proj-test", encoding="utf-8")
+
+    assert cwd_has_project_id(project_root) is True
+
+
+def test_cwd_has_project_id_false_without_meridian_dir(tmp_path: Path) -> None:
+    project_root = tmp_path / "bare"
+    project_root.mkdir()
+
+    assert cwd_has_project_id(project_root) is False
+
+
+def test_cwd_has_project_id_false_for_ancestor_id_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    nested = project_root / "src"
+    project_root.mkdir()
+    nested.mkdir()
+    (project_root / ".meridian").mkdir()
+    (project_root / ".meridian" / "id").write_text("proj-parent", encoding="utf-8")
+    monkeypatch.chdir(nested)
+
+    resolution = resolve_project_root_resolution()
+    assert resolution.source == "cwd"
+    assert cwd_has_project_id(resolution.project_root) is False
+
+
+def test_resolve_cli_project_root_establishes_cwd_with_project_id(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    (project_root / ".meridian").mkdir()
+    (project_root / ".meridian" / "id").write_text("proj-cwd", encoding="utf-8")
+    monkeypatch.chdir(project_root)
+    monkeypatch.delenv("MERIDIAN_PROJECT_DIR", raising=False)
+
+    resolution = resolve_cli_project_root()
+
+    assert resolution.established is True
+    assert resolution.project_root == project_root.resolve()
+    assert resolution.source == "cwd"
+
+
+def test_resolve_cli_project_root_rejects_bare_cwd_without_project_id(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bare_cwd = tmp_path / "no-project"
+    bare_cwd.mkdir()
+    monkeypatch.chdir(bare_cwd)
+    monkeypatch.delenv("MERIDIAN_PROJECT_DIR", raising=False)
+
+    resolution = resolve_cli_project_root()
+
+    assert resolution.established is False
+    assert resolution.project_root is None
+    assert resolution.source == "cwd"
+
+
+def test_resolve_cli_project_root_env_still_establishes_without_cwd_id(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    other_cwd = tmp_path / "elsewhere"
+    project_root.mkdir()
+    other_cwd.mkdir()
+    monkeypatch.chdir(other_cwd)
+    monkeypatch.setenv("MERIDIAN_PROJECT_DIR", project_root.as_posix())
+
+    resolution = resolve_cli_project_root()
+
+    assert resolution.established is True
+    assert resolution.project_root == project_root.resolve()
+    assert resolution.source == "env"

--- a/tests/unit/cli/test_startup_classify.py
+++ b/tests/unit/cli/test_startup_classify.py
@@ -1,5 +1,13 @@
 from meridian.cli.startup.catalog import COMMAND_CATALOG
 from meridian.cli.startup.classify import classify_invocation
+from meridian.cli.startup.policy import StartupClass, StateRequirement
+
+
+def test_doctor_is_read_runtime_without_pre_dispatch_state() -> None:
+    descriptor = COMMAND_CATALOG.get(("doctor",))
+    assert descriptor is not None
+    assert descriptor.startup_class is StartupClass.READ_RUNTIME
+    assert descriptor.state_requirement is StateRequirement.NONE
 
 
 def test_deleted_chat_command_is_not_startup_classified() -> None:

--- a/tests/unit/cli/test_startup_classify.py
+++ b/tests/unit/cli/test_startup_classify.py
@@ -3,10 +3,24 @@ from meridian.cli.startup.classify import classify_invocation
 from meridian.cli.startup.policy import StartupClass, StateRequirement
 
 
-def test_doctor_is_read_runtime_without_pre_dispatch_state() -> None:
+def test_doctor_is_read_rootless_without_pre_dispatch_state() -> None:
     descriptor = COMMAND_CATALOG.get(("doctor",))
     assert descriptor is not None
-    assert descriptor.startup_class is StartupClass.READ_RUNTIME
+    assert descriptor.startup_class is StartupClass.READ_ROOTLESS
+    assert descriptor.state_requirement is StateRequirement.NONE
+
+
+def test_qi_root_is_read_rootless_without_pre_dispatch_state() -> None:
+    descriptor = COMMAND_CATALOG.get(("qi",))
+    assert descriptor is not None
+    assert descriptor.startup_class is StartupClass.READ_ROOTLESS
+    assert descriptor.state_requirement is StateRequirement.NONE
+
+
+def test_config_show_is_read_rootless_without_pre_dispatch_state() -> None:
+    descriptor = COMMAND_CATALOG.get(("config", "show"))
+    assert descriptor is not None
+    assert descriptor.startup_class is StartupClass.READ_ROOTLESS
     assert descriptor.state_requirement is StateRequirement.NONE
 
 


### PR DESCRIPTION
## Why

After #335 removed project-root walk-up, project resolution is explicit-only.
That **exposed a latent mis-categorization**: a family of tool-level commands
were registered with a project-requiring `StateRequirement`, so dispatch called
`require_established_project_root()` and **hard-failed** (`SystemExit(1)`,
"No Meridian project found.") in a clean no-project shell — even though they
operate on a path/cwd or user-level config and never needed a project.

Walk-up had been *masking* this: it scanned cwd + every ancestor for a marker
(`.meridian`/`.mars`/`meridian.toml`/**`.git`**), so it almost always found
*some* project (often the wrong one — any ancestor `.git` counted), and the gate
never fired. Removing walk-up was correct; it just surfaced the real bug.

`meridian doctor` was the first to bite — its exit-1 **failed the v0.3.11 release
pipeline** (the wheel-validation smoke runs `meridian doctor` in an isolated
no-project env).

## Goal

Tool-level / content-linter / user-config-read commands run from any cwd and
exit 0; project-scoped commands still (correctly) require a project.

## Summary

- New `_read_rootless` catalog helper (`StateRequirement.NONE`, startup class +
  telemetry preserved). Re-tiered: **`doctor`**, the linters **`kg check`/`graph`,
  `qi check`/`list`, `mermaid check`**, config readers **`config show`/`get`**,
  and **`ext list`/`commands`** (extension inventory is tool-level).
- New `optional_cli_project_root_posix()` — non-raising sibling of
  `require_established_project_root()`: returns the root when explicitly targeted
  (`-C`/env), else `None` so config/inspection callers degrade to user/builtin
  layers (`doctor_sync` already self-resolved cwd; config/qi/ext handlers updated
  to degrade gracefully).
- Left project-scoped commands gated: `spawn *`, `session *`, `work *`,
  `telemetry *`, `workspace list`, `hooks list` — "run from the project root or
  pass `-C`" is the correct UX there.

## Resulting Behavior

```
meridian doctor            # diagnostics, exit 0, anywhere
meridian mermaid check ./docs   # lints in CI/pre-commit, no project needed
meridian kg check          # exit 0
meridian config get defaults.max_depth  # "3 [source: builtin]", no project
```
None of these print "No Meridian project found" anymore. Project-scoped commands
unchanged. Unblocks the release: the next release-on-main (v0.3.12) validates and
publishes.

## Changes

- `src/meridian/cli/startup/catalog.py` — `_read_rootless` helper; re-tier the
  command family above.
- `src/meridian/cli/utils.py` — `optional_cli_project_root_posix()`.
- `src/meridian/cli/config_cmd.py`, `qi_cmd.py`, `ext_registration.py` — degrade
  to user/default layers without a project.
- Tests: `tests/integration/cli/test_doctor_cli.py`,
  `tests/integration/cli/test_rootless_tool_commands.py` (9 cases) — clear all
  `MERIDIAN_*`, no-project tmp cwd → assert exit 0 and no "No Meridian project found".
- `tests/unit/cli/test_startup_classify.py`, `CHANGELOG.md`.

## Work Item

`inheritable-launch-surface`

## Verification

- Each re-tiered command exits 0 in a clean `MERIDIAN_*`-free no-project shell
  (manual repro + the 9 hermetic regression tests).
- The exact release repro (`uv run --isolated --no-project --with <wheel> meridian doctor`)
  now exits 0.
- `uv run ruff check .` clean; `uv run --extra dev python -m pyright` 0 errors;
  `uv run pytest-llm` full suite 1281 passed, 2 skipped.

## Knowledge Updates

None (behavior fix). New helpers documented inline.

## Spawn Trace

- p4679 coder — doctor startup fix + test.
- p4691 coder — re-tier the tool-level family + handler degradation + 9 tests.

## Release Label Guide

`release:patch` — bug fix; cutting v0.3.12 re-runs the release pipeline v0.3.11 failed.