### PR TITLE
Add spawn guidance for --skills and -m flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- Spawn guidance now documents `--skills` flag and deemphasizes `-m` (agent profiles already set the right model).
+
 ## [0.3.23] - 2026-07-03
 
 ### Changed


### PR DESCRIPTION
## Why

Spawn guidance text didn't document the `--skills` flag or clarify when to use `-m`. Agents didn't know they could load additional skills onto subagents, and some were overusing `-m` when profiles already set the right model.

## Goal

Agents see `--skills` guidance in their spawn instructions and understand `-m` is for deliberate fan-out only.

## Summary

- Document `--skills skill1,skill2` for loading additional skills onto subagents
- Deemphasize `-m`: agent profiles already set the right model, use `-m` only for deliberate fan-out (e.g. reviewer perspective diversity)

## Resulting Behavior

Spawn instructions now include guidance on `--skills` and `-m` flags. Agents can load skills onto subagents and understand when model override is appropriate.

## Changes

- `src/meridian/lib/launch/spawn_guidance.py`: added two lines of guidance text to the prompting section

## Work Item

N/A (prompt improvement)

## Verification

- `uv run ruff check .` passes
- `uv run pyright` 0 errors
- `uv run pytest` 1355 passed

## Knowledge Updates

Not applicable; this is the guidance text itself.

## Spawn Trace

N/A (manual edit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)