### PR TITLE
[codex] Centralize exact continue replay contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- Bump mars-agents to 0.10.2, which rewrites foreign MCP tokens in map-form tool declarations during lift/import.
+
 ### Fixed
 - Exact continue replay now centralizes launch-contract replay for primary and spawn continuations, uses in-memory `None` for harness-default model replay, rejects agent opt-out as a launch-identity mutation, and suppresses ambient work/task inheritance when the source had none.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Exact continue replay now centralizes launch-contract replay for primary and spawn continuations, uses in-memory `None` for harness-default model replay, rejects agent opt-out as a launch-identity mutation, and suppresses ambient work/task inheritance when the source had none.
+
 ## [0.3.23-rc.1] - 2026-07-03
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "cyclopts>=3.0",
   "fastapi>=0.115",
   "markdown-it-py>=4.0",
-  "mars-agents==0.10.1",
+  "mars-agents==0.10.2",
   "mcp>=1.0",
   "pathspec>=1.1.0",
   "psutil>=7.2.2",

--- a/src/meridian/cli/primary_launch.py
+++ b/src/meridian/cli/primary_launch.py
@@ -15,9 +15,13 @@ from meridian.lib.core.util import FormatContext
 from meridian.lib.harness.registry import get_default_harness_registry
 from meridian.lib.launch import LaunchRequest, SessionMode, launch_primary
 from meridian.lib.launch.composition import PromptDocument
+from meridian.lib.launch.continue_replay import (
+    build_continue_replay_contract,
+    continue_replay_source_from_reference,
+)
 from meridian.lib.launch.request import SessionRequest
 from meridian.lib.launch.resolve import resolve_agent_launch_input
-from meridian.lib.ops.reference import resolve_session_reference
+from meridian.lib.ops.reference import ResolvedSessionReference, resolve_session_reference
 from meridian.lib.ops.spawn.models import normalize_goal
 
 
@@ -87,56 +91,15 @@ class PrimaryLaunchOutput(BaseModel):
         return "\n".join(lines)
 
 
-class _ResolvedSessionTarget(BaseModel):
-    model_config = ConfigDict(frozen=True)
-
-    harness_session_id: str | None
-    chat_id: str | None = None
-    harness: str | None
-    source_model: str | None = None
-    source_agent: str | None = None
-    source_work_id: str | None = None
-    source_control_root: str | None = None
-    source_execution_cwd: str | None = None
-    source_claude_config_dir: str | None = None
-    source_pi_session_dir: str | None = None
-    source_launch_policy_snapshot: LaunchPolicySnapshot | None = None
-    tracked: bool = False
-    warning: str | None = None
-
-    @property
-    def missing_harness_session_id(self) -> bool:
-        return self.tracked and self.harness_session_id is None
-
-
-ResolvedSessionTarget = _ResolvedSessionTarget
-
-
 def resolve_session_target(
     *,
     project_root: Path,
     continue_ref: str,
-) -> ResolvedSessionTarget:
+) -> ResolvedSessionReference:
     normalized = continue_ref.strip()
     if not normalized:
         raise ValueError("--continue requires a non-empty session reference.")
-
-    resolved = resolve_session_reference(project_root, normalized)
-    return _ResolvedSessionTarget(
-        harness_session_id=resolved.authoritative_harness_session_id,
-        chat_id=resolved.source_chat_id,
-        harness=resolved.harness,
-        source_model=resolved.source_model,
-        source_agent=resolved.source_agent,
-        source_work_id=resolved.source_work_id,
-        source_control_root=resolved.source_control_root,
-        source_execution_cwd=resolved.source_execution_cwd,
-        source_claude_config_dir=resolved.source_claude_config_dir,
-        source_pi_session_dir=resolved.source_pi_session_dir,
-        source_launch_policy_snapshot=resolved.source_launch_policy_snapshot,
-        tracked=resolved.tracked,
-        warning=resolved.warning,
-    )
+    return resolve_session_reference(project_root, normalized)
 
 
 def run_primary_launch(
@@ -245,16 +208,15 @@ def run_primary_launch(
     session_mode = SessionMode.FRESH
     explicit_harness = harness.strip() if harness is not None and harness.strip() else None
     agent_launch = resolve_agent_launch_input(agent)
-    requested_model = model
-    requested_agent = agent_launch.agent
+    requested_model: str | None = model
+    requested_agent: str | None = agent_launch.agent
     agent_opt_out = agent_launch.agent_opt_out
+    requested_skills: tuple[str, ...] = skills
     requested_work_id = work.strip() or None
     launch_task_dir = normalized_task_dir
     if resume_target is not None:
         if model.strip():
             raise ValueError("Cannot combine --continue with --model.")
-        if agent is not None and agent.strip():
-            raise ValueError("Cannot combine --continue with --agent.")
         if skills:
             raise ValueError("Cannot combine --continue with --skills.")
         if passthrough:
@@ -268,46 +230,38 @@ def run_primary_launch(
                     source_ref=resume_target,
                     project_root=project_root,
                     source_harness=resolved_continue.harness,
-                    source_chat_id=resolved_continue.chat_id,
+                    source_chat_id=resolved_continue.source_chat_id,
                 )
             )
-        source_harness = (
-            resolved_continue.harness.strip()
-            if resolved_continue.harness is not None and resolved_continue.harness.strip()
-            else None
+        continue_contract = build_continue_replay_contract(
+            source=continue_replay_source_from_reference(
+                source_ref=resume_target,
+                resolved_reference=resolved_continue,
+                harness_session_id=resolved_continue.authoritative_harness_session_id,
+            ),
+            explicit_harness=explicit_harness,
+            requested_agent=agent_launch.agent,
+            agent_opt_out=agent_launch.agent_opt_out,
         )
-        if (
-            explicit_harness is not None
-            and source_harness is not None
-            and explicit_harness != source_harness
-        ):
-            raise ValueError(
-                "Cannot continue across harnesses: "
-                f"source is '{source_harness}', target is '{explicit_harness}'."
-            )
-        continue_harness_session_id = resolved_continue.harness_session_id
-        continue_chat_id = resolved_continue.chat_id
-        continue_harness = explicit_harness or source_harness
-        if continue_harness is None:
-            raise ValueError(
-                f"Session '{resolved_continue.harness_session_id or resume_target}' "
-                "not recognized by any harness. "
-                "Use --harness to specify which harness owns this session."
-            )
+        continue_harness_session_id = continue_contract.session.requested_harness_session_id
+        continue_chat_id = continue_contract.session.continue_chat_id
+        continue_harness = continue_contract.harness
         continue_warning = resolved_continue.warning
-        source_control_root = resolved_continue.source_control_root
-        source_execution_cwd = resolved_continue.source_execution_cwd
-        source_claude_config_dir = resolved_continue.source_claude_config_dir
-        source_pi_session_dir = resolved_continue.source_pi_session_dir
+        source_control_root = continue_contract.session.source_control_root
+        source_execution_cwd = continue_contract.session.source_execution_cwd
+        source_claude_config_dir = continue_contract.session.source_claude_config_dir
+        source_pi_session_dir = continue_contract.session.source_pi_session_dir
         if requested_work_id is None:
-            requested_work_id = resolved_continue.source_work_id
-        launch_task_dir = resolved_continue.source_execution_cwd
-        continue_source_tracked = resolved_continue.tracked
-        continue_source_ref = resume_target
-        # Replay persisted launch contract so agent/model/skills stay fixed on resume.
-        continue_launch_policy_snapshot = resolved_continue.source_launch_policy_snapshot
-        if continue_launch_policy_snapshot is not None:
-            continue_passthrough_args = continue_launch_policy_snapshot.extra_args
+            requested_work_id = continue_contract.work_id
+        launch_task_dir = continue_contract.task_dir
+        continue_source_tracked = continue_contract.session.continue_source_tracked
+        continue_source_ref = continue_contract.session.continue_source_ref
+        continue_launch_policy_snapshot = continue_contract.launch_policy_snapshot
+        continue_passthrough_args = continue_contract.passthrough_args
+        requested_model = continue_contract.model
+        requested_agent = continue_contract.agent
+        agent_opt_out = continue_contract.agent_opt_out
+        requested_skills = continue_contract.skills
         session_mode = SessionMode.RESUME
     elif selected_fork_target is not None:
         resolved_fork = resolve_session_target(
@@ -319,7 +273,7 @@ def run_primary_launch(
                     source_ref=selected_fork_target,
                     project_root=project_root,
                     source_harness=resolved_fork.harness,
-                    source_chat_id=resolved_fork.chat_id,
+                    source_chat_id=resolved_fork.source_chat_id,
                 )
             )
 
@@ -338,24 +292,27 @@ def run_primary_launch(
                 f"source is '{source_harness}', target is '{explicit_harness}'."
             )
 
-        continue_harness_session_id = resolved_fork.harness_session_id
+        continue_harness_session_id = resolved_fork.authoritative_harness_session_id
         continue_harness = explicit_harness or source_harness
         if continue_harness is None:
+            missing_session_ref = (
+                resolved_fork.authoritative_harness_session_id or selected_fork_target
+            )
             raise ValueError(
-                f"Session '{resolved_fork.harness_session_id or selected_fork_target}' "
+                f"Session '{missing_session_ref}' "
                 "not recognized by any harness. "
                 "Use --harness to specify which harness owns this session."
             )
         continue_warning = resolved_fork.warning
         continue_fork = True
-        forked_from_chat_id = resolved_fork.chat_id
+        forked_from_chat_id = resolved_fork.source_chat_id
         source_control_root = resolved_fork.source_control_root
         source_execution_cwd = resolved_fork.source_execution_cwd
         source_claude_config_dir = resolved_fork.source_claude_config_dir
         source_pi_session_dir = resolved_fork.source_pi_session_dir
         continue_source_tracked = resolved_fork.tracked
         continue_source_ref = selected_fork_target
-        output_forked_from = resolved_fork.chat_id or selected_fork_target
+        output_forked_from = resolved_fork.source_chat_id or selected_fork_target
         session_mode = SessionMode.FORK
 
         if not model.strip() and resolved_fork.source_model is not None:
@@ -390,7 +347,7 @@ def run_primary_launch(
             context_from=fork_resolution.resolved_context_from,
             reference_files=reference_files,
             prompt=prompt,
-            skills=skills,
+            skills=requested_skills,
             goal=resolved_goal,
             dry_run=dry_run,
             execution_policy=ResolvedExecutionPolicy(

--- a/src/meridian/lib/launch/.context/CONTEXT.md
+++ b/src/meridian/lib/launch/.context/CONTEXT.md
@@ -56,18 +56,31 @@ The report and `system-prompt.md` paths are derived in `bind_launch_context` fro
 ### Exact Continue Replay
 
 Primary `meridian --continue` and subagent `spawn --continue` are exact
-continuations. They replay the source task directory, work attachment, session
-identity, and launch-policy snapshot rather than resolving from the caller's
-current CWD/config/env. The absence of source work is a preserved value: bind must
-suppress inherited `MERIDIAN_ACTIVE_WORK_*` when continuing a source with no work
-item, not attach the caller's ambient work.
+continuations. `continue_replay.py` owns the launch-level seam:
+`ContinueReplaySource` normalizes the resolved reference shape, and
+`ContinueReplayContract` carries the launch-ready result consumed by primary and
+spawn continue. Callers pass the authoritative recovered harness session ID into
+the source; recovery policy stays in `ops/reference.py`, not in launch.
+
+The contract replays the source task directory, work attachment, session identity,
+and launch-policy snapshot rather than resolving from the caller's current
+CWD/config/env. The absence of source work is a preserved value: exact continue
+suppresses inherited `MERIDIAN_ACTIVE_WORK_*` and inherited task-dir state when the
+source had none, instead of attaching the caller's ambient work/task context.
 
 Launch-policy snapshot replay preserves cache- and prompt-shaping fields: model,
-harness, agent, skills, loaded skill content, execution policy, tool/MCP grants,
-inventory prompt, and passthrough args. A snapshot with `model=""` and a harness is
-valid; it means "omit Meridian's managed model override and let the harness
-default." Explicit `agent_opt_out` stays authoritative and must not reintroduce a
-configured default agent through routing fallback.
+harness, agent, agent opt-out, agent profile, skills, loaded skill content,
+execution policy, tool/MCP grants, terminal surface mode, matched policy rule,
+fallback chain, inventory prompt, env, and passthrough args. A persisted snapshot
+with `model=""` and a harness is valid legacy JSON; policy snapshot replay
+normalizes it to in-memory `model=None`, meaning "omit Meridian's managed model
+override and let the harness default." This normalization belongs in
+`policy_snapshot.py`, not in continue-specific code.
+
+Exact continue rejects launch-identity, policy, work, and task mutations. That
+includes model, agent, skills, execution policy, passthrough args, env, `--work`,
+`--task-dir`, and agent opt-out (`--agent ''`) because opt-out changes how default
+agent routing behaves. Use a divergent mode instead.
 
 KB: `decisions/launch.md#d-continue-replays-recorded-launch-contract-same-session-continue-is-not-live-policy-recomputation`.
 

--- a/src/meridian/lib/launch/AGENTS.md
+++ b/src/meridian/lib/launch/AGENTS.md
@@ -44,6 +44,13 @@ precedence, `--from` work inheritance, task cwd selection, reference anchoring,
 and `-f` validation. Primary and spawn may differ in prompt/session projection,
 but they should not hand-roll directory or reference resolution.
 
+Exact continue (`meridian --continue`, `spawn --continue`) enters through
+`continue_replay.py`. `ContinueReplayContract` is the launch-owned seam that
+primary and spawn share for replaying source session identity, launch-policy
+snapshot, work, and task directory. Persisted `LaunchPolicySnapshot.model == ""`
+is legacy JSON for harness-default model; replay normalizes it to in-memory
+`None` in `policy_snapshot.py`, not in continue-specific callers.
+
 **Why the split?** The primary CLI path calls `bind_launch_context()` twice: once
 with `dry_run=True` for `--dry-run` display, then again with real spawn ID and paths.
 `prepare_launch_surface()` is expensive and safe to call once. `bind_launch_context()`
@@ -163,9 +170,9 @@ See [.context/CONTEXT.md](.context/CONTEXT.md#why-user-turn-not-system-prompt) f
    injection, reference loading and anchor semantics (`kb:` prefix, `@` unsupported),
    worktree path assignment vs managed ownership separation, workspace projection
    detail, env injection, background worker trust model, MERIDIAN_HARNESS child env
-   behavior, full invariant table, model-policy overlay composition and fallback
-   chain rules, user-turn context threading (`resolve_task_context_inputs()`) and
-   why prior-context goes in the user turn.
+   behavior, exact continue replay contract, full invariant table, model-policy
+   overlay composition and fallback chain rules, user-turn context threading
+   (`resolve_task_context_inputs()`) and why prior-context goes in the user turn.
 
 ## Related
 

--- a/src/meridian/lib/launch/__init__.py
+++ b/src/meridian/lib/launch/__init__.py
@@ -116,6 +116,9 @@ def launch_primary(
         runtime_root=runtime_root_for_context,
     )
     inherit_ambient_work = request.session_mode.value != "resume"
+    inherited_task_dir = (
+        None if request.session_mode.value == "resume" else runtime_context.inherited_task_dir
+    )
     ambient_work_id = (
         None
         if explicit_work_id is not None or not inherit_ambient_work
@@ -129,7 +132,7 @@ def launch_primary(
         reference_files=request.reference_files,
         explicit_task_dir=request.task_dir,
         explicit_work_id=explicit_work_id,
-        inherited_task_dir=runtime_context.inherited_task_dir,
+        inherited_task_dir=inherited_task_dir,
         ambient_work_id=ambient_work_id,
         caller_cwd=Path.cwd(),
     )

--- a/src/meridian/lib/launch/continue_replay.py
+++ b/src/meridian/lib/launch/continue_replay.py
@@ -1,0 +1,248 @@
+"""Canonical exact-continue replay contract for primary and spawn paths."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from meridian.lib.core.launch_policy_snapshot import LaunchPolicySnapshot
+from meridian.lib.launch.policy_snapshot import managed_model_override_from_persisted_model
+from meridian.lib.launch.request import SessionRequest
+
+
+def _present(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+@dataclass(frozen=True)
+class ContinueReplaySource:
+    """Resolved source-session data needed to launch an exact continue."""
+
+    source_ref: str
+    harness_session_id: str | None
+    harness: str | None
+    source_chat_id: str | None
+    source_work_id: str | None
+    source_execution_cwd: str | None
+    source_control_root: str | None
+    source_claude_config_dir: str | None
+    source_pi_session_dir: str | None
+    source_launch_policy_snapshot: LaunchPolicySnapshot | None
+    tracked: bool
+    source_model: str | None = None
+    source_agent: str | None = None
+    source_skills: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ContinueReplayContract:
+    """Launch-ready exact-continue replay contract."""
+
+    model: str | None
+    agent: str | None
+    agent_opt_out: bool
+    skills: tuple[str, ...]
+    harness: str
+    passthrough_args: tuple[str, ...]
+    launch_policy_snapshot: LaunchPolicySnapshot | None
+    session: SessionRequest
+    work_id: str | None
+    task_dir: str | None
+
+
+class ContinueReplayReference(Protocol):
+    """Resolved reference shape needed to build a continue replay source.
+
+    The protocol is expressed in launch-owned terms. Recovery choices, such as
+    whether a recovered harness session id is authoritative enough to use, stay
+    in the caller; the caller passes the final harness_session_id explicitly.
+    """
+
+    @property
+    def harness(self) -> str | None: ...
+
+    @property
+    def source_chat_id(self) -> str | None: ...
+
+    @property
+    def source_model(self) -> str | None: ...
+
+    @property
+    def source_agent(self) -> str | None: ...
+
+    @property
+    def source_skills(self) -> tuple[str, ...]: ...
+
+    @property
+    def source_work_id(self) -> str | None: ...
+
+    @property
+    def source_execution_cwd(self) -> str | None: ...
+
+    @property
+    def source_control_root(self) -> str | None: ...
+
+    @property
+    def source_claude_config_dir(self) -> str | None: ...
+
+    @property
+    def source_pi_session_dir(self) -> str | None: ...
+
+    @property
+    def source_launch_policy_snapshot(self) -> LaunchPolicySnapshot | None: ...
+
+    @property
+    def tracked(self) -> bool: ...
+
+
+def continue_replay_source_from_reference(
+    source_ref: str,
+    resolved_reference: ContinueReplayReference,
+    *,
+    harness_session_id: str | None,
+) -> ContinueReplaySource:
+    """Build continue replay source inputs from a resolved session reference."""
+
+    return ContinueReplaySource(
+        source_ref=source_ref,
+        harness_session_id=harness_session_id,
+        harness=resolved_reference.harness,
+        source_chat_id=resolved_reference.source_chat_id,
+        source_model=resolved_reference.source_model,
+        source_agent=resolved_reference.source_agent,
+        source_skills=resolved_reference.source_skills,
+        source_work_id=resolved_reference.source_work_id,
+        source_execution_cwd=resolved_reference.source_execution_cwd,
+        source_control_root=resolved_reference.source_control_root,
+        source_claude_config_dir=resolved_reference.source_claude_config_dir,
+        source_pi_session_dir=resolved_reference.source_pi_session_dir,
+        source_launch_policy_snapshot=resolved_reference.source_launch_policy_snapshot,
+        tracked=resolved_reference.tracked,
+    )
+
+
+def _resolve_replay_harness(
+    *,
+    source: ContinueReplaySource,
+    explicit_harness: str | None,
+) -> str:
+    explicit = _present(explicit_harness)
+    source_harness = _present(source.harness)
+    snapshot_harness = (
+        _present(source.source_launch_policy_snapshot.harness)
+        if source.source_launch_policy_snapshot is not None
+        else None
+    )
+    named = tuple(
+        (name, value)
+        for name, value in (
+            ("explicit", explicit),
+            ("source", source_harness),
+            ("snapshot", snapshot_harness),
+        )
+        if value is not None
+    )
+    unique_values = {value for _, value in named}
+    if len(unique_values) > 1:
+        details = ", ".join(f"{name} is '{value}'" for name, value in named)
+        flag_hint = " --harness" if explicit is not None else ""
+        raise ValueError(
+            f"Cannot continue across harnesses{flag_hint}: {details}. "
+            "Use --fork-fresh to change launch identity."
+        )
+    if named:
+        return named[0][1]
+    raise ValueError(
+        f"Session '{source.harness_session_id or source.source_ref}' "
+        "not recognized by any harness. "
+        "Use --harness to specify which harness owns this session."
+    )
+
+
+def _reject_exact_continue_agent_override(
+    *,
+    requested_agent: str | None,
+    agent_opt_out: bool,
+) -> None:
+    if _present(requested_agent) is not None:
+        raise ValueError(
+            "Cannot combine exact continue with --agent. "
+            "Use --fork-fresh to change launch identity."
+        )
+    if agent_opt_out:
+        raise ValueError(
+            "Cannot combine exact continue with agent opt-out (--agent ''). "
+            "Use --fork-fresh to change launch identity."
+        )
+
+
+def build_continue_replay_contract(
+    *,
+    source: ContinueReplaySource,
+    explicit_harness: str | None = None,
+    requested_agent: str | None = None,
+    agent_opt_out: bool = False,
+    fork: bool = False,
+) -> ContinueReplayContract:
+    """Build the normalized exact-continue contract from a resolved source."""
+
+    _reject_exact_continue_agent_override(
+        requested_agent=requested_agent,
+        agent_opt_out=agent_opt_out,
+    )
+    replay_harness = _resolve_replay_harness(
+        source=source,
+        explicit_harness=explicit_harness,
+    )
+
+    snapshot = source.source_launch_policy_snapshot
+    if snapshot is not None:
+        model = managed_model_override_from_persisted_model(snapshot.model)
+        agent = _present(snapshot.agent)
+        replay_agent_opt_out = snapshot.agent_opt_out
+        skills = snapshot.skills
+        passthrough_args = snapshot.extra_args
+    else:
+        model = _present(source.source_model)
+        agent = None
+        replay_agent_opt_out = False
+        skills = ()
+        passthrough_args = ()
+
+    session = SessionRequest(
+        requested_harness_session_id=source.harness_session_id,
+        continue_harness=replay_harness,
+        continue_source_tracked=source.tracked,
+        continue_source_ref=source.source_ref,
+        continue_fork=fork,
+        continue_chat_id=source.source_chat_id,
+        forked_from_chat_id=source.source_chat_id if fork else None,
+        source_control_root=source.source_control_root,
+        source_execution_cwd=source.source_execution_cwd,
+        source_claude_config_dir=source.source_claude_config_dir,
+        source_pi_session_dir=source.source_pi_session_dir,
+    )
+
+    return ContinueReplayContract(
+        model=model,
+        agent=agent,
+        agent_opt_out=replay_agent_opt_out,
+        skills=skills,
+        harness=replay_harness,
+        passthrough_args=passthrough_args,
+        launch_policy_snapshot=snapshot,
+        session=session,
+        work_id=source.source_work_id,
+        task_dir=source.source_execution_cwd,
+    )
+
+
+__all__ = [
+    "ContinueReplayContract",
+    "ContinueReplaySource",
+    "build_continue_replay_contract",
+    "continue_replay_source_from_reference",
+]

--- a/src/meridian/lib/launch/policies.py
+++ b/src/meridian/lib/launch/policies.py
@@ -148,7 +148,7 @@ class ResolvedLaunchPolicy:
     """Resolved launch policy shared across launch-like surfaces."""
 
     profile: AgentProfile | None
-    model: str
+    model: str | None
     harness: HarnessId
     adapter: SubprocessHarness
     resolved_skills: ResolvedSkills

--- a/src/meridian/lib/launch/policy_snapshot.py
+++ b/src/meridian/lib/launch/policy_snapshot.py
@@ -49,7 +49,7 @@ class ReplayedLaunchPolicySnapshot:
     """Resolved policy fields reconstructed directly from a snapshot."""
 
     profile: AgentProfile | None
-    model: str
+    model: str | None
     harness: HarnessId
     adapter: SubprocessHarness
     resolved_skills: ResolvedSkills
@@ -62,6 +62,18 @@ class ReplayedLaunchPolicySnapshot:
     model_selection: ReplayedModelSelection | None = None
     fallback_chain: tuple[dict[str, object], ...] = ()
     alias_catalog: dict[str, AliasEntry] | None = None
+
+
+def managed_model_override_from_persisted_model(model: str) -> str | None:
+    """Return managed model token from persisted snapshot data.
+
+    Legacy persisted snapshots may store an empty string to mean that Meridian
+    should not pass a managed model override and the harness should choose its
+    default.
+    """
+
+    token = model.strip()
+    return token or None
 
 
 def build_launch_policy_snapshot(
@@ -133,6 +145,7 @@ def replay_launch_policy_snapshot(
         raise ValueError("Launch policy snapshot is missing harness.")
 
     harness_id = HarnessId(snapshot_harness)
+    managed_model = managed_model_override_from_persisted_model(snapshot.model)
     snapshot_model = snapshot.model.strip()
     adapter = harness_registry.get_subprocess_harness(harness_id)
     snapshot_agent = (snapshot.agent or "").strip() or None
@@ -164,7 +177,7 @@ def replay_launch_policy_snapshot(
     )
     return ReplayedLaunchPolicySnapshot(
         profile=profile,
-        model=snapshot_model,
+        model=managed_model,
         harness=harness_id,
         adapter=adapter,
         resolved_skills=resolved_skills,
@@ -306,5 +319,6 @@ __all__ = [
     "ReplayedModelSelection",
     "SnapshotModelSelection",
     "build_launch_policy_snapshot",
+    "managed_model_override_from_persisted_model",
     "replay_launch_policy_snapshot",
 ]

--- a/src/meridian/lib/launch/types.py
+++ b/src/meridian/lib/launch/types.py
@@ -45,7 +45,7 @@ class LaunchRequest(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    model: str = ""
+    model: str | None = None
     harness: str | None = None
     agent: str | None = None
     agent_opt_out: bool = False

--- a/src/meridian/lib/ops/spawn/.context/CONTEXT.md
+++ b/src/meridian/lib/ops/spawn/.context/CONTEXT.md
@@ -94,6 +94,13 @@ harnesses differ, the operation raises `ValueError` — cross-harness continuati
 
 `spawn_fork_sync()` copies `goal` from the source spawn row when no `--goal` is provided.
 
+`spawn_continue_sync()` does not assemble replay policy. It resolves the source spawn/session,
+rejects launch-identity, policy, work, and task-dir mutations
+(`api.py:_reject_continue_policy_overrides`), then delegates exact-continue normalization to
+`launch/continue_replay.py` (`ContinueReplayContract`). Agent opt-out is a launch-identity
+mutation, not a harmless absence. Contract depth:
+[launch/.context/CONTEXT.md#exact-continue-replay](../../../launch/.context/CONTEXT.md#exact-continue-replay).
+
 ## prepare.py — The One REQUIRED Path
 
 `prepare.py` uses `LaunchArgvIntent.REQUIRED` on `LaunchCompositionSurface.SPAWN_PREPARE`. This is

--- a/src/meridian/lib/ops/spawn/AGENTS.md
+++ b/src/meridian/lib/ops/spawn/AGENTS.md
@@ -48,6 +48,12 @@ Fork and continue operations check that the target spawn's harness matches the
 current harness context. Cross-harness fork/continue is not supported — the guard
 raises before any state is created.
 
+`spawn_continue` does not assemble replay policy itself. It resolves the source
+spawn/session, rejects launch-identity, policy, work, and task-dir mutations, then
+delegates exact-continue normalization to `launch/continue_replay.py`'s
+`ContinueReplayContract`. Agent opt-out is treated as a launch-identity mutation,
+not as a harmless absence.
+
 ## Key Entry Points
 
 - `api.py` — all spawn operations (sync and async variants).
@@ -80,5 +86,6 @@ a real argv — execution paths use `SPEC_ONLY`.
 
 - [../.context/CONTEXT.md](../.context/CONTEXT.md) — ops/ policy layer overview;
   SpawnApplicationService layer diagram; execution path ownership.
-- [../../launch/.context/CONTEXT.md](../../launch/.context/CONTEXT.md) — mechanism
-  layer this drives.
+- [../../launch/.context/CONTEXT.md](../../launch/.context/CONTEXT.md) — launch mechanism
+  this drives; [exact continue replay contract](../../launch/.context/CONTEXT.md#exact-continue-replay)
+  (`ContinueReplayContract`).

--- a/src/meridian/lib/ops/spawn/api.py
+++ b/src/meridian/lib/ops/spawn/api.py
@@ -18,7 +18,6 @@ from meridian.lib.bootstrap.services import (
 from meridian.lib.config.settings import MeridianConfig, load_config
 from meridian.lib.core.context import RuntimeContext
 from meridian.lib.core.depth import max_depth_reached
-from meridian.lib.core.launch_policy_snapshot import LaunchPolicySnapshot
 from meridian.lib.core.sink import NullSink, OutputSink
 from meridian.lib.core.spawn_lifecycle import (
     ACTIVE_SPAWN_STATUSES,
@@ -31,6 +30,10 @@ from meridian.lib.core.spawn_lifecycle import (
 from meridian.lib.core.spawn_service import CancelOutcome
 from meridian.lib.core.telemetry import register_debug_trace_observer
 from meridian.lib.core.types import SpawnId
+from meridian.lib.launch.continue_replay import (
+    build_continue_replay_contract,
+    continue_replay_source_from_reference,
+)
 from meridian.lib.launch.request import SessionRequest
 from meridian.lib.ops.mars import mars_agent_subagents, mars_list_subagents
 from meridian.lib.ops.reference import ResolvedSessionReference, resolve_session_reference
@@ -78,7 +81,6 @@ from .models import (
     SpawnCreateInput,
     SpawnDetailOutput,
     SpawnForkInput,
-    SpawnLaunchOptionUpdates,
     SpawnListEntry,
     SpawnListInput,
     SpawnListOutput,
@@ -1889,24 +1891,14 @@ def _prompt_for_follow_up(
     return existing_prompt
 
 
-def _model_for_follow_up(source_spawn: SpawnRecord, override_model: str) -> str:
-    if override_model.strip():
-        return override_model
-    return (source_spawn.model or "").strip()
-
-
 def _reject_continue_policy_overrides(payload: SpawnContinueInput) -> None:
     """Reject launch-contract changes for exact continuation."""
 
     rejected: list[str] = []
     if payload.model.strip():
         rejected.append("--model")
-    if payload.agent is not None and payload.agent.strip():
-        rejected.append("--agent")
     if payload.skills:
         rejected.append("--skills")
-    if (payload.harness or "").strip():
-        rejected.append("--harness")
     if payload.approval is not None:
         rejected.append("--approval")
     if payload.sandbox is not None:
@@ -1938,104 +1930,51 @@ def _reject_continue_policy_overrides(payload: SpawnContinueInput) -> None:
         )
 
 
-def _continue_launch_options(
-    *,
-    payload: SpawnContinueInput,
-    source_snapshot: LaunchPolicySnapshot | None,
-    source_harness: str | None,
-) -> SpawnLaunchOptionUpdates:
-    launch_options = payload.launch_option_updates()
-    if source_snapshot is None:
-        launch_options["harness"] = source_harness
-        return launch_options
-
-    launch_options.update(
-        {
-            "approval": source_snapshot.execution_policy.approval,
-            "autocompact": source_snapshot.execution_policy.autocompact,
-            "autocompact_pct": source_snapshot.execution_policy.autocompact_pct,
-            "effort": source_snapshot.execution_policy.effort,
-            "sandbox": source_snapshot.execution_policy.sandbox,
-            "harness": source_snapshot.harness,
-            "passthrough_args": source_snapshot.extra_args,
-        }
-    )
-    return launch_options
-
-
 def _build_continue_create_input(
     *,
     payload: SpawnContinueInput,
     source_spawn: SpawnRecord,
     source_spawn_id: str,
     resolved_reference: ResolvedSessionReference,
-    source_harness: str | None,
-    source_snapshot: LaunchPolicySnapshot | None,
 ) -> SpawnCreateInput:
-    launch_options = _continue_launch_options(
-        payload=payload,
-        source_snapshot=source_snapshot,
-        source_harness=source_harness,
+    continue_contract = build_continue_replay_contract(
+        source=continue_replay_source_from_reference(
+            source_spawn_id,
+            resolved_reference,
+            harness_session_id=resolved_reference.authoritative_harness_session_id,
+        ),
+        explicit_harness=(payload.harness or "").strip() or None,
+        requested_agent=payload.agent,
+        agent_opt_out=payload.agent_opt_out,
+        fork=payload.fork,
     )
+    launch_options = payload.launch_option_updates()
+    launch_options.update(
+        {
+            "harness": continue_contract.harness,
+            "passthrough_args": continue_contract.passthrough_args,
+        }
+    )
+
     resolved_goal = payload.goal if payload.goal is not None else source_spawn.goal
     derived_prompt = _prompt_for_follow_up(source_spawn, source_spawn_id, payload.prompt)
+
     return SpawnCreateInput(
         prompt=derived_prompt,
-        model=(
-            source_snapshot.model
-            if source_snapshot is not None
-            else _model_for_follow_up(source_spawn, payload.model)
-        ),
+        model=continue_contract.model,
         files=payload.files,
         template_vars=payload.template_vars,
-        agent=(
-            None
-            if payload.agent_opt_out
-            else (
-                payload.agent
-                if payload.agent is not None
-                else (source_snapshot.agent if source_snapshot is not None else None)
-            )
-        ),
-        agent_opt_out=payload.agent_opt_out,
-        skills=source_snapshot.skills if source_snapshot is not None else payload.skills,
+        agent=continue_contract.agent,
+        agent_opt_out=continue_contract.agent_opt_out,
+        skills=continue_contract.skills,
         goal=resolved_goal,
         desc=payload.desc,
-        work=source_spawn.work_id or "",
-        task_dir=resolved_reference.source_execution_cwd,
+        work=continue_contract.work_id or "",
+        task_dir=continue_contract.task_dir,
         caller_cwd=payload.caller_cwd,
-        launch_policy_snapshot=source_snapshot,
-        session=SessionRequest(
-            requested_harness_session_id=resolved_reference.authoritative_harness_session_id,
-            continue_harness=resolved_reference.harness,
-            continue_source_tracked=resolved_reference.tracked,
-            continue_source_ref=source_spawn_id,
-            continue_fork=payload.fork,
-            continue_chat_id=resolved_reference.source_chat_id,
-            forked_from_chat_id=resolved_reference.source_chat_id if payload.fork else None,
-            source_control_root=resolved_reference.source_control_root,
-            source_execution_cwd=resolved_reference.source_execution_cwd,
-            source_claude_config_dir=resolved_reference.source_claude_config_dir,
-            source_pi_session_dir=resolved_reference.source_pi_session_dir,
-        ),
+        launch_policy_snapshot=continue_contract.launch_policy_snapshot,
+        session=continue_contract.session,
         **launch_options,
-    )
-
-
-def _resolve_continue_target_harness(
-    *,
-    create_input: SpawnCreateInput,
-    source_snapshot: LaunchPolicySnapshot | None,
-    source_harness: str | None,
-    project_root: Path,
-) -> str:
-    if source_snapshot is not None:
-        return source_snapshot.harness
-    if source_harness is not None:
-        return source_harness
-    return _resolve_effective_fork_target_harness(
-        create_input,
-        resolved_project_root=project_root,
     )
 
 
@@ -2241,41 +2180,12 @@ def spawn_continue_sync(
         )
 
     _reject_continue_policy_overrides(payload)
-    source_snapshot = source_spawn.launch_policy_snapshot
-
-    requested_harness = (payload.harness or "").strip() or None
-    source_harness = (resolved_reference.harness or "").strip() or None
-    if (
-        requested_harness is not None
-        and source_harness is not None
-        and requested_harness != source_harness
-    ):
-        raise ValueError(
-            f"Cannot continue spawn '{resolved_spawn_id}' with harness '{requested_harness}'; "
-            f"source spawn uses '{source_harness}'."
-        )
-
     create_input = _build_continue_create_input(
         payload=payload,
         source_spawn=source_spawn,
         source_spawn_id=resolved_spawn_id,
         resolved_reference=resolved_reference,
-        source_harness=source_harness,
-        source_snapshot=source_snapshot,
     )
-    target_harness = _resolve_continue_target_harness(
-        create_input=create_input,
-        source_snapshot=source_snapshot,
-        source_harness=source_harness,
-        project_root=project_root,
-    )
-    if source_harness is not None and source_harness != target_harness:
-        raise ValueError(
-            "Cannot continue across harnesses: "
-            f"source is '{source_harness}', target is '{target_harness}'."
-        )
-
-    create_input = create_input.model_copy(update={"harness": target_harness})
     if prepared is not None:
         result = spawn_create_sync(create_input, ctx=ctx, sink=sink, prepared=prepared)
     else:

--- a/src/meridian/lib/ops/spawn/models.py
+++ b/src/meridian/lib/ops/spawn/models.py
@@ -124,7 +124,7 @@ class SpawnLaunchOptions(BaseModel):
 class SpawnCreateInput(SpawnLaunchOptions):
     prompt: str = ""
     goal: str | None = None
-    model: str = ""
+    model: str | None = None
     files: tuple[str, ...] = ()
     context_from: tuple[str, ...] = ()
     template_vars: tuple[str, ...] = ()

--- a/src/meridian/lib/ops/spawn/prepare.py
+++ b/src/meridian/lib/ops/spawn/prepare.py
@@ -138,11 +138,15 @@ def build_create_payload(
         spawn_id = (
             str(resolved_context.spawn_id) if resolved_context.spawn_id is not None else None
         )
-        inherited_for_child = derive_inheritable_task_dir(
-            project_root=project_root,
-            project_state_dir=project_state_dir,
-            spawn_id=spawn_id,
-            work_id=ambient_work_id,
+        inherited_for_child = (
+            None
+            if _is_exact_continue(payload)
+            else derive_inheritable_task_dir(
+                project_root=project_root,
+                project_state_dir=project_state_dir,
+                spawn_id=spawn_id,
+                work_id=ambient_work_id,
+            )
         )
         launch_resolution = resolve_launch_inputs(
             authority_root=project_root,

--- a/tests/integration/cli/test_primary_continue.py
+++ b/tests/integration/cli/test_primary_continue.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 import pytest
 
+import meridian.lib.launch.context as launch_context
 from meridian.cli.primary_launch import run_primary_launch
 from meridian.lib.catalog.catalog_session import CatalogSession
 from meridian.lib.core.domain import SkillContent
@@ -16,7 +17,12 @@ from meridian.lib.core.execution_policy import ResolvedExecutionPolicy
 from meridian.lib.core.launch_policy_snapshot import LaunchPolicySnapshot
 from meridian.lib.core.types import HarnessId
 from meridian.lib.harness.registry import get_default_harness_registry
-from meridian.lib.launch import LaunchRequest, LaunchResult, compile_prepared_policy_surface
+from meridian.lib.launch import (
+    LaunchRequest,
+    LaunchResult,
+    compile_prepared_policy_surface,
+    launch_primary,
+)
 from meridian.lib.launch.context import build_launch_context
 from meridian.lib.launch.plan import build_primary_launch_runtime, build_primary_spawn_request
 from meridian.lib.launch.process import ProcessOutcome
@@ -169,9 +175,9 @@ def test_primary_continue_replays_source_launch_policy_snapshot(
     assert request.launch_policy_snapshot.tools == snapshot.tools
     assert request.launch_policy_snapshot.mcp_tools == snapshot.mcp_tools
     assert request.passthrough_args == snapshot.extra_args
-    assert request.agent is None
-    assert request.model == ""
-    assert request.skills == ()
+    assert request.agent == snapshot.agent
+    assert request.model == snapshot.model
+    assert request.skills == snapshot.skills
 
 
 def test_primary_continue_spawn_session_ref_recovers_linked_spawn_snapshot(
@@ -607,6 +613,55 @@ def test_primary_continue_uses_legacy_bundle_resolution_without_snapshot(
     assert request.launch_policy_snapshot is None
 
 
+def test_primary_exact_continue_without_source_task_suppresses_ambient_task_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    _state_root(project_root)
+    ambient_task_dir = tmp_path / "ambient-task"
+    ambient_task_dir.mkdir()
+    monkeypatch.setenv("MERIDIAN_TASK_DIR", ambient_task_dir.as_posix())
+    stub_bundle_request_and_resolve(
+        monkeypatch,
+        model="gpt-5.3-codex",
+        model_token="gpt-5.3-codex",
+        harness=HarnessId.CODEX,
+        harness_model="openai/gpt-5.3-codex",
+    )
+
+    captured_task_cwds: list[str | None] = []
+    real_bind_launch_context = launch_context.bind_launch_context
+
+    def capture_bind_launch_context(*args: Any, **kwargs: Any) -> Any:
+        ctx = real_bind_launch_context(*args, **kwargs)
+        captured_task_cwds.append(ctx.resolved_request.task_cwd)
+        return ctx
+
+    monkeypatch.setattr(launch_context, "bind_launch_context", capture_bind_launch_context)
+
+    launch_primary(
+        project_root=project_root,
+        request=LaunchRequest(
+            model="gpt-5.3-codex",
+            harness="codex",
+            session_mode=SessionMode.RESUME,
+            dry_run=True,
+            session=SessionRequest(
+                requested_harness_session_id="raw-session",
+                continue_harness="codex",
+                continue_source_ref="raw-session",
+                continue_source_tracked=False,
+            ),
+        ),
+        harness_registry=get_default_harness_registry(),
+    )
+
+    assert captured_task_cwds
+    assert captured_task_cwds[0] != ambient_task_dir.as_posix()
+
+
 def test_primary_continue_snapshot_replay_preserves_agent_over_config_default(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -776,7 +831,7 @@ def test_primary_continue_replays_codex_empty_model_snapshot_as_default_model(
     )
 
     assert ctx.resolved_request.launch_policy_snapshot == snapshot
-    assert ctx.resolved_request.model == ""
+    assert ctx.resolved_request.model is None
     assert ctx.resolved_request.harness == "codex"
     assert ctx.resolved_request.agent == "tech-lead"
     assert ctx.model_selection is None

--- a/tests/integration/ops/test_spawn_continue.py
+++ b/tests/integration/ops/test_spawn_continue.py
@@ -15,14 +15,19 @@ from meridian.lib.core.domain import SkillContent
 from meridian.lib.core.execution_policy import ResolvedExecutionPolicy
 from meridian.lib.core.launch_policy_snapshot import LaunchPolicySnapshot
 from meridian.lib.core.types import HarnessId
-from meridian.lib.launch.request import SpawnRequest
+from meridian.lib.harness.registry import get_default_harness_registry
+from meridian.lib.launch.composition_spawn import bind_spawn_launch_context
+from meridian.lib.launch.context import RuntimeBindings
+from meridian.lib.launch.plan import build_spawn_mars_runtime
+from meridian.lib.launch.request import LaunchArgvIntent, SpawnRequest
 from meridian.lib.ops.reference import ResolvedSessionReference
 from meridian.lib.ops.reference_recovery import RecoveryProvenance, RecoveryResult
+from meridian.lib.ops.runtime import build_runtime
 from meridian.lib.ops.spawn.execute_init import resolve_spawn_work_id
 from meridian.lib.ops.spawn.models import SpawnActionOutput, SpawnContinueInput, SpawnCreateInput
+from meridian.lib.ops.spawn.prepare import build_create_payload
 from meridian.lib.state import spawn_store
 from meridian.lib.state.paths import resolve_project_runtime_root
-from meridian.lib.state.spawn.model import SpawnRecord
 from tests.support.fixtures import write_skill
 from tests.support.launch import stub_bundle_request_and_resolve
 
@@ -301,28 +306,173 @@ def test_spawn_continue_replays_source_launch_policy_snapshot(
     )
 
     assert result.command == "spawn.continue"
-    create_input = captured_request[0]
+    spawn_request = captured_request[0]
     continue_input = captured_payload[0]
     assert continue_input.work == "w-spawn"
     assert continue_input.task_dir == source_task_dir.as_posix()
     assert continue_input.launch_policy_snapshot == snapshot
-    assert create_input.launch_policy_snapshot == snapshot
-    assert create_input.launch_policy_snapshot is not None
-    assert create_input.work_id_hint == "w-spawn"
-    assert create_input.task_cwd == source_task_dir.as_posix()
-    assert create_input.task_cwd_work_item == "w-spawn"
-    assert create_input.model == snapshot.model
-    assert create_input.harness == snapshot.harness
-    assert create_input.agent == snapshot.agent
-    assert create_input.skills == snapshot.skills
-    assert create_input.launch_policy_snapshot.loaded_skills == snapshot.loaded_skills
-    assert create_input.execution_policy.approval == snapshot.execution_policy.approval
-    assert create_input.execution_policy.sandbox == snapshot.execution_policy.sandbox
-    assert create_input.execution_policy.effort == snapshot.execution_policy.effort
-    assert create_input.tools == snapshot.tools
-    assert create_input.mcp_tools == snapshot.mcp_tools
-    assert create_input.extra_args == snapshot.extra_args
+    assert spawn_request.launch_policy_snapshot == snapshot
+    assert spawn_request.launch_policy_snapshot is not None
+    assert spawn_request.work_id_hint == "w-spawn"
+    assert spawn_request.task_cwd == source_task_dir.as_posix()
+    assert spawn_request.task_cwd_work_item == "w-spawn"
+    assert continue_input.model == snapshot.model
 
+    artifacts = build_create_payload(continue_input, runtime=build_runtime(project_root))
+    resolved = artifacts.prepared.request
+    assert resolved.model == snapshot.model
+    assert resolved.harness == snapshot.harness
+    assert resolved.agent == snapshot.agent
+    assert resolved.skills == snapshot.skills
+    assert resolved.execution_policy == snapshot.execution_policy
+    assert resolved.tools == snapshot.tools
+    assert resolved.mcp_tools == snapshot.mcp_tools
+    assert resolved.extra_args == snapshot.extra_args
+
+
+def test_spawn_continue_replays_snapshot_harness_when_reference_harness_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    runtime_root = _state_root(project_root)
+    snapshot = LaunchPolicySnapshot(model="gpt-5.3-codex", harness="codex", agent="coder")
+    _seed_spawn(
+        runtime_root,
+        spawn_id="p46",
+        harness_session_id="session-46",
+        launch_policy_snapshot=snapshot,
+    )
+
+    def resolve_without_harness(
+        project_root: Path,
+        ref: str,
+        *,
+        runtime_root: Path | None = None,
+    ) -> ResolvedSessionReference:
+        _ = (project_root, ref, runtime_root)
+        return ResolvedSessionReference(
+            harness_session_id="session-46",
+            harness=None,
+            source_chat_id="c-seed",
+            source_model=snapshot.model,
+            source_agent=snapshot.agent,
+            source_skills=snapshot.skills,
+            source_work_id="w-spawn",
+            tracked=True,
+            source_launch_policy_snapshot=snapshot,
+        )
+
+    monkeypatch.setattr(spawn_api, "resolve_session_reference", resolve_without_harness)
+
+    captured_request: list[SpawnRequest] = []
+
+    def fake_execute_spawn_blocking(
+        *,
+        payload: SpawnCreateInput,
+        request: SpawnRequest,
+        runtime: object,
+        ctx: object = None,
+        prepared: object = None,
+        on_spawn_id: object = None,
+    ) -> SpawnActionOutput:
+        _ = (payload, runtime, ctx, prepared, on_spawn_id)
+        captured_request.append(request)
+        return SpawnActionOutput(command="spawn.create", status="running", spawn_id="p46c")
+
+    monkeypatch.setattr(spawn_api, "execute_spawn_blocking", fake_execute_spawn_blocking)
+
+    result = spawn_api.spawn_continue_sync(
+        SpawnContinueInput(
+            spawn_id="p46",
+            prompt="follow-up prompt",
+            project_root=project_root.as_posix(),
+        )
+    )
+
+    assert result.command == "spawn.continue"
+    assert captured_request[0].harness == "codex"
+    assert captured_request[0].launch_policy_snapshot == snapshot
+
+
+def test_spawn_continue_replays_codex_empty_model_snapshot_as_default_model(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    runtime_root = _state_root(project_root)
+    snapshot = LaunchPolicySnapshot(
+        model="",
+        harness="codex",
+        agent="coder",
+        skills=(),
+        execution_policy=ResolvedExecutionPolicy(approval="default", sandbox="workspace-write"),
+    )
+    _seed_spawn(
+        runtime_root,
+        spawn_id="p45",
+        harness_session_id="session-45",
+        launch_policy_snapshot=snapshot,
+    )
+    monkeypatch.setenv("MERIDIAN_MODEL", "claude-sonnet-4-6")
+
+    def fail_bundle_resolution(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("empty-model snapshot replay should not call mars launch-bundle")
+
+    monkeypatch.setattr(
+        "meridian.lib.launch.bundle_adapter.request_and_resolve",
+        fail_bundle_resolution,
+    )
+
+    captured_payload: list[SpawnCreateInput] = []
+
+    def fake_execute_spawn_blocking(
+        *,
+        payload: SpawnCreateInput,
+        request: SpawnRequest,
+        runtime: object,
+        ctx: object = None,
+        prepared: object = None,
+        on_spawn_id: object = None,
+    ) -> SpawnActionOutput:
+        _ = (request, runtime, ctx, prepared, on_spawn_id)
+        captured_payload.append(payload)
+        return SpawnActionOutput(command="spawn.create", status="running", spawn_id="p45c")
+
+    monkeypatch.setattr(spawn_api, "execute_spawn_blocking", fake_execute_spawn_blocking)
+
+    spawn_api.spawn_continue_sync(
+        SpawnContinueInput(
+            spawn_id="p45",
+            prompt="follow-up prompt",
+            project_root=project_root.as_posix(),
+        )
+    )
+
+    continue_input = captured_payload[0]
+    artifacts = build_create_payload(continue_input, runtime=build_runtime(project_root))
+    resolved = artifacts.prepared.request
+    assert resolved.model is None
+    assert resolved.harness == "codex"
+    launch_runtime = build_spawn_mars_runtime(
+        runtime=build_runtime(project_root),
+        runtime_root=runtime_root,
+        control_root=project_root,
+        execution_cwd=project_root.as_posix(),
+        argv_intent=LaunchArgvIntent.REQUIRED,
+    )
+    ctx = bind_spawn_launch_context(
+        prepared=artifacts.prepared,
+        bindings=RuntimeBindings(spawn_id="p45-replay", dry_run=True),
+        runtime=launch_runtime,
+        harness_registry=get_default_harness_registry(),
+    )
+    assert ctx.model_selection is None
+    assert ctx.binding.run_params.model is None
+    assert ctx.binding.spec.model is None
+    assert "--model" not in ctx.binding.argv
 
 def test_spawn_continue_from_source_without_work_suppresses_ambient_work(
     tmp_path: Path,
@@ -382,6 +532,57 @@ def test_spawn_continue_from_source_without_work_suppresses_ambient_work(
     assert create_request.task_cwd == source_task_dir.as_posix()
     assert create_request.task_cwd_work_item is None
     assert resolve_spawn_work_id(continue_input, create_request) is None
+
+
+def test_spawn_continue_from_source_without_task_dir_suppresses_ambient_task_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    ambient_task_dir = tmp_path / "ambient-task"
+    ambient_task_dir.mkdir()
+    runtime_root = _state_root(project_root)
+    _seed_spawn(
+        runtime_root,
+        spawn_id="p299",
+        harness_session_id="session-299",
+        work_id=None,
+        task_cwd=None,
+        launch_policy_snapshot=LaunchPolicySnapshot(model="gpt-5.3-codex", harness="codex"),
+    )
+    monkeypatch.setenv("MERIDIAN_TASK_DIR", ambient_task_dir.as_posix())
+
+    captured_payload: list[SpawnCreateInput] = []
+    captured_request: list[SpawnRequest] = []
+
+    def fake_execute_spawn_blocking(
+        *,
+        payload: SpawnCreateInput,
+        request: SpawnRequest,
+        runtime: object,
+        ctx: object = None,
+        prepared: object = None,
+        on_spawn_id: object = None,
+    ) -> SpawnActionOutput:
+        _ = (runtime, ctx, prepared, on_spawn_id)
+        captured_payload.append(payload)
+        captured_request.append(request)
+        return SpawnActionOutput(command="spawn.create", status="running", spawn_id="p299c")
+
+    monkeypatch.setattr(spawn_api, "execute_spawn_blocking", fake_execute_spawn_blocking)
+
+    result = spawn_api.spawn_continue_sync(
+        SpawnContinueInput(
+            spawn_id="p299",
+            prompt="follow-up prompt",
+            project_root=project_root.as_posix(),
+        )
+    )
+
+    assert result.command == "spawn.continue"
+    assert captured_payload[0].task_dir != ambient_task_dir.as_posix()
+    assert captured_request[0].task_cwd != ambient_task_dir.as_posix()
 
 
 def test_spawn_continue_uses_legacy_source_launch_policy_without_snapshot(
@@ -464,73 +665,138 @@ def test_spawn_continue_uses_legacy_source_launch_policy_without_snapshot(
     assert create_input.model == "gpt-5.3-codex"
 
 
-def test_continue_create_input_uses_authoritative_recovered_session_id(
+def test_spawn_continue_uses_authoritative_recovered_session_id(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     project_root = tmp_path / "repo"
     project_root.mkdir()
     runtime_root = _state_root(project_root)
     _seed_spawn(runtime_root, spawn_id="p32", harness_session_id=None)
-    source_spawn = spawn_store.get_spawn(runtime_root, "p32")
-    assert isinstance(source_spawn, SpawnRecord)
-    resolved_reference = ResolvedSessionReference(
-        harness_session_id=None,
-        harness="codex",
-        source_chat_id="c-seed",
-        source_model="gpt-5.3-codex",
-        source_agent="coder",
-        source_skills=("skill-c",),
-        source_work_id="w-spawn",
-        tracked=True,
-        source_execution_cwd=tmp_path.as_posix(),
-        recovery=RecoveryResult(
-            harness_session_id="recovered-session",
-            provenance=RecoveryProvenance.SESSION_STORE,
-        ),
+
+    def resolve_recovered(
+        project_root: Path,
+        ref: str,
+        *,
+        runtime_root: Path | None = None,
+    ) -> ResolvedSessionReference:
+        _ = (project_root, ref, runtime_root)
+        return ResolvedSessionReference(
+            harness_session_id=None,
+            harness="codex",
+            source_chat_id="c-seed",
+            source_model="gpt-5.3-codex",
+            source_agent=None,
+            source_skills=("skill-c",),
+            source_work_id="w-spawn",
+            tracked=True,
+            source_execution_cwd=tmp_path.as_posix(),
+            recovery=RecoveryResult(
+                harness_session_id="recovered-session",
+                provenance=RecoveryProvenance.SESSION_STORE,
+            ),
+        )
+
+    monkeypatch.setattr(spawn_api, "resolve_session_reference", resolve_recovered)
+    stub_bundle_request_and_resolve(
+        monkeypatch,
+        model="gpt-5.3-codex",
+        model_token="gpt-5.3-codex",
+        harness=HarnessId.CODEX,
+        harness_model="openai/gpt-5.3-codex",
     )
 
-    build_continue_create_input = vars(spawn_api)["_build_continue_create_input"]
-    create_input = build_continue_create_input(
-        payload=SpawnContinueInput(spawn_id="p32", prompt="follow-up prompt"),
-        source_spawn=source_spawn,
-        source_spawn_id="p32",
-        resolved_reference=resolved_reference,
-        source_harness="codex",
-        source_snapshot=None,
+    captured_payload: list[SpawnCreateInput] = []
+
+    def fake_execute_spawn_blocking(
+        *,
+        payload: SpawnCreateInput,
+        request: SpawnRequest,
+        runtime: object,
+        ctx: object = None,
+        prepared: object = None,
+        on_spawn_id: object = None,
+    ) -> SpawnActionOutput:
+        _ = (request, runtime, ctx, prepared, on_spawn_id)
+        captured_payload.append(payload)
+        return SpawnActionOutput(command="spawn.create", status="running", spawn_id="p32c")
+
+    monkeypatch.setattr(spawn_api, "execute_spawn_blocking", fake_execute_spawn_blocking)
+
+    spawn_api.spawn_continue_sync(
+        SpawnContinueInput(
+            spawn_id="p32",
+            prompt="follow-up prompt",
+            project_root=project_root.as_posix(),
+        )
     )
 
-    assert create_input.session.requested_harness_session_id == "recovered-session"
+    assert captured_payload[0].session.requested_harness_session_id == "recovered-session"
 
 
-def test_fork_create_input_uses_authoritative_recovered_session_id() -> None:
-    resolved_reference = ResolvedSessionReference(
-        harness_session_id=None,
-        harness="codex",
-        source_chat_id="c-seed",
-        source_model="gpt-5.3-codex",
-        source_agent="coder",
-        source_skills=("skill-c",),
-        source_work_id="w-spawn",
-        tracked=True,
-        source_execution_cwd="/tmp/source",
-        recovery=RecoveryResult(
-            harness_session_id="recovered-session",
-            provenance=RecoveryProvenance.SPAWN_ROW,
-        ),
+def test_spawn_fork_uses_authoritative_recovered_session_id(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    _state_root(project_root)
+
+    def resolve_recovered(
+        project_root: Path,
+        ref: str,
+        *,
+        runtime_root: Path | None = None,
+    ) -> ResolvedSessionReference:
+        _ = (project_root, ref, runtime_root)
+        return ResolvedSessionReference(
+            harness_session_id=None,
+            harness="codex",
+            source_chat_id="c-seed",
+            source_model="gpt-5.3-codex",
+            source_agent=None,
+            source_skills=("skill-c",),
+            source_work_id="w-spawn",
+            tracked=True,
+            source_execution_cwd=tmp_path.as_posix(),
+            recovery=RecoveryResult(
+                harness_session_id="recovered-session",
+                provenance=RecoveryProvenance.SPAWN_ROW,
+            ),
+        )
+
+    monkeypatch.setattr(spawn_api, "resolve_session_reference", resolve_recovered)
+    stub_bundle_request_and_resolve(
+        monkeypatch,
+        model="gpt-5.3-codex",
+        model_token="gpt-5.3-codex",
+        harness=HarnessId.CODEX,
+        harness_model="openai/gpt-5.3-codex",
     )
 
-    build_fork_create_input = vars(spawn_api)["_build_fork_create_input"]
-    create_input = build_fork_create_input(
-        payload=spawn_api.SpawnForkInput(source_ref="p33", prompt="fork prompt"),
-        normalized_source_ref="p33",
-        resolved_reference=resolved_reference,
-        requested_model="",
-        requested_agent=None,
-        inherited_skills=resolved_reference.source_skills,
-        requested_work="",
-        requested_task_dir=None,
-        requested_goal=None,
-        harness="codex",
+    captured_payload: list[SpawnCreateInput] = []
+
+    def fake_execute_spawn_blocking(
+        *,
+        payload: SpawnCreateInput,
+        request: SpawnRequest,
+        runtime: object,
+        ctx: object = None,
+        prepared: object = None,
+        on_spawn_id: object = None,
+    ) -> SpawnActionOutput:
+        _ = (request, runtime, ctx, prepared, on_spawn_id)
+        captured_payload.append(payload)
+        return SpawnActionOutput(command="spawn.create", status="running", spawn_id="p33c")
+
+    monkeypatch.setattr(spawn_api, "execute_spawn_blocking", fake_execute_spawn_blocking)
+
+    spawn_api.spawn_fork_sync(
+        spawn_api.SpawnForkInput(
+            source_ref="p33",
+            prompt="fork prompt",
+            project_root=project_root.as_posix(),
+        )
     )
 
-    assert create_input.session.requested_harness_session_id == "recovered-session"
+    assert captured_payload[0].session.requested_harness_session_id == "recovered-session"

--- a/tests/unit/launch/test_policy_snapshot.py
+++ b/tests/unit/launch/test_policy_snapshot.py
@@ -1,0 +1,61 @@
+"""Unit tests for launch-policy snapshot replay normalization."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from meridian.lib.core.launch_policy_snapshot import LaunchPolicySnapshot
+from meridian.lib.core.types import HarnessId
+from meridian.lib.harness.registry import get_default_harness_registry
+from meridian.lib.launch.launch_types import TerminalSurfaceMode
+from meridian.lib.launch.policy_snapshot import (
+    managed_model_override_from_persisted_model,
+    replay_launch_policy_snapshot,
+)
+
+
+def test_managed_model_override_from_persisted_model_empty_is_none() -> None:
+    assert managed_model_override_from_persisted_model("") is None
+    assert managed_model_override_from_persisted_model("   ") is None
+
+
+def test_managed_model_override_from_persisted_model_preserves_token() -> None:
+    assert managed_model_override_from_persisted_model("gpt-5.3-codex") == "gpt-5.3-codex"
+    assert managed_model_override_from_persisted_model("  claude-sonnet  ") == "claude-sonnet"
+
+
+def test_replay_launch_policy_snapshot_normalizes_empty_model_to_none(tmp_path: Path) -> None:
+    def terminal_surface_mode(*, harness_id: HarnessId) -> TerminalSurfaceMode:
+        _ = harness_id
+        return TerminalSurfaceMode.PTY_MEDIATED
+
+    replayed = replay_launch_policy_snapshot(
+        snapshot=LaunchPolicySnapshot(model="", harness="codex"),
+        project_root=tmp_path,
+        harness_registry=get_default_harness_registry(),
+        skills_readonly=True,
+        alias_catalog={},
+        resolve_terminal_surface_mode=terminal_surface_mode,
+    )
+
+    assert replayed.model is None
+    assert replayed.routing.model is None
+    assert replayed.model_selection is None
+
+
+def test_replay_launch_policy_snapshot_rejects_empty_harness(tmp_path: Path) -> None:
+    def terminal_surface_mode(*, harness_id: HarnessId) -> TerminalSurfaceMode:
+        _ = harness_id
+        return TerminalSurfaceMode.PTY_MEDIATED
+
+    with pytest.raises(ValueError, match="missing harness"):
+        replay_launch_policy_snapshot(
+            snapshot=LaunchPolicySnapshot(model="gpt-5.3-codex", harness=""),
+            project_root=tmp_path,
+            harness_registry=get_default_harness_registry(),
+            skills_readonly=True,
+            alias_catalog={},
+            resolve_terminal_surface_mode=terminal_surface_mode,
+        )

--- a/tests/unit/launch/test_spawn_capability_gate.py
+++ b/tests/unit/launch/test_spawn_capability_gate.py
@@ -345,7 +345,7 @@ def test_snapshot_replay_allows_empty_model_for_opencode_without_model_flag(
         resolve_terminal_surface_mode=terminal_surface_mode,
     )
 
-    assert replayed.model == ""
+    assert replayed.model is None
     assert replayed.routing.model is None
     assert replayed.model_selection is None
 

--- a/tests/unit/ops/test_continue_replay.py
+++ b/tests/unit/ops/test_continue_replay.py
@@ -1,0 +1,178 @@
+"""Unit tests for exact-continue replay contract builders."""
+
+from __future__ import annotations
+
+import pytest
+
+from meridian.lib.core.execution_policy import ResolvedExecutionPolicy
+from meridian.lib.core.launch_policy_snapshot import LaunchPolicySnapshot
+from meridian.lib.launch.continue_replay import (
+    ContinueReplaySource,
+    build_continue_replay_contract,
+    continue_replay_source_from_reference,
+)
+from meridian.lib.ops.reference import ResolvedSessionReference
+from meridian.lib.ops.reference_recovery import RecoveryProvenance, RecoveryResult
+
+
+def _snapshot() -> LaunchPolicySnapshot:
+    return LaunchPolicySnapshot(
+        model="claude-sonnet-4-6",
+        harness="claude",
+        agent="agent-a",
+        skills=("skill-a",),
+        execution_policy=ResolvedExecutionPolicy(approval="auto"),
+        extra_args=("--permission-mode", "acceptEdits"),
+    )
+
+
+def test_build_continue_replay_contract_from_snapshot() -> None:
+    snapshot = _snapshot()
+    source = ContinueReplaySource(
+        source_ref="p41",
+        harness_session_id="session-41",
+        harness="claude",
+        source_chat_id="c41",
+        source_work_id="source-work",
+        source_execution_cwd="/tmp/source",
+        source_control_root="/tmp/repo",
+        source_claude_config_dir=None,
+        source_pi_session_dir=None,
+        source_launch_policy_snapshot=snapshot,
+        tracked=True,
+        source_model="ignored-live-model",
+        source_agent="ignored-agent",
+        source_skills=("ignored-skill",),
+    )
+
+    contract = build_continue_replay_contract(source=source)
+
+    assert contract.launch_policy_snapshot == snapshot
+    assert contract.work_id == "source-work"
+    assert contract.task_dir == "/tmp/source"
+    assert contract.harness == "claude"
+    assert contract.model == "claude-sonnet-4-6"
+    assert contract.agent == "agent-a"
+    assert contract.agent_opt_out is False
+    assert contract.skills == ("skill-a",)
+    assert contract.passthrough_args == snapshot.extra_args
+    assert contract.session.requested_harness_session_id == "session-41"
+    assert contract.session.continue_source_ref == "p41"
+    assert contract.session.continue_chat_id == "c41"
+    assert contract.session.source_execution_cwd == "/tmp/source"
+
+
+def test_continue_replay_source_from_reference_uses_authoritative_session_id() -> None:
+    resolved = ResolvedSessionReference(
+        harness_session_id=None,
+        harness="claude",
+        source_chat_id="c41",
+        source_model="claude-sonnet-4-6",
+        source_agent="agent-a",
+        source_skills=("skill-a",),
+        source_work_id="source-work",
+        tracked=True,
+        source_execution_cwd="/tmp/source",
+        source_launch_policy_snapshot=None,
+        recovery=RecoveryResult(
+            harness_session_id="recovered-session",
+            provenance=RecoveryProvenance.SESSION_STORE,
+        ),
+    )
+
+    contract = build_continue_replay_contract(
+        source=continue_replay_source_from_reference(
+            "p41",
+            resolved,
+            harness_session_id=resolved.authoritative_harness_session_id,
+        ),
+    )
+
+    assert contract.session.requested_harness_session_id == "recovered-session"
+    assert contract.work_id == "source-work"
+    assert contract.task_dir == "/tmp/source"
+    assert contract.model == "claude-sonnet-4-6"
+    assert contract.agent is None
+    assert contract.skills == ()
+
+
+def test_build_continue_replay_contract_legacy_empty_model_override() -> None:
+    snapshot = LaunchPolicySnapshot(model="", harness="codex", agent="tech-lead")
+    source = ContinueReplaySource(
+        source_ref="p44",
+        harness_session_id="session-44",
+        harness="codex",
+        source_chat_id="c44",
+        source_work_id=None,
+        source_execution_cwd=None,
+        source_control_root=None,
+        source_claude_config_dir=None,
+        source_pi_session_dir=None,
+        source_launch_policy_snapshot=snapshot,
+        tracked=True,
+    )
+
+    contract = build_continue_replay_contract(source=source)
+
+    assert contract.model is None
+    assert contract.launch_policy_snapshot == snapshot
+
+
+def test_build_continue_replay_contract_uses_snapshot_harness_when_reference_has_none() -> None:
+    snapshot = LaunchPolicySnapshot(model="", harness="codex", agent="tech-lead")
+    source = ContinueReplaySource(
+        source_ref="p44",
+        harness_session_id="session-44",
+        harness=None,
+        source_chat_id="c44",
+        source_work_id=None,
+        source_execution_cwd=None,
+        source_control_root=None,
+        source_claude_config_dir=None,
+        source_pi_session_dir=None,
+        source_launch_policy_snapshot=snapshot,
+        tracked=True,
+    )
+
+    contract = build_continue_replay_contract(source=source)
+
+    assert contract.harness == "codex"
+
+
+def test_build_continue_replay_contract_rejects_harness_conflict() -> None:
+    snapshot = LaunchPolicySnapshot(model="", harness="codex")
+    source = ContinueReplaySource(
+        source_ref="p44",
+        harness_session_id="session-44",
+        harness="claude",
+        source_chat_id="c44",
+        source_work_id=None,
+        source_execution_cwd=None,
+        source_control_root=None,
+        source_claude_config_dir=None,
+        source_pi_session_dir=None,
+        source_launch_policy_snapshot=snapshot,
+        tracked=True,
+    )
+
+    with pytest.raises(ValueError, match="Cannot continue across harnesses"):
+        build_continue_replay_contract(source=source)
+
+
+def test_build_continue_replay_contract_rejects_agent_opt_out() -> None:
+    source = ContinueReplaySource(
+        source_ref="p44",
+        harness_session_id="session-44",
+        harness="codex",
+        source_chat_id="c44",
+        source_work_id=None,
+        source_execution_cwd=None,
+        source_control_root=None,
+        source_claude_config_dir=None,
+        source_pi_session_dir=None,
+        source_launch_policy_snapshot=None,
+        tracked=True,
+    )
+
+    with pytest.raises(ValueError, match="agent opt-out"):
+        build_continue_replay_contract(source=source, agent_opt_out=True)

--- a/uv.lock
+++ b/uv.lock
@@ -666,15 +666,15 @@ wheels = [
 
 [[package]]
 name = "mars-agents"
-version = "0.10.1"
+version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8d/b1/42c2e871ffb5173b06bc3a8c66c20b379fa298d97c3b507f3d309fd26435/mars_agents-0.10.1.tar.gz", hash = "sha256:876a47a4ca9a0f88a0ae75ba320a56e219fb241283ab7abdfb36f934b2fee2ef", size = 707577, upload-time = "2026-06-25T03:05:28.096Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/5b/4d132d288574aadd8e4c8869f441bebe5504e05617455c94acb9fec4344f/mars_agents-0.10.2.tar.gz", hash = "sha256:25ac34e6f3d93ad9401995da693298c40f8f3c7a7cac6fc136a849832c9b4bde", size = 708288, upload-time = "2026-06-25T04:42:50.942Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/a7/0342ae585dfb5a52180d98a0e08c5ab73de896c8328402c9b09f0b80ae83/mars_agents-0.10.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9d986edcd5ef5ed35e4b82041a5f1611014afc93c6fe3fde4f78fc0db650764f", size = 3454536, upload-time = "2026-06-25T03:05:20.225Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/b6/c4ce6a5e1fa548cd0be7471cc11bcb20f29ceb9b68c7c61bbcffba30469d/mars_agents-0.10.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1d0c42c2b6aabe224573401a1fd60b57f0d9f313c54fe0a073f4817845755397", size = 3312929, upload-time = "2026-06-25T03:05:22.002Z" },
-    { url = "https://files.pythonhosted.org/packages/00/48/aa3e366f6156ef1541abbbef1d6252a48965635d6135cd34eafc2bc2a4ef/mars_agents-0.10.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5bd451962a237cf869a88d32046a4345eec1779bb1632324ae54587582e05d0e", size = 3357478, upload-time = "2026-06-25T03:05:23.497Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/a1/4af8558c33873617958af356b99e97d5cff2eb52e1087bc22efa47e9911a/mars_agents-0.10.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:01ab479d0e3557c7a44b89a79c69e7909a154ddf3951b4198901613b1bca7626", size = 3576682, upload-time = "2026-06-25T03:05:24.914Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/d4/73199f5d60d12efaf612ce2e7a3844b68331e2343fa50264dc33818e91c1/mars_agents-0.10.1-py3-none-win_amd64.whl", hash = "sha256:d6b19dfb1350168721615bb149417b7e63bbbde9e5379dd90c44c34f132db814", size = 3523223, upload-time = "2026-06-25T03:05:26.479Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/5b/e727f3f7aec3a1d2b50042eee5e102f997eb230fb8d10fab6d24d5c693da/mars_agents-0.10.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4e08aa3ef60fe10b85c28a20f13c4f80ca6c40fbf8bd43e0018690d5928669fc", size = 3465046, upload-time = "2026-06-25T04:42:42.937Z" },
+    { url = "https://files.pythonhosted.org/packages/46/21/ec9e1c1580fc13d25eb5d78d8f1e583b3ffac327218b3e48ec3bcdd203d5/mars_agents-0.10.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:cfa5f19acc6b38b3398b96dfc4007d51f6735dd0c5d00d6697a13ff830028534", size = 3309665, upload-time = "2026-06-25T04:42:44.574Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/60/390331d0d2b4c2561d62654142fed66069c74ccd34759e9f060b94f667aa/mars_agents-0.10.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0423039970a1bb0d0494355fe663ef311d3cc3533044ca010fb8c5a9b7efa81f", size = 3354617, upload-time = "2026-06-25T04:42:46.106Z" },
+    { url = "https://files.pythonhosted.org/packages/13/26/0fda7aaff69b50748fa76ebda094ce35fc1ecd7cfd3f2ded0fc12592bf40/mars_agents-0.10.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:346b781a96e884cb3436a7988d9a54873d66f305ad05785d844c4971f53d3119", size = 3583223, upload-time = "2026-06-25T04:42:47.907Z" },
+    { url = "https://files.pythonhosted.org/packages/37/3f/3410f69e2bf3aa70695a6b40ae2f098f1b0f8cb7a5cdc06a1cb2e3411bb1/mars_agents-0.10.2-py3-none-win_amd64.whl", hash = "sha256:e01be5c951cb734b5d92cad07789ce62cf31eff943dc82c85f2052b081d8c141", size = 3521311, upload-time = "2026-06-25T04:42:49.302Z" },
 ]
 
 [[package]]
@@ -766,7 +766,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'app'", specifier = ">=0.28" },
     { name = "jinja2", marker = "extra == 'templates'", specifier = ">=3.1" },
     { name = "markdown-it-py", specifier = ">=4.0" },
-    { name = "mars-agents", specifier = "==0.10.1" },
+    { name = "mars-agents", specifier = "==0.10.2" },
     { name = "mcp", specifier = ">=1.0" },
     { name = "pathspec", specifier = ">=1.1.0" },
     { name = "psutil", specifier = ">=7.2.2" },


### PR DESCRIPTION
## Why

`meridian --continue c4767` exposed that exact continue replay still had two weak spots: replay policy was split between primary/spawn callers and launch snapshot replay, and persisted empty model snapshots could leak as an in-memory empty-string sentinel. That made same-session continue vulnerable to config/env drift and special-case fixes.

## Goal

Exact continue should replay the recorded launch contract for primary and spawned sessions through one launch-owned seam, preserving harness-default model absence without passing `--model`, and rejecting identity/policy/work/task mutations.

## Summary

- Added `ContinueReplayContract` / `ContinueReplaySource` in `src/meridian/lib/launch/continue_replay.py` as the shared exact-continue seam.
- Primary `--continue` and `spawn --continue` now consume that contract instead of independently rebuilding replay identity.
- Moved legacy persisted model normalization to `policy_snapshot.py`: `LaunchPolicySnapshot.model == ""` stays valid persisted JSON, while in-memory replay uses `None`.
- Exact continue now rejects agent opt-out (`--agent ""`) as a launch-identity mutation.
- Suppresses ambient work/task-dir inheritance when the source session had no work/task context.
- Added focused unit/integration coverage and updated code-local/KB-facing documentation references.
- Bumped `mars-agents` to `0.10.2` so lift/import rewrites foreign MCP tokens in map-form tool declarations.

## Resulting Behavior

- `uv run meridian --continue c4767 --dry-run` renders `codex resume ...` with no `--model`.
- `MERIDIAN_MODEL` / `MERIDIAN_AGENT` drift does not change exact continue replay.
- Primary/spawn exact continue reject model, agent, agent opt-out, policy, env, work, and task-dir mutations.
- Spawn snapshot replay still works when the resolved reference lacks a harness but the persisted snapshot has one.

## Changes

- `launch/continue_replay.py` owns exact-continue harness selection, conflict rejection, agent override rejection, session projection, snapshot passthrough, and launch-ready model/agent/skills fields.
- `LaunchRequest.model`, `SpawnCreateInput.model`, and resolved replay policy model now allow `None` where absence is the contract.
- `policy_snapshot.py` owns `managed_model_override_from_persisted_model()` for generic snapshot replay.
- `launch_primary()` and spawn prepare suppress inherited task-dir state for resume/exact-continue.
- Tests cover snapshot replay, empty-model harness defaults, ambient context suppression, recovered session IDs, and mutation rejection.
- `pyproject.toml` / `uv.lock` now pin `mars-agents==0.10.2`; `CHANGELOG.md` records the dependency bump.

## Work Item

continue-replay-contract

## Verification

- `uv run ruff check .` — passed
- `uv run pytest tests/unit/launch/test_policy_snapshot.py tests/unit/ops/test_continue_replay.py tests/integration/cli/test_primary_continue.py tests/integration/ops/test_spawn_continue.py -q` — `43 passed`
- `uv run pytest-llm` — `1391 passed, 2 skipped`
- `uv run --extra dev python -m pyright` — `0 errors`, 5 existing warnings
- `uv run mars --version` — `mars 0.10.2`
- `uv run mars build launch-bundle --json --root . --harness codex >/tmp/mars-bundle-codex.json` — passed
- `uv run pytest tests/unit/launch/test_bundle_adapter.py tests/integration/launch/test_launch_resolution_runtime.py -q` — `24 passed`
- `uv run meridian --continue c4767 --dry-run` — passed; rendered command omitted `--model`
- Runtime regression probe `p4871`:
  - primary continue dry-run
  - ambient model/agent drift
  - primary and spawn mutation rejection, including `--agent ""`
  - non-continue launch/spawn smoke
  - ambient task-dir suppression scripts
  - focused continue regression suite: `33 passed`
- Push preflight hook:
  - ruff passed
  - pyright: `0 errors`, 5 existing warnings
  - full pytest: `1391 passed, 2 skipped`
  - `uv build --no-sources` passed

## Knowledge Updates

Updated code-local knowledge:
- `src/meridian/lib/launch/AGENTS.md`
- `src/meridian/lib/launch/.context/CONTEXT.md`
- `src/meridian/lib/ops/spawn/AGENTS.md`
- `src/meridian/lib/ops/spawn/.context/CONTEXT.md`

KB capture was run by `p4864` and reconciled after runtime regression by `p4872`; durable KB repos are clean after capture.

## Spawn Trace

- p4849 explorer — mapped launch-policy snapshot and continue replay duplication
- p4850 reviewer — challenged requirements/scope
- p4861 gpt-dev — implemented final continue replay contract cleanup
- p4862 reviewer — structural/correctness review, approved
- p4863 prober — initial runtime verification
- p4864 kb-lead — durable knowledge capture
- p4871 prober — broader runtime regression testing
- p4872 kb-lead — post-regression knowledge reconciliation

## Release Label Guide

Set one `release:*` label on this PR:

- `release:patch` / `release:stable` — next stable **patch** release after merge
- `release:minor` — next stable **minor** release after merge
- `release:major` — next stable **major** release after merge
- `release:rc` — next **prerelease (RC)** after merge
- `release:skip` — no release for this merge

No `release:*` label defaults to a prerelease (RC). Unknown `release:*` labels also default to RC.

## Post-Merge Automation

After merge to `main`, CI (`.github/workflows/release-on-merge.yml`) will:

1. Read the PR release label
2. Skip only when `release:skip` is present (no label defaults to RC)
3. Compute the next stable or RC version from existing `v*` tags
4. Update `src/meridian/__init__.py` + promote `CHANGELOG.md` `[Unreleased]`
5. Commit `Release X.Y.Z`, create/push `vX.Y.Z`
6. Run `.github/workflows/publish-pypi.yml`

## Cleanup

After merge, clean merged worktrees with:

```bash
scripts/prune-worktrees.sh
```

