### PR TITLE
fix: preserve continue launch context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - `meridian init` now works from an uninitialized directory in human mode instead of failing the pre-init project-root guard.
 - Creation/bootstrap commands (`meridian`, `spawn create`, `work start`, `config init`/`set`, `workspace init`) now auto-initialize an uninitialized cwd instead of failing the project-root guard; read and existing-state commands remain strict.
+- `--continue` now preserves the recorded work/task directory and cache-shaping launch contract for both primary sessions and spawned subagents. Same-session continue rejects work/task-dir overrides, and launch-policy snapshot replay now treats an empty recorded model as the valid “no managed model override; let the harness default” contract instead of failing with “Launch policy snapshot is missing model.”
 
 ## [0.3.20] - 2026-06-25
 

--- a/src/meridian/cli/primary_launch.py
+++ b/src/meridian/cli/primary_launch.py
@@ -207,6 +207,11 @@ def run_primary_launch(
         raise ValueError(
             "--continue does not accept --task-dir. Use --fork --task-dir to diverge."
         )
+    if resume_target is not None and work.strip():
+        raise ValueError(
+            "--continue does not accept --work. "
+            "Use --fork-fresh or a fresh session to change work context."
+        )
     resolved_approval = approval if approval is not None else ("never" if yolo else "default")
 
     fork_resolution = validate_fork_mode(
@@ -244,6 +249,7 @@ def run_primary_launch(
     requested_agent = agent_launch.agent
     agent_opt_out = agent_launch.agent_opt_out
     requested_work_id = work.strip() or None
+    launch_task_dir = normalized_task_dir
     if resume_target is not None:
         if model.strip():
             raise ValueError("Cannot combine --continue with --model.")
@@ -293,6 +299,9 @@ def run_primary_launch(
         source_execution_cwd = resolved_continue.source_execution_cwd
         source_claude_config_dir = resolved_continue.source_claude_config_dir
         source_pi_session_dir = resolved_continue.source_pi_session_dir
+        if requested_work_id is None:
+            requested_work_id = resolved_continue.source_work_id
+        launch_task_dir = resolved_continue.source_execution_cwd
         continue_source_tracked = resolved_continue.tracked
         continue_source_ref = resume_target
         # Replay persisted launch contract so agent/model/skills stay fixed on resume.
@@ -370,7 +379,7 @@ def run_primary_launch(
             agent=requested_agent,
             agent_opt_out=agent_opt_out,
             work_id=requested_work_id,
-            task_dir=normalized_task_dir,
+            task_dir=launch_task_dir,
             passthrough_args=(
                 continue_passthrough_args if resume_target is not None else passthrough
             ),

--- a/src/meridian/lib/launch/.context/CONTEXT.md
+++ b/src/meridian/lib/launch/.context/CONTEXT.md
@@ -53,6 +53,24 @@ These are the only things that differ between the preview bind and the real bind
 The report and `system-prompt.md` paths are derived in `bind_launch_context` from
 `spawn_id` (the spawn log dir), not carried here.
 
+### Exact Continue Replay
+
+Primary `meridian --continue` and subagent `spawn --continue` are exact
+continuations. They replay the source task directory, work attachment, session
+identity, and launch-policy snapshot rather than resolving from the caller's
+current CWD/config/env. The absence of source work is a preserved value: bind must
+suppress inherited `MERIDIAN_ACTIVE_WORK_*` when continuing a source with no work
+item, not attach the caller's ambient work.
+
+Launch-policy snapshot replay preserves cache- and prompt-shaping fields: model,
+harness, agent, skills, loaded skill content, execution policy, tool/MCP grants,
+inventory prompt, and passthrough args. A snapshot with `model=""` and a harness is
+valid; it means "omit Meridian's managed model override and let the harness
+default." Explicit `agent_opt_out` stays authoritative and must not reintroduce a
+configured default agent through routing fallback.
+
+KB: `decisions/launch.md#d-continue-replays-recorded-launch-contract-same-session-continue-is-not-live-policy-recomputation`.
+
 ### Four Driving Adapters
 
 Four paths call into this module — each converges on `build_launch_context()`:
@@ -457,6 +475,7 @@ exception paths. Do not replicate this logic inline.
 
 - `architecture/launch-system.md` — full adapter diagram, prepare/bind split detail, module map
 - `concepts/session-initiation.md` — four-mode initiation semantics, user-turn placement, identity lock, bare-flag inference
+- `decisions/launch.md#d-continue-replays-recorded-launch-contract-same-session-continue-is-not-live-policy-recomputation` — exact continue replay contract
 - `concepts/composition-pipeline.md` — user-turn composition and harness projection details for `TASK_CONTEXT`
 - `concepts/spawn-lifecycle.md` — spawn status machine, crash recovery, authority lattice
 - `architecture/spawn-finalization.md` — finalization policy, per-spawn lock, `CompleteSpawnOutcome`

--- a/src/meridian/lib/launch/__init__.py
+++ b/src/meridian/lib/launch/__init__.py
@@ -115,7 +115,12 @@ def launch_primary(
         project_root=resolved_project_root,
         runtime_root=runtime_root_for_context,
     )
-    ambient_work_id = None if explicit_work_id is not None else runtime_context.work_id
+    inherit_ambient_work = request.session_mode.value != "resume"
+    ambient_work_id = (
+        None
+        if explicit_work_id is not None or not inherit_ambient_work
+        else runtime_context.work_id
+    )
     project_state_dir = resolve_project_paths(resolved_project_root).root_dir
     launch_resolution = resolve_launch_inputs(
         authority_root=resolved_project_root,
@@ -166,7 +171,7 @@ def launch_primary(
             effective_work_id,
         )
         if effective_work_id is not None
-        else runtime_context.work_dir
+        else (runtime_context.work_dir if inherit_ambient_work else None)
     )
     request_updates = dict(launch_resolution.request_updates)
     request_updates["work_id_hint"] = effective_work_id

--- a/src/meridian/lib/launch/context.py
+++ b/src/meridian/lib/launch/context.py
@@ -125,6 +125,7 @@ from .request import (
     LaunchRuntime,
     RequestPromptPayload,
     SpawnRequest,
+    is_exact_continue_session,
 )
 from .resolve import (
     format_missing_skills_warning,
@@ -814,6 +815,10 @@ def normalize_explicit_work_id(
     return (runtime_work_id or "").strip() or (request_work_id_hint or "").strip() or None
 
 
+def _suppresses_ambient_work(request: SpawnRequest) -> bool:
+    return is_exact_continue_session(request.session)
+
+
 def _resolve_active_work_dir(
     *,
     project_paths: ProjectConfigPaths,
@@ -1397,6 +1402,12 @@ def prepare_launch_surface(
     project_paths = prepared_policy.project_paths
     active_work_dir = prepared_policy.active_work_dir
     policies = prepared_policy.resolved_policy
+    if request.agent_opt_out:
+        policies = replace(
+            policies,
+            profile=None,
+            routing=replace(policies.routing, agent=None),
+        )
     profile = policies.profile
     using_policy_snapshot = request.launch_policy_snapshot is not None
     has_profile = profile is not None
@@ -1455,6 +1466,14 @@ def prepare_launch_surface(
     warning = summarize_composition_warnings(composition_warnings)
 
     agent_metadata = dict(request.agent_metadata)
+    if request.agent_opt_out:
+        for metadata_key in (
+            "session_agent",
+            "session_agent_description",
+            "session_agent_profile_body",
+            "session_agent_path",
+        ):
+            agent_metadata.pop(metadata_key, None)
     model_selection_update: dict[str, str | None] = {
         "model_selection_requested_token": None,
         "model_selection_canonical_id": None,
@@ -1466,7 +1485,12 @@ def prepare_launch_surface(
             "model_selection_canonical_id": model_selection.canonical_model_id,
             "model_selection_harness_provenance": model_selection.harness_provenance,
         }
-    resolved_agent_name = profile.name if profile is not None else request.agent
+    if request.agent_opt_out:
+        resolved_agent_name = None
+    elif profile is not None:
+        resolved_agent_name = profile.name
+    else:
+        resolved_agent_name = policies.routing.agent or request.agent
     session_agent_path = resolve_profile_path(profile)
     if resolved_agent_name is not None:
         agent_metadata["session_agent"] = resolved_agent_name
@@ -1542,7 +1566,11 @@ def prepare_launch_surface(
     )
     resolved_request = resolved_request.model_copy(
         update={
-            "launch_policy_snapshot": request.launch_policy_snapshot
+            "launch_policy_snapshot": (
+                None
+                if request.agent_opt_out
+                else request.launch_policy_snapshot
+            )
             or build_launch_policy_snapshot(
                 resolved_request,
                 model_selection=model_selection,
@@ -1959,6 +1987,9 @@ def bind_launch_context(
         work_id=requested_work_id,
         increment_depth=not is_primary_launch,
     )
+    if requested_work_id is None and _suppresses_ambient_work(resolved_request):
+        child_context_env.pop("MERIDIAN_ACTIVE_WORK_ID", None)
+        child_context_env.pop("MERIDIAN_ACTIVE_WORK_DIR", None)
     effective_work_id = (
         child_context_env.get("MERIDIAN_ACTIVE_WORK_ID", "").strip() or requested_work_id
     )

--- a/src/meridian/lib/launch/policy_snapshot.py
+++ b/src/meridian/lib/launch/policy_snapshot.py
@@ -128,14 +128,12 @@ def replay_launch_policy_snapshot(
 ) -> ReplayedLaunchPolicySnapshot:
     """Resolve policy fields directly from persisted snapshot data."""
 
-    snapshot_model = snapshot.model.strip()
     snapshot_harness = snapshot.harness.strip()
-    if not snapshot_model:
-        raise ValueError("Launch policy snapshot is missing model.")
     if not snapshot_harness:
         raise ValueError("Launch policy snapshot is missing harness.")
 
     harness_id = HarnessId(snapshot_harness)
+    snapshot_model = snapshot.model.strip()
     adapter = harness_registry.get_subprocess_harness(harness_id)
     snapshot_agent = (snapshot.agent or "").strip() or None
     snapshot_skill_names = (
@@ -157,15 +155,7 @@ def replay_launch_policy_snapshot(
         harness_id=harness_id,
         snapshot_skill_names=snapshot_skill_names,
     )
-    model_selection = ReplayedModelSelection(
-        requested_token=snapshot.model_selection_requested_token or snapshot_model,
-        selected_model_token=snapshot.model_selection_selected_token
-        or snapshot.model_selection_requested_token
-        or snapshot_model,
-        canonical_model_id=snapshot.model_selection_canonical_id or snapshot_model,
-        harness_provenance=snapshot.model_selection_harness_provenance or "snapshot",
-        harness_model_id=snapshot.model_selection_harness_model_id,
-    )
+    model_selection = _snapshot_model_selection(snapshot=snapshot, snapshot_model=snapshot_model)
     terminal_surface_mode = _resolve_snapshot_terminal_mode(
         snapshot=snapshot,
         harness_id=harness_id,
@@ -179,7 +169,7 @@ def replay_launch_policy_snapshot(
         adapter=adapter,
         resolved_skills=resolved_skills,
         routing=ResolvedLaunchRouting(
-            model=model_selection.selected_model_token,
+            model=(model_selection.selected_model_token if model_selection is not None else None),
             harness=harness_id,
             agent=snapshot_agent,
         ),
@@ -191,6 +181,25 @@ def replay_launch_policy_snapshot(
         model_selection=model_selection,
         fallback_chain=snapshot.fallback_chain,
         alias_catalog=alias_catalog,
+    )
+
+
+def _snapshot_model_selection(
+    *,
+    snapshot: LaunchPolicySnapshot,
+    snapshot_model: str,
+) -> ReplayedModelSelection | None:
+    if not snapshot_model:
+        return None
+
+    return ReplayedModelSelection(
+        requested_token=snapshot.model_selection_requested_token or snapshot_model,
+        selected_model_token=snapshot.model_selection_selected_token
+        or snapshot.model_selection_requested_token
+        or snapshot_model,
+        canonical_model_id=snapshot.model_selection_canonical_id or snapshot_model,
+        harness_provenance=snapshot.model_selection_harness_provenance or "snapshot",
+        harness_model_id=snapshot.model_selection_harness_model_id,
     )
 
 

--- a/src/meridian/lib/launch/request.py
+++ b/src/meridian/lib/launch/request.py
@@ -61,6 +61,22 @@ class SessionRequest(BaseModel):
     primary_session_mode: str | None = None
 
 
+def is_exact_continue_session(session: SessionRequest) -> bool:
+    """True when a session request represents exact continuation, not fork/fresh."""
+
+    primary_mode = ((session.primary_session_mode or "").strip().lower()) or None
+    return (
+        not session.continue_fork
+        and (
+            primary_mode == "resume"
+            or (
+                ((session.requested_harness_session_id or "").strip() != "")
+                and ((session.continue_source_ref or "").strip() != "")
+            )
+        )
+    )
+
+
 class RequestPromptPayload(BaseModel):
     """Typed managed prompt payload carried across persisted request boundaries."""
 

--- a/src/meridian/lib/ops/spawn/api.py
+++ b/src/meridian/lib/ops/spawn/api.py
@@ -2002,11 +2002,11 @@ def _build_continue_create_input(
         goal=resolved_goal,
         desc=payload.desc,
         work=source_spawn.work_id or "",
-        task_dir=None,
+        task_dir=resolved_reference.source_execution_cwd,
         caller_cwd=payload.caller_cwd,
         launch_policy_snapshot=source_snapshot,
         session=SessionRequest(
-            requested_harness_session_id=resolved_reference.harness_session_id,
+            requested_harness_session_id=resolved_reference.authoritative_harness_session_id,
             continue_harness=resolved_reference.harness,
             continue_source_tracked=resolved_reference.tracked,
             continue_source_ref=source_spawn_id,
@@ -2089,7 +2089,7 @@ def _build_fork_create_input(
         caller_cwd=payload.caller_cwd,
         goal=requested_goal,
         session=SessionRequest(
-            requested_harness_session_id=resolved_reference.harness_session_id,
+            requested_harness_session_id=resolved_reference.authoritative_harness_session_id,
             continue_harness=resolved_reference.harness,
             continue_source_tracked=resolved_reference.tracked,
             continue_source_ref=normalized_source_ref,

--- a/src/meridian/lib/ops/spawn/execute_init.py
+++ b/src/meridian/lib/ops/spawn/execute_init.py
@@ -19,7 +19,7 @@ from meridian.lib.core.sink import OutputSink
 from meridian.lib.core.spawn_lifecycle import SpawnReservation
 from meridian.lib.core.types import ModelId, SpawnId
 from meridian.lib.launch.plan import build_spawn_mars_runtime
-from meridian.lib.launch.request import SpawnRequest
+from meridian.lib.launch.request import SpawnRequest, is_exact_continue_session
 from meridian.lib.launch.types import PrimarySessionMetadata
 from meridian.lib.ops.work_attachment import ensure_explicit_work_item
 from meridian.lib.state import spawn_store
@@ -143,12 +143,16 @@ def resolve_spawn_work_id(
     ctx: RuntimeContext | None = None,
 ) -> str | None:
     resolved_context = runtime_context(ctx)
+    ambient_work_id = (
+        None
+        if is_exact_continue_session(request.session)
+        else (resolved_context.work_id or "").strip() or None
+    )
     return (
         (request.task_cwd_work_item or "").strip()
         or (request.work_id_hint or "").strip()
         or payload.work.strip()
-        or (resolved_context.work_id or "").strip()
-        or None
+        or ambient_work_id
     )
 
 

--- a/src/meridian/lib/ops/spawn/prepare.py
+++ b/src/meridian/lib/ops/spawn/prepare.py
@@ -20,6 +20,7 @@ from meridian.lib.launch.request import (
     RetryPolicy,
     SessionRequest,
     SpawnRequest,
+    is_exact_continue_session,
 )
 from meridian.lib.launch.resolution import resolve_launch_inputs
 from meridian.lib.launch.resolve import parse_duration_seconds
@@ -63,6 +64,10 @@ def _resolve_spawn_env(payload: SpawnCreateInput) -> dict[str, str]:
     if payload.launch_policy_snapshot is not None:
         return dict(payload.launch_policy_snapshot.env)
     return {}
+
+
+def _is_exact_continue(payload: SpawnCreateInput) -> bool:
+    return is_exact_continue_session(payload.session)
 
 
 @dataclass(frozen=True)
@@ -116,8 +121,13 @@ def build_create_payload(
 
         resolved_context = runtime_context(ctx)
         explicit_work_id = payload.work.strip() or None
-        ambient_work_id = (resolved_context.work_id or "").strip() or None
-        if ambient_work_id is None and resolved_context.chat_id:
+        inherit_ambient_work = not _is_exact_continue(payload)
+        ambient_work_id = (
+            (resolved_context.work_id or "").strip() or None
+            if inherit_ambient_work
+            else None
+        )
+        if inherit_ambient_work and ambient_work_id is None and resolved_context.chat_id:
             try:
                 ambient_work_id = (
                     get_session_active_work_id(runtime_root, resolved_context.chat_id) or ""

--- a/tests/integration/cli/test_primary_continue.py
+++ b/tests/integration/cli/test_primary_continue.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -16,7 +17,9 @@ from meridian.lib.core.launch_policy_snapshot import LaunchPolicySnapshot
 from meridian.lib.core.types import HarnessId
 from meridian.lib.harness.registry import get_default_harness_registry
 from meridian.lib.launch import LaunchRequest, LaunchResult, compile_prepared_policy_surface
+from meridian.lib.launch.context import build_launch_context
 from meridian.lib.launch.plan import build_primary_launch_runtime, build_primary_spawn_request
+from meridian.lib.launch.process import ProcessOutcome
 from meridian.lib.launch.request import SessionRequest
 from meridian.lib.launch.types import SessionMode
 from meridian.lib.state import session_store, spawn_store
@@ -42,6 +45,8 @@ def _seed_primary_spawn(
     *,
     spawn_id: str,
     harness_session_id: str,
+    work_id: str | None = None,
+    task_cwd: str | None = None,
     launch_policy_snapshot: LaunchPolicySnapshot | None = None,
 ) -> None:
     model = launch_policy_snapshot.model if launch_policy_snapshot is not None else "gpt-5.3-codex"
@@ -62,6 +67,8 @@ def _seed_primary_spawn(
         harness=harness,
         kind="primary",
         prompt="primary prompt",
+        work_id=work_id,
+        task_cwd=task_cwd,
         harness_session_id=harness_session_id,
         launch_policy_snapshot=launch_policy_snapshot,
     )
@@ -73,6 +80,8 @@ def test_primary_continue_replays_source_launch_policy_snapshot(
 ) -> None:
     project_root = tmp_path / "repo"
     project_root.mkdir()
+    source_task_dir = tmp_path / "source-worktree"
+    source_task_dir.mkdir()
     runtime_root = _state_root(project_root)
     write_skill(project_root, "testing-principles")
     snapshot = LaunchPolicySnapshot(
@@ -98,18 +107,14 @@ def test_primary_continue_replays_source_launch_policy_snapshot(
         runtime_root,
         spawn_id="p41",
         harness_session_id="session-41",
+        work_id="source-work",
+        task_cwd=source_task_dir.as_posix(),
         launch_policy_snapshot=snapshot,
     )
     monkeypatch.setenv("MERIDIAN_MODEL", "gpt-5.4")
     monkeypatch.setenv("MERIDIAN_AGENT", "agent-b")
-
-    def fail_bundle_resolution(*_args: object, **_kwargs: object) -> object:
-        raise AssertionError("snapshot replay should not re-resolve live policy")
-
-    monkeypatch.setattr(
-        "meridian.lib.launch.bundle_adapter.request_and_resolve",
-        fail_bundle_resolution,
-    )
+    monkeypatch.setenv("MERIDIAN_APPROVAL", "confirm")
+    monkeypatch.setenv("MERIDIAN_SANDBOX", "read-only")
 
     captured: dict[str, LaunchRequest] = {}
 
@@ -151,7 +156,18 @@ def test_primary_continue_replays_source_launch_policy_snapshot(
         )
 
     request = captured["request"]
+    assert request.work_id == "source-work"
+    assert request.task_dir == source_task_dir.as_posix()
+    assert request.session.source_execution_cwd == source_task_dir.as_posix()
     assert request.launch_policy_snapshot == snapshot
+    assert request.launch_policy_snapshot is not None
+    assert request.launch_policy_snapshot.model == snapshot.model
+    assert request.launch_policy_snapshot.harness == snapshot.harness
+    assert request.launch_policy_snapshot.agent == snapshot.agent
+    assert request.launch_policy_snapshot.skills == snapshot.skills
+    assert request.launch_policy_snapshot.execution_policy == snapshot.execution_policy
+    assert request.launch_policy_snapshot.tools == snapshot.tools
+    assert request.launch_policy_snapshot.mcp_tools == snapshot.mcp_tools
     assert request.passthrough_args == snapshot.extra_args
     assert request.agent is None
     assert request.model == ""
@@ -267,6 +283,83 @@ def test_primary_continue_spawn_session_ref_recovers_linked_spawn_snapshot(
     assert request.passthrough_args == spawn_snapshot.extra_args
 
 
+def test_primary_continue_from_source_without_work_suppresses_ambient_work(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    source_task_dir = tmp_path / "source-worktree"
+    source_task_dir.mkdir()
+    ambient_work_dir = tmp_path / "ambient-work"
+    ambient_work_dir.mkdir()
+    runtime_root = _state_root(project_root)
+    snapshot = LaunchPolicySnapshot(model="gpt-5.3-codex", harness="codex")
+    _seed_primary_spawn(
+        runtime_root,
+        spawn_id="p45",
+        harness_session_id="session-45",
+        work_id=None,
+        task_cwd=source_task_dir.as_posix(),
+        launch_policy_snapshot=snapshot,
+    )
+    monkeypatch.setenv("MERIDIAN_ACTIVE_WORK_ID", "ambient-work")
+    monkeypatch.setenv("MERIDIAN_ACTIVE_WORK_DIR", ambient_work_dir.as_posix())
+
+    captured_contexts: list[Any] = []
+
+    def fake_run_harness_process(
+        context: Any,
+        harness_registry: object,
+        **kwargs: object,
+    ) -> ProcessOutcome:
+        _ = (harness_registry, kwargs)
+        captured_contexts.append(context)
+        return ProcessOutcome(
+            command=(),
+            exit_code=0,
+            chat_id="c45",
+            primary_spawn_id="p45-continue",
+            primary_started=0.0,
+            primary_started_epoch=0.0,
+            primary_started_local_iso=None,
+            resolved_harness_session_id="session-45",
+        )
+
+    monkeypatch.setattr(
+        "meridian.lib.launch.process.run_harness_process",
+        fake_run_harness_process,
+    )
+
+    run_primary_launch(
+        project_root=project_root,
+        continue_ref="p45",
+        fork_ref=None,
+        fork_fresh_ref=None,
+        model="",
+        harness=None,
+        agent=None,
+        work="",
+        task_dir=None,
+        yolo=False,
+        approval=None,
+        autocompact=None,
+        effort=None,
+        sandbox=None,
+        timeout=None,
+        dry_run=False,
+        passthrough=(),
+        skills=(),
+    )
+
+    context = captured_contexts[0]
+    assert context.work_id is None
+    assert context.resolved_request.work_id_hint is None
+    assert context.binding.work_id is None
+    assert "MERIDIAN_ACTIVE_WORK_ID" not in context.binding.environment.child_context_env
+    assert context.task_cwd == source_task_dir
+
+
 def test_primary_continue_rejects_passthrough_args(tmp_path: Path) -> None:
     project_root = tmp_path / "repo"
     project_root.mkdir()
@@ -304,6 +397,67 @@ def test_primary_continue_rejects_passthrough_args(tmp_path: Path) -> None:
         )
 
     assert "--" in str(exc_info.value)
+
+
+def test_primary_continue_rejects_task_dir_override(tmp_path: Path) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+
+    with pytest.raises(ValueError) as exc_info:
+        run_primary_launch(
+            project_root=project_root,
+            continue_ref="p52",
+            fork_ref=None,
+            fork_fresh_ref=None,
+            model="",
+            harness=None,
+            agent=None,
+            work="",
+            task_dir=tmp_path.as_posix(),
+            yolo=False,
+            approval=None,
+            autocompact=None,
+            effort=None,
+            sandbox=None,
+            timeout=None,
+            dry_run=False,
+            passthrough=(),
+            skills=(),
+        )
+
+    assert "--continue does not accept --task-dir" in str(exc_info.value)
+    assert "--fork --task-dir" in str(exc_info.value)
+
+
+def test_primary_continue_rejects_work_override(tmp_path: Path) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+
+    with pytest.raises(ValueError) as exc_info:
+        run_primary_launch(
+            project_root=project_root,
+            continue_ref="p52",
+            fork_ref=None,
+            fork_fresh_ref=None,
+            model="",
+            harness=None,
+            agent=None,
+            work="other-work",
+            task_dir=None,
+            yolo=False,
+            approval=None,
+            autocompact=None,
+            effort=None,
+            sandbox=None,
+            timeout=None,
+            dry_run=False,
+            passthrough=(),
+            skills=(),
+        )
+
+    assert "--work" in str(exc_info.value)
+    assert "--fork-fresh" in str(exc_info.value)
+    assert "fresh session" in str(exc_info.value)
 
 
 def test_primary_continue_replays_snapshot_extra_args_not_cli_passthrough(
@@ -386,11 +540,15 @@ def test_primary_continue_uses_legacy_bundle_resolution_without_snapshot(
 ) -> None:
     project_root = tmp_path / "repo"
     project_root.mkdir()
+    source_task_dir = tmp_path / "legacy-worktree"
+    source_task_dir.mkdir()
     runtime_root = _state_root(project_root)
     _seed_primary_spawn(
         runtime_root,
         spawn_id="p42",
         harness_session_id="session-42",
+        work_id="legacy-work",
+        task_cwd=source_task_dir.as_posix(),
         launch_policy_snapshot=None,
     )
 
@@ -443,6 +601,9 @@ def test_primary_continue_uses_legacy_bundle_resolution_without_snapshot(
         )
 
     request = captured["request"]
+    assert request.work_id == "legacy-work"
+    assert request.task_dir == source_task_dir.as_posix()
+    assert request.session.source_execution_cwd == source_task_dir.as_posix()
     assert request.launch_policy_snapshot is None
 
 
@@ -450,13 +611,13 @@ def test_primary_continue_snapshot_replay_preserves_agent_over_config_default(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Agent A at launch must survive --continue after config default moves to agent B."""
+    """Cache-shaping launch policy must survive --continue after config/env drift."""
 
     project_root = tmp_path / "repo"
     project_root.mkdir()
     (project_root / ".mars").mkdir()
     (project_root / ".mars" / "config.toml").write_text(
-        '[primary]\nagent = "agent-b"\n',
+        '[primary]\nagent = "agent-b"\nmodel = "gpt-5.4"\n',
         encoding="utf-8",
     )
     runtime_root = _state_root(project_root)
@@ -464,7 +625,20 @@ def test_primary_continue_snapshot_replay_preserves_agent_over_config_default(
         model="gpt-5.3-codex",
         harness="codex",
         agent="agent-a",
-        skills=(),
+        skills=("skill-a",),
+        loaded_skills=(
+            SkillContent(
+                name="skill-a",
+                description="skill-a skill",
+                path="/skills/skill-a/SKILL.md",
+                content="# skill-a\n\nPreserve cache contract.\n",
+                skill_type="reference",
+            ),
+        ),
+        execution_policy=ResolvedExecutionPolicy(approval="auto", sandbox="workspace-write"),
+        tools={"write": "allow"},
+        mcp_tools=("github",),
+        extra_args=("--search",),
     )
     _seed_primary_spawn(
         runtime_root,
@@ -472,6 +646,10 @@ def test_primary_continue_snapshot_replay_preserves_agent_over_config_default(
         harness_session_id="session-43",
         launch_policy_snapshot=snapshot,
     )
+    monkeypatch.setenv("MERIDIAN_MODEL", "claude-sonnet-4-6")
+    monkeypatch.setenv("MERIDIAN_AGENT", "agent-c")
+    monkeypatch.setenv("MERIDIAN_APPROVAL", "never")
+    monkeypatch.setenv("MERIDIAN_SANDBOX", "read-only")
 
     bundle_calls: list[object] = []
 
@@ -506,4 +684,102 @@ def test_primary_continue_snapshot_replay_preserves_agent_over_config_default(
     )
 
     assert bundle_calls == []
-    assert prepared_policy.resolved_policy.routing.agent == "agent-a"
+    resolved_policy = prepared_policy.resolved_policy
+    assert resolved_policy.model == snapshot.model
+    assert str(resolved_policy.harness) == snapshot.harness
+    assert resolved_policy.routing.agent == snapshot.agent
+    assert resolved_policy.resolved_skills.skill_names == snapshot.skills
+    assert resolved_policy.execution_policy == snapshot.execution_policy
+    assert resolved_policy.resolved_tools == snapshot.tools
+    assert resolved_policy.resolved_mcp_tools == snapshot.mcp_tools
+
+
+def test_primary_continue_replays_codex_empty_model_snapshot_as_default_model(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    (project_root / ".mars").mkdir()
+    (project_root / ".mars" / "config.toml").write_text(
+        '[primary]\nmodel = "gpt-5.4"\nagent = "agent-b"\n',
+        encoding="utf-8",
+    )
+    runtime_root = _state_root(project_root)
+    snapshot = LaunchPolicySnapshot(
+        model="",
+        harness="codex",
+        agent="tech-lead",
+        skills=(),
+        execution_policy=ResolvedExecutionPolicy(approval="default", sandbox="workspace-write"),
+    )
+    _seed_primary_spawn(
+        runtime_root,
+        spawn_id="p44",
+        harness_session_id="session-44",
+        launch_policy_snapshot=snapshot,
+    )
+    monkeypatch.setenv("MERIDIAN_MODEL", "claude-sonnet-4-6")
+    monkeypatch.setenv("MERIDIAN_AGENT", "agent-c")
+
+    def fail_bundle_resolution(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("empty-model snapshot replay should not call mars launch-bundle")
+
+    monkeypatch.setattr(
+        "meridian.lib.launch.bundle_adapter.request_and_resolve",
+        fail_bundle_resolution,
+    )
+
+    captured: dict[str, LaunchRequest] = {}
+
+    def fake_launch_primary(
+        *,
+        project_root: Path,
+        request: LaunchRequest,
+        harness_registry: object,
+    ) -> LaunchResult:
+        _ = (project_root, harness_registry)
+        captured["request"] = request
+        return LaunchResult(command=("codex",), exit_code=0, continue_ref="p44")
+
+    with patch("meridian.cli.primary_launch.launch_primary", side_effect=fake_launch_primary):
+        run_primary_launch(
+            project_root=project_root,
+            continue_ref="p44",
+            fork_ref=None,
+            fork_fresh_ref=None,
+            model="",
+            harness=None,
+            agent=None,
+            work="",
+            task_dir=None,
+            yolo=False,
+            approval=None,
+            autocompact=None,
+            effort=None,
+            sandbox=None,
+            timeout=None,
+            dry_run=False,
+            passthrough=(),
+            skills=(),
+        )
+
+    launch_request = captured["request"]
+    assert launch_request.launch_policy_snapshot == snapshot
+
+    ctx = build_launch_context(
+        spawn_id="p44-replay",
+        request=build_primary_spawn_request(request=launch_request),
+        runtime=build_primary_launch_runtime(project_root=project_root),
+        harness_registry=get_default_harness_registry(),
+        dry_run=True,
+    )
+
+    assert ctx.resolved_request.launch_policy_snapshot == snapshot
+    assert ctx.resolved_request.model == ""
+    assert ctx.resolved_request.harness == "codex"
+    assert ctx.resolved_request.agent == "tech-lead"
+    assert ctx.model_selection is None
+    assert ctx.binding.run_params.model is None
+    assert ctx.binding.spec.model is None
+    assert "--model" not in ctx.binding.argv

--- a/tests/integration/ops/test_spawn_continue.py
+++ b/tests/integration/ops/test_spawn_continue.py
@@ -6,6 +6,7 @@ SpawnForkInput tests live in test_spawn_fork.py and test_spawn_fork_harness.py.
 """
 
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 
@@ -14,9 +15,14 @@ from meridian.lib.core.domain import SkillContent
 from meridian.lib.core.execution_policy import ResolvedExecutionPolicy
 from meridian.lib.core.launch_policy_snapshot import LaunchPolicySnapshot
 from meridian.lib.core.types import HarnessId
+from meridian.lib.launch.request import SpawnRequest
+from meridian.lib.ops.reference import ResolvedSessionReference
+from meridian.lib.ops.reference_recovery import RecoveryProvenance, RecoveryResult
+from meridian.lib.ops.spawn.execute_init import resolve_spawn_work_id
 from meridian.lib.ops.spawn.models import SpawnActionOutput, SpawnContinueInput, SpawnCreateInput
 from meridian.lib.state import spawn_store
 from meridian.lib.state.paths import resolve_project_runtime_root
+from meridian.lib.state.spawn.model import SpawnRecord
 from tests.support.fixtures import write_skill
 from tests.support.launch import stub_bundle_request_and_resolve
 
@@ -40,6 +46,8 @@ def _seed_spawn(
     harness_session_id: str | None,
     prompt: str = "seed prompt",
     goal: str | None = None,
+    work_id: str | None = "w-spawn",
+    task_cwd: str | None = None,
     execution_cwd: str | None = None,
     launch_policy_snapshot: LaunchPolicySnapshot | None = None,
 ) -> None:
@@ -61,8 +69,9 @@ def _seed_spawn(
         harness=harness,
         prompt=prompt,
         goal=goal,
-        work_id="w-spawn",
+        work_id=work_id,
         harness_session_id=harness_session_id,
+        task_cwd=task_cwd,
         execution_cwd=execution_cwd,
         launch_policy_snapshot=launch_policy_snapshot,
     )
@@ -120,10 +129,19 @@ def test_spawn_continue_rejects_model_override_before_legacy_fallback_resolution
     project_root.mkdir()
     runtime_root = _state_root(project_root)
     _seed_spawn(runtime_root, spawn_id="p26", harness_session_id="session-26")
+
+    def resolve_claude_harness(
+        _create_input: SpawnCreateInput,
+        *,
+        resolved_project_root: Path | None = None,
+    ) -> str:
+        _ = resolved_project_root
+        return "claude"
+
     monkeypatch.setattr(
         spawn_api,
         "_resolve_effective_fork_target_harness",
-        lambda _create_input, *, resolved_project_root=None: "claude",
+        resolve_claude_harness,
     )
 
     with pytest.raises(ValueError) as exc_info:
@@ -172,7 +190,7 @@ def test_spawn_continue_rejects_policy_flags_without_snapshot(
                 spawn_id="p25",
                 prompt="follow-up prompt",
                 project_root=project_root.as_posix(),
-                **updates,
+                **cast("Any", updates),
             )
         )
 
@@ -212,6 +230,8 @@ def test_spawn_continue_replays_source_launch_policy_snapshot(
 ) -> None:
     project_root = tmp_path / "repo"
     project_root.mkdir()
+    source_task_dir = tmp_path / "source-worktree"
+    source_task_dir.mkdir()
     runtime_root = _state_root(project_root)
     write_skill(project_root, "testing-principles")
     snapshot = LaunchPolicySnapshot(
@@ -237,11 +257,13 @@ def test_spawn_continue_replays_source_launch_policy_snapshot(
         runtime_root,
         spawn_id="p28",
         harness_session_id="session-28",
+        task_cwd=source_task_dir.as_posix(),
         launch_policy_snapshot=snapshot,
     )
     monkeypatch.setenv("MERIDIAN_MODEL", "gpt-5.4")
     monkeypatch.setenv("MERIDIAN_APPROVAL", "confirm")
     monkeypatch.setenv("MERIDIAN_SANDBOX", "read-only")
+    monkeypatch.setenv("MERIDIAN_AGENT", "other-agent")
 
     def fail_bundle_resolution(*_args: object, **_kwargs: object) -> object:
         raise AssertionError("snapshot replay should not re-resolve live policy")
@@ -251,20 +273,21 @@ def test_spawn_continue_replays_source_launch_policy_snapshot(
         fail_bundle_resolution,
     )
 
-    captured: dict[str, object] = {}
+    captured_payload: list[SpawnCreateInput] = []
+    captured_request: list[SpawnRequest] = []
 
     def fake_execute_spawn_blocking(
         *,
         payload: SpawnCreateInput,
-        request: object,
+        request: SpawnRequest,
         runtime: object,
         ctx: object = None,
         prepared: object = None,
         on_spawn_id: object = None,
     ) -> SpawnActionOutput:
         _ = (runtime, ctx, prepared, on_spawn_id)
-        captured["payload"] = payload
-        captured["request"] = request
+        captured_payload.append(payload)
+        captured_request.append(request)
         return SpawnActionOutput(command="spawn.create", status="running", spawn_id="p29")
 
     monkeypatch.setattr(spawn_api, "execute_spawn_blocking", fake_execute_spawn_blocking)
@@ -278,11 +301,16 @@ def test_spawn_continue_replays_source_launch_policy_snapshot(
     )
 
     assert result.command == "spawn.continue"
-    create_input = captured["request"]
-    continue_input = captured["payload"]
-    assert isinstance(continue_input, SpawnCreateInput)
+    create_input = captured_request[0]
+    continue_input = captured_payload[0]
+    assert continue_input.work == "w-spawn"
+    assert continue_input.task_dir == source_task_dir.as_posix()
     assert continue_input.launch_policy_snapshot == snapshot
     assert create_input.launch_policy_snapshot == snapshot
+    assert create_input.launch_policy_snapshot is not None
+    assert create_input.work_id_hint == "w-spawn"
+    assert create_input.task_cwd == source_task_dir.as_posix()
+    assert create_input.task_cwd_work_item == "w-spawn"
     assert create_input.model == snapshot.model
     assert create_input.harness == snapshot.harness
     assert create_input.agent == snapshot.agent
@@ -291,7 +319,69 @@ def test_spawn_continue_replays_source_launch_policy_snapshot(
     assert create_input.execution_policy.approval == snapshot.execution_policy.approval
     assert create_input.execution_policy.sandbox == snapshot.execution_policy.sandbox
     assert create_input.execution_policy.effort == snapshot.execution_policy.effort
+    assert create_input.tools == snapshot.tools
+    assert create_input.mcp_tools == snapshot.mcp_tools
     assert create_input.extra_args == snapshot.extra_args
+
+
+def test_spawn_continue_from_source_without_work_suppresses_ambient_work(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    source_task_dir = tmp_path / "source-worktree"
+    source_task_dir.mkdir()
+    ambient_work_dir = tmp_path / "ambient-work"
+    ambient_work_dir.mkdir()
+    runtime_root = _state_root(project_root)
+    _seed_spawn(
+        runtime_root,
+        spawn_id="p29",
+        harness_session_id="session-29",
+        work_id=None,
+        task_cwd=source_task_dir.as_posix(),
+        launch_policy_snapshot=LaunchPolicySnapshot(model="gpt-5.3-codex", harness="codex"),
+    )
+    monkeypatch.setenv("MERIDIAN_ACTIVE_WORK_ID", "ambient-work")
+    monkeypatch.setenv("MERIDIAN_ACTIVE_WORK_DIR", ambient_work_dir.as_posix())
+
+    captured_payload: list[SpawnCreateInput] = []
+    captured_request: list[SpawnRequest] = []
+
+    def fake_execute_spawn_blocking(
+        *,
+        payload: SpawnCreateInput,
+        request: SpawnRequest,
+        runtime: object,
+        ctx: object = None,
+        prepared: object = None,
+        on_spawn_id: object = None,
+    ) -> SpawnActionOutput:
+        _ = (runtime, ctx, prepared, on_spawn_id)
+        captured_payload.append(payload)
+        captured_request.append(request)
+        return SpawnActionOutput(command="spawn.create", status="running", spawn_id="p29c")
+
+    monkeypatch.setattr(spawn_api, "execute_spawn_blocking", fake_execute_spawn_blocking)
+
+    result = spawn_api.spawn_continue_sync(
+        SpawnContinueInput(
+            spawn_id="p29",
+            prompt="follow-up prompt",
+            project_root=project_root.as_posix(),
+        )
+    )
+
+    assert result.command == "spawn.continue"
+    continue_input = captured_payload[0]
+    create_request = captured_request[0]
+    assert continue_input.work == ""
+    assert continue_input.task_dir == source_task_dir.as_posix()
+    assert create_request.work_id_hint is None
+    assert create_request.task_cwd == source_task_dir.as_posix()
+    assert create_request.task_cwd_work_item is None
+    assert resolve_spawn_work_id(continue_input, create_request) is None
 
 
 def test_spawn_continue_uses_legacy_source_launch_policy_without_snapshot(
@@ -300,8 +390,15 @@ def test_spawn_continue_uses_legacy_source_launch_policy_without_snapshot(
 ) -> None:
     project_root = tmp_path / "repo"
     project_root.mkdir()
+    source_task_dir = tmp_path / "legacy-worktree"
+    source_task_dir.mkdir()
     runtime_root = _state_root(project_root)
-    _seed_spawn(runtime_root, spawn_id="p30", harness_session_id="session-30")
+    _seed_spawn(
+        runtime_root,
+        spawn_id="p30",
+        harness_session_id="session-30",
+        task_cwd=source_task_dir.as_posix(),
+    )
 
     monkeypatch.setenv("MERIDIAN_MODEL", "claude-sonnet-4-6")
     monkeypatch.setenv("MERIDIAN_APPROVAL", "confirm")
@@ -327,20 +424,21 @@ def test_spawn_continue_uses_legacy_source_launch_policy_without_snapshot(
         fail_live_harness_resolution,
     )
 
-    captured: dict[str, object] = {}
+    captured_payload: list[SpawnCreateInput] = []
+    captured_request: list[SpawnRequest] = []
 
     def fake_execute_spawn_blocking(
         *,
         payload: SpawnCreateInput,
-        request: object,
+        request: SpawnRequest,
         runtime: object,
         ctx: object = None,
         prepared: object = None,
         on_spawn_id: object = None,
     ) -> SpawnActionOutput:
         _ = (runtime, ctx, prepared, on_spawn_id)
-        captured["payload"] = payload
-        captured["request"] = request
+        captured_payload.append(payload)
+        captured_request.append(request)
         return SpawnActionOutput(command="spawn.create", status="running", spawn_id="p31")
 
     monkeypatch.setattr(spawn_api, "execute_spawn_blocking", fake_execute_spawn_blocking)
@@ -354,9 +452,85 @@ def test_spawn_continue_uses_legacy_source_launch_policy_without_snapshot(
     )
 
     assert result.command == "spawn.continue"
-    create_input = captured["request"]
-    continue_input = captured["payload"]
-    assert isinstance(continue_input, SpawnCreateInput)
+    create_input = captured_request[0]
+    continue_input = captured_payload[0]
+    assert continue_input.work == "w-spawn"
+    assert continue_input.task_dir == source_task_dir.as_posix()
     assert continue_input.launch_policy_snapshot is None
+    assert create_input.work_id_hint == "w-spawn"
+    assert create_input.task_cwd == source_task_dir.as_posix()
+    assert create_input.task_cwd_work_item == "w-spawn"
     assert create_input.harness == "codex"
     assert create_input.model == "gpt-5.3-codex"
+
+
+def test_continue_create_input_uses_authoritative_recovered_session_id(
+    tmp_path: Path,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    runtime_root = _state_root(project_root)
+    _seed_spawn(runtime_root, spawn_id="p32", harness_session_id=None)
+    source_spawn = spawn_store.get_spawn(runtime_root, "p32")
+    assert isinstance(source_spawn, SpawnRecord)
+    resolved_reference = ResolvedSessionReference(
+        harness_session_id=None,
+        harness="codex",
+        source_chat_id="c-seed",
+        source_model="gpt-5.3-codex",
+        source_agent="coder",
+        source_skills=("skill-c",),
+        source_work_id="w-spawn",
+        tracked=True,
+        source_execution_cwd=tmp_path.as_posix(),
+        recovery=RecoveryResult(
+            harness_session_id="recovered-session",
+            provenance=RecoveryProvenance.SESSION_STORE,
+        ),
+    )
+
+    build_continue_create_input = vars(spawn_api)["_build_continue_create_input"]
+    create_input = build_continue_create_input(
+        payload=SpawnContinueInput(spawn_id="p32", prompt="follow-up prompt"),
+        source_spawn=source_spawn,
+        source_spawn_id="p32",
+        resolved_reference=resolved_reference,
+        source_harness="codex",
+        source_snapshot=None,
+    )
+
+    assert create_input.session.requested_harness_session_id == "recovered-session"
+
+
+def test_fork_create_input_uses_authoritative_recovered_session_id() -> None:
+    resolved_reference = ResolvedSessionReference(
+        harness_session_id=None,
+        harness="codex",
+        source_chat_id="c-seed",
+        source_model="gpt-5.3-codex",
+        source_agent="coder",
+        source_skills=("skill-c",),
+        source_work_id="w-spawn",
+        tracked=True,
+        source_execution_cwd="/tmp/source",
+        recovery=RecoveryResult(
+            harness_session_id="recovered-session",
+            provenance=RecoveryProvenance.SPAWN_ROW,
+        ),
+    )
+
+    build_fork_create_input = vars(spawn_api)["_build_fork_create_input"]
+    create_input = build_fork_create_input(
+        payload=spawn_api.SpawnForkInput(source_ref="p33", prompt="fork prompt"),
+        normalized_source_ref="p33",
+        resolved_reference=resolved_reference,
+        requested_model="",
+        requested_agent=None,
+        inherited_skills=resolved_reference.source_skills,
+        requested_work="",
+        requested_task_dir=None,
+        requested_goal=None,
+        harness="codex",
+    )
+
+    assert create_input.session.requested_harness_session_id == "recovered-session"

--- a/tests/unit/launch/test_spawn_capability_gate.py
+++ b/tests/unit/launch/test_spawn_capability_gate.py
@@ -25,11 +25,13 @@ from meridian.lib.launch.composition import (
 from meridian.lib.launch.context import (
     PreparedLaunchSurface,
     build_context_prompt,
+    build_launch_context,
     build_launch_policy_snapshot,
     compile_prepared_policy_surface,
     prepare_launch_surface,
 )
-from meridian.lib.launch.policy_snapshot import _snapshot_profile
+from meridian.lib.launch.launch_types import TerminalSurfaceMode
+from meridian.lib.launch.policy_snapshot import _snapshot_profile, replay_launch_policy_snapshot
 from meridian.lib.launch.request import (
     LaunchArgvIntent,
     LaunchCompositionSurface,
@@ -171,6 +173,7 @@ def test_gate_present_returns_inventory_and_contract_blocks(tmp_path: Path) -> N
         "context-env",
     ]
     context = build_context_prompt(project_root=tmp_path, active_work_dir=None)
+    assert context is not None
     assert "# Meridian Context" in context
     assert "meridian context -h" in context
 
@@ -193,6 +196,7 @@ def test_gate_absent_returns_empty_blocks_but_context_still_builds(tmp_path: Pat
         "context-env",
     ]
     context = build_context_prompt(project_root=tmp_path, active_work_dir=None)
+    assert context is not None
     assert "# Meridian Context" in context
     assert "meridian context -h" in context
 
@@ -320,6 +324,65 @@ def test_snapshot_round_trip_preserves_all_profile_fields() -> None:
     # resolved form rather than the raw original.
     assert reconstructed.path == profile.path.expanduser().resolve()
     assert reconstructed.skills == ("loaded-skill",)
+
+
+def test_snapshot_replay_allows_empty_model_for_opencode_without_model_flag(
+    tmp_path: Path,
+) -> None:
+    def terminal_surface_mode(*, harness_id: HarnessId) -> TerminalSurfaceMode:
+        _ = harness_id
+        return TerminalSurfaceMode.PTY_MEDIATED
+
+    snapshot = LaunchPolicySnapshot(model="", harness="opencode")
+    harness_registry = get_default_harness_registry()
+
+    replayed = replay_launch_policy_snapshot(
+        snapshot=snapshot,
+        project_root=tmp_path,
+        harness_registry=harness_registry,
+        skills_readonly=True,
+        alias_catalog={},
+        resolve_terminal_surface_mode=terminal_surface_mode,
+    )
+
+    assert replayed.model == ""
+    assert replayed.routing.model is None
+    assert replayed.model_selection is None
+
+    ctx = build_launch_context(
+        spawn_id="empty-opencode-model",
+        request=_replay_request_from_snapshot(snapshot, prompt="continue task"),
+        runtime=LaunchRuntime(
+            argv_intent=LaunchArgvIntent.REQUIRED,
+            composition_surface=LaunchCompositionSurface.SPAWN_PREPARE,
+            runtime_root=(tmp_path / ".meridian").as_posix(),
+            project_paths_project_root=tmp_path.as_posix(),
+            project_paths_execution_cwd=tmp_path.as_posix(),
+        ),
+        harness_registry=harness_registry,
+        dry_run=True,
+    )
+
+    assert ctx.model_selection is None
+    assert ctx.binding.run_params.model is None
+    assert ctx.binding.spec.model is None
+    assert "--model" not in ctx.binding.argv
+
+
+def test_snapshot_replay_keeps_empty_harness_invalid(tmp_path: Path) -> None:
+    def terminal_surface_mode(*, harness_id: HarnessId) -> TerminalSurfaceMode:
+        _ = harness_id
+        return TerminalSurfaceMode.PTY_MEDIATED
+
+    with pytest.raises(ValueError, match="missing harness"):
+        replay_launch_policy_snapshot(
+            snapshot=LaunchPolicySnapshot(model="gpt-5.3-codex", harness=""),
+            project_root=tmp_path,
+            harness_registry=get_default_harness_registry(),
+            skills_readonly=True,
+            alias_catalog={},
+            resolve_terminal_surface_mode=terminal_surface_mode,
+        )
 
 
 def _empty_alias_map(_self: CatalogSession) -> dict[str, object]:


### PR DESCRIPTION
## Why

`meridian --continue` could silently resume with the caller's current launch context instead of the source session's recorded context. In practice this showed up as `MERIDIAN_TASK_DIR` moving from a worktree back to the main checkout mid-session.

A related production repro also failed on a valid Codex snapshot:

```text
meridian --continue c1
error: Launch policy snapshot is missing model.
```

That snapshot had `model=""`, which is the intended contract for “no Meridian-managed model override; let the harness default.”

## Goal

Same-session continue should be an exact replay of the source session's launch context. Primary `meridian --continue` and subagent `spawn --continue` should preserve the source task cwd, work attachment, session identity, and cache/prompt-shaping launch policy instead of recomputing from the caller's current cwd/config/env.

## Summary

- Rebased the branch onto `origin/main` after #350 landed; the only conflict was `CHANGELOG.md`.
- Tightened primary `--continue` policy so it rejects context-diverging overrides (`--task-dir`, `--work`, model/agent/skills/passthrough).
- Replays source launch-policy snapshots for primary and spawn continue, including model/harness/agent/skills/tools/MCP/execution policy/passthrough args.
- Treats empty snapshot `model` as valid when `harness` is present: omit Meridian's managed model override and let the harness default.
- Preserves source task cwd and work context for primary continue and spawn continue.
- Preserves the absence of source work: exact continue suppresses caller ambient `MERIDIAN_ACTIVE_WORK_*` at primary resolution, spawn prepare, launch bind/env projection, and spawn execution reservation.
- Uses `authoritative_harness_session_id` for spawn continue/fork so recovered tracked references work correctly.
- Preserves explicit no-agent opt-out (`-a ""`) so configured defaults do not leak back in, while normal snapshot replay still preserves source agent identity.

## Resulting Behavior

```bash
uv run meridian -C /home/jimyao/gitrepos/personal/hiring-challenge --continue c1 --dry-run
```

now succeeds and emits a Codex `resume 019f1d80-...` command without a managed `--model` override.

For exact continue:

- source task directory stays the source task directory;
- source work item stays the source work item;
- if the source had no work item, the continued session has no work item even when the caller has ambient work;
- snapshot `model=""` is accepted as harness-default behavior;
- explicit no-agent remains no-agent.

## Changes

- `src/meridian/cli/primary_launch.py`
  - rejects divergent primary `--continue` inputs;
  - fills `LaunchRequest` work/task/session/policy snapshot from the resolved source reference.
- `src/meridian/lib/launch/request.py`
  - adds shared `is_exact_continue_session()` predicate.
- `src/meridian/lib/launch/policy_snapshot.py`
  - accepts empty model snapshots when harness is present;
  - replays snapshot model selection as “no managed model override” when model is empty.
- `src/meridian/lib/launch/__init__.py`
  - suppresses ambient work inheritance for primary resume resolution.
- `src/meridian/lib/launch/context.py`
  - preserves snapshot agent identity when appropriate;
  - keeps `agent_opt_out` authoritative;
  - removes ambient work env from exact-continue child contexts when source work is absent.
- `src/meridian/lib/ops/spawn/api.py`
  - uses authoritative recovered harness session IDs for continue/fork creation.
- `src/meridian/lib/ops/spawn/prepare.py`
  - suppresses ambient work while preparing exact continue payloads.
- `src/meridian/lib/ops/spawn/execute_init.py`
  - suppresses final ambient work fallback during spawn reservation for exact continue.
- Tests cover primary continue, spawn continue, empty snapshot model replay, recovered session IDs, no-source-work, and no-agent opt-out.

## Work Item

`continue-inherits-task-dir`

## Verification

```bash
uv run pytest -q \
  tests/integration/launch/test_launch_process_claude_prompt.py::test_explicit_no_agent_skips_claude_native_agent_projection \
  tests/integration/cli/test_primary_continue.py \
  tests/integration/ops/test_spawn_continue.py \
  tests/unit/launch/test_spawn_capability_gate.py \
  tests/unit/harness/test_codex_projection.py
# 57 passed
```

```bash
uv run pytest-llm
# 1371 passed, 2 skipped
```

```bash
uv run ruff check .
# All checks passed
```

```bash
uv run --extra dev python -m pyright
# 0 errors, 5 existing warnings
```

Runtime repro:

```bash
uv run meridian -C /home/jimyao/gitrepos/personal/hiring-challenge --continue c1 --dry-run
# succeeds; emits codex resume 019f1d80-... without managed --model
```

Note: `pytest-llm` required building ignored Pi extension artifacts first because the local worktree lacked `src/meridian/pi_runtime/dist/extensions/...`:

```bash
cd src/meridian/pi_runtime
pnpm install --frozen-lockfile
npm run build:extensions
```

## Knowledge Updates

Updated durable launch/continue knowledge:

- `src/meridian/lib/launch/.context/CONTEXT.md`
  - documents the exact continue replay contract and ambient work suppression requirement.
- KB updates captured by `kb-lead`:
  - `kb/concepts/session-initiation.md`
  - `kb/decisions/launch.md`
  - `kb/decisions/session-reference-resolution.md`
  - `kb/decisions.md`

Work artifact:

- `work/continue-inherits-task-dir/artifacts/continue-context-map.html`
  - interactive code-structure explainer for the continue paths.

## Spawn Trace

- `p4809` prober — verified original continue fixes and exact `hiring-challenge` repro.
- `p4810` reviewer — thermo/maintainability review; found missing “preserve absence of work” contract.
- `p4811` reviewer — architecture review; found raw session ID instead of authoritative recovered ID.
- `p4812` gpt-dev — fixed reviewer blockers around ambient work and authoritative session IDs.
- `p4813` reviewer — found remaining execution-time ambient work fallback.
- `p4815` reviewer — approved after execution-time ambient work fix.
- `p4816` prober — verified exact-continue work resolution and focused tests.
- `p4817` gpt-dev — fixed explicit no-agent opt-out regression found by full tests.
- `p4822` reviewer — approved no-agent/snapshot preservation behavior.
- `p4824` kb-lead — updated KB and launch-local context docs.

## Release Label Guide

Recommended label: `release:patch`.

This is a bug fix for continue/resume behavior with no schema migration or user-facing feature expansion.

## Post-Merge Automation

After merge to `main`, CI will promote the changelog, bump `src/meridian/__init__.py`, create the release commit/tag, and publish through the release workflow according to the PR label.

## Cleanup

After merge, clean merged worktrees with:

```bash
scripts/prune-worktrees.sh
```