### PR TITLE
deps: mars 0.10.1 (#119 import fidelity + opencode warn fix) + spawn/--continue fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - OpenCode spawn startup failures now surface an actionable diagnostic (captured stderr + an `XDG_DATA_HOME`/data-dir hint) instead of a bare error, and a spawn that fails before any session exists no longer prints a `meridian session log` transcript command that can never work.
 
 ### Changed
-- Bump mars-agents to 0.10.1rc1: inbound import fidelity, per-tool MCP tool bridge, and convention-based discovery for skills/agents (PR haowjy/mars-agents#119). The `build launch-bundle` schema stayed at v3, so meridian-cli's bundle-consumption contract is unchanged; validated end-to-end against discovery/sync/catalog surfaces (real agent resolve: tools/skills/warnings parse cleanly; full test suite + pyright green).
+- Bump mars-agents to 0.10.1: inbound import fidelity, per-tool MCP tool bridge, and convention-based discovery for skills/agents (PR haowjy/mars-agents#119), plus OpenCode skills no longer emitting per-skill `model-invocable` dropped-field warning noise (haowjy/mars-agents#123). The `build launch-bundle` schema stayed at v3, so meridian-cli's bundle-consumption contract is unchanged; validated end-to-end against discovery/sync/catalog surfaces (real agent resolve: tools/skills/warnings parse cleanly; full test suite + pyright green).
 
 ## [0.3.17] - 2026-06-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- `--from` now inherits the **same work** as the source reference. Previously the inherited work was carried only as a non-binding hint and never materialized, so the new session did not join the source's work; both primary launch and `spawn` now materialize it (`ensure_explicit_work_item`) exactly like an explicit `--work`. Explicit `--work` still takes precedence.
+- `--from` with a filesystem path now fails fast with an actionable error (it expects a spawn/chat reference) instead of an opaque reference-resolution failure.
+- Primary `meridian --continue` is now idempotent: it persists a `LaunchPolicySnapshot` and replays it on resume (parity with `spawn --continue`), so the agent/model/skills/system-prompt no longer silently drift to the current config/catalog default. Snapshots are recovered for all accepted reference forms (primary chat, tracked spawn-session chat, harness session id), passthrough args are rejected on `--continue`, and `extra_args` are replayed from the snapshot. Sessions without a snapshot fall back to the previous behavior.
+- OpenCode spawn startup failures now surface an actionable diagnostic (captured stderr + an `XDG_DATA_HOME`/data-dir hint) instead of a bare error, and a spawn that fails before any session exists no longer prints a `meridian session log` transcript command that can never work.
+
+### Changed
+- Bump mars-agents to 0.10.0: inbound import fidelity, per-tool MCP tool bridge, and convention-based discovery for skills/agents (PR haowjy/mars-agents#119). Validated against meridian-cli discovery/sync/catalog surfaces.
+
 ## [0.3.17] - 2026-06-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - OpenCode spawn startup failures now surface an actionable diagnostic (captured stderr + an `XDG_DATA_HOME`/data-dir hint) instead of a bare error, and a spawn that fails before any session exists no longer prints a `meridian session log` transcript command that can never work.
 
 ### Changed
-- Bump mars-agents to 0.10.0: inbound import fidelity, per-tool MCP tool bridge, and convention-based discovery for skills/agents (PR haowjy/mars-agents#119). Validated against meridian-cli discovery/sync/catalog surfaces.
+- Bump mars-agents to 0.10.1rc1: inbound import fidelity, per-tool MCP tool bridge, and convention-based discovery for skills/agents (PR haowjy/mars-agents#119). The `build launch-bundle` schema stayed at v3, so meridian-cli's bundle-consumption contract is unchanged; validated end-to-end against discovery/sync/catalog surfaces (real agent resolve: tools/skills/warnings parse cleanly; full test suite + pyright green).
 
 ## [0.3.17] - 2026-06-22
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "cyclopts>=3.0",
   "fastapi>=0.115",
   "markdown-it-py>=4.0",
-  "mars-agents==0.10.0",
+  "mars-agents==0.10.1rc1",
   "mcp>=1.0",
   "pathspec>=1.1.0",
   "psutil>=7.2.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "cyclopts>=3.0",
   "fastapi>=0.115",
   "markdown-it-py>=4.0",
-  "mars-agents==0.10.1rc1",
+  "mars-agents==0.10.1",
   "mcp>=1.0",
   "pathspec>=1.1.0",
   "psutil>=7.2.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "cyclopts>=3.0",
   "fastapi>=0.115",
   "markdown-it-py>=4.0",
-  "mars-agents==0.9.0",
+  "mars-agents==0.10.0",
   "mcp>=1.0",
   "pathspec>=1.1.0",
   "psutil>=7.2.2",

--- a/src/meridian/cli/primary_launch.py
+++ b/src/meridian/cli/primary_launch.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, ConfigDict
 from meridian.cli.argv_normalization import validate_fork_mode
 from meridian.cli.utils import missing_fork_session_error_with_discovery
 from meridian.lib.core.execution_policy import ResolvedExecutionPolicy
+from meridian.lib.core.launch_policy_snapshot import LaunchPolicySnapshot
 from meridian.lib.core.util import FormatContext
 from meridian.lib.harness.registry import get_default_harness_registry
 from meridian.lib.launch import LaunchRequest, SessionMode, launch_primary
@@ -99,6 +100,7 @@ class _ResolvedSessionTarget(BaseModel):
     source_execution_cwd: str | None = None
     source_claude_config_dir: str | None = None
     source_pi_session_dir: str | None = None
+    source_launch_policy_snapshot: LaunchPolicySnapshot | None = None
     tracked: bool = False
     warning: str | None = None
 
@@ -131,6 +133,7 @@ def resolve_session_target(
         source_execution_cwd=resolved.source_execution_cwd,
         source_claude_config_dir=resolved.source_claude_config_dir,
         source_pi_session_dir=resolved.source_pi_session_dir,
+        source_launch_policy_snapshot=resolved.source_launch_policy_snapshot,
         tracked=resolved.tracked,
         warning=resolved.warning,
     )
@@ -231,6 +234,7 @@ def run_primary_launch(
     source_pi_session_dir: str | None = None
     continue_source_tracked = False
     continue_source_ref: str | None = None
+    continue_launch_policy_snapshot: LaunchPolicySnapshot | None = None
     output_forked_from: str | None = None
     session_mode = SessionMode.FRESH
     explicit_harness = harness.strip() if harness is not None and harness.strip() else None
@@ -288,6 +292,8 @@ def run_primary_launch(
         source_pi_session_dir = resolved_continue.source_pi_session_dir
         continue_source_tracked = resolved_continue.tracked
         continue_source_ref = resume_target
+        # Replay persisted launch contract so agent/model/skills stay fixed on resume.
+        continue_launch_policy_snapshot = resolved_continue.source_launch_policy_snapshot
         session_mode = SessionMode.RESUME
     elif selected_fork_target is not None:
         resolved_fork = resolve_session_target(
@@ -379,6 +385,7 @@ def run_primary_launch(
                 autocompact=autocompact,
                 autocompact_pct=autocompact_pct,
             ),
+            launch_policy_snapshot=continue_launch_policy_snapshot,
             session=SessionRequest(
                 requested_harness_session_id=continue_harness_session_id,
                 continue_harness=continue_harness,

--- a/src/meridian/cli/primary_launch.py
+++ b/src/meridian/cli/primary_launch.py
@@ -235,6 +235,7 @@ def run_primary_launch(
     continue_source_tracked = False
     continue_source_ref: str | None = None
     continue_launch_policy_snapshot: LaunchPolicySnapshot | None = None
+    continue_passthrough_args: tuple[str, ...] = ()
     output_forked_from: str | None = None
     session_mode = SessionMode.FRESH
     explicit_harness = harness.strip() if harness is not None and harness.strip() else None
@@ -250,6 +251,8 @@ def run_primary_launch(
             raise ValueError("Cannot combine --continue with --agent.")
         if skills:
             raise ValueError("Cannot combine --continue with --skills.")
+        if passthrough:
+            raise ValueError("Cannot combine --continue with passthrough args (--).")
         resolved_continue = resolve_session_target(
             project_root=project_root, continue_ref=resume_target
         )
@@ -294,6 +297,8 @@ def run_primary_launch(
         continue_source_ref = resume_target
         # Replay persisted launch contract so agent/model/skills stay fixed on resume.
         continue_launch_policy_snapshot = resolved_continue.source_launch_policy_snapshot
+        if continue_launch_policy_snapshot is not None:
+            continue_passthrough_args = continue_launch_policy_snapshot.extra_args
         session_mode = SessionMode.RESUME
     elif selected_fork_target is not None:
         resolved_fork = resolve_session_target(
@@ -366,7 +371,9 @@ def run_primary_launch(
             agent_opt_out=agent_opt_out,
             work_id=requested_work_id,
             task_dir=normalized_task_dir,
-            passthrough_args=passthrough,
+            passthrough_args=(
+                continue_passthrough_args if resume_target is not None else passthrough
+            ),
             session_mode=session_mode,
             pinned_context="",
             supplemental_prompt_documents=supplemental_prompt_documents,

--- a/src/meridian/lib/harness/connections/opencode_http.py
+++ b/src/meridian/lib/harness/connections/opencode_http.py
@@ -1099,12 +1099,18 @@ class OpenCodeConnection(HarnessConnection[ResolvedLaunchSpec]):
                 "OpenCode backend failed to bind HTTP port "
                 f"(exit={exit_code}): {stderr_excerpt or '<no stderr>'}"
             )
-        if stderr_excerpt:
-            return RuntimeError(
-                "OpenCode process exited before becoming healthy "
-                f"(exit={exit_code}): {stderr_excerpt}"
-            )
-        return RuntimeError(f"OpenCode process exited before becoming healthy (exit={exit_code})")
+        message = _format_opencode_startup_failure_message(
+            exit_code=exit_code,
+            stderr_excerpt=stderr_excerpt,
+            env=self._startup_child_env(),
+        )
+        return RuntimeError(message)
+
+    def _startup_child_env(self) -> dict[str, str]:
+        config = self._config
+        if config is None:
+            return dict(os.environ)
+        return inherit_child_env(os.environ, config.env_overrides)
 
     def _read_startup_stderr_excerpt(self) -> str:
         stderr_handle = self._stderr_handle
@@ -1269,3 +1275,50 @@ def _materialize_system_prompt(
 def _looks_like_address_in_use(stderr_text: str) -> bool:
     normalized = stderr_text.lower()
     return any(marker in normalized for marker in _ADDRESS_IN_USE_MARKERS)
+
+
+def _format_opencode_startup_failure_message(
+    *,
+    exit_code: int | None,
+    stderr_excerpt: str,
+    env: Mapping[str, str],
+) -> str:
+    lines = [f"OpenCode backend failed to start (exit={exit_code})."]
+    if stderr_excerpt:
+        lines.append(stderr_excerpt)
+    hint = _opencode_startup_failure_hint(stderr_excerpt, env)
+    if hint is not None:
+        lines.append("")
+        lines.append(f"Hint: {hint}")
+    return "\n".join(lines)
+
+
+def _opencode_startup_failure_hint(stderr_text: str, env: Mapping[str, str]) -> str | None:
+    normalized = stderr_text.lower()
+    if not normalized:
+        return None
+
+    data_dir_markers = (
+        "eacces",
+        "eperm",
+        "permission denied",
+        "enotdir",
+        "read-only file system",
+        "erofs",
+    )
+    if not any(marker in normalized for marker in data_dir_markers):
+        return None
+    if "mkdir" not in normalized and "opencode" not in normalized:
+        return None
+
+    xdg_data_home = env.get("XDG_DATA_HOME", "").strip()
+    if xdg_data_home:
+        return (
+            f"OpenCode cannot write its data directory under XDG_DATA_HOME ({xdg_data_home}). "
+            "Ensure that path exists and is writable, or unset XDG_DATA_HOME to use the default "
+            "(~/.local/share)."
+        )
+    return (
+        "OpenCode cannot create its data directory. Check permissions for ~/.local/share/opencode, "
+        "or set XDG_DATA_HOME to a writable directory."
+    )

--- a/src/meridian/lib/launch/__init__.py
+++ b/src/meridian/lib/launch/__init__.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any
 
 from meridian.lib.launch.launch_types import summarize_composition_warnings
 from meridian.lib.launch.resolution import resolve_launch_inputs
-from meridian.lib.state import work_store
 from meridian.lib.state.paths import resolve_project_paths, resolve_work_scratch_dir_for_project
 
 if TYPE_CHECKING:
@@ -49,25 +48,41 @@ if TYPE_CHECKING:
     )
 
 
-def _resolve_work_id_for_launch(project_root: Path, request: LaunchRequest) -> str | None:
+def _explicit_work_id_for_launch(request: LaunchRequest) -> str | None:
+    return (request.work_id or "").strip() or None
+
+
+def _resolve_work_id_for_launch(
+    project_root: Path,
+    request: LaunchRequest,
+    *,
+    context_work_id: str | None,
+) -> str | None:
     """Resolve work item before entering the launch layer (policy, not mechanism)."""
 
-    from meridian.lib.ops.work_attachment import ensure_explicit_work_item
+    from meridian.lib.ops.work_attachment import materialize_launch_work_id
 
-    explicit_work_id = (request.work_id or "").strip() or None
-    if explicit_work_id is not None:
-        project_local_root = resolve_project_paths(project_root).root_dir
-        return ensure_explicit_work_item(project_local_root, explicit_work_id)
-    return None
+    project_local_root = resolve_project_paths(project_root).root_dir
+    return materialize_launch_work_id(
+        project_local_root,
+        explicit_work_id=_explicit_work_id_for_launch(request),
+        context_work_id=context_work_id,
+    )
 
 
-def _preview_work_id_for_launch(request: LaunchRequest) -> str | None:
-    """Normalize an explicit work item for dry-run preview without creating it."""
+def _preview_work_id_for_launch(
+    request: LaunchRequest,
+    *,
+    context_work_id: str | None,
+) -> str | None:
+    """Normalize explicit or inherited work for dry-run preview without creating it."""
 
-    explicit_work_id = (request.work_id or "").strip()
-    if not explicit_work_id:
-        return None
-    return work_store.slugify(explicit_work_id) or None
+    from meridian.lib.ops.work_attachment import preview_launch_work_id
+
+    return preview_launch_work_id(
+        explicit_work_id=_explicit_work_id_for_launch(request),
+        context_work_id=context_work_id,
+    )
 
 
 def launch_primary(
@@ -94,13 +109,13 @@ def launch_primary(
     from .types import LaunchResult
 
     resolved_project_root = resolve_project_root_resolution(project_root).project_root
-    preview_work_id = _preview_work_id_for_launch(request)
+    explicit_work_id = _explicit_work_id_for_launch(request)
     runtime_root_for_context = resolve_runtime_root_for_read(resolved_project_root)
     runtime_context = resolve_runtime_context(
         project_root=resolved_project_root,
         runtime_root=runtime_root_for_context,
     )
-    ambient_work_id = None if preview_work_id is not None else runtime_context.work_id
+    ambient_work_id = None if explicit_work_id is not None else runtime_context.work_id
     project_state_dir = resolve_project_paths(resolved_project_root).root_dir
     launch_resolution = resolve_launch_inputs(
         authority_root=resolved_project_root,
@@ -108,10 +123,14 @@ def launch_primary(
         context_from=request.context_from,
         reference_files=request.reference_files,
         explicit_task_dir=request.task_dir,
-        explicit_work_id=preview_work_id,
+        explicit_work_id=explicit_work_id,
         inherited_task_dir=runtime_context.inherited_task_dir,
         ambient_work_id=ambient_work_id,
         caller_cwd=Path.cwd(),
+    )
+    preview_work_id = _preview_work_id_for_launch(
+        request,
+        context_work_id=launch_resolution.context_work_id,
     )
 
     runtime = build_primary_launch_runtime(
@@ -130,9 +149,13 @@ def launch_primary(
             }
         )
     resolved_work_id = (
-        _preview_work_id_for_launch(request)
+        preview_work_id
         if request.dry_run
-        else _resolve_work_id_for_launch(resolved_project_root, request)
+        else _resolve_work_id_for_launch(
+            resolved_project_root,
+            request,
+            context_work_id=launch_resolution.context_work_id,
+        )
     )
 
     runtime = runtime.model_copy(update=launch_resolution.runtime_updates)

--- a/src/meridian/lib/launch/plan.py
+++ b/src/meridian/lib/launch/plan.py
@@ -99,6 +99,7 @@ def build_primary_spawn_request(
         session=normalized_session,
         goal=request.goal,
         work_id_hint=(request.work_id or "").strip() or None,
+        launch_policy_snapshot=request.launch_policy_snapshot,
     )
 
 

--- a/src/meridian/lib/launch/process/runner.py
+++ b/src/meridian/lib/launch/process/runner.py
@@ -1037,6 +1037,16 @@ def run_harness_process(
                 resolved_harness_session_id = (
                     runtime_context.binding.effective_harness_session_id or ""
                 )
+                persisted_launch_policy_snapshot = (
+                    runtime_context.resolved_request.launch_policy_snapshot
+                )
+                if persisted_launch_policy_snapshot is not None:
+                    # Persist resolved launch contract for idempotent primary --continue.
+                    spawn_store.update_spawn(
+                        runtime_root,
+                        primary_spawn_id,
+                        launch_policy_snapshot=persisted_launch_policy_snapshot,
+                    )
                 launch_child_cwd = runtime_context.binding.child_cwd
                 child_env = dict(runtime_context.binding.environment.final_env)
                 if managed.chat_id:

--- a/src/meridian/lib/launch/request.py
+++ b/src/meridian/lib/launch/request.py
@@ -110,6 +110,7 @@ class SpawnRequest(BaseModel):
 
     # Routing & metadata
     work_id_hint: str | None = None
+    inherited_context_work_id: str | None = None
     goal: str | None = None
     warning: str | None = None
     agent_metadata: dict[str, str] = Field(default_factory=_empty_agent_metadata)

--- a/src/meridian/lib/launch/resolution.py
+++ b/src/meridian/lib/launch/resolution.py
@@ -15,6 +15,7 @@ class LaunchInputResolution:
     """Resolved work, task cwd, and reference path surface shared by launch callers."""
 
     effective_work_id: str | None
+    context_work_id: str | None
     task_cwd_resolution: TaskCwdResolution
     directory_context: LaunchDirectoryContext
     reference_files: tuple[Path, ...]
@@ -109,6 +110,7 @@ def resolve_launch_inputs(
 
     return LaunchInputResolution(
         effective_work_id=effective_work_id,
+        context_work_id=context_work_id,
         task_cwd_resolution=task_cwd_resolution,
         directory_context=directory_context,
         reference_files=validated_reference_files,

--- a/src/meridian/lib/launch/types.py
+++ b/src/meridian/lib/launch/types.py
@@ -6,6 +6,7 @@ from enum import StrEnum
 from pydantic import BaseModel, ConfigDict, Field
 
 from meridian.lib.core.execution_policy import ResolvedExecutionPolicy
+from meridian.lib.core.launch_policy_snapshot import LaunchPolicySnapshot
 from meridian.lib.launch.composition import PromptDocument
 from meridian.lib.launch.request import SessionRequest
 
@@ -61,6 +62,8 @@ class LaunchRequest(BaseModel):
     goal: str | None = None
     include_bootstrap_documents: bool = False
     dry_run: bool = False
+    # Replay persisted launch contract on primary --continue (idempotent resume).
+    launch_policy_snapshot: LaunchPolicySnapshot | None = None
     # Execution policy carrier (replaces flat effort/sandbox/approval/autocompact/etc.)
     execution_policy: ResolvedExecutionPolicy = Field(default_factory=ResolvedExecutionPolicy)
     session: SessionRequest = Field(default_factory=SessionRequest)

--- a/src/meridian/lib/ops/reference.py
+++ b/src/meridian/lib/ops/reference.py
@@ -6,6 +6,7 @@ import re
 from dataclasses import dataclass, replace
 from pathlib import Path
 
+from meridian.lib.core.launch_policy_snapshot import LaunchPolicySnapshot
 from meridian.lib.core.types import SpawnId
 from meridian.lib.harness.registry import get_default_harness_registry
 from meridian.lib.harness.session_detection import infer_harness_from_untracked_session_ref
@@ -16,6 +17,7 @@ from meridian.lib.ops.reference_recovery import (
 from meridian.lib.ops.runtime import resolve_runtime_root_for_read
 from meridian.lib.state import primary_meta, session_identity, session_store, spawn_store
 from meridian.lib.state.paths import resolve_spawn_log_dir
+from meridian.lib.state.spawn.model import SpawnRecord
 
 _SPAWN_REF_RE = re.compile(r"^p\d+$")
 _CHAT_REF_RE = re.compile(r"^c\d+$")
@@ -37,6 +39,7 @@ class ResolvedSessionReference:
     source_execution_cwd: str | None = None
     source_claude_config_dir: str | None = None
     source_pi_session_dir: str | None = None
+    source_launch_policy_snapshot: LaunchPolicySnapshot | None = None
     warning: str | None = None
     recovery: RecoveryResult | None = None
 
@@ -117,6 +120,31 @@ def _latest_primary_spawn_id_for_chat(runtime_root: Path, chat_id: str) -> str |
     return primary_rows[-1].id
 
 
+def _primary_launch_policy_snapshot(
+    runtime_root: Path,
+    *,
+    spawn_row: SpawnRecord | None = None,
+    chat_id: str | None = None,
+) -> LaunchPolicySnapshot | None:
+    """Load a persisted launch-policy snapshot for a primary session source."""
+
+    if spawn_row is not None:
+        return spawn_row.launch_policy_snapshot
+
+    normalized_chat_id = (chat_id or "").strip()
+    if not normalized_chat_id:
+        return None
+
+    primary_spawn_id = _latest_primary_spawn_id_for_chat(runtime_root, normalized_chat_id)
+    if primary_spawn_id is None:
+        return None
+
+    primary_row = spawn_store.get_spawn(runtime_root, primary_spawn_id)
+    if primary_row is None:
+        return None
+    return primary_row.launch_policy_snapshot
+
+
 def _read_primary_pi_session_dir(runtime_root: Path, spawn_id: str) -> str | None:
     metadata = primary_meta.read_primary_metadata(runtime_root, spawn_id)
     if metadata is None:
@@ -159,6 +187,7 @@ def _build_tracked_reference(
     source_execution_cwd: str | None = None,
     source_claude_config_dir: str | None = None,
     source_pi_session_dir: str | None = None,
+    source_launch_policy_snapshot: LaunchPolicySnapshot | None = None,
     project_root: Path,
 ) -> ResolvedSessionReference:
     registry = get_default_harness_registry()
@@ -183,6 +212,7 @@ def _build_tracked_reference(
         source_execution_cwd=source_execution_cwd,
         source_claude_config_dir=source_claude_config_dir,
         source_pi_session_dir=source_pi_session_dir,
+        source_launch_policy_snapshot=source_launch_policy_snapshot,
         tracked=True,
     )
 
@@ -228,6 +258,7 @@ def _resolve_spawn_reference(
         source_execution_cwd=source_execution_cwd,
         source_claude_config_dir=_normalize_optional(row.claude_config_dir),
         source_pi_session_dir=source_pi_session_dir,
+        source_launch_policy_snapshot=row.launch_policy_snapshot,
         project_root=project_root,
     )
 
@@ -270,6 +301,10 @@ def _resolve_chat_reference(
         ),
         source_claude_config_dir=_normalize_optional(session.claude_config_dir),
         source_pi_session_dir=source_pi_session_dir,
+        source_launch_policy_snapshot=_primary_launch_policy_snapshot(
+            runtime_root,
+            chat_id=session.chat_id,
+        ),
         project_root=project_root,
     )
 
@@ -312,6 +347,10 @@ def _resolve_harness_session_reference(
         ),
         source_claude_config_dir=_normalize_optional(session.claude_config_dir),
         source_pi_session_dir=source_pi_session_dir,
+        source_launch_policy_snapshot=_primary_launch_policy_snapshot(
+            runtime_root,
+            chat_id=session.chat_id,
+        ),
         project_root=project_root,
     )
 

--- a/src/meridian/lib/ops/reference.py
+++ b/src/meridian/lib/ops/reference.py
@@ -145,6 +145,27 @@ def _primary_launch_policy_snapshot(
     return primary_row.launch_policy_snapshot
 
 
+def _launch_policy_snapshot_for_session(
+    runtime_root: Path,
+    session: session_store.SessionRecord,
+) -> LaunchPolicySnapshot | None:
+    """Load a persisted launch-policy snapshot for a tracked session reference."""
+
+    normalized_spawn_id = (session.spawn_id or "").strip()
+    if session.kind == "spawn" or normalized_spawn_id:
+        if not normalized_spawn_id:
+            return None
+        spawn_row = spawn_store.get_spawn(runtime_root, normalized_spawn_id)
+        if spawn_row is None:
+            return None
+        return spawn_row.launch_policy_snapshot
+
+    return _primary_launch_policy_snapshot(
+        runtime_root,
+        chat_id=session.chat_id,
+    )
+
+
 def _read_primary_pi_session_dir(runtime_root: Path, spawn_id: str) -> str | None:
     metadata = primary_meta.read_primary_metadata(runtime_root, spawn_id)
     if metadata is None:
@@ -301,9 +322,9 @@ def _resolve_chat_reference(
         ),
         source_claude_config_dir=_normalize_optional(session.claude_config_dir),
         source_pi_session_dir=source_pi_session_dir,
-        source_launch_policy_snapshot=_primary_launch_policy_snapshot(
+        source_launch_policy_snapshot=_launch_policy_snapshot_for_session(
             runtime_root,
-            chat_id=session.chat_id,
+            session,
         ),
         project_root=project_root,
     )
@@ -347,9 +368,9 @@ def _resolve_harness_session_reference(
         ),
         source_claude_config_dir=_normalize_optional(session.claude_config_dir),
         source_pi_session_dir=source_pi_session_dir,
-        source_launch_policy_snapshot=_primary_launch_policy_snapshot(
+        source_launch_policy_snapshot=_launch_policy_snapshot_for_session(
             runtime_root,
-            chat_id=session.chat_id,
+            session,
         ),
         project_root=project_root,
     )

--- a/src/meridian/lib/ops/spawn/context_ref.py
+++ b/src/meridian/lib/ops/spawn/context_ref.py
@@ -20,6 +20,34 @@ from .query import (
 
 _SESSION_REF_RE = re.compile(r"^c\d+$")
 _SPAWN_REF_RE = re.compile(r"^p\d+$")
+_WINDOWS_DRIVE_PATH_RE = re.compile(r"^[A-Za-z]:[\\/]")
+
+
+def _is_filesystem_path_ref(value: str) -> bool:
+    """Return True when a ``--from`` value looks like a filesystem path, not a session ref."""
+
+    normalized = value.strip()
+    if not normalized or normalized.startswith("@"):
+        return False
+    if _SPAWN_REF_RE.fullmatch(normalized) or _SESSION_REF_RE.fullmatch(normalized):
+        return False
+    if normalized.startswith(("./", "../", "/", "~")):
+        return True
+    if "\\" in normalized:
+        return True
+    if "/" in normalized:
+        return True
+    return bool(_WINDOWS_DRIVE_PATH_RE.match(normalized))
+
+
+def _reject_filesystem_path_context_ref(value: str) -> None:
+    if not _is_filesystem_path_ref(value):
+        return
+    raise ValueError(
+        f"--from does not accept filesystem paths ({value!r}). "
+        "Use a spawn id (p123), chat id (c123), or harness session id. "
+        "To include file contents in the prompt, use --file/-f instead."
+    )
 
 
 class SpawnContextRef(BaseModel):
@@ -102,6 +130,8 @@ def resolve_context_ref(project_root: Path, ref: str) -> ContextRef:
     normalized = ref.strip()
     if not normalized:
         raise ValueError("context reference is required")
+
+    _reject_filesystem_path_context_ref(normalized)
 
     if normalized.startswith("@") or _SPAWN_REF_RE.fullmatch(normalized):
         spawn_id = resolve_spawn_reference(project_root, normalized)

--- a/src/meridian/lib/ops/spawn/execute.py
+++ b/src/meridian/lib/ops/spawn/execute.py
@@ -674,7 +674,9 @@ def execute_spawn_blocking(
         session_log_available=_session_log_available_for_spawn(
             context.runtime_root,
             spawn_id_text,
-            harness_session_id=getattr(row, "harness_session_id", None) if row is not None else None,
+            harness_session_id=(
+                getattr(row, "harness_session_id", None) if row is not None else None
+            ),
         ),
     )
 

--- a/src/meridian/lib/ops/spawn/execute.py
+++ b/src/meridian/lib/ops/spawn/execute.py
@@ -60,11 +60,24 @@ from .execute_runner import launch_prepared_spawn
 from .failure_policy import finalize_launch_failure_sync
 from .models import SpawnActionOutput, SpawnCreateInput
 from .pre_init import EXPECTED_PRE_INIT_EXCEPTIONS, PreInitFailure, run_pre_init_boundary
-from .query import read_report, read_spawn_row
+from .query import read_report, read_spawn_row, spawn_session_log_available
 from .task_dir import derive_inheritable_task_dir
 
 logger = structlog.get_logger(__name__)
 _BACKGROUND_SUBMIT_MESSAGE = "Background spawn submitted."
+
+
+def _session_log_available_for_spawn(
+    runtime_root: Path,
+    spawn_id: str,
+    *,
+    harness_session_id: str | None = None,
+) -> bool:
+    return spawn_session_log_available(
+        runtime_root,
+        spawn_id,
+        harness_session_id=harness_session_id,
+    )
 
 
 def _build_detached_popen_kwargs() -> dict[str, Any]:
@@ -245,6 +258,7 @@ def _reserve_then_prepare(
     context = _materialize_spawn_work_item(
         context=context,
         payload=payload,
+        request=request,
         project_root=project_paths.project_root,
     )
     _persist_execution_contract(context, preparation.execution_contract)
@@ -371,6 +385,7 @@ def execute_spawn_background(
             reference_anchor=request.reference_anchor or execution_cwd_str,
             task_cwd_source=request.task_cwd_source,
             task_cwd_work_item=request.task_cwd_work_item,
+            session_log_available=False,
         )
 
     stdout_path = log_dir / BACKGROUND_STDOUT_FILENAME
@@ -441,6 +456,7 @@ def execute_spawn_background(
             reference_anchor=request.reference_anchor or execution_cwd_str,
             task_cwd_source=request.task_cwd_source,
             task_cwd_work_item=request.task_cwd_work_item,
+            session_log_available=False,
         )
 
     _record_launch_boundary_observation(
@@ -572,6 +588,7 @@ def execute_spawn_blocking(
             str(exc),
         )
         logger.exception("Foreground spawn crashed.", spawn_id=spawn_id_text)
+        failure_row = read_spawn_row(project_paths.project_root, spawn_id_text)
         return SpawnActionOutput(
             command="spawn.create",
             status="failed",
@@ -591,6 +608,13 @@ def execute_spawn_blocking(
             reference_anchor=request.reference_anchor or initial_execution_cwd,
             task_cwd_source=request.task_cwd_source,
             task_cwd_work_item=request.task_cwd_work_item,
+            session_log_available=_session_log_available_for_spawn(
+                context.runtime_root,
+                spawn_id_text,
+                harness_session_id=getattr(failure_row, "harness_session_id", None)
+                if failure_row is not None
+                else None,
+            ),
         )
 
     duration = time.monotonic() - started
@@ -647,6 +671,11 @@ def execute_spawn_blocking(
         reference_anchor=request.reference_anchor or initial_execution_cwd,
         task_cwd_source=request.task_cwd_source,
         task_cwd_work_item=request.task_cwd_work_item,
+        session_log_available=_session_log_available_for_spawn(
+            context.runtime_root,
+            spawn_id_text,
+            harness_session_id=getattr(row, "harness_session_id", None) if row is not None else None,
+        ),
     )
 
 

--- a/src/meridian/lib/ops/spawn/execute_init.py
+++ b/src/meridian/lib/ops/spawn/execute_init.py
@@ -234,15 +234,15 @@ def _materialize_spawn_work_item(
     *,
     context: _SpawnContext,
     payload: SpawnCreateInput,
+    request: SpawnRequest,
     project_root: Path,
 ) -> _SpawnContext:
-    """Create or attach the explicit work item and patch the spawn row when needed."""
+    """Create or attach explicit or inherited ``--from`` work and patch the spawn row."""
     final_work_id = context.work_id
-    if (payload.work or "").strip():
-        from typing import cast
-
+    explicit_work = (payload.work or "").strip()
+    inherited_context_work = (request.inherited_context_work_id or "").strip()
+    if (explicit_work or inherited_context_work) and final_work_id:
         project_local_root = resolve_project_paths(project_root).root_dir
-        final_work_id = cast("str", final_work_id)
         final_work_id = ensure_explicit_work_item(project_local_root, final_work_id)
         if final_work_id != context.work_id:
             spawn_store.update_spawn(

--- a/src/meridian/lib/ops/spawn/models.py
+++ b/src/meridian/lib/ops/spawn/models.py
@@ -189,6 +189,7 @@ class SpawnActionOutput(BaseModel):
     duration_secs: float | None = None
     background: bool = False
     forked_from: str | None = None
+    session_log_available: bool | None = None
 
     @computed_field
     @property
@@ -202,6 +203,12 @@ class SpawnActionOutput(BaseModel):
 
     def _transcript_command(self) -> str | None:
         if self.command != "spawn.create" or self.spawn_id is None or self.background:
+            return None
+        if self.session_log_available is False:
+            return None
+        if self.session_log_available is True:
+            return f"meridian session log {self.spawn_id}"
+        if self.status == "failed":
             return None
         return f"meridian session log {self.spawn_id}"
 
@@ -384,8 +391,10 @@ class SpawnActionOutput(BaseModel):
         elif self.status == "succeeded":
             lines.append("")
             lines.append("(no report)")
-        lines.append("")
-        lines.append(f"Transcript: meridian session log {self.spawn_id}")
+        transcript_command = self._transcript_command()
+        if transcript_command is not None:
+            lines.append("")
+            lines.append(f"Transcript: {transcript_command}")
         return "\n".join(lines)
 
     def _format_default_text(self) -> str:
@@ -809,6 +818,7 @@ class SpawnDetailOutput(BaseModel):
     last_attempt_exited_at: str | None = None
     last_attempt_exit_code: int | None = None
     session_config_dir: str | None = None
+    session_log_available: bool = False
 
     def _normalized_report_body(self) -> str | None:
         report_text = (self.report_body or "").strip()
@@ -851,7 +861,9 @@ class SpawnDetailOutput(BaseModel):
             return None
         return f"Report for {self.spawn_id}\n{report_text}"
 
-    def transcript_command(self) -> str:
+    def transcript_command(self) -> str | None:
+        if not self.session_log_available:
+            return None
         return f"meridian session log {self.spawn_id}"
 
     def _has_distinct_task_cwd(self) -> bool:
@@ -987,7 +999,9 @@ class SpawnDetailOutput(BaseModel):
             lines.append("")
         else:
             lines.append("")
-        lines.append(f"Transcript: {self.transcript_command()}")
+        transcript_command = self.transcript_command()
+        if transcript_command is not None:
+            lines.append(f"Transcript: {transcript_command}")
 
         return "\n".join(lines)
 
@@ -1017,7 +1031,9 @@ class SpawnDetailOutput(BaseModel):
             lines.append(report_text)
 
         lines.append("")
-        lines.append(f"Transcript: {self.transcript_command()}")
+        transcript_command = self.transcript_command()
+        if transcript_command is not None:
+            lines.append(f"Transcript: {transcript_command}")
         return "\n".join(lines)
 
     def _format_verbose_text(self, *, always_show_transcript: bool = False) -> str:
@@ -1119,8 +1135,7 @@ class SpawnDetailOutput(BaseModel):
             (
                 "Transcript",
                 self.transcript_command()
-                if always_show_transcript
-                or (self.harness_session_id is not None and self.harness_session_id.strip())
+                if always_show_transcript or self.session_log_available
                 else None,
             ),
         ]
@@ -1332,14 +1347,18 @@ class SpawnWaitMultiOutput(BaseModel):
             wire["exit_code"] = self.exit_code
         if len(self.spawns) == 1:
             single = self.spawns[0]
-            wire["transcript_command"] = single.transcript_command()
+            transcript_command = single.transcript_command()
+            if transcript_command is not None:
+                wire["transcript_command"] = transcript_command
             if single.report_body is not None:
                 wire["report_body"] = single.report_body
         # Sparse spawn details.
         spawn_wires: list[dict[str, object]] = []
         for spawn in self.spawns:
             spawn_wire = spawn.to_cli_wire()
-            spawn_wire["transcript_command"] = spawn.transcript_command()
+            transcript_command = spawn.transcript_command()
+            if transcript_command is not None:
+                spawn_wire["transcript_command"] = transcript_command
             spawn_wires.append(spawn_wire)
         wire["spawns"] = spawn_wires
         return wire

--- a/src/meridian/lib/ops/spawn/prepare.py
+++ b/src/meridian/lib/ops/spawn/prepare.py
@@ -197,6 +197,7 @@ def build_create_payload(
             template_vars=parsed_template_vars,
             goal=payload.goal,
             work_id_hint=resolved_work_id_hint,
+            inherited_context_work_id=launch_resolution.context_work_id,
             warning=preflight_warning.strip() if preflight_warning is not None else None,
             authority_root=launch_resolution.directory_context.authority_root.as_posix(),
             task_cwd=launch_resolution.directory_context.logical_task_cwd.as_posix(),

--- a/src/meridian/lib/ops/spawn/query.py
+++ b/src/meridian/lib/ops/spawn/query.py
@@ -526,6 +526,19 @@ def read_written_files(
     return extract_written_files(artifacts, SpawnId(spawn_id))
 
 
+def spawn_session_log_available(
+    runtime_root: Path,
+    spawn_id: str,
+    *,
+    harness_session_id: str | None = None,
+) -> bool:
+    """Return whether ``meridian session log`` can resolve content for one spawn."""
+    if (harness_session_id or "").strip():
+        return True
+    history_path = runtime_root / "spawns" / spawn_id / "history.jsonl"
+    return history_path.is_file()
+
+
 def detail_from_row(
     *,
     project_root: Path,
@@ -554,6 +567,8 @@ def detail_from_row(
         row.id,
         runtime_root=runtime_root,
     )
+
+    resolved_runtime_root = runtime_root or resolve_runtime_root_for_read(project_root)
 
     return SpawnDetailOutput(
         spawn_id=row.id,
@@ -596,6 +611,11 @@ def detail_from_row(
         last_attempt_exited_at=row.last_attempt_exited_at,
         last_attempt_exit_code=row.last_attempt_exit_code,
         session_config_dir=row.claude_config_dir,
+        session_log_available=spawn_session_log_available(
+            resolved_runtime_root,
+            row.id,
+            harness_session_id=row.harness_session_id,
+        ),
     )
 
 
@@ -608,4 +628,5 @@ __all__ = [
     "read_written_files",
     "resolve_spawn_reference",
     "resolve_spawn_references",
+    "spawn_session_log_available",
 ]

--- a/src/meridian/lib/ops/work_attachment.py
+++ b/src/meridian/lib/ops/work_attachment.py
@@ -31,3 +31,30 @@ def ensure_explicit_work_item(runtime_root: Path, work_id: str) -> str:
     """Create-or-attach an explicitly named work item and return its slug."""
 
     return work_store.ensure_work_item_metadata(runtime_root, work_id).name
+
+
+def materialize_launch_work_id(
+    runtime_root: Path,
+    *,
+    explicit_work_id: str | None,
+    context_work_id: str | None,
+) -> str | None:
+    """Materialize explicit ``--work`` or inherited ``--from`` work onto disk."""
+
+    candidate = (explicit_work_id or "").strip() or (context_work_id or "").strip() or None
+    if candidate is None:
+        return None
+    return ensure_explicit_work_item(runtime_root, candidate)
+
+
+def preview_launch_work_id(
+    *,
+    explicit_work_id: str | None,
+    context_work_id: str | None,
+) -> str | None:
+    """Normalize explicit or inherited work for dry-run without creating it."""
+
+    candidate = (explicit_work_id or "").strip() or (context_work_id or "").strip() or None
+    if candidate is None:
+        return None
+    return work_store.slugify(candidate) or None

--- a/src/meridian/lib/state/spawn_store.py
+++ b/src/meridian/lib/state/spawn_store.py
@@ -404,6 +404,7 @@ def update_spawn(
     error: str | None = None,
     desc: str | None = None,
     work_id: str | None = None,
+    launch_policy_snapshot: LaunchPolicySnapshot | None = None,
 ) -> None:
     """Update v2 spawn metadata under the per-spawn state lock."""
 
@@ -442,6 +443,8 @@ def update_spawn(
             updates["desc"] = desc
         if work_id is not None:
             updates["work_id"] = work_id.strip() or None
+        if launch_policy_snapshot is not None:
+            updates["launch_policy_snapshot"] = launch_policy_snapshot
         return current.model_copy(update=updates)
 
     try:

--- a/tests/integration/cli/test_primary_continue.py
+++ b/tests/integration/cli/test_primary_continue.py
@@ -1,0 +1,286 @@
+# qa-validated: test-suite-redesign
+"""Primary --continue launch-policy snapshot replay and legacy fallback."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest  # noqa: TC002
+
+from meridian.cli.primary_launch import run_primary_launch
+from meridian.lib.catalog.catalog_session import CatalogSession
+from meridian.lib.core.domain import SkillContent
+from meridian.lib.core.execution_policy import ResolvedExecutionPolicy
+from meridian.lib.core.launch_policy_snapshot import LaunchPolicySnapshot
+from meridian.lib.core.types import HarnessId
+from meridian.lib.harness.registry import get_default_harness_registry
+from meridian.lib.launch import LaunchRequest, LaunchResult, compile_prepared_policy_surface
+from meridian.lib.launch.plan import build_primary_launch_runtime, build_primary_spawn_request
+from meridian.lib.launch.request import SessionRequest
+from meridian.lib.launch.types import SessionMode
+from meridian.lib.state import spawn_store
+from meridian.lib.state.paths import resolve_project_runtime_root
+from tests.support.fixtures import write_skill
+from tests.support.launch import stub_bundle_request_and_resolve
+
+
+def _state_root(project_root: Path) -> Path:
+    mars_toml = project_root / "mars.toml"
+    if not mars_toml.exists():
+        mars_toml.write_text(
+            '[settings]\ntargets = [".claude", ".codex", ".opencode"]\n',
+            encoding="utf-8",
+        )
+    runtime_root = resolve_project_runtime_root(project_root)
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    return runtime_root
+
+
+def _seed_primary_spawn(
+    runtime_root: Path,
+    *,
+    spawn_id: str,
+    harness_session_id: str,
+    launch_policy_snapshot: LaunchPolicySnapshot | None = None,
+) -> None:
+    model = launch_policy_snapshot.model if launch_policy_snapshot is not None else "gpt-5.3-codex"
+    agent = (
+        (launch_policy_snapshot.agent or "agent-a")
+        if launch_policy_snapshot is not None
+        else "agent-a"
+    )
+    skills = launch_policy_snapshot.skills if launch_policy_snapshot is not None else ("skill-a",)
+    harness = launch_policy_snapshot.harness if launch_policy_snapshot is not None else "codex"
+    spawn_store.start_spawn(
+        runtime_root,
+        spawn_id=spawn_id,
+        chat_id="c-primary",
+        model=model,
+        agent=agent,
+        skills=skills,
+        harness=harness,
+        kind="primary",
+        prompt="primary prompt",
+        harness_session_id=harness_session_id,
+        launch_policy_snapshot=launch_policy_snapshot,
+    )
+
+
+def test_primary_continue_replays_source_launch_policy_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    runtime_root = _state_root(project_root)
+    write_skill(project_root, "testing-principles")
+    snapshot = LaunchPolicySnapshot(
+        model="claude-sonnet-4-6",
+        harness="claude",
+        agent="agent-a",
+        skills=("testing-principles",),
+        loaded_skills=(
+            SkillContent(
+                name="testing-principles",
+                description="testing-principles skill",
+                path="/skills/testing-principles/SKILL.md",
+                content="# testing-principles\n\nBe consistent.\n",
+                skill_type="reference",
+            ),
+        ),
+        execution_policy=ResolvedExecutionPolicy(approval="auto", sandbox="workspace-write"),
+        tools={"write": "allow"},
+        mcp_tools=("github",),
+        extra_args=("--permission-mode", "acceptEdits"),
+    )
+    _seed_primary_spawn(
+        runtime_root,
+        spawn_id="p41",
+        harness_session_id="session-41",
+        launch_policy_snapshot=snapshot,
+    )
+    monkeypatch.setenv("MERIDIAN_MODEL", "gpt-5.4")
+    monkeypatch.setenv("MERIDIAN_AGENT", "agent-b")
+
+    def fail_bundle_resolution(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("snapshot replay should not re-resolve live policy")
+
+    monkeypatch.setattr(
+        "meridian.lib.launch.bundle_adapter.request_and_resolve",
+        fail_bundle_resolution,
+    )
+
+    captured: dict[str, LaunchRequest] = {}
+
+    def fake_launch_primary(
+        *,
+        project_root: Path,
+        request: LaunchRequest,
+        harness_registry: object,
+    ) -> LaunchResult:
+        _ = (project_root, harness_registry)
+        captured["request"] = request
+        return LaunchResult(
+            command=(),
+            exit_code=0,
+            continue_ref="session-41",
+            continue_chat_id="c41",
+        )
+
+    with patch("meridian.cli.primary_launch.launch_primary", side_effect=fake_launch_primary):
+        run_primary_launch(
+            project_root=project_root,
+            continue_ref="p41",
+            fork_ref=None,
+            fork_fresh_ref=None,
+            model="",
+            harness=None,
+            agent=None,
+            work="",
+            task_dir=None,
+            yolo=False,
+            approval=None,
+            autocompact=None,
+            effort=None,
+            sandbox=None,
+            timeout=None,
+            dry_run=False,
+            passthrough=(),
+            skills=(),
+        )
+
+    request = captured["request"]
+    assert request.launch_policy_snapshot == snapshot
+    assert request.agent is None
+    assert request.model == ""
+    assert request.skills == ()
+
+
+def test_primary_continue_uses_legacy_bundle_resolution_without_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    runtime_root = _state_root(project_root)
+    _seed_primary_spawn(
+        runtime_root,
+        spawn_id="p42",
+        harness_session_id="session-42",
+        launch_policy_snapshot=None,
+    )
+
+    monkeypatch.setenv("MERIDIAN_MODEL", "claude-sonnet-4-6")
+    stub_bundle_request_and_resolve(
+        monkeypatch,
+        model="gpt-5.3-codex",
+        model_token="gpt-5.3-codex",
+        harness=HarnessId.CODEX,
+        harness_model="openai/gpt-5.3-codex",
+    )
+
+    captured: dict[str, LaunchRequest] = {}
+
+    def fake_launch_primary(
+        *,
+        project_root: Path,
+        request: LaunchRequest,
+        harness_registry: object,
+    ) -> LaunchResult:
+        _ = (project_root, harness_registry)
+        captured["request"] = request
+        return LaunchResult(
+            command=(),
+            exit_code=0,
+            continue_ref="session-42",
+            continue_chat_id="c42",
+        )
+
+    with patch("meridian.cli.primary_launch.launch_primary", side_effect=fake_launch_primary):
+        run_primary_launch(
+            project_root=project_root,
+            continue_ref="p42",
+            fork_ref=None,
+            fork_fresh_ref=None,
+            model="",
+            harness=None,
+            agent=None,
+            work="",
+            task_dir=None,
+            yolo=False,
+            approval=None,
+            autocompact=None,
+            effort=None,
+            sandbox=None,
+            timeout=None,
+            dry_run=False,
+            passthrough=(),
+            skills=(),
+        )
+
+    request = captured["request"]
+    assert request.launch_policy_snapshot is None
+
+
+def test_primary_continue_snapshot_replay_preserves_agent_over_config_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Agent A at launch must survive --continue after config default moves to agent B."""
+
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    (project_root / ".mars").mkdir()
+    (project_root / ".mars" / "config.toml").write_text(
+        '[primary]\nagent = "agent-b"\n',
+        encoding="utf-8",
+    )
+    runtime_root = _state_root(project_root)
+    snapshot = LaunchPolicySnapshot(
+        model="gpt-5.3-codex",
+        harness="codex",
+        agent="agent-a",
+        skills=(),
+    )
+    _seed_primary_spawn(
+        runtime_root,
+        spawn_id="p43",
+        harness_session_id="session-43",
+        launch_policy_snapshot=snapshot,
+    )
+
+    bundle_calls: list[object] = []
+
+    def fail_bundle_resolution(*_args: object, **_kwargs: object) -> object:
+        bundle_calls.append(True)
+        raise AssertionError("snapshot replay should not call mars launch-bundle")
+
+    monkeypatch.setattr(
+        "meridian.lib.launch.bundle_adapter.request_and_resolve",
+        fail_bundle_resolution,
+    )
+
+    launch_request = LaunchRequest(
+        harness="codex",
+        session_mode=SessionMode.RESUME,
+        launch_policy_snapshot=snapshot,
+        session=SessionRequest(
+            requested_harness_session_id="session-43",
+            continue_harness="codex",
+        ),
+    )
+    spawn_request = build_primary_spawn_request(request=launch_request)
+    runtime = build_primary_launch_runtime(project_root=project_root)
+    prepared_policy = compile_prepared_policy_surface(
+        request=spawn_request,
+        runtime=runtime,
+        project_root=project_root,
+        harness_registry=get_default_harness_registry(),
+        catalog=CatalogSession(project_root),
+        active_work_dir=None,
+        dry_run=True,
+    )
+
+    assert bundle_calls == []
+    assert prepared_policy.resolved_policy.routing.agent == "agent-a"

--- a/tests/integration/cli/test_primary_continue.py
+++ b/tests/integration/cli/test_primary_continue.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest  # noqa: TC002
+import pytest
 
 from meridian.cli.primary_launch import run_primary_launch
 from meridian.lib.catalog.catalog_session import CatalogSession
@@ -19,7 +19,7 @@ from meridian.lib.launch import LaunchRequest, LaunchResult, compile_prepared_po
 from meridian.lib.launch.plan import build_primary_launch_runtime, build_primary_spawn_request
 from meridian.lib.launch.request import SessionRequest
 from meridian.lib.launch.types import SessionMode
-from meridian.lib.state import spawn_store
+from meridian.lib.state import session_store, spawn_store
 from meridian.lib.state.paths import resolve_project_runtime_root
 from tests.support.fixtures import write_skill
 from tests.support.launch import stub_bundle_request_and_resolve
@@ -152,9 +152,232 @@ def test_primary_continue_replays_source_launch_policy_snapshot(
 
     request = captured["request"]
     assert request.launch_policy_snapshot == snapshot
+    assert request.passthrough_args == snapshot.extra_args
     assert request.agent is None
     assert request.model == ""
     assert request.skills == ()
+
+
+def test_primary_continue_spawn_session_ref_recovers_linked_spawn_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tracked spawn-session chat refs must load the linked spawn row's snapshot."""
+
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    runtime_root = _state_root(project_root)
+    primary_snapshot = LaunchPolicySnapshot(
+        model="gpt-5.3-codex",
+        harness="codex",
+        agent="agent-primary",
+        skills=(),
+    )
+    spawn_snapshot = LaunchPolicySnapshot(
+        model="claude-sonnet-4-6",
+        harness="claude",
+        agent="agent-spawn",
+        skills=("testing-principles",),
+        extra_args=("--permission-mode", "acceptEdits"),
+    )
+    _seed_primary_spawn(
+        runtime_root,
+        spawn_id="p50",
+        harness_session_id="session-primary",
+        launch_policy_snapshot=primary_snapshot,
+    )
+    spawn_store.start_spawn(
+        runtime_root,
+        spawn_id="p51",
+        chat_id="c-spawn",
+        owner_chat_id="c-primary",
+        model=spawn_snapshot.model,
+        agent=spawn_snapshot.agent or "agent-spawn",
+        skills=spawn_snapshot.skills,
+        harness=spawn_snapshot.harness,
+        kind="child",
+        prompt="child prompt",
+        harness_session_id="session-spawn",
+        launch_policy_snapshot=spawn_snapshot,
+    )
+    spawn_chat_id = session_store.start_session(
+        runtime_root,
+        harness="claude",
+        harness_session_id="session-spawn",
+        model=spawn_snapshot.model,
+        chat_id="c-spawn",
+        agent=spawn_snapshot.agent or "agent-spawn",
+        skills=spawn_snapshot.skills,
+        kind="spawn",
+        spawn_id="p51",
+    )
+
+    def fail_bundle_resolution(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("snapshot replay should not re-resolve live policy")
+
+    monkeypatch.setattr(
+        "meridian.lib.launch.bundle_adapter.request_and_resolve",
+        fail_bundle_resolution,
+    )
+
+    captured: dict[str, LaunchRequest] = {}
+
+    def fake_launch_primary(
+        *,
+        project_root: Path,
+        request: LaunchRequest,
+        harness_registry: object,
+    ) -> LaunchResult:
+        _ = (project_root, harness_registry)
+        captured["request"] = request
+        return LaunchResult(
+            command=(),
+            exit_code=0,
+            continue_ref="session-spawn",
+            continue_chat_id=spawn_chat_id,
+        )
+
+    try:
+        with patch("meridian.cli.primary_launch.launch_primary", side_effect=fake_launch_primary):
+            run_primary_launch(
+                project_root=project_root,
+                continue_ref=spawn_chat_id,
+                fork_ref=None,
+                fork_fresh_ref=None,
+                model="",
+                harness=None,
+                agent=None,
+                work="",
+                task_dir=None,
+                yolo=False,
+                approval=None,
+                autocompact=None,
+                effort=None,
+                sandbox=None,
+                timeout=None,
+                dry_run=False,
+                passthrough=(),
+                skills=(),
+            )
+    finally:
+        session_store.stop_session(runtime_root, spawn_chat_id)
+
+    request = captured["request"]
+    assert request.launch_policy_snapshot == spawn_snapshot
+    assert request.passthrough_args == spawn_snapshot.extra_args
+
+
+def test_primary_continue_rejects_passthrough_args(tmp_path: Path) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    runtime_root = _state_root(project_root)
+    _seed_primary_spawn(
+        runtime_root,
+        spawn_id="p52",
+        harness_session_id="session-52",
+        launch_policy_snapshot=LaunchPolicySnapshot(
+            model="gpt-5.3-codex",
+            harness="codex",
+        ),
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        run_primary_launch(
+            project_root=project_root,
+            continue_ref="p52",
+            fork_ref=None,
+            fork_fresh_ref=None,
+            model="",
+            harness=None,
+            agent=None,
+            work="",
+            task_dir=None,
+            yolo=False,
+            approval=None,
+            autocompact=None,
+            effort=None,
+            sandbox=None,
+            timeout=None,
+            dry_run=False,
+            passthrough=("--custom",),
+            skills=(),
+        )
+
+    assert "--" in str(exc_info.value)
+
+
+def test_primary_continue_replays_snapshot_extra_args_not_cli_passthrough(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    runtime_root = _state_root(project_root)
+    snapshot = LaunchPolicySnapshot(
+        model="claude-sonnet-4-6",
+        harness="claude",
+        agent="agent-a",
+        skills=(),
+        extra_args=("--permission-mode", "acceptEdits"),
+    )
+    _seed_primary_spawn(
+        runtime_root,
+        spawn_id="p53",
+        harness_session_id="session-53",
+        launch_policy_snapshot=snapshot,
+    )
+
+    def fail_bundle_resolution(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("snapshot replay should not re-resolve live policy")
+
+    monkeypatch.setattr(
+        "meridian.lib.launch.bundle_adapter.request_and_resolve",
+        fail_bundle_resolution,
+    )
+
+    captured: dict[str, LaunchRequest] = {}
+
+    def fake_launch_primary(
+        *,
+        project_root: Path,
+        request: LaunchRequest,
+        harness_registry: object,
+    ) -> LaunchResult:
+        _ = (project_root, harness_registry)
+        captured["request"] = request
+        return LaunchResult(
+            command=(),
+            exit_code=0,
+            continue_ref="session-53",
+            continue_chat_id="c53",
+        )
+
+    with patch("meridian.cli.primary_launch.launch_primary", side_effect=fake_launch_primary):
+        run_primary_launch(
+            project_root=project_root,
+            continue_ref="p53",
+            fork_ref=None,
+            fork_fresh_ref=None,
+            model="",
+            harness=None,
+            agent=None,
+            work="",
+            task_dir=None,
+            yolo=False,
+            approval=None,
+            autocompact=None,
+            effort=None,
+            sandbox=None,
+            timeout=None,
+            dry_run=False,
+            passthrough=(),
+            skills=(),
+        )
+
+    spawn_request = build_primary_spawn_request(request=captured["request"])
+    assert captured["request"].passthrough_args == snapshot.extra_args
+    assert spawn_request.extra_args == snapshot.extra_args
+    assert spawn_request.extra_args != ("--custom",)
 
 
 def test_primary_continue_uses_legacy_bundle_resolution_without_snapshot(

--- a/tests/integration/harness/test_opencode_connection.py
+++ b/tests/integration/harness/test_opencode_connection.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Mapping
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -23,6 +24,7 @@ from meridian.lib.platform.process_scope import ProcessScopeSnapshot, ScopedProc
 from meridian.lib.safety.permissions import (
     UnsafeNoOpPermissionResolver,
 )
+from meridian.lib.state.paths import resolve_spawn_log_dir
 from tests.support.async_determinism import AsyncDeterminism
 from tests.support.fakes import FakeClock
 
@@ -671,3 +673,84 @@ async def test_opencode_launch_process_passes_env_overrides_to_managed_backend(
     assert connection.subprocess_pid == fake_process.pid
 
     await connection._cleanup_runtime()
+
+
+class _EarlyExitStartupOpenCodeConnection(OpenCodeConnection):
+    def __init__(self, *, stderr_text: str) -> None:
+        super().__init__()
+        self._startup_stderr_text = stderr_text
+
+    async def _launch_process(self, config: ConnectionConfig, spec: ResolvedLaunchSpec) -> None:
+        _ = spec
+        spawn_dir = resolve_spawn_log_dir(config.control_root, config.spawn_id)
+        spawn_dir.mkdir(parents=True, exist_ok=True)
+        self._stderr_log_path = spawn_dir / "stderr.log"
+        self._stderr_log_path.write_text(self._startup_stderr_text, encoding="utf-8")
+        self._stderr_read_offset = 0
+        self._process = _FakeProcess()
+        self._process.returncode = 1
+
+
+def _write_startup_stderr(connection: OpenCodeConnection, tmp_path: Path, text: str) -> None:
+    spawn_dir = tmp_path / "spawns" / "p-startup-fail"
+    spawn_dir.mkdir(parents=True, exist_ok=True)
+    connection._stderr_log_path = spawn_dir / "stderr.log"
+    connection._stderr_log_path.write_text(text, encoding="utf-8")
+    connection._stderr_read_offset = 0
+    connection._process = _FakeProcess()
+    connection._process.returncode = 1
+    connection._config = _build_connection_config(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_opencode_startup_exit_surfaces_stderr_and_xdg_hint(tmp_path: Path) -> None:
+    connection = _EarlyExitStartupOpenCodeConnection(
+        stderr_text=(
+            "EACCES: permission denied, mkdir '/root/meridian-probe-opencode-no-access/opencode'\n"
+        ),
+    )
+    config = _build_connection_config(tmp_path)
+    config = replace(
+        config,
+        env_overrides={"XDG_DATA_HOME": "/root/meridian-probe-opencode-no-access"},
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await connection.start(
+            config,
+            ResolvedLaunchSpec(
+                permission_resolver=UnsafeNoOpPermissionResolver(_suppress_warning=True),
+            ),
+        )
+
+    message = str(exc_info.value)
+    assert "OpenCode backend failed to start (exit=1)" in message
+    assert "EACCES: permission denied" in message
+    assert "Hint:" in message
+    assert "XDG_DATA_HOME (/root/meridian-probe-opencode-no-access)" in message
+    assert connection.state == "failed"
+
+
+def test_opencode_startup_exit_message_without_stderr(tmp_path: Path) -> None:
+    connection = OpenCodeConnection()
+    _write_startup_stderr(connection, tmp_path, "")
+
+    message = str(connection._startup_exit_exception())
+
+    assert message == "OpenCode backend failed to start (exit=1)."
+
+
+def test_spawn_action_output_omits_transcript_when_session_log_unavailable() -> None:
+    from meridian.lib.ops.spawn.models import SpawnActionOutput
+
+    output = SpawnActionOutput(
+        command="spawn.create",
+        status="failed",
+        spawn_id="p4735",
+        session_log_available=False,
+        duration_secs=0.5,
+    )
+
+    text = output.format_text()
+    assert "Transcript:" not in text
+    assert output.to_wire().get("transcript_command") is None

--- a/tests/integration/launch/test_launch_resolution_runtime.py
+++ b/tests/integration/launch/test_launch_resolution_runtime.py
@@ -25,6 +25,7 @@ from meridian.lib.launch.request import LaunchCompositionSurface
 from meridian.lib.launch.types import LaunchRequest, build_primary_prompt
 from meridian.lib.ops.spawn import context_ref
 from meridian.lib.state import work_store
+from meridian.lib.state.paths import resolve_project_paths
 from tests.support.fixtures import write_agent
 from tests.support.launch import stub_bundle_request_and_resolve
 
@@ -357,6 +358,114 @@ def test_primary_launch_invalid_reference_does_not_create_explicit_work(
 
     assert not (project_root / ".meridian" / "work").exists()
     assert not (project_root / ".meridian" / "id").exists()
+
+
+def test_primary_launch_materializes_context_from_work(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    _write_minimal_mars_config(project_root)
+    project_state_dir = resolve_project_paths(project_root).root_dir
+    stub_bundle_request_and_resolve(
+        monkeypatch,
+        model="gpt-5.4-mini",
+        harness=HarnessId.CODEX,
+    )
+
+    def fake_resolve_context_ref(_root: Path, _ref: str) -> context_ref.SpawnContextRef:
+        return context_ref.SpawnContextRef(
+            spawn_id="p123",
+            status="succeeded",
+            agent="coder",
+            desc="prior task",
+            model="gpt-5.4-mini",
+            harness="codex",
+            work_id="inherited-work",
+        )
+
+    monkeypatch.setattr(context_ref, "resolve_context_ref", fake_resolve_context_ref)
+
+    from meridian.lib.launch.process import ProcessOutcome
+
+    def fake_run_harness_process(preview_context, harness_registry, *, prepared=None):
+        _ = (preview_context, harness_registry, prepared)
+        return ProcessOutcome(
+            command=(),
+            exit_code=0,
+            chat_id="c1",
+            primary_spawn_id="p1",
+            primary_started=0.0,
+            primary_started_epoch=0.0,
+            primary_started_local_iso=None,
+            resolved_harness_session_id="sess-1",
+        )
+
+    monkeypatch.setattr(
+        "meridian.lib.launch.process.run_harness_process",
+        fake_run_harness_process,
+    )
+
+    assert work_store.get_work_item(project_state_dir, "inherited-work") is None
+
+    result = launch_primary(
+        project_root=project_root,
+        request=PrimaryLaunchRequest(
+            model="gpt-5.4-mini",
+            harness=HarnessId.CODEX.value,
+            context_from=("p123",),
+            dry_run=False,
+        ),
+        harness_registry=get_default_harness_registry(),
+    )
+
+    assert result.exit_code == 0
+    assert work_store.get_work_item(project_state_dir, "inherited-work") is not None
+
+
+def test_primary_launch_explicit_work_precedence_over_context_from(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    _write_minimal_mars_config(project_root)
+    project_state_dir = resolve_project_paths(project_root).root_dir
+    stub_bundle_request_and_resolve(
+        monkeypatch,
+        model="gpt-5.4-mini",
+        harness=HarnessId.CODEX,
+    )
+
+    def fake_resolve_context_ref(_root: Path, _ref: str) -> context_ref.SpawnContextRef:
+        return context_ref.SpawnContextRef(
+            spawn_id="p123",
+            status="succeeded",
+            agent="coder",
+            desc="prior task",
+            model="gpt-5.4-mini",
+            harness="codex",
+            work_id="from-work",
+        )
+
+    monkeypatch.setattr(context_ref, "resolve_context_ref", fake_resolve_context_ref)
+
+    result = launch_primary(
+        project_root=project_root,
+        request=PrimaryLaunchRequest(
+            model="gpt-5.4-mini",
+            harness=HarnessId.CODEX.value,
+            work_id="explicit-work",
+            context_from=("p123",),
+            dry_run=True,
+        ),
+        harness_registry=get_default_harness_registry(),
+    )
+
+    assert result.exit_code == 0
+    assert work_store.get_work_item(project_state_dir, "explicit-work") is None
+    assert work_store.get_work_item(project_state_dir, "from-work") is None
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/ops/test_spawn_execute_report_output.py
+++ b/tests/integration/ops/test_spawn_execute_report_output.py
@@ -111,6 +111,8 @@ def test_execute_spawn_blocking_reads_report_and_does_not_print_running_preamble
         report_path = runtime_root / "spawns" / spawn_id / "report.md"
         report_path.parent.mkdir(parents=True, exist_ok=True)
         report_path.write_text("fake report body\n", encoding="utf-8")
+        history_path = runtime_root / "spawns" / spawn_id / "history.jsonl"
+        history_path.write_text('{"event_type":"session.idle"}\n', encoding="utf-8")
         spawn_store.finalize_spawn(
             runtime_root,
             spawn_id,
@@ -400,6 +402,58 @@ def test_execute_spawn_blocking_persists_unified_work_id_precedence(
     row = spawn_store.get_spawn(authority.runtime_root, result.spawn_id)
     assert row is not None
     assert row.work_id == "from-request"
+
+
+def test_reserve_then_prepare_materializes_context_from_work(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hook = LifecycleEventHook()
+    sink = RecordingOutputSink()
+    runtime = _build_test_runtime(tmp_path, monkeypatch, sink=sink)
+    project_root = tmp_path / "repo"
+    project_state_dir = resolve_project_paths(project_root).root_dir
+    authority = resolve_runtime_authority_for_write(project_root)
+    assert authority.runtime_root is not None
+
+    _patch_lifecycle_service_with_hook(monkeypatch, hook)
+    work_store.create_work_item(project_state_dir, "source-work", "", None)
+
+    async def _fake_launch_prepared_spawn(**kwargs: object) -> int:
+        spawn = cast("Any", kwargs["spawn"])
+        spawn_store.finalize_spawn(
+            authority.runtime_root,
+            str(spawn.spawn_id),
+            "succeeded",
+            0,
+            origin="runner",
+        )
+        return 0
+
+    monkeypatch.setattr(execute_module, "launch_prepared_spawn", _fake_launch_prepared_spawn)
+
+    result = execute_module.execute_spawn_blocking(
+        payload=SpawnCreateInput(prompt="run", context_from=("p123",)),
+        request=SpawnRequest(
+            prompt="run",
+            model="gpt-5.4",
+            harness="codex",
+            agent="coder",
+            context_from=("p123",),
+            work_id_hint="source-work",
+            task_cwd_work_item="source-work",
+            inherited_context_work_id="source-work",
+        ),
+        runtime=runtime,
+        ctx=RuntimeContext(depth=1, spawn_id="p-parent"),
+    )
+
+    assert result.status == "succeeded"
+    assert result.spawn_id is not None
+    row = spawn_store.get_spawn(authority.runtime_root, result.spawn_id)
+    assert row is not None
+    assert row.work_id == "source-work"
+    assert work_store.get_work_item(project_state_dir, "source-work") is not None
 
 
 def test_execute_spawn_background_pre_init_failure_returns_failed_output(

--- a/tests/integration/ops/test_spawn_prepare_fork.py
+++ b/tests/integration/ops/test_spawn_prepare_fork.py
@@ -132,6 +132,7 @@ def test_build_create_payload_inherits_work_from_context_from(
     )
 
     assert artifacts.request.task_cwd_work_item == "feature-x"
+    assert artifacts.request.inherited_context_work_id == "feature-x"
     assert artifacts.request.task_cwd_source == "ambient-work-authority-root"
 
 
@@ -164,8 +165,10 @@ def test_build_create_payload_work_precedence_over_context_from(
     )
 
     assert explicit.request.task_cwd_work_item == "explicit-work"
+    assert explicit.request.inherited_context_work_id is None
     assert explicit.request.task_cwd_source == "explicit-work-authority-root"
     assert ambient.request.task_cwd_work_item == "ambient-work"
+    assert ambient.request.inherited_context_work_id is None
     assert ambient.request.task_cwd_source == "ambient-work-authority-root"
 
 

--- a/tests/unit/launch/test_resolution.py
+++ b/tests/unit/launch/test_resolution.py
@@ -40,6 +40,7 @@ def test_resolve_launch_inputs_inherits_context_work_as_last_resort(
     )
 
     assert resolution.effective_work_id == "from-work"
+    assert resolution.context_work_id == "from-work"
     assert resolution.directory_context.work_item == "from-work"
     assert resolution.directory_context.task_cwd_source == "ambient-work-authority-root"
     assert resolution.request_updates["work_id_hint"] == "from-work"
@@ -68,8 +69,10 @@ def test_resolve_launch_inputs_keeps_explicit_and_ambient_precedence(
     )
 
     assert explicit.effective_work_id == "explicit-work"
+    assert explicit.context_work_id is None
     assert explicit.directory_context.task_cwd_source == "explicit-work-authority-root"
     assert ambient.effective_work_id == "ambient-work"
+    assert ambient.context_work_id is None
     assert ambient.directory_context.task_cwd_source == "ambient-work-authority-root"
 
 

--- a/tests/unit/ops/test_context_ref.py
+++ b/tests/unit/ops/test_context_ref.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+import pytest
+
+from meridian.lib.ops.spawn.context_ref import resolve_context_ref
+
+
+def test_resolve_context_ref_rejects_filesystem_path(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="--from does not accept filesystem paths"):
+        resolve_context_ref(tmp_path, "./notes/context.md")
+
+    with pytest.raises(ValueError, match="use --file/-f instead"):
+        resolve_context_ref(tmp_path, "/tmp/report.md")
+
+
+def test_resolve_context_ref_still_accepts_spawn_and_session_refs(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="Spawn 'p999' not found"):
+        resolve_context_ref(tmp_path, "p999")
+
+    with pytest.raises(ValueError, match="No primary spawn found"):
+        resolve_context_ref(tmp_path, "c999")

--- a/uv.lock
+++ b/uv.lock
@@ -666,15 +666,15 @@ wheels = [
 
 [[package]]
 name = "mars-agents"
-version = "0.10.1rc1"
+version = "0.10.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/99/50/d62983daa0fb5576e6dce1fead6a9416663d5529a0e206cdbb28b10fe534/mars_agents-0.10.1rc1.tar.gz", hash = "sha256:3e29425bacd7abb85580dde144a9fbc5252bf0968f6782f9db23636faeeb61a4", size = 707031, upload-time = "2026-06-24T12:58:33.965Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/b1/42c2e871ffb5173b06bc3a8c66c20b379fa298d97c3b507f3d309fd26435/mars_agents-0.10.1.tar.gz", hash = "sha256:876a47a4ca9a0f88a0ae75ba320a56e219fb241283ab7abdfb36f934b2fee2ef", size = 707577, upload-time = "2026-06-25T03:05:28.096Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/e8/1c4deb0a38bcb382df2922d130c9f9e4af738b9db077bb44fab9544e9d9f/mars_agents-0.10.1rc1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e9e76ceedc74ee065b446fee62e3b742b740bf4e5ac92f9a11022216ab0d5d6c", size = 3455280, upload-time = "2026-06-24T12:58:25.794Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/37/657c9825ba7dee31dc5b64584d5b801cc5f5be8e4231a9860e677bb856de/mars_agents-0.10.1rc1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2ea551cf023342a29700a085ab25602b4f8a95daab85629aeedf5ffb4fc7d7c1", size = 3309037, upload-time = "2026-06-24T12:58:27.669Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/c0/3df3ec6d6d312d772ca5f465fc77c516c445df1a319fb21dd10b26eec837/mars_agents-0.10.1rc1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7efb603ebd4c3fb8094c679e1c187220d46c11beaeba54e9dad01ce7db6ee16e", size = 3355484, upload-time = "2026-06-24T12:58:29.286Z" },
-    { url = "https://files.pythonhosted.org/packages/93/01/382362d759aaed07433e7ac55d42152722320a08a25b74f2d5d849aa0211/mars_agents-0.10.1rc1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bcfa86bed296b6caffd5a6587add4c7e028c2d0b4a5b33b1581d22339eeb25ed", size = 3571695, upload-time = "2026-06-24T12:58:30.909Z" },
-    { url = "https://files.pythonhosted.org/packages/92/e0/471ec6b665402656c6e821f23e17ecb65f7a8321c7ae156e29f566ad1f8e/mars_agents-0.10.1rc1-py3-none-win_amd64.whl", hash = "sha256:9a3a72b51d2e8d84bd2318211581437ef96d63a148d5fd7ec7e7fc4140fde090", size = 3521929, upload-time = "2026-06-24T12:58:32.444Z" },
+    { url = "https://files.pythonhosted.org/packages/17/a7/0342ae585dfb5a52180d98a0e08c5ab73de896c8328402c9b09f0b80ae83/mars_agents-0.10.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9d986edcd5ef5ed35e4b82041a5f1611014afc93c6fe3fde4f78fc0db650764f", size = 3454536, upload-time = "2026-06-25T03:05:20.225Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/b6/c4ce6a5e1fa548cd0be7471cc11bcb20f29ceb9b68c7c61bbcffba30469d/mars_agents-0.10.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1d0c42c2b6aabe224573401a1fd60b57f0d9f313c54fe0a073f4817845755397", size = 3312929, upload-time = "2026-06-25T03:05:22.002Z" },
+    { url = "https://files.pythonhosted.org/packages/00/48/aa3e366f6156ef1541abbbef1d6252a48965635d6135cd34eafc2bc2a4ef/mars_agents-0.10.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5bd451962a237cf869a88d32046a4345eec1779bb1632324ae54587582e05d0e", size = 3357478, upload-time = "2026-06-25T03:05:23.497Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/a1/4af8558c33873617958af356b99e97d5cff2eb52e1087bc22efa47e9911a/mars_agents-0.10.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:01ab479d0e3557c7a44b89a79c69e7909a154ddf3951b4198901613b1bca7626", size = 3576682, upload-time = "2026-06-25T03:05:24.914Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d4/73199f5d60d12efaf612ce2e7a3844b68331e2343fa50264dc33818e91c1/mars_agents-0.10.1-py3-none-win_amd64.whl", hash = "sha256:d6b19dfb1350168721615bb149417b7e63bbbde9e5379dd90c44c34f132db814", size = 3523223, upload-time = "2026-06-25T03:05:26.479Z" },
 ]
 
 [[package]]
@@ -766,7 +766,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'app'", specifier = ">=0.28" },
     { name = "jinja2", marker = "extra == 'templates'", specifier = ">=3.1" },
     { name = "markdown-it-py", specifier = ">=4.0" },
-    { name = "mars-agents", specifier = "==0.10.1rc1" },
+    { name = "mars-agents", specifier = "==0.10.1" },
     { name = "mcp", specifier = ">=1.0" },
     { name = "pathspec", specifier = ">=1.1.0" },
     { name = "psutil", specifier = ">=7.2.2" },

--- a/uv.lock
+++ b/uv.lock
@@ -666,15 +666,15 @@ wheels = [
 
 [[package]]
 name = "mars-agents"
-version = "0.10.0"
+version = "0.10.1rc1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a3/e7/cc19c99844efdec83fc54aedee6e4afe6e42a7be6911cc407865a93e5159/mars_agents-0.10.0.tar.gz", hash = "sha256:c5b03d4e6a3aa826f3118f2c016c6cd5c3d234fdc3a3907e60b480474c1352dd", size = 701374, upload-time = "2026-06-24T10:28:26.591Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/50/d62983daa0fb5576e6dce1fead6a9416663d5529a0e206cdbb28b10fe534/mars_agents-0.10.1rc1.tar.gz", hash = "sha256:3e29425bacd7abb85580dde144a9fbc5252bf0968f6782f9db23636faeeb61a4", size = 707031, upload-time = "2026-06-24T12:58:33.965Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/08/d1880112b151ab7430156cbf3467b8f61fc30c76dd25a5f9a7fd9be11bee/mars_agents-0.10.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4ff8dfce3c1c272a9d52e647766e1501e6c81d75fc81e4acfc79595cbee4ee52", size = 3463552, upload-time = "2026-06-24T10:28:17.818Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/a4/3d98f703d48cc3f55f7ddb70a9dcf6be320b3d1d1968c84d46affd6d90a8/mars_agents-0.10.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:be7fe1a047d66866546dac87c93f44354e4f824d4987a532192c772b57063d94", size = 3300954, upload-time = "2026-06-24T10:28:19.563Z" },
-    { url = "https://files.pythonhosted.org/packages/32/cd/fee3b5e30538e8b6d6ec891e06fa61c0489098179b93f62eb545364cc0a4/mars_agents-0.10.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4c103bed39e8f30201b62b85b71d2d19130a72a3e651e10b14ea05580208a3c2", size = 3353511, upload-time = "2026-06-24T10:28:21.375Z" },
-    { url = "https://files.pythonhosted.org/packages/18/2c/2185017c1cdb465a815cc715d83a7d50ac7a5748a95d4bd88e95ca33c93d/mars_agents-0.10.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd953c1653f4ec5c8aa69231527df36102317cb847871d705e599f25398cb87d", size = 3568407, upload-time = "2026-06-24T10:28:23.014Z" },
-    { url = "https://files.pythonhosted.org/packages/96/b6/26bee520e8169d1324a9b185eb414aa73512bddf62a61f99480bf10eeb45/mars_agents-0.10.0-py3-none-win_amd64.whl", hash = "sha256:b700e1a8588856f1732dcc24e99310023adc3ce0200aad4217717f7c6b19118c", size = 3519282, upload-time = "2026-06-24T10:28:24.958Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/1c4deb0a38bcb382df2922d130c9f9e4af738b9db077bb44fab9544e9d9f/mars_agents-0.10.1rc1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e9e76ceedc74ee065b446fee62e3b742b740bf4e5ac92f9a11022216ab0d5d6c", size = 3455280, upload-time = "2026-06-24T12:58:25.794Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/37/657c9825ba7dee31dc5b64584d5b801cc5f5be8e4231a9860e677bb856de/mars_agents-0.10.1rc1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2ea551cf023342a29700a085ab25602b4f8a95daab85629aeedf5ffb4fc7d7c1", size = 3309037, upload-time = "2026-06-24T12:58:27.669Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/3df3ec6d6d312d772ca5f465fc77c516c445df1a319fb21dd10b26eec837/mars_agents-0.10.1rc1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7efb603ebd4c3fb8094c679e1c187220d46c11beaeba54e9dad01ce7db6ee16e", size = 3355484, upload-time = "2026-06-24T12:58:29.286Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/382362d759aaed07433e7ac55d42152722320a08a25b74f2d5d849aa0211/mars_agents-0.10.1rc1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bcfa86bed296b6caffd5a6587add4c7e028c2d0b4a5b33b1581d22339eeb25ed", size = 3571695, upload-time = "2026-06-24T12:58:30.909Z" },
+    { url = "https://files.pythonhosted.org/packages/92/e0/471ec6b665402656c6e821f23e17ecb65f7a8321c7ae156e29f566ad1f8e/mars_agents-0.10.1rc1-py3-none-win_amd64.whl", hash = "sha256:9a3a72b51d2e8d84bd2318211581437ef96d63a148d5fd7ec7e7fc4140fde090", size = 3521929, upload-time = "2026-06-24T12:58:32.444Z" },
 ]
 
 [[package]]
@@ -766,7 +766,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'app'", specifier = ">=0.28" },
     { name = "jinja2", marker = "extra == 'templates'", specifier = ">=3.1" },
     { name = "markdown-it-py", specifier = ">=4.0" },
-    { name = "mars-agents", specifier = "==0.10.0" },
+    { name = "mars-agents", specifier = "==0.10.1rc1" },
     { name = "mcp", specifier = ">=1.0" },
     { name = "pathspec", specifier = ">=1.1.0" },
     { name = "psutil", specifier = ">=7.2.2" },

--- a/uv.lock
+++ b/uv.lock
@@ -666,15 +666,15 @@ wheels = [
 
 [[package]]
 name = "mars-agents"
-version = "0.9.0"
+version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/eb/79/90af10c443737530ae7936c15b42a8c72de25401b34720f89229853ae721/mars_agents-0.9.0.tar.gz", hash = "sha256:f40ae56236ddbff126b1836be1bc9f2ed620e368a6d9641af41cfa9637ea66c3", size = 638770, upload-time = "2026-06-22T10:46:37.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/e7/cc19c99844efdec83fc54aedee6e4afe6e42a7be6911cc407865a93e5159/mars_agents-0.10.0.tar.gz", hash = "sha256:c5b03d4e6a3aa826f3118f2c016c6cd5c3d234fdc3a3907e60b480474c1352dd", size = 701374, upload-time = "2026-06-24T10:28:26.591Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/d1/2f91bcc581c09665d97eeabbf072ebfa6a11e49a8513120c1a05641d1f5f/mars_agents-0.9.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7aa2f8ac1084be6f23638360804be6b3391751c8c261da4016801482e1fd5264", size = 3397610, upload-time = "2026-06-22T10:46:29.435Z" },
-    { url = "https://files.pythonhosted.org/packages/15/d9/f613b3757263b60951da29019ec93663db4019739130c5b3358ccf0bd254/mars_agents-0.9.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:09887161379056d0b2cf7d0482f9db73bd1295121bc4d91b3c1cfec58ee707b8", size = 3237232, upload-time = "2026-06-22T10:46:31.404Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/b2/cd61e27ee6b7c50574b9798127812408d56c1d294f382fffcdab7d386ad3/mars_agents-0.9.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ea43b8b8383585604ae3cf697890af974e2907f5bbbcaeb63b8d337984127718", size = 3290734, upload-time = "2026-06-22T10:46:32.951Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/16/f198ad0ad8b152db9b827984c4d46e0c584f2b541d81e1ba647c8592cceb/mars_agents-0.9.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48cb8633e8ac875e2befb2dcfd3e1e7a6ce82819b6573acf7caac0ee50f95abb", size = 3517055, upload-time = "2026-06-22T10:46:34.412Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/3d/a70e311faf10aa5e16fb4db50c305d371795124e53ddb50cf1c1ff938849/mars_agents-0.9.0-py3-none-win_amd64.whl", hash = "sha256:ec0e2f924e564cfd4cbda2c7c202ce0db8ca237d13720946c32409084b009280", size = 3468661, upload-time = "2026-06-22T10:46:35.843Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/08/d1880112b151ab7430156cbf3467b8f61fc30c76dd25a5f9a7fd9be11bee/mars_agents-0.10.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4ff8dfce3c1c272a9d52e647766e1501e6c81d75fc81e4acfc79595cbee4ee52", size = 3463552, upload-time = "2026-06-24T10:28:17.818Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/a4/3d98f703d48cc3f55f7ddb70a9dcf6be320b3d1d1968c84d46affd6d90a8/mars_agents-0.10.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:be7fe1a047d66866546dac87c93f44354e4f824d4987a532192c772b57063d94", size = 3300954, upload-time = "2026-06-24T10:28:19.563Z" },
+    { url = "https://files.pythonhosted.org/packages/32/cd/fee3b5e30538e8b6d6ec891e06fa61c0489098179b93f62eb545364cc0a4/mars_agents-0.10.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4c103bed39e8f30201b62b85b71d2d19130a72a3e651e10b14ea05580208a3c2", size = 3353511, upload-time = "2026-06-24T10:28:21.375Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2c/2185017c1cdb465a815cc715d83a7d50ac7a5748a95d4bd88e95ca33c93d/mars_agents-0.10.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd953c1653f4ec5c8aa69231527df36102317cb847871d705e599f25398cb87d", size = 3568407, upload-time = "2026-06-24T10:28:23.014Z" },
+    { url = "https://files.pythonhosted.org/packages/96/b6/26bee520e8169d1324a9b185eb414aa73512bddf62a61f99480bf10eeb45/mars_agents-0.10.0-py3-none-win_amd64.whl", hash = "sha256:b700e1a8588856f1732dcc24e99310023adc3ce0200aad4217717f7c6b19118c", size = 3519282, upload-time = "2026-06-24T10:28:24.958Z" },
 ]
 
 [[package]]
@@ -766,7 +766,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'app'", specifier = ">=0.28" },
     { name = "jinja2", marker = "extra == 'templates'", specifier = ">=3.1" },
     { name = "markdown-it-py", specifier = ">=4.0" },
-    { name = "mars-agents", specifier = "==0.9.0" },
+    { name = "mars-agents", specifier = "==0.10.0" },
     { name = "mcp", specifier = ">=1.0" },
     { name = "pathspec", specifier = ">=1.1.0" },
     { name = "psutil", specifier = ">=7.2.2" },


### PR DESCRIPTION
## Why

meridian-cli consumes mars exclusively through the `mars build launch-bundle`
CLI contract. mars shipped haowjy/mars-agents#119 (inbound import fidelity,
per-tool MCP tool bridge, unified skill/agent tool schema, convention-based
discovery) in `0.10.1-rc.1`, and meridian-cli was still pinned to `0.10.0`.
Separately, a cluster of spawn/launch correctness bugs (notably primary
`--continue` silently dropping the source session's identity) needed fixing.

## Goal

meridian-cli runs against the #119-bearing mars release with its bundle-consumption
contract proven intact, and the outstanding spawn/launch bugs are fixed and
covered by tests.

## Summary

- **mars bump `0.10.0 → 0.10.1rc1`** (pyproject + uv.lock). The `build
  launch-bundle` JSON schema stayed at **v3** — meridian's `bundle_adapter`
  consumption contract is unchanged, so #119's schema unification and `.mars/`
  normalization required **no meridian-side code changes**.
- **Primary `--continue` is now idempotent.** It persists a `LaunchPolicySnapshot`
  and replays it on resume (parity with `spawn --continue`), so
  agent/model/skills/system-prompt no longer drift to the current config/catalog
  default. Snapshots recovered for all reference forms (primary chat, tracked
  spawn-session chat, harness session id); passthrough rejected; `extra_args`
  replayed. Sessions without a snapshot fall back to prior behavior.
- **`--from` inherits the source work item** (materialized via
  `ensure_explicit_work_item`, not a non-binding hint); explicit `--work` still wins.
- **`--from` with a filesystem path fails fast** with an actionable error.
- **OpenCode spawn startup failures** surface an actionable diagnostic (captured
  stderr + `XDG_DATA_HOME` hint); a pre-session failure no longer prints a
  `meridian session log` command that can never resolve.

## Resulting Behavior

- `meridian --continue <ref>` resumes with the **same** agent/model/skills the
  source session launched with, regardless of how the current config has drifted.
- `meridian … --from <spawn|chat>` joins the source's work item.
- Importing skills/agents authored for Claude/Codex/OpenCode/Cursor now flows
  through mars #119's faithful lift on the mars side; meridian consumes the
  resulting bundle unchanged.

## Changes

- `pyproject.toml` / `uv.lock`: `mars-agents==0.10.1rc1` (exact RC pin resolves
  without a global prerelease flag).
- Spawn/launch: `LaunchPolicySnapshot` persist+replay, `--from` work
  materialization, `--from` path guard, OpenCode startup diagnostics.
- Tests: new `tests/integration/cli/test_primary_continue.py` (+509),
  opencode connection, launch-resolution runtime, context-ref, fork-prepare
  coverage.

## Work Item

`mars-import-fidelity`

## Verification

Against the bundled mars `0.10.1-rc.1` binary:
- `pytest` full suite — **1339 passed, 2 skipped**.
- `pyright src/` — **0 errors** (5 pre-existing unrelated warnings).
- Real end-to-end `bundle_adapter.request_and_resolve` against this repo's
  `.mars/`: ad-hoc resolve OK; real agent (`alignment-reviewer`) resolve parses
  `tools_allowed=10 / disallowed=4 / mcp=0`, `skills loaded=1 / available=2 /
  missing=0`, `warnings=0`. `build launch-bundle --json` emits schema `version: 3`
  (meridian's supported set).

## Knowledge Updates

`CHANGELOG.md` `[Unreleased]` updated. No `.context/`/KB changes — the bundle
contract and meridian behavior surfaces are unchanged by the bump.

## Spawn Trace

- (prior session) implementation of spawn/launch fixes + mars 0.10.x bump
- p2608/p2609/p2610/p2611 reviewers — fan-out on the mars #119 diff (separate repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
