### PR TITLE
test(codex): guard app-server command emits only accepted flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Added a guard test asserting the `codex app-server` (streaming) command only ever emits app-server-accepted flags — bare flags valid on `codex exec` but not app-server (like the `--search` regression) now fail CI instead of crashing a live streaming spawn.
+
 ## [0.3.20] - 2026-06-25
 
 ### Fixed

--- a/src/meridian/lib/harness/projections/project_codex_streaming.py
+++ b/src/meridian/lib/harness/projections/project_codex_streaming.py
@@ -118,6 +118,35 @@ def _consume_streaming_lifecycle_fields(spec: ResolvedLaunchSpec) -> None:
         )
 
 
+# Flags accepted by `codex app-server` (from `codex app-server --help`). Unlike
+# `codex exec`, app-server takes almost nothing as a bare flag — model/sandbox/etc.
+# must be `-c key=value` config overrides (or per-WS-request). Any other bare flag
+# (e.g. the exec-only `--search`) crashes the transport with "unexpected argument".
+# `APPSERVER_ACCEPTED_FLAGS` is the contract; the guard test asserts the builder
+# only ever emits flags from this set. Keep in sync with the codex CLI.
+APPSERVER_ACCEPTED_FLAGS: frozenset[str] = frozenset(
+    {
+        "-c",
+        "--config",
+        "--enable",
+        "--disable",
+        "--strict-config",
+        "--listen",
+        "--stdio",
+        "--analytics-default-enabled",
+        "--ws-auth",
+        "--ws-token-file",
+        "--ws-token-sha256",
+        "--ws-shared-secret-file",
+        "--ws-issuer",
+        "--ws-audience",
+        "--ws-max-clock-skew-seconds",
+        "-h",
+        "--help",
+    }
+)
+
+
 def project_codex_spec_to_appserver_command(
     spec: ResolvedLaunchSpec,
     *,

--- a/tests/unit/harness/test_codex_projection.py
+++ b/tests/unit/harness/test_codex_projection.py
@@ -9,6 +9,7 @@ from meridian.lib.core.types import HarnessId
 from meridian.lib.harness.adapter import SpawnParams
 from meridian.lib.harness.codex import CodexAdapter
 from meridian.lib.harness.projections.project_codex_streaming import (
+    APPSERVER_ACCEPTED_FLAGS,
     project_codex_spec_to_appserver_command,
 )
 from meridian.lib.harness.projections.project_codex_subprocess import (
@@ -113,6 +114,55 @@ def test_codex_streaming_projection_emits_search_when_web_search_enabled() -> No
     command = project_codex_spec_to_appserver_command(spec, host="127.0.0.1", port=8765)
 
     assert "tools.web_search=true" in command
+
+
+def test_appserver_command_emits_only_appserver_accepted_flags() -> None:
+    """Guard: `codex app-server` accepts a tiny flag set — everything else must be
+    `-c key=value` (or per-WS-request). A bare flag valid on `codex exec` but not
+    app-server (e.g. `--search`) crashes the streaming transport, and that's
+    invisible to dry-runs and unit-level projection tests. Build a fully-featured
+    app-server command and assert every dash-led token is app-server-accepted.
+    """
+    spec = CodexAdapter().resolve_launch_spec(
+        SpawnParams(prompt="research topic"),
+        TieredPermissionResolver(
+            config=PermissionConfig(sandbox="workspace-write", approval="never")
+        ),
+    ).model_copy(
+        update={
+            "web_search_enabled": True,
+            "mcp_tools": ("demo=run-demo",),
+            "projected_roots": (Path("/tmp/workspace-root"),),
+        }
+    )
+
+    command = project_codex_spec_to_appserver_command(spec, host="127.0.0.1", port=8765)
+
+    # Sanity: the features we set must actually have produced `-c` overrides, else
+    # the guard would pass vacuously.
+    assert "tools.web_search=true" in command
+    assert any(tok.startswith("sandbox_mode=") for tok in command)
+    assert any(tok.startswith("approval_policy=") for tok in command)
+    assert any(tok.startswith("mcp.servers.") for tok in command)
+    assert any(tok.startswith("sandbox_workspace_write.writable_roots=") for tok in command)
+
+    offenders: list[str] = []
+    skip_next = False
+    for token in command:
+        if skip_next:
+            # `-c`/`--config` payload is `key=value`, not a flag.
+            skip_next = False
+            continue
+        if token in ("-c", "--config"):
+            skip_next = True
+            continue
+        if token.startswith("-") and token not in APPSERVER_ACCEPTED_FLAGS:
+            offenders.append(token)
+
+    assert not offenders, (
+        f"codex app-server rejects these bare flags: {offenders}. "
+        "Pass them as `-c key=value` config overrides instead."
+    )
 
 
 def test_bind_codex_argv_includes_search_when_bundle_grants_web_search(


### PR DESCRIPTION
## Why
The `--search` regression (#348) was a flag valid on `codex exec` but rejected by `codex app-server` — invisible to dry-runs and unit projection tests, only crashing a **live streaming spawn**. This class of bug needs a guardrail.

## What
- `APPSERVER_ACCEPTED_FLAGS` — the documented contract of flags `codex app-server` accepts (from `codex app-server --help`). Everything else must be `-c key=value` (or per-WS-request).
- A guard test builds a fully-featured app-server command (sandbox + approval + MCP + web_search + writable-roots all active) and asserts every dash-led token is in the accepted set. Future bare flags (like `--search`) fail CI.
- Includes a vacuity check (the `-c` overrides are actually present) so the guard can't pass trivially. The guard intentionally ignores user `extra_args` passthrough.

## Verification
- `pytest tests/unit/harness/test_codex_projection.py` — 12 passed; manually confirmed the guard flags a stray injected `--search`. ruff clean.

## Release Label Guide
`release:skip` — test-only; no user-facing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)