### PR TITLE
Fix init before project bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - Added a guard test asserting the `codex app-server` (streaming) command only ever emits app-server-accepted flags — bare flags valid on `codex exec` but not app-server (like the `--search` regression) now fail CI instead of crashing a live streaming spawn.
 
+### Fixed
+- `meridian init` now works from an uninitialized directory in human mode instead of failing the pre-init project-root guard.
+
 ## [0.3.20] - 2026-06-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - `meridian init` now works from an uninitialized directory in human mode instead of failing the pre-init project-root guard.
+- Creation/bootstrap commands (`meridian`, `spawn create`, `work start`, `config init`/`set`, `workspace init`) now auto-initialize an uninitialized cwd instead of failing the project-root guard; read and existing-state commands remain strict.
 
 ## [0.3.20] - 2026-06-25
 

--- a/src/meridian/cli/.context/CONTEXT.md
+++ b/src/meridian/cli/.context/CONTEXT.md
@@ -6,7 +6,7 @@ Every CLI invocation is classified against `COMMAND_CATALOG` before any
 heavy module loads. `CommandDescriptor` carries all routing information:
 
 - `startup_class` — drives telemetry mode + primary-launch background repairs (TRIVIAL, READ_ROOTLESS, READ_PROJECT, READ_RUNTIME, WRITE_PROJECT, WRITE_RUNTIME, PRIMARY_LAUNCH, SERVICE_ROOTLESS, SERVICE_RUNTIME)
-- `state_requirement` — `none | project-read | runtime-read | project-write | runtime-write`; drives bootstrap preparation
+- `bootstrap_plan` — state preparation plus cwd auto-init policy
 - `telemetry_mode` — `none | stderr | segment`
 - `lazy_target` — import path string for the Cyclopts handler
 - `root_source` — `"cwd"` (default) or `"argv"` (post-parse root resolution)
@@ -25,7 +25,7 @@ never queries the extension registry for routing answers.
 | `READ_RUNTIME` | `spawn list`, `session log` | runtime-read | none |
 | `WRITE_PROJECT` | `config init` | project-write | optional |
 | `WRITE_RUNTIME` | `spawn create`, `work start` | runtime-write | segment |
-| `PRIMARY_LAUNCH` | bare `meridian` | runtime-write | segment |
+| `PRIMARY_LAUNCH` | bare `meridian` | runtime-write; `bootstrap_plan.auto_init_cwd` auto-inits config first | segment |
 | `SERVICE_ROOTLESS` | `serve` | none | stderr |
 | `SERVICE_RUNTIME` | `streaming serve` | runtime-write | segment |
 
@@ -79,6 +79,13 @@ A project is **established** when:
 
 CWD resolution where `cwd_has_project_id()` returns `False` is **not established** —
 project-required commands exit 1; rootless commands exit 0.
+
+Descriptors whose `bootstrap_plan.auto_init_cwd` is true are the write-path
+exception: when the literal cwd is not established, they treat cwd as a new
+project, scaffold `meridian.toml`, then run normal project/runtime bootstrap.
+This flag belongs on creation/bootstrap commands (`meridian`, `spawn create`,
+`work start`), not existing-state operations (`spawn cancel`, `work switch`,
+`config reset`) or read commands.
 
 ### Adapters
 

--- a/src/meridian/cli/AGENTS.md
+++ b/src/meridian/cli/AGENTS.md
@@ -8,9 +8,9 @@ Command-line surface. Descriptor-driven: every invocation is classified before a
 argv
   └── normalize_optional_value_flags()  ← pre-Cyclopts: rewrites bare --fork/--from
         └── classify_invocation()       ← longest-prefix match against COMMAND_CATALOG
-              └── CommandDescriptor     ← routing information for this invocation
+                    └── CommandDescriptor     ← routing information for this invocation
                     ├── startup_class   → telemetry mode + primary-launch handling
-                    ├── state_requirement → bootstrap/state preparation
+                    ├── bootstrap_plan  → state preparation + cwd auto-init policy
                     ├── telemetry_mode
                     ├── lazy_target     → import path string (deferred import)
                     └── redirect        → optional redirect (e.g. models list → mars models list)
@@ -24,6 +24,7 @@ argv
 - **`app_tree.py` breaks the circular import.** It defines top-level Cyclopts app objects (`spawn_app`, `session_app`, etc.) without importing any command implementations. If you import command implementations from `app_tree.py`, the lazy strategy collapses.
 - **`to_cli_output()` dispatch, not `isinstance` in `main.py`.** Command handlers return typed result objects. Each implements `to_cli_output()`. Adding result types does not require editing `main.py`.
 - **Read-only invocation classes install no telemetry, create no filesystem state.** `READ_ROOTLESS`, `READ_PROJECT`, and `READ_RUNTIME` classes never write UUIDs, create directories, or spawn writer threads.
+- **Auto-init is explicit, not inferred from write-ness.** Only descriptors whose `bootstrap_plan.auto_init_cwd` is true may turn an unestablished literal cwd into a new project. Use it for creation/bootstrap commands (`meridian`, `spawn create`, `work start`), not existing-state mutations (`spawn cancel`, `work switch`, `config reset`).
 - **`root_source = RootSource.ARGV`** commands (e.g. `meridian init [path]`) defer bootstrap until after argument parsing. They call `prepare_for_project_write(arg_derived_root)` themselves — they don't receive a pre-prepared context.
 - **`validate_fork_mode()` is the single place for fork/from/continue conflict checks.** `spawn.py` and `primary_launch.py` both call it and consume `ForkModeResolution`. Do not re-implement conflict logic or ref resolution in handlers.
 - **`normalize_optional_value_flags()` runs before everything.** It rewrites bare `--fork`/`--fork-fresh`/`--from` to `--fork __SELF__` so Cyclopts always receives a value. Never call Cyclopts on raw argv containing these flags.
@@ -38,7 +39,7 @@ argv
 | `READ_RUNTIME` | `spawn list`, `session log` | `prepare_for_runtime_read()` |
 | `WRITE_PROJECT` | `config init` | `prepare_for_project_write()` |
 | `WRITE_RUNTIME` | `spawn create`, `work start` | `prepare_for_runtime_write()` |
-| `PRIMARY_LAUNCH` | bare `meridian` | `prepare_for_runtime_write()` |
+| `PRIMARY_LAUNCH` | bare `meridian` | `prepare_for_runtime_write()`; `bootstrap_plan.auto_init_cwd` auto-inits config first |
 | `SERVICE_ROOTLESS` | `serve` | none |
 | `SERVICE_RUNTIME` | `streaming serve` | `prepare_for_runtime_write()` |
 

--- a/src/meridian/cli/bootstrap.py
+++ b/src/meridian/cli/bootstrap.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from meridian.cli.mode import RenderMode, is_agent_render_mode, parse_render_mode
-from meridian.cli.startup.policy import StateRequirement
+from meridian.cli.startup.policy import BootstrapPlan, StateRequirement
 
 # Keep these startup parse tables in sync with `@app.default root(...)` in
 # `main.py` plus startup-only flags parsed before cyclopts (`--verbose` at root).
@@ -310,23 +310,10 @@ def is_root_help_request(argv: Sequence[str]) -> bool:
     return _first_positional_token(argv) is None
 
 
-def _state_requirement_for_argv(argv: Sequence[str]) -> StateRequirement | None:
-    """Return catalog startup state policy for argv without importing handlers."""
-
-    from meridian.cli.startup.catalog import COMMAND_CATALOG
-    from meridian.cli.startup.classify import classify_invocation
-
-    descriptor = classify_invocation(argv, COMMAND_CATALOG)
-    if descriptor is None:
-        return None
-    return descriptor.state_requirement
-
-
 def maybe_bootstrap_runtime_state(
-    argv: Sequence[str],
     *,
     render_mode: RenderMode,
-    state_requirement: StateRequirement | None = None,
+    plan: BootstrapPlan | None,
 ) -> Path | None:
     """Prepare startup state according to catalog policy and return project root.
 
@@ -337,19 +324,29 @@ def maybe_bootstrap_runtime_state(
     if is_agent_render_mode(render_mode):
         return None
 
-    requirement = state_requirement or _state_requirement_for_argv(argv)
+    requirement = plan.state_requirement if plan is not None else None
     if requirement in {None, StateRequirement.NONE}:
         return None
 
     from meridian.cli.utils import exit_no_established_project, resolve_cli_project_root
 
     resolution = resolve_cli_project_root()
-    if not resolution.established or resolution.project_root is None:
-        exit_no_established_project()
-    assert resolution.project_root is not None
     project_root = resolution.project_root
+    auto_initialized_cwd = False
+    if not resolution.established or project_root is None:
+        if plan is not None and plan.auto_init_cwd and resolution.source == "cwd":
+            project_root = Path.cwd().resolve()
+            auto_initialized_cwd = True
+        else:
+            exit_no_established_project()
+    assert project_root is not None
 
     try:
+        if auto_initialized_cwd:
+            from meridian.lib.ops.config import ConfigInitInput, config_init_sync
+
+            config_init_sync(ConfigInitInput(project_root=project_root.as_posix()))
+
         from meridian.lib.bootstrap.services import (
             prepare_for_project_read,
             prepare_for_project_write,

--- a/src/meridian/cli/main.py
+++ b/src/meridian/cli/main.py
@@ -68,7 +68,7 @@ from meridian.cli.output import emit as emit_output
 from meridian.cli.startup.catalog import COMMAND_CATALOG
 from meridian.cli.startup.classify import classify_invocation
 from meridian.cli.startup.help import render_root_help
-from meridian.cli.startup.policy import StartupClass, StateRequirement
+from meridian.cli.startup.policy import RootSource, StartupClass, StateRequirement
 from meridian.cli.startup.policy import TelemetryMode as StartupTelemetryMode
 from meridian.cli.utils import parse_csv_list
 from meridian.lib.core.sink import OutputSink
@@ -1100,6 +1100,11 @@ def _main_impl(argv: Sequence[str] | None = None) -> None:
     help_request = _is_help_request(cleaned_args)
     bootstrap_skipped = help_request
     state_requirement = descriptor.state_requirement if descriptor is not None else None
+    # Commands whose target root comes from argv (for example `meridian init [path]`)
+    # must parse first, then let the handler bootstrap that target. Pre-bootstrap
+    # cannot require an already-established project for commands that create one.
+    if descriptor is not None and descriptor.root_source == RootSource.ARGV:
+        state_requirement = StateRequirement.NONE
     # bootstrap --add/--link must resolve root with init semantics in the handler
     # and reject invalid --dry-run combinations before any startup writes.
     if _bootstrap_setup_requested(cleaned_args):

--- a/src/meridian/cli/main.py
+++ b/src/meridian/cli/main.py
@@ -68,7 +68,7 @@ from meridian.cli.output import emit as emit_output
 from meridian.cli.startup.catalog import COMMAND_CATALOG
 from meridian.cli.startup.classify import classify_invocation
 from meridian.cli.startup.help import render_root_help
-from meridian.cli.startup.policy import RootSource, StartupClass, StateRequirement
+from meridian.cli.startup.policy import StartupClass
 from meridian.cli.startup.policy import TelemetryMode as StartupTelemetryMode
 from meridian.cli.utils import parse_csv_list
 from meridian.lib.core.sink import OutputSink
@@ -1099,16 +1099,11 @@ def _main_impl(argv: Sequence[str] | None = None) -> None:
     )
     help_request = _is_help_request(cleaned_args)
     bootstrap_skipped = help_request
-    state_requirement = descriptor.state_requirement if descriptor is not None else None
-    # Commands whose target root comes from argv (for example `meridian init [path]`)
-    # must parse first, then let the handler bootstrap that target. Pre-bootstrap
-    # cannot require an already-established project for commands that create one.
-    if descriptor is not None and descriptor.root_source == RootSource.ARGV:
-        state_requirement = StateRequirement.NONE
+    bootstrap_plan = descriptor.bootstrap_plan if descriptor is not None else None
     # bootstrap --add/--link must resolve root with init semantics in the handler
     # and reject invalid --dry-run combinations before any startup writes.
     if _bootstrap_setup_requested(cleaned_args):
-        state_requirement = StateRequirement.NONE
+        bootstrap_plan = None
     # Install options early so resolve_cli_project_root() sees project_root
     # from -C / --directory during bootstrap resolution.
     _pre_bootstrap_token = _GLOBAL_OPTIONS.set(options)
@@ -1118,9 +1113,8 @@ def _main_impl(argv: Sequence[str] | None = None) -> None:
     ):
         if not bootstrap_skipped:
             bootstrap_project_root = maybe_bootstrap_runtime_state(
-                cleaned_args,
                 render_mode=options.render_mode,
-                state_requirement=state_requirement,
+                plan=bootstrap_plan,
             )
     _GLOBAL_OPTIONS.reset(_pre_bootstrap_token)
     # Prefer bootstrap's resolved root; fall back to -C path if bootstrap was skipped/no-op.

--- a/src/meridian/cli/startup/catalog.py
+++ b/src/meridian/cli/startup/catalog.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 
 from meridian.cli.startup.policy import (
+    BootstrapPlan,
     RootSource,
     StartupClass,
     StateRequirement,
@@ -29,7 +30,7 @@ class CommandDescriptor:
     lazy_target: str
     summary: str
     startup_class: StartupClass
-    state_requirement: StateRequirement
+    bootstrap_plan: BootstrapPlan
     telemetry_mode: TelemetryMode
     default_output_mode: str
     redirect: RedirectPolicy | None = None
@@ -89,14 +90,19 @@ def _descriptor(
     redirect: RedirectPolicy | None = None,
     extension_ref: str | None = None,
     root_source: RootSource = RootSource.CWD,
+    auto_init_cwd: bool = False,
 ) -> CommandDescriptor:
     target = lazy_target or f"meridian.cli.main:{'.'.join(path) if path else 'root'}"
+    bootstrap_plan = BootstrapPlan(
+        StateRequirement.NONE if root_source == RootSource.ARGV else state_requirement,
+        auto_init_cwd=auto_init_cwd,
+    )
     return CommandDescriptor(
         command_path=path,
         lazy_target=target,
         summary=summary,
         startup_class=startup_class,
-        state_requirement=state_requirement,
+        bootstrap_plan=bootstrap_plan,
         telemetry_mode=telemetry_mode,
         default_output_mode=default_output_mode,
         redirect=redirect,
@@ -146,6 +152,7 @@ def _write_project(
     *,
     extension_ref: str | None = None,
     root_source: RootSource = RootSource.CWD,
+    auto_init_cwd: bool = False,
 ) -> CommandDescriptor:
     return _descriptor(
         path,
@@ -156,6 +163,7 @@ def _write_project(
         summary,
         extension_ref=extension_ref,
         root_source=root_source,
+        auto_init_cwd=auto_init_cwd,
     )
 
 
@@ -183,6 +191,7 @@ def _write_runtime(
     *,
     default_output_mode: str = "text",
     extension_ref: str | None = None,
+    auto_init_cwd: bool = False,
 ) -> CommandDescriptor:
     return _descriptor(
         path,
@@ -192,6 +201,7 @@ def _write_runtime(
         default_output_mode,
         summary,
         extension_ref=extension_ref,
+        auto_init_cwd=auto_init_cwd,
     )
 
 
@@ -203,6 +213,7 @@ _COMMAND_DESCRIPTORS: tuple[CommandDescriptor, ...] = (
         TelemetryMode.SEGMENT,
         "text",
         "Launch or resume the primary harness.",
+        auto_init_cwd=True,
     ),
     _descriptor(
         ("serve",),
@@ -269,12 +280,14 @@ _COMMAND_DESCRIPTORS: tuple[CommandDescriptor, ...] = (
         "Create a spawn via spawn default route.",
         default_output_mode="text",
         extension_ref="meridian.spawn.create",
+        auto_init_cwd=True,
     ),
     _write_runtime(
         ("spawn", "create"),
         "Create a spawn.",
         default_output_mode="text",
         extension_ref="meridian.spawn.create",
+        auto_init_cwd=True,
     ),
     _write_runtime(
         ("spawn", "continue"),
@@ -369,7 +382,12 @@ _COMMAND_DESCRIPTORS: tuple[CommandDescriptor, ...] = (
         extension_ref="meridian.work.path",
     ),
     _read_runtime(("work", "root"), "Show work root.", extension_ref="meridian.work.root"),
-    _write_runtime(("work", "start"), "Start work item.", extension_ref="meridian.work.start"),
+    _write_runtime(
+        ("work", "start"),
+        "Start work item.",
+        extension_ref="meridian.work.start",
+        auto_init_cwd=True,
+    ),
     _write_runtime(
         ("work", "switch"), "Switch current work.", extension_ref="meridian.work.switch"
     ),
@@ -388,8 +406,18 @@ _COMMAND_DESCRIPTORS: tuple[CommandDescriptor, ...] = (
         ("config", "show"), "Show resolved config.", extension_ref="meridian.config.show"
     ),
     _read_rootless(("config", "get"), "Get config value.", extension_ref="meridian.config.get"),
-    _write_project(("config", "init"), "Initialize config.", extension_ref="meridian.config.init"),
-    _write_project(("config", "set"), "Set config value.", extension_ref="meridian.config.set"),
+    _write_project(
+        ("config", "init"),
+        "Initialize config.",
+        extension_ref="meridian.config.init",
+        root_source=RootSource.ARGV,
+    ),
+    _write_project(
+        ("config", "set"),
+        "Set config value.",
+        extension_ref="meridian.config.set",
+        auto_init_cwd=True,
+    ),
     _write_project(
         ("config", "reset"), "Reset config value.", extension_ref="meridian.config.reset"
     ),
@@ -443,6 +471,7 @@ _COMMAND_DESCRIPTORS: tuple[CommandDescriptor, ...] = (
         ("workspace", "init"),
         "Initialize workspace config.",
         extension_ref="meridian.workspace.init",
+        auto_init_cwd=True,
     ),
     _read_rootless(("kg", "graph"), "Render knowledge graph."),
     _read_rootless(("kg", "check"), "Check knowledge graph links."),
@@ -467,6 +496,7 @@ _COMMAND_DESCRIPTORS: tuple[CommandDescriptor, ...] = (
         TelemetryMode.SEGMENT,
         "text",
         "Bootstrap an agent runtime.",
+        auto_init_cwd=True,
     ),
 )
 

--- a/src/meridian/cli/startup/policy.py
+++ b/src/meridian/cli/startup/policy.py
@@ -1,5 +1,6 @@
 """Startup policy enums for command classification."""
 
+from dataclasses import dataclass
 from enum import StrEnum
 
 
@@ -41,3 +42,11 @@ class RootSource(StrEnum):
 
     CWD = "cwd"
     ARGV = "argv"
+
+
+@dataclass(frozen=True)
+class BootstrapPlan:
+    """Pre-dispatch filesystem bootstrap policy for a command."""
+
+    state_requirement: StateRequirement
+    auto_init_cwd: bool = False

--- a/src/meridian/lib/bootstrap/.context/CONTEXT.md
+++ b/src/meridian/lib/bootstrap/.context/CONTEXT.md
@@ -24,7 +24,8 @@ Pick based on the `StartupClass` of the command (from `cli/startup/policy.py`):
 | `READ_PROJECT` | `prepare_for_project_read()` |
 | `READ_RUNTIME` | `prepare_for_runtime_read()` |
 | `WRITE_PROJECT` | `prepare_for_project_write()` |
-| `WRITE_RUNTIME`, `PRIMARY_LAUNCH`, `SERVICE_RUNTIME` | `prepare_for_runtime_write()` |
+| `WRITE_RUNTIME`, `SERVICE_RUNTIME` | `prepare_for_runtime_write()` |
+| `PRIMARY_LAUNCH` | `prepare_for_runtime_write()`; `bootstrap_plan.auto_init_cwd` auto-inits config first |
 | `SERVICE_ROOTLESS` | None (or minimal manual setup) |
 
 ## Context Hierarchy

--- a/src/meridian/lib/bootstrap/AGENTS.md
+++ b/src/meridian/lib/bootstrap/AGENTS.md
@@ -11,7 +11,8 @@ Four entry points, one per invocation class tier. Pick based on what the command
 | `READ_PROJECT` | `prepare_for_project_read()` |
 | `READ_RUNTIME` | `prepare_for_runtime_read()` |
 | `WRITE_PROJECT` | `prepare_for_project_write()` |
-| `WRITE_RUNTIME`, `PRIMARY_LAUNCH`, `SERVICE_RUNTIME` | `prepare_for_runtime_write()` |
+| `WRITE_RUNTIME`, `SERVICE_RUNTIME` | `prepare_for_runtime_write()` |
+| `PRIMARY_LAUNCH` | `prepare_for_runtime_write()`; `bootstrap_plan.auto_init_cwd` auto-inits config first |
 
 Each function returns a typed context object (`ProjectReadContext`, `RuntimeReadContext`, `ProjectWriteContext`, `RuntimeWriteContext`). These carry the prepared state downstream to command handlers without exposing bootstrap internals.
 
@@ -28,6 +29,7 @@ This is the central invariant. Violating it causes read-only command paths to si
 
 - **Don't instantiate `SpawnApplicationService` directly.** Use `build_spawn_application_service(runtime_write_ctx)`. It's the correct factory.
 - **Post-parse bootstrap exception**: commands with `root_source = RootSource.ARGV` (e.g. `meridian init [path]`) call `prepare_for_project_write(arg_derived_root)` themselves after argument parsing. All other commands receive a pre-prepared context.
+- **Auto-init exception**: descriptors whose `bootstrap_plan.auto_init_cwd` is true may create `meridian.toml` and project/runtime state from an unestablished literal cwd before continuing. Do not infer this from write-ness; existing-state mutations stay strict.
 - **Entrypoint carriers** (`SpawnEntryPoint`, `ExtensionEntryPoint`) carry `ApplicationContext + ApplicationServices` downstream. Use `build_spawn_entrypoint()`, `build_extension_entrypoint()` — don't assemble them manually.
 
 ## Context Hierarchy

--- a/tests/integration/cli/test_cwd_project_resolution.py
+++ b/tests/integration/cli/test_cwd_project_resolution.py
@@ -33,6 +33,16 @@ def _run_meridian(
     )
 
 
+def _assert_project_initialized(project_root: Path) -> None:
+    assert (project_root / "meridian.toml").is_file()
+    assert (project_root / ".meridian" / "id").is_file()
+
+
+def _assert_project_not_initialized(project_root: Path) -> None:
+    assert not (project_root / "meridian.toml").exists()
+    assert not (project_root / ".meridian").exists()
+
+
 @pytest.fixture
 def meridian_home(tmp_path: Path) -> Path:
     home = tmp_path / "meridian-home"
@@ -80,6 +90,7 @@ def test_spawn_list_fails_from_cwd_without_project_id(
 
     assert result.returncode == 1
     assert NO_PROJECT_MSG in (result.stdout + result.stderr)
+    _assert_project_not_initialized(cwd_without_project_id)
 
 
 @pytest.mark.integration
@@ -95,8 +106,7 @@ def test_init_succeeds_from_cwd_without_project_id(
 
     assert result.returncode == 0, result.stderr or result.stdout
     assert NO_PROJECT_MSG not in (result.stdout + result.stderr)
-    assert (cwd_without_project_id / "meridian.toml").is_file()
-    assert (cwd_without_project_id / ".meridian" / "id").is_file()
+    _assert_project_initialized(cwd_without_project_id)
 
 
 @pytest.mark.integration
@@ -115,10 +125,107 @@ def test_init_succeeds_for_explicit_path_from_cwd_without_project_id(
 
     assert result.returncode == 0, result.stderr or result.stdout
     assert NO_PROJECT_MSG not in (result.stdout + result.stderr)
-    assert (target / "meridian.toml").is_file()
-    assert (target / ".meridian" / "id").is_file()
-    assert not (cwd_without_project_id / "meridian.toml").exists()
-    assert not (cwd_without_project_id / ".meridian").exists()
+    _assert_project_initialized(target)
+    _assert_project_not_initialized(cwd_without_project_id)
+
+
+@pytest.mark.integration
+def test_primary_launch_auto_initializes_cwd_without_project_id(
+    cwd_without_project_id: Path,
+    meridian_home: Path,
+) -> None:
+    result = _run_meridian(
+        [
+            "--mode",
+            "human",
+            "--harness",
+            "definitely-missing",
+            "--timeout",
+            "0.1",
+        ],
+        cwd=cwd_without_project_id,
+        meridian_home=meridian_home,
+    )
+
+    assert result.returncode == 1
+    assert NO_PROJECT_MSG not in (result.stdout + result.stderr)
+    _assert_project_initialized(cwd_without_project_id)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["--mode", "human", "config", "init"],
+        ["--mode", "human", "config", "set", "defaults.max_depth", "7"],
+        ["--mode", "human", "work", "start", "first work"],
+        ["--mode", "human", "--harness", "definitely-missing", "spawn", "-p", "hi"],
+        ["--mode", "human", "workspace", "init"],
+    ],
+)
+def test_create_commands_auto_initialize_cwd_without_project_id(
+    args: list[str],
+    cwd_without_project_id: Path,
+    meridian_home: Path,
+) -> None:
+    result = _run_meridian(
+        args,
+        cwd=cwd_without_project_id,
+        meridian_home=meridian_home,
+    )
+
+    assert NO_PROJECT_MSG not in (result.stdout + result.stderr)
+    _assert_project_initialized(cwd_without_project_id)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["--mode", "human", "spawn", "cancel", "p999"],
+        ["--mode", "human", "config", "reset", "defaults.max_depth"],
+        ["--mode", "human", "work", "list"],
+        ["--mode", "human", "streaming", "test"],
+        ["--mode", "human", "test", "harness"],
+    ],
+)
+def test_strict_commands_do_not_auto_initialize_cwd_without_project_id(
+    args: list[str],
+    cwd_without_project_id: Path,
+    meridian_home: Path,
+) -> None:
+    result = _run_meridian(
+        args,
+        cwd=cwd_without_project_id,
+        meridian_home=meridian_home,
+    )
+
+    assert result.returncode == 1
+    assert NO_PROJECT_MSG in (result.stdout + result.stderr)
+    _assert_project_not_initialized(cwd_without_project_id)
+
+
+@pytest.mark.integration
+def test_primary_launch_does_not_scaffold_config_for_established_cwd(
+    cwd_with_project_id: Path,
+    meridian_home: Path,
+) -> None:
+    result = _run_meridian(
+        [
+            "--mode",
+            "human",
+            "--harness",
+            "definitely-missing",
+            "--timeout",
+            "0.1",
+        ],
+        cwd=cwd_with_project_id,
+        meridian_home=meridian_home,
+    )
+
+    assert result.returncode == 1
+    assert NO_PROJECT_MSG not in (result.stdout + result.stderr)
+    assert not (cwd_with_project_id / "meridian.toml").exists()
 
 
 @pytest.mark.integration

--- a/tests/integration/cli/test_cwd_project_resolution.py
+++ b/tests/integration/cli/test_cwd_project_resolution.py
@@ -83,6 +83,45 @@ def test_spawn_list_fails_from_cwd_without_project_id(
 
 
 @pytest.mark.integration
+def test_init_succeeds_from_cwd_without_project_id(
+    cwd_without_project_id: Path,
+    meridian_home: Path,
+) -> None:
+    result = _run_meridian(
+        ["--mode", "human", "init"],
+        cwd=cwd_without_project_id,
+        meridian_home=meridian_home,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert NO_PROJECT_MSG not in (result.stdout + result.stderr)
+    assert (cwd_without_project_id / "meridian.toml").is_file()
+    assert (cwd_without_project_id / ".meridian" / "id").is_file()
+
+
+@pytest.mark.integration
+def test_init_succeeds_for_explicit_path_from_cwd_without_project_id(
+    cwd_without_project_id: Path,
+    meridian_home: Path,
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "target-project"
+
+    result = _run_meridian(
+        ["--mode", "human", "init", target.as_posix()],
+        cwd=cwd_without_project_id,
+        meridian_home=meridian_home,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert NO_PROJECT_MSG not in (result.stdout + result.stderr)
+    assert (target / "meridian.toml").is_file()
+    assert (target / ".meridian" / "id").is_file()
+    assert not (cwd_without_project_id / "meridian.toml").exists()
+    assert not (cwd_without_project_id / ".meridian").exists()
+
+
+@pytest.mark.integration
 def test_doctor_runs_from_cwd_with_project_id(
     cwd_with_project_id: Path,
     meridian_home: Path,

--- a/tests/unit/cli/test_startup_classify.py
+++ b/tests/unit/cli/test_startup_classify.py
@@ -1,27 +1,49 @@
 from meridian.cli.startup.catalog import COMMAND_CATALOG
 from meridian.cli.startup.classify import classify_invocation
-from meridian.cli.startup.policy import StartupClass, StateRequirement
+from meridian.cli.startup.policy import RootSource, StartupClass, StateRequirement
 
 
 def test_doctor_is_read_rootless_without_pre_dispatch_state() -> None:
     descriptor = COMMAND_CATALOG.get(("doctor",))
     assert descriptor is not None
     assert descriptor.startup_class is StartupClass.READ_ROOTLESS
-    assert descriptor.state_requirement is StateRequirement.NONE
+    assert descriptor.bootstrap_plan.state_requirement is StateRequirement.NONE
 
 
 def test_qi_root_is_read_rootless_without_pre_dispatch_state() -> None:
     descriptor = COMMAND_CATALOG.get(("qi",))
     assert descriptor is not None
     assert descriptor.startup_class is StartupClass.READ_ROOTLESS
-    assert descriptor.state_requirement is StateRequirement.NONE
+    assert descriptor.bootstrap_plan.state_requirement is StateRequirement.NONE
 
 
 def test_config_show_is_read_rootless_without_pre_dispatch_state() -> None:
     descriptor = COMMAND_CATALOG.get(("config", "show"))
     assert descriptor is not None
     assert descriptor.startup_class is StartupClass.READ_ROOTLESS
-    assert descriptor.state_requirement is StateRequirement.NONE
+    assert descriptor.bootstrap_plan.state_requirement is StateRequirement.NONE
+
+
+def test_argv_root_commands_have_no_pre_dispatch_bootstrap() -> None:
+    for command_path in [("init",), ("config", "init")]:
+        descriptor = COMMAND_CATALOG.get(command_path)
+        assert descriptor is not None
+        assert descriptor.root_source is RootSource.ARGV
+        assert descriptor.bootstrap_plan.state_requirement is StateRequirement.NONE
+
+
+def test_create_commands_opt_in_to_cwd_auto_init() -> None:
+    for command_path in [(), ("spawn",), ("spawn", "create"), ("work", "start")]:
+        descriptor = COMMAND_CATALOG.get(command_path)
+        assert descriptor is not None
+        assert descriptor.bootstrap_plan.auto_init_cwd is True
+
+
+def test_existing_state_commands_do_not_auto_init_cwd() -> None:
+    for command_path in [("spawn", "cancel"), ("config", "reset"), ("work", "list")]:
+        descriptor = COMMAND_CATALOG.get(command_path)
+        assert descriptor is not None
+        assert descriptor.bootstrap_plan.auto_init_cwd is False
 
 
 def test_deleted_chat_command_is_not_startup_classified() -> None:


### PR DESCRIPTION
## Why

`meridian init` failed in human mode from a directory that did not already have a Meridian project. Other creation commands had the same root problem: startup rejected an uninitialized cwd before they could create project state.

## Goal

Initialization should be frictionless for commands that create/bootstrap new Meridian state, while read/inspection and existing-state commands stay strict.

## Summary

- Add `BootstrapPlan` as the single pre-dispatch bootstrap policy object carried by each `CommandDescriptor`.
- Add explicit `bootstrap_plan.auto_init_cwd` instead of inferring auto-init from `WRITE_*` classification.
- Enable cwd auto-init for creation/bootstrap commands: bare `meridian`, `spawn create`, `work start`, `config set`, `workspace init`, and `bootstrap`.
- Treat `init` and `config init` as post-parse root commands (`root_source=ARGV`) so their handlers own project creation and `created:` output; catalog construction maps these to no pre-dispatch bootstrap.
- Keep read commands and existing-state mutations strict (`spawn list/cancel`, `work list`, `config reset`, unwired test descriptors).
- Add integration and unit regressions for the auto-init allow-list, strict commands, and bootstrap-plan invariants.
- Update startup/bootstrap knowledge docs and `CHANGELOG.md`.

## Resulting Behavior

From a bare directory, these initialize project state:

```bash
meridian
meridian init
meridian config init
meridian config set defaults.max_depth 7
meridian spawn -p hi
meridian work start "first work"
meridian workspace init
```

They create `meridian.toml` and `.meridian/id` before continuing.

These remain strict from a bare directory:

```bash
meridian spawn list
meridian spawn cancel p999
meridian config reset defaults.max_depth
meridian work list
```

They still print `No Meridian project found` and create no files.

## Changes

The startup catalog now carries the product policy directly via `BootstrapPlan`. Bootstrap consumes only that plan; it no longer re-classifies argv or receives parallel state/auto-init fields from `main.py`. `root_source=ARGV` remains the declaration for commands whose handler resolves the target itself (`init`, `config init`), and catalog construction translates that into `StateRequirement.NONE` inside the plan.

## Work Item

mellow-hollow-brood

## Verification

- `uv run pytest tests/unit/cli/test_startup_classify.py tests/integration/cli/test_cwd_project_resolution.py -q` — 25 passed
- `uv run ruff check ...` on touched files — passed
- `uv run --extra dev python -m pyright` — 0 errors, 5 existing warnings
- `uv run pytest-llm` — 1362 passed, 2 skipped
- Prober p4804: verified representative auto-init and strict commands
- Reviewer p4803: found/remediated bad allow-list entries for unwired `streaming test` / `test harness`
- Reviewer p4807: requested collapsing split bootstrap policy
- Reviewer p4808: approved final `BootstrapPlan` refactor
- Push hook: `ruff`, `pyright`, full pytest, and `uv build --no-sources` passed

## Knowledge Updates

Updated startup/bootstrap AGENTS and `.context/CONTEXT.md` files to document `BootstrapPlan`, `bootstrap_plan.auto_init_cwd`, `root_source=ARGV`, and the read/write/create distinction.

Updated KB `architecture/startup-pipeline.md` with the same current-truth model and removed stale chat-era `CLIENT_READ` references.

## Spawn Trace

- p4786 reviewer — initial init fix review
- p4787 prober — initial init fix runtime verification
- p4791 reviewer — found over-broad primary-launch scaffolding
- p4792 prober — first primary-launch runtime probe
- p4795 reviewer — approved narrowed primary auto-init fix
- p4796 prober — verified narrowed runtime behavior
- p4803 reviewer — audited broader auto-init classification, found unwired descriptor blocker
- p4804 prober — runtime-probed broader classification
- p4805 reviewer — approved blocker fix
- p4806 prober — verified blocker fix
- p4807 reviewer — thermo review found split bootstrap-policy model
- p4808 reviewer — approved final `BootstrapPlan` model

## Release Label Guide

Set one `release:*` label on this PR: `release:patch`.

## Post-Merge Automation

After merge to `main`, CI (`.github/workflows/release-on-merge.yml`) will compute the release from the PR label and publish normally.

## Cleanup

After merge, clean merged worktrees with:

```bash
scripts/prune-worktrees.sh
```

