### PR TITLE
refactor(state): drop dead RuntimePaths.chat_policy_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Removed
+- Removed dead `RuntimePaths.chat_policy_path()` (`chats/<id>/policy.json`) — never written or read; launch-policy snapshots persist in spawn state (`spawns/<pid>/state.json`).
+
 ## [0.3.18] - 2026-06-25
 
 ### Fixed

--- a/src/meridian/lib/state/paths.py
+++ b/src/meridian/lib/state/paths.py
@@ -69,11 +69,6 @@ class RuntimePaths(BaseModel):
 
         return self.chats_dir / c_id / "lifecycle.jsonl"
 
-    def chat_policy_path(self, c_id: str) -> Path:
-        """Return policy snapshot path for a chat."""
-
-        return self.chats_dir / c_id / "policy.json"
-
     def spawn_history_path(self, p_id: str) -> Path:
         """Return history.jsonl path for a spawn."""
 


### PR DESCRIPTION
## Why
The live `--continue` probe found `RuntimePaths.chat_policy_path()` (`chats/<id>/policy.json`) is **defined but never written or read** — launch-policy snapshots actually persist in spawn state (`spawns/<pid>/state.json`). Dead, misleading path helper.

## Summary
Remove the unused method.

## Verification
- `pyright src/meridian/lib/state/paths.py` clean (0 errors); no remaining references to `chat_policy_path` / `policy.json` in `src/` or `tests/`.
- (Pre-existing local pi-runtime-extension test failures are environmental — the `pi_runtime/dist` isn't built in the worktree — and unrelated to this one-method removal; CI builds the runtime.)

## Release Label Guide
`release:patch` (no behavior change; pure dead-code removal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)