### PR TITLE
test(reaper): fix Windows flake — patch nested read-path liveness in fake_reaper_liveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Internal (tests): the `fake_reaper_liveness` reaper-test helper now also patches the nested read-projection liveness binding (`meridian.lib.ops.spawn.query.is_process_alive`), not just the reaper binding. The nested read path (`MERIDIAN_DEPTH=1`) consulted a real-OS PID liveness check the fake didn't cover, making `test_read_projection_does_not_reap_recorded_scope_but_explicit_reconcile_does` flaky on Windows when the fixture PID happened to be live.
+
 ## [0.3.14] - 2026-06-22
 
 ### Changed

--- a/tests/integration/state/conftest.py
+++ b/tests/integration/state/conftest.py
@@ -170,13 +170,22 @@ def fake_reaper_liveness(
     monkeypatch,
     live_pids,
 ) -> None:
-    """Patch reaper runner liveness to a PID allowlist or predicate."""
+    """Patch runner liveness to a PID allowlist or predicate.
+
+    Both the reaper reconcile path and the nested read-projection path
+    (``query._read_only_nested_staleness_view`` under ``MERIDIAN_DEPTH=1``)
+    consult ``is_process_alive`` via their own module-local bindings. Patch
+    both so a test that exercises either path is fully deterministic — a fake
+    that covered only the reaper binding let the nested read path fall through
+    to the real OS, which is flaky on Windows when the fixture PID happens to
+    be live (e.g. 9301)."""
 
     def _is_alive(pid: int, created_after_epoch: float | None = None) -> bool:
         _ = created_after_epoch
         return live_pids(pid) if callable(live_pids) else pid in live_pids
 
     monkeypatch.setattr("meridian.lib.state.reaper.is_process_alive", _is_alive)
+    monkeypatch.setattr("meridian.lib.ops.spawn.query.is_process_alive", _is_alive)
 
 
 def fake_managed_primary_birth_liveness(


### PR DESCRIPTION
## Why

The `windows-gate` CI job was intermittently failing on `test_read_projection_does_not_reap_recorded_scope_but_explicit_reconcile_does` with `TimeoutError: Wait checkpoint after 0m. Still running: p1`. The same test passed on other runs minutes apart — a genuine Windows-only flake that failed the v0.3.14 release run.

## Goal

The reaper read-projection test is deterministic on every platform; the flake is gone.

## Summary

Root cause is a test-fidelity gap, not a production bug. The test sets `MERIDIAN_DEPTH=1`, so `read_spawn_row` takes the nested read-projection branch `query._read_only_nested_staleness_view()`, which checks `is_process_alive(runner_pid)` via the `query` module's own `from … import is_process_alive` binding. The `fake_reaper_liveness` helper only patched `meridian.lib.state.reaper.is_process_alive`, so the nested read path fell through to the real OS. On a Windows runner where the fixture `runner_pid` (9301) happened to map to a live process, the orphan read back as `running`, and `spawn_wait_sync(timeout=0.01)` raised `TimeoutError`. (`spawn_list`/`spawn_stats` pass because they reconcile via `peek_reconciled_active_spawn` → the patched `reaper` binding — a split-brain.)

Fix: `fake_reaper_liveness` now also patches `meridian.lib.ops.spawn.query.is_process_alive`, so any test exercising either the reconcile path or the nested read path is fully deterministic.

## Resulting Behavior

No user-facing change. CI no longer flakes on this test on Windows.

## Changes

- `tests/integration/state/conftest.py` — `fake_reaper_liveness` patches both the reaper and nested-read liveness bindings; docstring explains why.
- `CHANGELOG.md` — internal (tests) note under Unreleased.
- No production code changed.

## Work Item

cursor-stall-recovery (adjacent — surfaced while shipping that work)

## Verification

- Reproduced the exact CI failure locally by simulating the Windows condition (forcing `query.is_process_alive` to report pid 9301 alive): **fails** with the same `TimeoutError` at `api.py:1829` without the second patch, **passes** with it.
- Full reaper integration suite: `tests/integration/state/` — 102 passed.
- `ruff check` clean. Pre-push full suite green (after building Pi extensions in the fresh worktree).

## Knowledge Updates

None. Test-only fix, no new behavior. (Investigator noted a latent docs drift in `src/meridian/lib/state/AGENTS.md` re: read-path projection naming and a deeper "single canonical liveness seam" opportunity — filed as a follow-up thought, out of scope here.)

## Spawn Trace

- p4722 investigator — root-caused the nested-read vs reaper liveride split; pinpointed the fix location
