### PR TITLE
security: sanitize child env by default, argv hooks, fail-closed spawn depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - External hooks accept argv-array `command = ["/path/to/script", "arg"]` (`shell=False`); string `command` still works but logs a deprecation warning on load.
 - Spawn depth limits derive from coordinator spawn ancestry when `MERIDIAN_SPAWN_ID` resolves in the spawn store (`max(env, records)`), closing env-forged depth bypass.
 
+### Changed
+- Hook docs now describe `command` as `str | array[str]` with POSIX and Windows argv-array examples.
+
 ## [0.3.24] - 2026-07-04
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Security
 - Harness and hook child processes now default to sanitized coordinator env: secret-like variables are dropped unless harness-declared, listed in `[spawn].env_passthrough`, or set via `[env]` / `spawn --env`. Opt back into full inheritance with `[spawn].inherit_full_env = true`.
+- Child-env sanitization now keeps OS/network/TLS baseline vars (proxy, cert bundles, Windows process env), harness-declared auth alternatives (`ANTHROPIC_AUTH_TOKEN`, provider base URLs), and Pi/Node runtime prefixes while still dropping undeclared `*_KEY` / `*_TOKEN` / `*_SECRET`.
 - External hooks accept argv-array `command = ["/path/to/script", "arg"]` (`shell=False`); string `command` still works but logs a deprecation warning on load.
 - Spawn depth limits derive from coordinator spawn ancestry when `MERIDIAN_SPAWN_ID` resolves in the spawn store (`max(env, records)`), closing env-forged depth bypass.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Harness and hook child processes now default to sanitized coordinator env: secret-like variables are dropped unless harness-declared, listed in `[spawn].env_passthrough`, or set via `[env]` / `spawn --env`. Opt back into full inheritance with `[spawn].inherit_full_env = true`.
 - Child-env sanitization now keeps OS/network/TLS baseline vars (proxy, cert bundles, Windows process env), harness-declared auth alternatives (`ANTHROPIC_AUTH_TOKEN`, provider base URLs), and Pi/Node runtime prefixes while still dropping undeclared `*_KEY` / `*_TOKEN` / `*_SECRET`.
 - `[spawn].inherit_full_env` and `env_passthrough` now apply to external hook subprocesses, restoring legacy full-env behavior when opted in.
+- Spawn depth limits read persisted `meridian_depth` from spawn records (O(1)) so pruned ancestry cannot undercount depth via forged `MERIDIAN_DEPTH`.
 - External hooks accept argv-array `command = ["/path/to/script", "arg"]` (`shell=False`); string `command` still works but logs a deprecation warning on load.
 - Spawn depth limits derive from coordinator spawn ancestry when `MERIDIAN_SPAWN_ID` resolves in the spawn store (`max(env, records)`), closing env-forged depth bypass.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Spawn depth limits derive from coordinator spawn ancestry when `MERIDIAN_SPAWN_ID` resolves in the spawn store (`max(env, records)`), closing env-forged depth bypass.
 
 ### Changed
+- Per-harness coordinator env passthrough declarations moved from `launch/harness_env_passthrough.py` onto `HarnessContract.coordinator_env_passthrough`; launch and connections read grants from the adapter contract.
 - Record-backed spawn depth resolution moved from `core/depth.py` to `state/depth_resolution.py`; ops and launch apply `max(env, records)` at their boundaries so core stays free of spawn-store imports.
 - Hook docs now describe `command` as `str | array[str]` with POSIX and Windows argv-array examples.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Security
 - Harness and hook child processes now default to sanitized coordinator env: secret-like variables are dropped unless harness-declared, listed in `[spawn].env_passthrough`, or set via `[env]` / `spawn --env`. Opt back into full inheritance with `[spawn].inherit_full_env = true`.
 - Child-env sanitization now keeps OS/network/TLS baseline vars (proxy, cert bundles, Windows process env), harness-declared auth alternatives (`ANTHROPIC_AUTH_TOKEN`, provider base URLs), and Pi/Node runtime prefixes while still dropping undeclared `*_KEY` / `*_TOKEN` / `*_SECRET`.
+- `[spawn].inherit_full_env` and `env_passthrough` now apply to external hook subprocesses, restoring legacy full-env behavior when opted in.
 - External hooks accept argv-array `command = ["/path/to/script", "arg"]` (`shell=False`); string `command` still works but logs a deprecation warning on load.
 - Spawn depth limits derive from coordinator spawn ancestry when `MERIDIAN_SPAWN_ID` resolves in the spawn store (`max(env, records)`), closing env-forged depth bypass.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Security
 - Harness and hook child processes now default to sanitized coordinator env: secret-like variables are dropped unless harness-declared, listed in `[spawn].env_passthrough`, or set via `[env]` / `spawn --env`. Opt back into full inheritance with `[spawn].inherit_full_env = true`.
 - Child-env sanitization now keeps OS/network/TLS baseline vars (proxy, cert bundles, Windows process env), harness-declared auth alternatives (`ANTHROPIC_AUTH_TOKEN`, provider base URLs), and Pi/Node runtime prefixes while still dropping undeclared `*_KEY` / `*_TOKEN` / `*_SECRET`.
+- Pi and OpenCode child launches now declare exact provider credential env vars (e.g. `DEEPSEEK_API_KEY`, `ANTHROPIC_AUTH_TOKEN`) so sanitized spawn env no longer strips load-bearing auth.
 - `[spawn].inherit_full_env` and `env_passthrough` now apply to external hook subprocesses, restoring legacy full-env behavior when opted in.
 - Spawn depth limits read persisted `meridian_depth` from spawn records (O(1)) so pruned ancestry cannot undercount depth via forged `MERIDIAN_DEPTH`.
 - External hooks accept argv-array `command = ["/path/to/script", "arg"]` (`shell=False`); string `command` still works but logs a deprecation warning on load.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Spawn depth limits derive from coordinator spawn ancestry when `MERIDIAN_SPAWN_ID` resolves in the spawn store (`max(env, records)`), closing env-forged depth bypass.
 
 ### Changed
+- Record-backed spawn depth resolution moved from `core/depth.py` to `state/depth_resolution.py`; ops and launch apply `max(env, records)` at their boundaries so core stays free of spawn-store imports.
 - Hook docs now describe `command` as `str | array[str]` with POSIX and Windows argv-array examples.
 
 ## [0.3.24] - 2026-07-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Harness and hook child processes now default to sanitized coordinator env: secret-like variables are dropped unless harness-declared, listed in `[spawn].env_passthrough`, or set via `[env]` / `spawn --env`. Opt back into full inheritance with `[spawn].inherit_full_env = true`.
 - Child-env sanitization now keeps OS/network/TLS baseline vars (proxy, cert bundles, Windows process env), harness-declared auth alternatives (`ANTHROPIC_AUTH_TOKEN`, provider base URLs), and Pi/Node runtime prefixes while still dropping undeclared `*_KEY` / `*_TOKEN` / `*_SECRET`.
 - Pi and OpenCode child launches now declare exact provider credential env vars (e.g. `DEEPSEEK_API_KEY`, `ANTHROPIC_AUTH_TOKEN`) so sanitized spawn env no longer strips load-bearing auth.
+- Child-env allowlist no longer uses broad `NPM_CONFIG_`, `NODE_`, or `COREPACK_` prefixes; only exact npm/node/corepack runtime vars pass, with inline credentials scrubbed from `NPM_CONFIG_REGISTRY`.
 - `[spawn].inherit_full_env` and `env_passthrough` now apply to external hook subprocesses, restoring legacy full-env behavior when opted in.
 - Spawn depth limits read persisted `meridian_depth` from spawn records (O(1)) so pruned ancestry cannot undercount depth via forged `MERIDIAN_DEPTH`.
 - External hooks accept argv-array `command = ["/path/to/script", "arg"]` (`shell=False`); string `command` still works but logs a deprecation warning on load.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Security
+- Harness and hook child processes now default to sanitized coordinator env: secret-like variables are dropped unless harness-declared, listed in `[spawn].env_passthrough`, or set via `[env]` / `spawn --env`. Opt back into full inheritance with `[spawn].inherit_full_env = true`.
+- External hooks accept argv-array `command = ["/path/to/script", "arg"]` (`shell=False`); string `command` still works but logs a deprecation warning on load.
+- Spawn depth limits derive from coordinator spawn ancestry when `MERIDIAN_SPAWN_ID` resolves in the spawn store (`max(env, records)`), closing env-forged depth bypass.
+
 ## [0.3.24] - 2026-07-04
 
 ### Changed

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -526,7 +526,7 @@ event   = "spawn.finalized"
 failure_policy = "warn"
 ```
 
-Hook `command` strings run via the platform default shell — `sh -c` on POSIX, `cmd.exe /c` on Windows. Bash syntax in inline commands will not work on Windows; use a `.sh` / `.ps1` / `.bat` script file instead for cross-platform hooks.
+Hook `command` accepts a shell string or an argv array (`command = ["bash", "scripts/check.sh"]`). String form runs via the platform default shell — `sh -c` on POSIX, `cmd.exe /c` on Windows. Array form runs with `shell=False`; on Windows use an explicit interpreter such as `["powershell", "-File", "scripts/check.ps1"]`.
 
 See [hooks.md](hooks.md) for the full hook schema, event names, builtin reference, and cross-platform guidance.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -251,6 +251,25 @@ it with no Claude `agent_copy`:
 harnesses = []
 ```
 
+### Child environment passthrough
+
+Harness launches now default to a sanitized child environment: coordinator
+variables ending in `_TOKEN`, `_KEY`, or `_SECRET` are dropped unless the
+harness declares them, they appear in `[spawn].env_passthrough`, or they are
+set explicitly via `[env]` / `meridian spawn --env`.
+
+```toml
+[spawn]
+# Opt back into full coordinator env inheritance (legacy behavior).
+inherit_full_env = false
+
+# Additional coordinator env vars to pass through to harness children.
+env_passthrough = ["MY_SERVICE_TOKEN"]
+```
+
+`MERIDIAN_*` coordination variables still flow through the launch pipeline as
+before. Hooks use the same sanitized default.
+
 ### Model aliases
 
 Project-local aliases live under `[models.<alias>]`:

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -67,7 +67,7 @@ event   = "spawn.finalized"
 | ----- | ---- | -------- | ------- | ------- |
 | `name` | str | yes (unless `builtin`) | builtin name or synthesized builtin identity | Unique identifier; used by `hooks run NAME` |
 | `builtin` | str | one of `builtin`/`command` | — | Use a builtin hook |
-| `command` | str | one of `builtin`/`command` | — | Shell command to run |
+| `command` | str \| array[str] | one of `builtin`/`command` | — | Shell command string or argv array (see Shell Behavior) |
 | `event` | str | yes (unless builtin supplies defaults) | builtin default | Event that triggers the hook |
 | `remote` | str | required by `git-autosync` | — | Git remote URL for hooks that operate on a remote repo |
 | `enabled` | bool | no | `true` | Set to `false` to disable without removing |
@@ -87,18 +87,39 @@ If you omit `name` for a builtin hook, Meridian may synthesize a stable name fro
 
 ### Shell Behavior
 
-Hook `command` strings are executed via the platform default shell: `sh -c` on POSIX (Linux/macOS) and `cmd.exe /c` on Windows. This is standard Python `subprocess(shell=True)` behavior. Inline commands that rely on bash syntax — `&&`, `||`, `$()`, `[[`, or POSIX-only tools — will fail on Windows because `cmd.exe` does not understand them.
+Hook `command` accepts either a shell string or an argv array:
 
-For hooks that must run on both platforms, use a script file with an appropriate extension:
+- **String form** runs via the platform default shell: `sh -c` on POSIX (Linux/macOS) and `cmd.exe /c` on Windows. This is standard Python `subprocess(shell=True)` behavior.
+- **Array form** runs with `shell=False`: the first element is the executable and the rest are arguments. Use this when you need injection hardening or explicit interpreter selection.
+
+Inline commands that rely on bash syntax — `&&`, `||`, `$()`, `[[`, or POSIX-only tools — will fail on Windows because `cmd.exe` does not understand them.
+
+For hooks that must run on both platforms, prefer argv arrays that invoke an interpreter explicitly:
 
 ```toml
-# POSIX — shell script
+# POSIX — explicit bash
+[[hooks]]
+name    = "check"
+command = ["bash", "scripts/check.sh"]
+event   = "spawn.finalized"
+
+# Windows — explicit PowerShell
+[[hooks]]
+name    = "check-win"
+command = ["powershell", "-File", "scripts/check.ps1"]
+event   = "spawn.finalized"
+```
+
+String form with script files still works when the platform shell can execute them directly:
+
+```toml
+# POSIX — shell script (string form)
 [[hooks]]
 name    = "check"
 command = "./scripts/check.sh"
 event   = "spawn.finalized"
 
-# Windows — batch file or PowerShell
+# Windows — batch file or PowerShell (string form)
 [[hooks]]
 name    = "check"
 command = "powershell -File scripts/check.ps1"

--- a/src/meridian/lib/config/settings.py
+++ b/src/meridian/lib/config/settings.py
@@ -454,6 +454,17 @@ def _normalize_spawn_table(raw_value: object, *, source: str) -> dict[str, objec
         if key == "deny_headless_harnesses":
             values[key] = _parse_toml_list(raw_value=value, source=f"{source}.{key}")
             continue
+        if key == "env_passthrough":
+            values[key] = _parse_toml_list(raw_value=value, source=f"{source}.{key}")
+            continue
+        if key == "inherit_full_env":
+            if not isinstance(value, bool):
+                raise ValueError(
+                    f"Invalid value for '{source}.{key}': expected bool, got "
+                    f"{type(value).__name__} ({value!r})."
+                )
+            values[key] = value
+            continue
         if key not in {"default_wait_yield_seconds", "min_wait_yield_seconds"}:
             logger.warning("Ignoring unknown Meridian config key '%s.%s'.", source, key)
             continue
@@ -522,7 +533,6 @@ def _normalize_hooks_array(raw_value: object, *, source: str) -> tuple[dict[str,
             if key in {
                 "name",
                 "event",
-                "command",
                 "builtin",
                 "interval",
                 "failure_policy",
@@ -535,6 +545,32 @@ def _normalize_hooks_array(raw_value: object, *, source: str) -> tuple[dict[str,
                         f"{type(value).__name__} ({value!r})."
                     )
                 row[key] = _normalize_required_string(value, source=field_source)
+                continue
+
+            if key == "command":
+                if isinstance(value, str):
+                    row[key] = _normalize_required_string(value, source=field_source)
+                elif isinstance(value, list):
+                    argv = _parse_toml_list(raw_value=value, source=field_source)
+                    if not argv:
+                        raise ValueError(
+                            f"Invalid value for '{field_source}': expected non-empty array."
+                        )
+                    row["command_argv"] = argv
+                else:
+                    raise ValueError(
+                        f"Invalid value for '{field_source}': expected str or array, got "
+                        f"{type(value).__name__} ({value!r})."
+                    )
+                continue
+
+            if key == "command_argv":
+                argv = _parse_toml_list(raw_value=value, source=field_source)
+                if not argv:
+                    raise ValueError(
+                        f"Invalid value for '{field_source}': expected non-empty array."
+                    )
+                row[key] = argv
                 continue
 
             if key in {"enabled", "require_serial"}:
@@ -1434,6 +1470,15 @@ class MeridianConfig(BaseSettings):
             file_aliases=(file_alias("spawn", "deny_headless_harnesses"),),
         ),
     ] = ("claude",)
+    env_passthrough: Annotated[
+        tuple[str, ...],
+        config_field(
+            "spawn.env_passthrough",
+            value_kind="str_list",
+            file_aliases=(file_alias("spawn", "env_passthrough"),),
+        ),
+    ] = ()
+    inherit_full_env: bool = False
     harness: HarnessConfig = Field(default_factory=HarnessConfig)
     primary: PrimaryConfig = Field(default_factory=PrimaryConfig)
     output: OutputConfig = Field(default_factory=OutputConfig)

--- a/src/meridian/lib/core/depth.py
+++ b/src/meridian/lib/core/depth.py
@@ -29,13 +29,19 @@ def depth_from_spawn_ancestry(
     spawn_id: str | SpawnId,
     runtime_root: Path,
 ) -> int | None:
-    """Return spawn depth from persisted parent links, or ``None`` when unknown."""
+    """Return spawn depth from persisted records, or ``None`` when unknown."""
 
     from meridian.lib.state import spawn_store
 
     normalized_spawn_id = str(spawn_id).strip()
     if not normalized_spawn_id:
         return None
+
+    record = spawn_store.get_spawn(runtime_root, normalized_spawn_id)
+    if record is None:
+        return None
+    if record.meridian_depth is not None:
+        return record.meridian_depth
 
     depth = 0
     current_id = normalized_spawn_id
@@ -44,10 +50,12 @@ def depth_from_spawn_ancestry(
         if current_id in visited:
             return None
         visited.add(current_id)
-        record = spawn_store.get_spawn(runtime_root, current_id)
-        if record is None:
-            return None if current_id == normalized_spawn_id else depth
-        parent_id = (record.parent_id or "").strip() or None
+        walk_record = spawn_store.get_spawn(runtime_root, current_id)
+        if walk_record is None:
+            if current_id == normalized_spawn_id:
+                return None
+            return max(depth, record.meridian_depth or 0)
+        parent_id = (walk_record.parent_id or "").strip() or None
         if parent_id is None:
             return depth
         depth += 1

--- a/src/meridian/lib/core/depth.py
+++ b/src/meridian/lib/core/depth.py
@@ -3,6 +3,9 @@
 import os
 from collections.abc import Mapping
 from contextlib import suppress
+from pathlib import Path
+
+from meridian.lib.core.types import SpawnId
 
 MERIDIAN_DEPTH_ENV = "MERIDIAN_DEPTH"
 MERIDIAN_SPAWN_ID_ENV = "MERIDIAN_SPAWN_ID"
@@ -20,6 +23,53 @@ def current_meridian_depth(env: Mapping[str, str] | None = None) -> int:
     """Return the current process's normalized Meridian depth."""
     source = os.environ if env is None else env
     return parse_meridian_depth(source.get(MERIDIAN_DEPTH_ENV))
+
+
+def depth_from_spawn_ancestry(
+    spawn_id: str | SpawnId,
+    runtime_root: Path,
+) -> int | None:
+    """Return spawn depth from persisted parent links, or ``None`` when unknown."""
+
+    from meridian.lib.state import spawn_store
+
+    normalized_spawn_id = str(spawn_id).strip()
+    if not normalized_spawn_id:
+        return None
+
+    depth = 0
+    current_id = normalized_spawn_id
+    visited: set[str] = set()
+    while current_id:
+        if current_id in visited:
+            return None
+        visited.add(current_id)
+        record = spawn_store.get_spawn(runtime_root, current_id)
+        if record is None:
+            return None if current_id == normalized_spawn_id else depth
+        parent_id = (record.parent_id or "").strip() or None
+        if parent_id is None:
+            return depth
+        depth += 1
+        current_id = parent_id
+    return depth
+
+
+def resolve_effective_meridian_depth(
+    env: Mapping[str, str],
+    *,
+    runtime_root: Path | None = None,
+) -> int:
+    """Return depth using coordinator records when the caller spawn is known."""
+
+    env_depth = parse_meridian_depth(env.get(MERIDIAN_DEPTH_ENV))
+    spawn_id = (env.get(MERIDIAN_SPAWN_ID_ENV) or "").strip()
+    if not spawn_id or runtime_root is None:
+        return env_depth
+    record_depth = depth_from_spawn_ancestry(spawn_id, runtime_root)
+    if record_depth is None:
+        return env_depth
+    return max(env_depth, record_depth)
 
 
 def has_valid_meridian_depth(env: Mapping[str, str] | None = None) -> bool:
@@ -91,6 +141,7 @@ __all__ = [
     "MERIDIAN_SPAWN_ID_ENV",
     "child_meridian_depth",
     "current_meridian_depth",
+    "depth_from_spawn_ancestry",
     "has_valid_meridian_depth",
     "is_managed_meridian_session",
     "is_nested_meridian_depth",
@@ -98,4 +149,5 @@ __all__ = [
     "is_root_side_effect_process",
     "max_depth_reached",
     "parse_meridian_depth",
+    "resolve_effective_meridian_depth",
 ]

--- a/src/meridian/lib/core/depth.py
+++ b/src/meridian/lib/core/depth.py
@@ -3,9 +3,6 @@
 import os
 from collections.abc import Mapping
 from contextlib import suppress
-from pathlib import Path
-
-from meridian.lib.core.types import SpawnId
 
 MERIDIAN_DEPTH_ENV = "MERIDIAN_DEPTH"
 MERIDIAN_SPAWN_ID_ENV = "MERIDIAN_SPAWN_ID"
@@ -23,61 +20,6 @@ def current_meridian_depth(env: Mapping[str, str] | None = None) -> int:
     """Return the current process's normalized Meridian depth."""
     source = os.environ if env is None else env
     return parse_meridian_depth(source.get(MERIDIAN_DEPTH_ENV))
-
-
-def depth_from_spawn_ancestry(
-    spawn_id: str | SpawnId,
-    runtime_root: Path,
-) -> int | None:
-    """Return spawn depth from persisted records, or ``None`` when unknown."""
-
-    from meridian.lib.state import spawn_store
-
-    normalized_spawn_id = str(spawn_id).strip()
-    if not normalized_spawn_id:
-        return None
-
-    record = spawn_store.get_spawn(runtime_root, normalized_spawn_id)
-    if record is None:
-        return None
-    if record.meridian_depth is not None:
-        return record.meridian_depth
-
-    depth = 0
-    current_id = normalized_spawn_id
-    visited: set[str] = set()
-    while current_id:
-        if current_id in visited:
-            return None
-        visited.add(current_id)
-        walk_record = spawn_store.get_spawn(runtime_root, current_id)
-        if walk_record is None:
-            if current_id == normalized_spawn_id:
-                return None
-            return max(depth, record.meridian_depth or 0)
-        parent_id = (walk_record.parent_id or "").strip() or None
-        if parent_id is None:
-            return depth
-        depth += 1
-        current_id = parent_id
-    return depth
-
-
-def resolve_effective_meridian_depth(
-    env: Mapping[str, str],
-    *,
-    runtime_root: Path | None = None,
-) -> int:
-    """Return depth using coordinator records when the caller spawn is known."""
-
-    env_depth = parse_meridian_depth(env.get(MERIDIAN_DEPTH_ENV))
-    spawn_id = (env.get(MERIDIAN_SPAWN_ID_ENV) or "").strip()
-    if not spawn_id or runtime_root is None:
-        return env_depth
-    record_depth = depth_from_spawn_ancestry(spawn_id, runtime_root)
-    if record_depth is None:
-        return env_depth
-    return max(env_depth, record_depth)
 
 
 def has_valid_meridian_depth(env: Mapping[str, str] | None = None) -> bool:
@@ -149,7 +91,6 @@ __all__ = [
     "MERIDIAN_SPAWN_ID_ENV",
     "child_meridian_depth",
     "current_meridian_depth",
-    "depth_from_spawn_ancestry",
     "has_valid_meridian_depth",
     "is_managed_meridian_session",
     "is_nested_meridian_depth",
@@ -157,5 +98,4 @@ __all__ = [
     "is_root_side_effect_process",
     "max_depth_reached",
     "parse_meridian_depth",
-    "resolve_effective_meridian_depth",
 ]

--- a/src/meridian/lib/core/lifecycle.py
+++ b/src/meridian/lib/core/lifecycle.py
@@ -297,6 +297,7 @@ class SpawnLifecycleService:
                 worker_pid=reservation.worker_pid,
                 runner_pid=reservation.runner_pid,
                 launch_policy_snapshot=reservation.launch_policy_snapshot,
+                meridian_depth=reservation.meridian_depth,
                 status=reservation.status,
                 started_at=reservation.started_at,
                 clock=reservation.clock,

--- a/src/meridian/lib/core/resolved_context.py
+++ b/src/meridian/lib/core/resolved_context.py
@@ -14,6 +14,7 @@ from meridian.lib.core.depth import (
     MERIDIAN_DEPTH_ENV,
     child_meridian_depth,
     parse_meridian_depth,
+    resolve_effective_meridian_depth,
 )
 from meridian.lib.core.types import SpawnId
 from meridian.lib.state import paths as state_paths
@@ -115,6 +116,12 @@ class ResolvedContext:
             runtime_root = derive_runtime_root_from_project(project_root)
         else:
             runtime_root = None
+
+        if runtime_root is not None:
+            depth = resolve_effective_meridian_depth(
+                os.environ,
+                runtime_root=runtime_root,
+            )
 
         # Authoritative work-ID precedence:
         # explicit override > MERIDIAN_ACTIVE_WORK_ID > session attachment.

--- a/src/meridian/lib/core/resolved_context.py
+++ b/src/meridian/lib/core/resolved_context.py
@@ -14,7 +14,6 @@ from meridian.lib.core.depth import (
     MERIDIAN_DEPTH_ENV,
     child_meridian_depth,
     parse_meridian_depth,
-    resolve_effective_meridian_depth,
 )
 from meridian.lib.core.types import SpawnId
 from meridian.lib.state import paths as state_paths
@@ -62,6 +61,7 @@ class ResolvedContext:
         explicit_chat_id: str | None = None,
         explicit_project_root: Path | None = None,
         explicit_runtime_root: Path | None = None,
+        explicit_depth: int | None = None,
         backend: ContextBackend | None = None,
         context_config: ContextConfig | None = None,
     ) -> Self:
@@ -101,7 +101,11 @@ class ResolvedContext:
             work_id_raw = os.getenv("MERIDIAN_ACTIVE_WORK_ID", "").strip()
             work_dir_raw = os.getenv("MERIDIAN_ACTIVE_WORK_DIR", "").strip()
 
-        depth = parse_meridian_depth(depth_raw)
+        depth = (
+            max(0, explicit_depth)
+            if explicit_depth is not None
+            else parse_meridian_depth(depth_raw)
+        )
 
         project_root = (
             explicit_project_root
@@ -116,12 +120,6 @@ class ResolvedContext:
             runtime_root = derive_runtime_root_from_project(project_root)
         else:
             runtime_root = None
-
-        if runtime_root is not None:
-            depth = resolve_effective_meridian_depth(
-                os.environ,
-                runtime_root=runtime_root,
-            )
 
         # Authoritative work-ID precedence:
         # explicit override > MERIDIAN_ACTIVE_WORK_ID > session attachment.

--- a/src/meridian/lib/core/spawn_lifecycle.py
+++ b/src/meridian/lib/core/spawn_lifecycle.py
@@ -31,6 +31,7 @@ class SpawnReservation:
     prompt: str
     owner_chat_id: str | None = None
     parent_id: str | None = None
+    meridian_depth: int | None = None
     kind: str = "child"
     metadata: SpawnStartMetadata | None = None
     desc: str | None = None

--- a/src/meridian/lib/harness/adapter.py
+++ b/src/meridian/lib/harness/adapter.py
@@ -17,6 +17,7 @@ from meridian.lib.harness.connections.base import (
     PrimaryRuntimeEventSurface,
     PrimaryRuntimeRequestPolicy,
 )
+from meridian.lib.harness.coordinator_env import CoordinatorEnvPassthrough
 from meridian.lib.harness.launch_types import SessionSeed
 from meridian.lib.launch.composition import (
     ComposedLaunchContent,
@@ -200,6 +201,9 @@ class HarnessContract(BaseModel):
     extraction: ExtractionContract
     approval: ApprovalContract
     bootstrap: BootstrapContract
+    coordinator_env_passthrough: CoordinatorEnvPassthrough = Field(
+        default_factory=CoordinatorEnvPassthrough
+    )
     capability_limits: tuple[str, ...] = ()
 
 

--- a/src/meridian/lib/harness/claude.py
+++ b/src/meridian/lib/harness/claude.py
@@ -59,6 +59,7 @@ from meridian.lib.harness.common import (
     extract_session_id_from_artifacts_with_patterns,
 )
 from meridian.lib.harness.connections.claude_ws import ClaudeConnection
+from meridian.lib.harness.coordinator_env import CLAUDE_COORDINATOR_ENV
 from meridian.lib.harness.extractors.claude import CLAUDE_EXTRACTOR
 from meridian.lib.harness.launch_types import SessionSeed
 from meridian.lib.harness.projections.project_claude import project_claude_spec_to_cli_args
@@ -228,6 +229,7 @@ class ClaudeAdapter(BaseHarnessAdapter[ResolvedLaunchSpec]):
                 streaming_session_seed_mode=SessionSeedMode.PROJECTED_ARGS,
                 prelaunch_bootstrap_mode=PrelaunchBootstrapMode.ENV_OVERLAY_AND_SESSION_ACCESS,
             ),
+            coordinator_env_passthrough=CLAUDE_COORDINATOR_ENV,
             capability_limits=(
                 "terminal_surface_mode limited to pty_mediated",
                 "no observer/controller backend contract",

--- a/src/meridian/lib/harness/codex.py
+++ b/src/meridian/lib/harness/codex.py
@@ -54,6 +54,7 @@ from meridian.lib.harness.connections.base import (
     PrimaryRuntimeRequestPolicy,
 )
 from meridian.lib.harness.connections.codex_ws import CodexConnection
+from meridian.lib.harness.coordinator_env import CODEX_COORDINATOR_ENV
 from meridian.lib.harness.extractors.codex import CODEX_EXTRACTOR
 from meridian.lib.harness.projections.project_codex_streaming import (
     project_codex_spec_to_appserver_command,
@@ -328,6 +329,7 @@ class CodexAdapter(BaseHarnessAdapter[ResolvedLaunchSpec]):
                 primary_attach_failure_policy="raise",
                 observer_controller=observer,
             ),
+            coordinator_env_passthrough=CODEX_COORDINATOR_ENV,
             capability_limits=(
                 "native_inherit declared as contract capability only; policy remains pty_mediated",
             ),

--- a/src/meridian/lib/harness/connections/claude_ws.py
+++ b/src/meridian/lib/harness/connections/claude_ws.py
@@ -29,6 +29,7 @@ from meridian.lib.harness.connections.base import (
     StopResult,
     validate_prompt_size,
 )
+from meridian.lib.harness.coordinator_env import coordinator_env_passthrough_for
 from meridian.lib.harness.errors import HarnessBinaryNotFound
 from meridian.lib.harness.semantics import clears_signal
 from meridian.lib.launch.constants import (
@@ -356,7 +357,7 @@ class ClaudeConnection(HarnessConnection[ResolvedLaunchSpec]):
         command = self._build_command(config, spec)
 
         env = build_connection_child_env(
-            harness_id=self.harness_id,
+            harness_passthrough=coordinator_env_passthrough_for(self.harness_id),
             base_env=os.environ,
             env_overrides=config.env_overrides,
             blocked=_BLOCKED_CHILD_ENV_VARS,

--- a/src/meridian/lib/harness/connections/claude_ws.py
+++ b/src/meridian/lib/harness/connections/claude_ws.py
@@ -35,7 +35,7 @@ from meridian.lib.launch.constants import (
     BASE_COMMAND_CLAUDE_STREAMING,
     BLOCKED_CHILD_ENV_VARS,
 )
-from meridian.lib.launch.env import inherit_child_env
+from meridian.lib.launch.env_sanitize import build_connection_child_env
 from meridian.lib.launch.launch_types import ResolvedLaunchSpec
 from meridian.lib.observability.trace_helpers import (
     trace_parse_error,
@@ -355,9 +355,10 @@ class ClaudeConnection(HarnessConnection[ResolvedLaunchSpec]):
 
         command = self._build_command(config, spec)
 
-        env = inherit_child_env(
-            os.environ,
-            config.env_overrides,
+        env = build_connection_child_env(
+            harness_id=self.harness_id,
+            base_env=os.environ,
+            env_overrides=config.env_overrides,
             blocked=_BLOCKED_CHILD_ENV_VARS,
         )
 

--- a/src/meridian/lib/harness/connections/codex_ws.py
+++ b/src/meridian/lib/harness/connections/codex_ws.py
@@ -64,6 +64,7 @@ from meridian.lib.harness.connections.resident_backend import (
     LivenessResidentBackendControl,
     ResidentBackendControl,
 )
+from meridian.lib.harness.coordinator_env import coordinator_env_passthrough_for
 from meridian.lib.harness.semantics import (
     PrimaryEventScope,
     clears_signal,
@@ -370,7 +371,7 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
         ws_url = f"ws://{host}:{port}"
 
         env = build_connection_child_env(
-            harness_id=self.harness_id,
+            harness_passthrough=coordinator_env_passthrough_for(self.harness_id),
             base_env=os.environ,
             env_overrides=config.env_overrides,
         )

--- a/src/meridian/lib/harness/connections/codex_ws.py
+++ b/src/meridian/lib/harness/connections/codex_ws.py
@@ -69,7 +69,7 @@ from meridian.lib.harness.semantics import (
     clears_signal,
     codex_primary_event_scope,
 )
-from meridian.lib.launch.env import inherit_child_env
+from meridian.lib.launch.env_sanitize import build_connection_child_env
 from meridian.lib.launch.launch_types import ResolvedLaunchSpec
 from meridian.lib.observability.trace_helpers import (
     trace_parse_error,
@@ -369,7 +369,11 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
         port = config.ws_port if config.ws_port > 0 else _reserve_port(host)
         ws_url = f"ws://{host}:{port}"
 
-        env = inherit_child_env(os.environ, config.env_overrides)
+        env = build_connection_child_env(
+            harness_id=self.harness_id,
+            base_env=os.environ,
+            env_overrides=config.env_overrides,
+        )
         self._codex_home = resolve_codex_home(env)
         effective_cwd = self._effective_project_root()
         spawn_dir = resolve_spawn_log_dir(config.control_root, config.spawn_id)

--- a/src/meridian/lib/harness/connections/cursor_subprocess.py
+++ b/src/meridian/lib/harness/connections/cursor_subprocess.py
@@ -25,6 +25,7 @@ from meridian.lib.harness.connections.base import (
     StopResult,
     validate_prompt_size,
 )
+from meridian.lib.harness.coordinator_env import coordinator_env_passthrough_for
 from meridian.lib.harness.extractors.cursor import CURSOR_EXTRACTOR
 from meridian.lib.launch.constants import BASE_COMMAND_CURSOR_SUBPROCESS, BLOCKED_CHILD_ENV_VARS
 from meridian.lib.launch.env_sanitize import build_connection_child_env
@@ -105,7 +106,7 @@ class CursorSubprocessConnection(HarnessConnection[ResolvedLaunchSpec]):
         self._stderr_handle = (spawn_dir / "stderr.log").open("ab")
 
         env = build_connection_child_env(
-            harness_id=self.harness_id,
+            harness_passthrough=coordinator_env_passthrough_for(self.harness_id),
             base_env=os.environ,
             env_overrides=config.env_overrides,
             blocked=BLOCKED_CHILD_ENV_VARS,

--- a/src/meridian/lib/harness/connections/cursor_subprocess.py
+++ b/src/meridian/lib/harness/connections/cursor_subprocess.py
@@ -27,7 +27,7 @@ from meridian.lib.harness.connections.base import (
 )
 from meridian.lib.harness.extractors.cursor import CURSOR_EXTRACTOR
 from meridian.lib.launch.constants import BASE_COMMAND_CURSOR_SUBPROCESS, BLOCKED_CHILD_ENV_VARS
-from meridian.lib.launch.env import inherit_child_env
+from meridian.lib.launch.env_sanitize import build_connection_child_env
 from meridian.lib.launch.launch_types import ResolvedLaunchSpec
 from meridian.lib.state.paths import resolve_spawn_log_dir
 
@@ -104,9 +104,10 @@ class CursorSubprocessConnection(HarnessConnection[ResolvedLaunchSpec]):
         spawn_dir.mkdir(parents=True, exist_ok=True)
         self._stderr_handle = (spawn_dir / "stderr.log").open("ab")
 
-        env = inherit_child_env(
-            os.environ,
-            config.env_overrides,
+        env = build_connection_child_env(
+            harness_id=self.harness_id,
+            base_env=os.environ,
+            env_overrides=config.env_overrides,
             blocked=BLOCKED_CHILD_ENV_VARS,
         )
         self._session_id_observer = config.session_id_observer

--- a/src/meridian/lib/harness/connections/opencode_http.py
+++ b/src/meridian/lib/harness/connections/opencode_http.py
@@ -51,6 +51,7 @@ from meridian.lib.harness.connections.resident_backend import (
     LivenessResidentBackendControl,
     ResidentBackendControl,
 )
+from meridian.lib.harness.coordinator_env import coordinator_env_passthrough_for
 from meridian.lib.harness.projections.project_opencode_streaming import (
     project_opencode_spec_to_session_payload as _project_opencode_spec_to_session_payload,
 )
@@ -506,7 +507,7 @@ class OpenCodeConnection(HarnessConnection[ResolvedLaunchSpec]):
             port=port,
         )
         env = build_connection_child_env(
-            harness_id=self.harness_id,
+            harness_passthrough=coordinator_env_passthrough_for(self.harness_id),
             base_env=os.environ,
             env_overrides=config.env_overrides,
         )
@@ -1115,7 +1116,7 @@ class OpenCodeConnection(HarnessConnection[ResolvedLaunchSpec]):
         if config is None:
             return dict(os.environ)
         return build_connection_child_env(
-            harness_id=self.harness_id,
+            harness_passthrough=coordinator_env_passthrough_for(self.harness_id),
             base_env=os.environ,
             env_overrides=config.env_overrides,
         )

--- a/src/meridian/lib/harness/connections/opencode_http.py
+++ b/src/meridian/lib/harness/connections/opencode_http.py
@@ -60,7 +60,7 @@ from meridian.lib.harness.semantics import (
     clears_signal,
     opencode_primary_event_scope,
 )
-from meridian.lib.launch.env import inherit_child_env
+from meridian.lib.launch.env_sanitize import build_connection_child_env
 from meridian.lib.launch.launch_types import ResolvedLaunchSpec
 from meridian.lib.launch.workspace_projection import OPENCODE_CONFIG_CONTENT_ENV
 from meridian.lib.observability.trace_helpers import (
@@ -505,7 +505,11 @@ class OpenCodeConnection(HarnessConnection[ResolvedLaunchSpec]):
             host=host,
             port=port,
         )
-        env = inherit_child_env(os.environ, config.env_overrides)
+        env = build_connection_child_env(
+            harness_id=self.harness_id,
+            base_env=os.environ,
+            env_overrides=config.env_overrides,
+        )
         spawn_dir = resolve_spawn_log_dir(config.control_root, config.spawn_id)
         spawn_dir.mkdir(parents=True, exist_ok=True)
         _materialize_system_prompt(spawn_dir, config.system, env)
@@ -1110,7 +1114,11 @@ class OpenCodeConnection(HarnessConnection[ResolvedLaunchSpec]):
         config = self._config
         if config is None:
             return dict(os.environ)
-        return inherit_child_env(os.environ, config.env_overrides)
+        return build_connection_child_env(
+            harness_id=self.harness_id,
+            base_env=os.environ,
+            env_overrides=config.env_overrides,
+        )
 
     def _read_startup_stderr_excerpt(self) -> str:
         stderr_handle = self._stderr_handle

--- a/src/meridian/lib/harness/connections/pi_rpc.py
+++ b/src/meridian/lib/harness/connections/pi_rpc.py
@@ -30,6 +30,7 @@ from meridian.lib.harness.connections.base import (
     StopResult,
     validate_prompt_size,
 )
+from meridian.lib.harness.coordinator_env import coordinator_env_passthrough_for
 from meridian.lib.harness.errors import HarnessBinaryNotFound
 from meridian.lib.harness.pi_lifecycle_events import (
     PI_CANONICAL_LIFECYCLE_TYPE_PREFIXES,
@@ -443,7 +444,7 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
             base_command=BASE_COMMAND_PI_SUBPROCESS,
         )
         env = build_connection_child_env(
-            harness_id=self.harness_id,
+            harness_passthrough=coordinator_env_passthrough_for(self.harness_id),
             base_env=os.environ,
             env_overrides=config.env_overrides,
             blocked=_BLOCKED_CHILD_ENV_VARS,

--- a/src/meridian/lib/harness/connections/pi_rpc.py
+++ b/src/meridian/lib/harness/connections/pi_rpc.py
@@ -43,7 +43,7 @@ from meridian.lib.harness.pi_runtime_resolver import (
     resolve_pi_runtime,
 )
 from meridian.lib.launch.constants import BASE_COMMAND_PI_SUBPROCESS, BLOCKED_CHILD_ENV_VARS
-from meridian.lib.launch.env import inherit_child_env
+from meridian.lib.launch.env_sanitize import build_connection_child_env
 from meridian.lib.launch.launch_types import ResolvedLaunchSpec
 from meridian.lib.launch.report import compact_pi_failure_output
 from meridian.lib.observability.trace_helpers import (
@@ -442,9 +442,10 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
             spec,
             base_command=BASE_COMMAND_PI_SUBPROCESS,
         )
-        env = inherit_child_env(
-            os.environ,
-            config.env_overrides,
+        env = build_connection_child_env(
+            harness_id=self.harness_id,
+            base_env=os.environ,
+            env_overrides=config.env_overrides,
             blocked=_BLOCKED_CHILD_ENV_VARS,
         )
         env.update(pi_agent_dir_env_override())

--- a/src/meridian/lib/harness/coordinator_env.py
+++ b/src/meridian/lib/harness/coordinator_env.py
@@ -1,12 +1,8 @@
-"""Per-harness coordinator env passthrough declarations for child launches.
-
-TODO(P3-bundle-contract): harness-specific env policy belongs under ``harness/``;
-this launch-local data module is interim only to avoid bootstrap import cycles.
-"""
+"""Per-harness coordinator env passthrough declarations for child launches."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from pydantic import BaseModel, ConfigDict, Field
 
 from meridian.lib.core.types import HarnessId
 
@@ -82,38 +78,53 @@ _OPENCODE_EXACT = _PROVIDER_API_KEYS | frozenset(
     }
 )
 
-_HARNESS_EXACT: dict[HarnessId, frozenset[str]] = {
-    HarnessId.CLAUDE: _CLAUDE_EXACT,
-    HarnessId.CODEX: _CODEX_EXACT,
-    HarnessId.OPENCODE: _OPENCODE_EXACT,
-    HarnessId.CURSOR: frozenset(),
-    HarnessId.PI: _PI_EXACT,
-}
 
-_HARNESS_PREFIXES: dict[HarnessId, tuple[str, ...]] = {
-    HarnessId.CLAUDE: ("CLAUDE_", "CLAUDE_CODE_", "ANTHROPIC_VERTEX_"),
-    HarnessId.CODEX: ("CODEX_", "AZURE_OPENAI_", "OPENAI_ORG"),
-    HarnessId.OPENCODE: ("OPENCODE_",),
-    HarnessId.CURSOR: ("CURSOR_",),
-    HarnessId.PI: ("PI_", "AZURE_OPENAI_", "OPENAI_ORG"),
-}
-
-
-@dataclass(frozen=True)
-class HarnessEnvPassthrough:
+class CoordinatorEnvPassthrough(BaseModel):
     """Coordinator env keys one harness may inherit beyond the default allowlist."""
 
-    exact: frozenset[str] = frozenset()
+    model_config = ConfigDict(frozen=True)
+
+    exact: frozenset[str] = Field(default_factory=frozenset)
     prefixes: tuple[str, ...] = ()
 
 
-def harness_env_passthrough(harness_id: HarnessId) -> HarnessEnvPassthrough:
-    """Return declared passthrough for one harness."""
+CLAUDE_COORDINATOR_ENV = CoordinatorEnvPassthrough(
+    exact=_CLAUDE_EXACT,
+    prefixes=("CLAUDE_", "CLAUDE_CODE_", "ANTHROPIC_VERTEX_"),
+)
 
-    return HarnessEnvPassthrough(
-        exact=_HARNESS_EXACT.get(harness_id, frozenset()),
-        prefixes=_HARNESS_PREFIXES.get(harness_id, ()),
-    )
+CODEX_COORDINATOR_ENV = CoordinatorEnvPassthrough(
+    exact=_CODEX_EXACT,
+    prefixes=("CODEX_", "AZURE_OPENAI_", "OPENAI_ORG"),
+)
+
+OPENCODE_COORDINATOR_ENV = CoordinatorEnvPassthrough(
+    exact=_OPENCODE_EXACT,
+    prefixes=("OPENCODE_",),
+)
+
+CURSOR_COORDINATOR_ENV = CoordinatorEnvPassthrough()
+
+PI_COORDINATOR_ENV = CoordinatorEnvPassthrough(
+    exact=_PI_EXACT,
+    prefixes=("PI_", "AZURE_OPENAI_", "OPENAI_ORG"),
+)
 
 
-__all__ = ["HarnessEnvPassthrough", "harness_env_passthrough"]
+def coordinator_env_passthrough_for(harness_id: HarnessId) -> CoordinatorEnvPassthrough:
+    """Return declared passthrough for one harness from its registered contract."""
+
+    from meridian.lib.harness.bundle import get_harness_bundle
+
+    return get_harness_bundle(harness_id).adapter.contract.coordinator_env_passthrough
+
+
+__all__ = [
+    "CLAUDE_COORDINATOR_ENV",
+    "CODEX_COORDINATOR_ENV",
+    "CURSOR_COORDINATOR_ENV",
+    "OPENCODE_COORDINATOR_ENV",
+    "PI_COORDINATOR_ENV",
+    "CoordinatorEnvPassthrough",
+    "coordinator_env_passthrough_for",
+]

--- a/src/meridian/lib/harness/cursor.py
+++ b/src/meridian/lib/harness/cursor.py
@@ -34,6 +34,7 @@ from meridian.lib.harness.bundle import (
     register_harness_bundle,
 )
 from meridian.lib.harness.connections.cursor_subprocess import CursorSubprocessConnection
+from meridian.lib.harness.coordinator_env import CURSOR_COORDINATOR_ENV
 from meridian.lib.harness.extractors.cursor import CURSOR_EXTRACTOR
 from meridian.lib.harness.projections.project_cursor import project_cursor_spec_to_cli_args
 from meridian.lib.launch.constants import BASE_COMMAND_CURSOR_SUBPROCESS
@@ -109,6 +110,7 @@ class CursorAdapter(BaseHarnessAdapter[ResolvedLaunchSpec]):
                 mode=BootstrapMode.SUBPROCESS_ONLY,
                 fork_materialization=ForkMaterializationMode.NATIVE_CONTINUE_FORK,
             ),
+            coordinator_env_passthrough=CURSOR_COORDINATOR_ENV,
         )
 
     @property

--- a/src/meridian/lib/harness/opencode.py
+++ b/src/meridian/lib/harness/opencode.py
@@ -38,6 +38,7 @@ from meridian.lib.harness.bundle import (
     register_harness_bundle,
 )
 from meridian.lib.harness.connections.opencode_http import OpenCodeConnection
+from meridian.lib.harness.coordinator_env import OPENCODE_COORDINATOR_ENV
 from meridian.lib.harness.extractors.opencode import OPENCODE_EXTRACTOR
 from meridian.lib.harness.launch_types import SessionSeed
 from meridian.lib.harness.opencode_report import (
@@ -391,6 +392,7 @@ class OpenCodeAdapter(BaseHarnessAdapter[ResolvedLaunchSpec]):
                 primary_attach_failure_policy="fallback_to_blackbox",
                 observer_controller=observer,
             ),
+            coordinator_env_passthrough=OPENCODE_COORDINATOR_ENV,
             capability_limits=(
                 "native_inherit declared as contract capability only; policy remains pty_mediated",
             ),

--- a/src/meridian/lib/harness/pi.py
+++ b/src/meridian/lib/harness/pi.py
@@ -34,6 +34,7 @@ from meridian.lib.harness.bundle import (
     register_harness_bundle,
 )
 from meridian.lib.harness.connections.pi_rpc import PiRpcConnection
+from meridian.lib.harness.coordinator_env import PI_COORDINATOR_ENV
 from meridian.lib.harness.extractors.pi import (
     PI_EXTRACTOR,
     detect_pi_session_id_from_session_files,
@@ -145,6 +146,7 @@ class PiAdapter(BaseHarnessAdapter[ResolvedLaunchSpec]):
                 mode=BootstrapMode.SUBPROCESS_ONLY,
                 fork_materialization=ForkMaterializationMode.NATIVE_CONTINUE_FORK,
             ),
+            coordinator_env_passthrough=PI_COORDINATOR_ENV,
         )
 
     @property

--- a/src/meridian/lib/hooks/config.py
+++ b/src/meridian/lib/hooks/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import re
 import tomllib
 from collections import OrderedDict
@@ -40,6 +41,8 @@ _HOOK_NAME_COMPONENT_PATTERN = re.compile(r"[^a-z0-9._-]+")
 _HOOK_NAME_REPEATED_DASH_PATTERN = re.compile(r"-+")
 _KNOWN_FAILURE_POLICIES = frozenset({"fail", "warn", "ignore"})
 _KNOWN_SPAWN_STATUSES = frozenset(get_args(SpawnStatus))
+
+logger = logging.getLogger(__name__)
 
 # Backward-compatible alias; registry remains the single source of truth.
 BUILTIN_HOOK_DEFAULTS = BUILTIN_HOOK_REGISTRY
@@ -202,6 +205,16 @@ def _hook_from_row(
     auto_registered: bool = False,
 ) -> tuple[Hook, ...]:
     command = cast("str | None", row.get("command"))
+    command_argv_raw = row.get("command_argv")
+    command_argv: tuple[str, ...] | None
+    if command_argv_raw is None:
+        command_argv = None
+    elif isinstance(command_argv_raw, tuple):
+        command_argv = cast("tuple[str, ...]", command_argv_raw)
+    else:
+        raise ValueError(
+            f"Invalid hook config '{row_source}': 'command_argv' must be a string array."
+        )
     builtin = cast("str | None", row.get("builtin"))
 
     raw_options = row.get("options")
@@ -224,9 +237,19 @@ def _hook_from_row(
         raise ValueError(
             f"Invalid hook config '{row_source}': 'command' and 'builtin' are mutually exclusive."
         )
-    if command is None and builtin is None:
+    if command_argv is not None and builtin is not None:
         raise ValueError(
-            f"Invalid hook config '{row_source}': expected either 'command' or 'builtin'."
+            f"Invalid hook config '{row_source}': "
+            "'command_argv' and 'builtin' are mutually exclusive."
+        )
+    if command is not None and command_argv is not None:
+        raise ValueError(
+            f"Invalid hook config '{row_source}': "
+            "'command' and 'command_argv' are mutually exclusive."
+        )
+    if command is None and command_argv is None and builtin is None:
+        raise ValueError(
+            f"Invalid hook config '{row_source}': expected 'command', 'command_argv', or 'builtin'."
         )
 
     name = cast("str | None", row.get("name"))
@@ -239,6 +262,13 @@ def _hook_from_row(
             )
         else:
             raise ValueError(f"Invalid hook config '{row_source}': 'name' is required.")
+
+    if command is not None:
+        logger.warning(
+            "Hook '%s' uses deprecated shell-string 'command'; prefer argv-array form: "
+            "command = [\"/path/to/script\", \"arg\"].",
+            name,
+        )
 
     if builtin is not None and builtin not in BUILTIN_HOOK_REGISTRY:
         valid = ", ".join(sorted(BUILTIN_HOOK_REGISTRY.keys()))
@@ -306,6 +336,7 @@ def _hook_from_row(
             event=event,
             source=source,
             command=command,
+            command_argv=command_argv,
             builtin=builtin,
             timeout_secs=timeout_secs,
             interval=interval,

--- a/src/meridian/lib/hooks/dispatch.py
+++ b/src/meridian/lib/hooks/dispatch.py
@@ -25,6 +25,7 @@ from meridian.lib.hooks.types import (
     HookResult,
     SpawnStatus,
 )
+from meridian.lib.launch.env_sanitize import ChildEnvPolicy, child_env_policy_from_config
 from meridian.plugin_api import Hook as PluginHook
 from meridian.plugin_api import HookContext as PluginHookContext
 
@@ -52,6 +53,22 @@ class _ExternalRunnerLike(Protocol):
 logger = structlog.get_logger(__name__)
 
 
+def _resolve_hook_env_policy(
+    project_root: Path,
+    *,
+    env_policy: ChildEnvPolicy | None = None,
+) -> ChildEnvPolicy | None:
+    if env_policy is not None:
+        return env_policy
+    try:
+        from meridian.lib.config.settings import load_config
+
+        return child_env_policy_from_config(load_config(project_root))
+    except Exception:
+        logger.debug("hook_env_policy_load_failed", project_root=str(project_root))
+        return None
+
+
 class HookDispatcher(LifecycleHook):
     """Coordinate hook execution for lifecycle events."""
 
@@ -65,6 +82,7 @@ class HookDispatcher(LifecycleHook):
         interval_tracker: _IntervalTrackerLike | None = None,
         external_runner: _ExternalRunnerLike | None = None,
         builtin_hooks: Mapping[str, BuiltinHook] | None = None,
+        env_policy: ChildEnvPolicy | None = None,
     ) -> None:
         if authority is not None:
             self._project_root = authority.project_root.expanduser().resolve()
@@ -86,7 +104,14 @@ class HookDispatcher(LifecycleHook):
             authority=self._authority,
         )
         self._interval_tracker = interval_tracker or IntervalTracker(self._runtime_root)
-        self._external_runner = external_runner or ExternalHookRunner(self._project_root)
+        resolved_env_policy = _resolve_hook_env_policy(
+            self._project_root,
+            env_policy=env_policy,
+        )
+        self._external_runner = external_runner or ExternalHookRunner(
+            self._project_root,
+            env_policy=resolved_env_policy,
+        )
         self._builtin_hooks = builtin_hooks or BUILTIN_HOOKS
 
     @classmethod
@@ -98,6 +123,7 @@ class HookDispatcher(LifecycleHook):
         interval_tracker: _IntervalTrackerLike | None = None,
         external_runner: _ExternalRunnerLike | None = None,
         builtin_hooks: Mapping[str, BuiltinHook] | None = None,
+        env_policy: ChildEnvPolicy | None = None,
     ) -> HookDispatcher:
         """Build a dispatcher from shared application context authority."""
 
@@ -120,6 +146,12 @@ class HookDispatcher(LifecycleHook):
             interval_tracker=interval_tracker,
             external_runner=external_runner,
             builtin_hooks=builtin_hooks,
+            env_policy=env_policy
+            or (
+                child_env_policy_from_config(context.config)
+                if context.config is not None
+                else None
+            ),
         )
 
     def on_event(self, event: LifecycleEvent) -> None:

--- a/src/meridian/lib/hooks/runner.py
+++ b/src/meridian/lib/hooks/runner.py
@@ -9,6 +9,7 @@ from collections.abc import Mapping
 from pathlib import Path
 
 from meridian.lib.hooks.types import Hook, HookContext, HookResult
+from meridian.lib.launch.env_sanitize import build_meridian_subprocess_env
 from meridian.lib.platform.process_scope.fallback import terminate_tree_sync
 
 _TAIL_BYTES = 1024
@@ -83,7 +84,7 @@ class ExternalHookRunner:
         if timeout_secs <= 0:
             raise ValueError("timeout_secs must be > 0.")
 
-        if not hook.command:
+        if not hook.command and not hook.command_argv:
             return HookResult(
                 hook_name=hook.name,
                 event=context.event_name,
@@ -92,21 +93,37 @@ class ExternalHookRunner:
                 error="Hook command is required for external execution.",
             )
 
-        env = {**os.environ, **context.to_env()}
+        env = build_meridian_subprocess_env(
+            base_env=os.environ,
+            env_overrides=context.to_env(),
+        )
         env.pop("MERIDIAN_RUNTIME_DIR", None)
         start = time.monotonic()
         process: subprocess.Popen[bytes] | None = None
 
         try:
-            process = subprocess.Popen(
-                hook.command,
-                shell=True,
-                cwd=self._project_root,
-                env=env,
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-            )
+            if hook.command_argv:
+                process = subprocess.Popen(
+                    list(hook.command_argv),
+                    shell=False,
+                    cwd=self._project_root,
+                    env=env,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+            elif hook.command is not None:
+                process = subprocess.Popen(
+                    hook.command,
+                    shell=True,
+                    cwd=self._project_root,
+                    env=env,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+            else:
+                raise RuntimeError("hook command resolution failed")
             stdout, stderr = process.communicate(
                 input=context.to_json().encode("utf-8"),
                 timeout=timeout_secs,

--- a/src/meridian/lib/hooks/runner.py
+++ b/src/meridian/lib/hooks/runner.py
@@ -9,7 +9,10 @@ from collections.abc import Mapping
 from pathlib import Path
 
 from meridian.lib.hooks.types import Hook, HookContext, HookResult
-from meridian.lib.launch.env_sanitize import build_meridian_subprocess_env
+from meridian.lib.launch.env_sanitize import (
+    ChildEnvPolicy,
+    build_meridian_subprocess_env,
+)
 from meridian.lib.platform.process_scope.fallback import terminate_tree_sync
 
 _TAIL_BYTES = 1024
@@ -65,8 +68,14 @@ def _terminate_process_tree(process: subprocess.Popen[bytes], *, grace_secs: flo
 class ExternalHookRunner:
     """Run one external hook command with context transport and timeout handling."""
 
-    def __init__(self, project_root: Path) -> None:
+    def __init__(
+        self,
+        project_root: Path,
+        *,
+        env_policy: ChildEnvPolicy | None = None,
+    ) -> None:
         self._project_root = project_root.expanduser().resolve()
+        self._env_policy = env_policy
 
     def run(self, hook: Hook, context: HookContext, *, timeout_secs: int) -> HookResult:
         """Execute one hook command and return structured result."""
@@ -96,6 +105,7 @@ class ExternalHookRunner:
         env = build_meridian_subprocess_env(
             base_env=os.environ,
             env_overrides=context.to_env(),
+            env_policy=self._env_policy,
         )
         env.pop("MERIDIAN_RUNTIME_DIR", None)
         start = time.monotonic()

--- a/src/meridian/lib/hooks/types.py
+++ b/src/meridian/lib/hooks/types.py
@@ -70,6 +70,7 @@ class Hook:
     event: HookEventName
     source: str
     command: str | None = None
+    command_argv: tuple[str, ...] | None = None
     builtin: str | None = None
     timeout_secs: int | None = None
     interval: str | None = None

--- a/src/meridian/lib/launch/__init__.py
+++ b/src/meridian/lib/launch/__init__.py
@@ -96,6 +96,7 @@ def launch_primary(
     from meridian.lib.catalog.catalog_session import CatalogSession
     from meridian.lib.config.project_root import resolve_project_root_resolution
     from meridian.lib.core.context import resolve_runtime_context
+    from meridian.lib.ops.depth import with_record_backed_depth
     from meridian.lib.ops.runtime import resolve_runtime_root_for_read
 
     from .context import (
@@ -111,9 +112,11 @@ def launch_primary(
     resolved_project_root = resolve_project_root_resolution(project_root).project_root
     explicit_work_id = _explicit_work_id_for_launch(request)
     runtime_root_for_context = resolve_runtime_root_for_read(resolved_project_root)
-    runtime_context = resolve_runtime_context(
-        project_root=resolved_project_root,
-        runtime_root=runtime_root_for_context,
+    runtime_context = with_record_backed_depth(
+        resolve_runtime_context(
+            project_root=resolved_project_root,
+            runtime_root=runtime_root_for_context,
+        )
     )
     inherit_ambient_work = request.session_mode.value != "resume"
     inherited_task_dir = (

--- a/src/meridian/lib/launch/context.py
+++ b/src/meridian/lib/launch/context.py
@@ -172,6 +172,9 @@ class ChildEnvContext:
             explicit_runtime_root=resolved_runtime_root,
             context_config=context_config,
         )
+        from meridian.lib.ops.depth import with_record_backed_depth
+
+        resolved = with_record_backed_depth(resolved)
         return cls(resolved=resolved)
 
     @property

--- a/src/meridian/lib/launch/context.py
+++ b/src/meridian/lib/launch/context.py
@@ -85,7 +85,7 @@ from .composition import (
 )
 from .constants import DRY_RUN_REPORT_PATH, REPORT_FILENAME, SYSTEM_PROMPT_FILENAME
 from .cwd import LaunchDirectoryContext
-from .env import build_env_plan
+from .env import build_env_plan, child_env_policy_from_config
 from .env import merge_env_overrides as _merge_env_overrides
 from .permissions import (
     CLAUDE_NATIVE_DELEGATION_TOOLS,
@@ -2016,12 +2016,25 @@ def bind_launch_context(
         preflight_overrides=preflight.extra_env,
     )
     bind_env_overrides.update(workspace_projection.env_overrides)
+    launch_config = (
+        MeridianConfig.model_validate(runtime.config_snapshot)
+        if runtime.config_snapshot
+        else load_config(project_paths.project_root)
+    )
+    env_policy = child_env_policy_from_config(launch_config)
+    explicit_env_grants = tuple(
+        key
+        for key in bindings.plan_overrides
+        if key.strip() and not key.upper().startswith("MERIDIAN_")
+    )
     env = build_env_plan(
         base_env=os.environ,
         adapter=harness,
         run_inputs=run_params,
         permission_config=permission_config,
         runtime_env_overrides=bind_env_overrides,
+        env_policy=env_policy,
+        explicit_env_grants=explicit_env_grants,
     )
     environment = ResolvedLaunchEnvironment.build(
         child_context_env=child_context_env,

--- a/src/meridian/lib/launch/env.py
+++ b/src/meridian/lib/launch/env.py
@@ -166,7 +166,7 @@ def build_harness_child_env(
             blocked=blocked,
         )
     passthrough = collect_child_env_passthrough(
-        harness_id=adapter.id,
+        harness_passthrough=adapter.contract.coordinator_env_passthrough,
         policy=env_policy,
         explicit_grants=explicit_env_grants,
     )

--- a/src/meridian/lib/launch/env.py
+++ b/src/meridian/lib/launch/env.py
@@ -12,97 +12,33 @@ from meridian.lib.harness.connections.base import PiSessionRole
 from meridian.lib.safety.permissions import PermissionConfig
 
 from .constants import BLOCKED_CHILD_ENV_VARS
-
-_CHILD_ENV_ALLOWLIST = frozenset(
-    {
-        "PATH",
-        "HOME",
-        "USER",
-        "SHELL",
-        "LANG",
-        "TERM",
-        "TMPDIR",
-        "PYTHONPATH",
-        "VIRTUAL_ENV",
-    }
+from .env_sanitize import (
+    ChildEnvPolicy,
+    build_connection_child_env,
+    build_meridian_subprocess_env,
+    child_env_policy_from_config,
+    collect_child_env_passthrough,
+    inherit_child_env,
+    sanitize_child_env,
 )
-_CHILD_ENV_ALLOWLIST_PREFIXES = ("LC_", "XDG_", "UV_")
-_CHILD_ENV_SECRET_SUFFIXES = ("_TOKEN", "_KEY", "_SECRET")
+
 _PI_SESSION_DIR_ENV = "PI_CODING_AGENT_SESSION_DIR"
 
-
-def _is_allowlisted_child_env_var(key: str) -> bool:
-    normalized = key.upper()
-    if normalized in _CHILD_ENV_ALLOWLIST:
-        return True
-    return any(normalized.startswith(prefix) for prefix in _CHILD_ENV_ALLOWLIST_PREFIXES)
-
-
-def _looks_like_secret_env_var(key: str) -> bool:
-    normalized = key.upper()
-    return any(normalized.endswith(suffix) for suffix in _CHILD_ENV_SECRET_SUFFIXES)
-
-
-def _normalize_meridian_env(env: dict[str, str]) -> None:
-    """Normalize MERIDIAN_CONTEXT_*_DIR path overrides.
-
-    Trims whitespace and drops blank placeholders.
-    """
-    import re
-
-    context_pattern = re.compile(r"^MERIDIAN_CONTEXT_[A-Z][A-Z0-9_]*_DIR$")
-    to_drop: list[str] = []
-    normalize_keys = ("MERIDIAN_ACTIVE_WORK_DIR", "MERIDIAN_PROJECT_ROOT", "MERIDIAN_TASK_DIR")
-    for key in env:
-        if key not in normalize_keys and not context_pattern.match(key):
-            continue
-        normalized = env[key].strip()
-        if normalized:
-            env[key] = normalized
-        else:
-            to_drop.append(key)
-    for key in to_drop:
-        env.pop(key, None)
-
-
-def sanitize_child_env(
-    base_env: Mapping[str, str],
-    env_overrides: Mapping[str, str] | None,
-    pass_through: Collection[str],
-) -> dict[str, str]:
-    """Return a sanitized child environment with explicit pass-through controls."""
-
-    pass_through_keys = {name.upper() for name in pass_through}
-    sanitized: dict[str, str] = {}
-
-    for key, value in base_env.items():
-        normalized = key.upper()
-        if _looks_like_secret_env_var(normalized) and normalized not in pass_through_keys:
-            continue
-        if normalized in pass_through_keys or _is_allowlisted_child_env_var(normalized):
-            sanitized[key] = value
-
-    if env_overrides is not None:
-        sanitized.update(env_overrides)
-
-    _normalize_meridian_env(sanitized)
-    return sanitized
-
-
-def inherit_child_env(
-    base_env: Mapping[str, str],
-    env_overrides: Mapping[str, str] | None,
-    *,
-    blocked: Collection[str] = BLOCKED_CHILD_ENV_VARS,
-) -> dict[str, str]:
-    """Return an inherited child environment with targeted non-propagation."""
-
-    blocked_keys = {name.upper() for name in blocked}
-    inherited = {key: value for key, value in base_env.items() if key.upper() not in blocked_keys}
-    if env_overrides is not None:
-        inherited.update(env_overrides)
-    _normalize_meridian_env(inherited)
-    return inherited
+__all__ = [
+    "ChildEnvPolicy",
+    "build_connection_child_env",
+    "build_env_plan",
+    "build_harness_child_env",
+    "build_harness_env_overrides",
+    "build_meridian_subprocess_env",
+    "child_env_policy_from_config",
+    "collect_child_env_passthrough",
+    "inherit_child_env",
+    "merge_env_overrides",
+    "resolve_pi_session_role",
+    "sanitize_child_env",
+    "scope_pi_session_dir_for_spawn",
+]
 
 
 def build_harness_env_overrides(
@@ -205,8 +141,10 @@ def build_harness_child_env(
     run_params: SpawnParams,
     permission_config: PermissionConfig,
     runtime_env_overrides: Mapping[str, str] | None = None,
+    env_policy: ChildEnvPolicy | None = None,
+    explicit_env_grants: Collection[str] = (),
 ) -> dict[str, str]:
-    """Build one inherited child env for a trusted harness launch."""
+    """Build one child env for a harness launch."""
 
     merged_env = build_harness_env_overrides(
         adapter=adapter,
@@ -220,10 +158,22 @@ def build_harness_child_env(
         adapter_blocked = cast("Callable[[], frozenset[str]]", blocked_child_env_vars)()
     else:
         adapter_blocked = cast("frozenset[str]", frozenset())
-    return inherit_child_env(
+    blocked = BLOCKED_CHILD_ENV_VARS | adapter_blocked | RUNTIME_OVERRIDE_ENV_VARS
+    if env_policy is not None and env_policy.inherit_full_env:
+        return inherit_child_env(
+            base_env=base_env,
+            env_overrides=merged_env,
+            blocked=blocked,
+        )
+    passthrough = collect_child_env_passthrough(
+        harness_id=adapter.id,
+        policy=env_policy,
+        explicit_grants=explicit_env_grants,
+    )
+    return sanitize_child_env(
         base_env=base_env,
         env_overrides=merged_env,
-        blocked=BLOCKED_CHILD_ENV_VARS | adapter_blocked | RUNTIME_OVERRIDE_ENV_VARS,
+        pass_through=passthrough,
     )
 
 
@@ -234,6 +184,8 @@ def build_env_plan(
     run_inputs: SpawnParams,
     permission_config: PermissionConfig,
     runtime_env_overrides: Mapping[str, str] | None = None,
+    env_policy: ChildEnvPolicy | None = None,
+    explicit_env_grants: Collection[str] = (),
 ) -> dict[str, str]:
     """Stage-owned entrypoint for launch child-environment construction."""
 
@@ -243,4 +195,6 @@ def build_env_plan(
         run_params=run_inputs,
         permission_config=permission_config,
         runtime_env_overrides=runtime_env_overrides,
+        env_policy=env_policy,
+        explicit_env_grants=explicit_env_grants,
     )

--- a/src/meridian/lib/launch/env_sanitize.py
+++ b/src/meridian/lib/launch/env_sanitize.py
@@ -5,11 +5,7 @@ from dataclasses import dataclass
 from typing import cast
 from urllib.parse import urlsplit, urlunsplit
 
-from meridian.lib.core.types import HarnessId
-from meridian.lib.launch.harness_env_passthrough import (
-    HarnessEnvPassthrough,
-    harness_env_passthrough,
-)
+from meridian.lib.harness.coordinator_env import CoordinatorEnvPassthrough
 
 from .constants import BLOCKED_CHILD_ENV_VARS
 
@@ -119,7 +115,7 @@ def _looks_like_secret_env_var(key: str) -> bool:
     return any(normalized.endswith(suffix) for suffix in _CHILD_ENV_SECRET_SUFFIXES)
 
 
-def _matches_passthrough(key: str, passthrough: HarnessEnvPassthrough) -> bool:
+def _matches_passthrough(key: str, passthrough: CoordinatorEnvPassthrough) -> bool:
     normalized = key.upper()
     if normalized in passthrough.exact:
         return True
@@ -136,19 +132,18 @@ class ChildEnvPolicy:
 
 def collect_child_env_passthrough(
     *,
-    harness_id: HarnessId,
+    harness_passthrough: CoordinatorEnvPassthrough,
     policy: ChildEnvPolicy | None = None,
     explicit_grants: Collection[str] = (),
-) -> HarnessEnvPassthrough:
+) -> CoordinatorEnvPassthrough:
     """Merge harness, config, and explicit env-grant passthrough declarations."""
 
-    harness = harness_env_passthrough(harness_id)
     extra_exact = {name.upper() for name in explicit_grants}
     if policy is not None:
         extra_exact.update(policy.extra_passthrough)
-    return HarnessEnvPassthrough(
-        exact=harness.exact | extra_exact,
-        prefixes=harness.prefixes,
+    return CoordinatorEnvPassthrough(
+        exact=harness_passthrough.exact | extra_exact,
+        prefixes=harness_passthrough.prefixes,
     )
 
 
@@ -177,14 +172,14 @@ def _normalize_meridian_env(env: dict[str, str]) -> None:
 def sanitize_child_env(
     base_env: Mapping[str, str],
     env_overrides: Mapping[str, str] | None,
-    pass_through: Collection[str] | HarnessEnvPassthrough,
+    pass_through: Collection[str] | CoordinatorEnvPassthrough,
 ) -> dict[str, str]:
     """Return a sanitized child environment with explicit pass-through controls."""
 
-    if isinstance(pass_through, HarnessEnvPassthrough):
+    if isinstance(pass_through, CoordinatorEnvPassthrough):
         passthrough = pass_through
     else:
-        passthrough = HarnessEnvPassthrough(
+        passthrough = CoordinatorEnvPassthrough(
             exact=frozenset(name.upper() for name in pass_through),
         )
     sanitized: dict[str, str] = {}
@@ -230,7 +225,7 @@ def inherit_child_env(
 
 def build_connection_child_env(
     *,
-    harness_id: HarnessId,
+    harness_passthrough: CoordinatorEnvPassthrough,
     base_env: Mapping[str, str],
     env_overrides: Mapping[str, str] | None,
     env_policy: ChildEnvPolicy | None = None,
@@ -246,7 +241,7 @@ def build_connection_child_env(
             blocked=blocked,
         )
     passthrough = collect_child_env_passthrough(
-        harness_id=harness_id,
+        harness_passthrough=harness_passthrough,
         policy=env_policy,
         explicit_grants=explicit_env_grants,
     )
@@ -271,7 +266,7 @@ def build_meridian_subprocess_env(
             env_overrides=env_overrides,
             blocked=BLOCKED_CHILD_ENV_VARS,
         )
-    passthrough = HarnessEnvPassthrough(
+    passthrough = CoordinatorEnvPassthrough(
         exact=env_policy.extra_passthrough if env_policy is not None else frozenset(),
     )
     return sanitize_child_env(

--- a/src/meridian/lib/launch/env_sanitize.py
+++ b/src/meridian/lib/launch/env_sanitize.py
@@ -3,6 +3,7 @@
 from collections.abc import Collection, Mapping
 from dataclasses import dataclass
 from typing import cast
+from urllib.parse import urlsplit, urlunsplit
 
 from meridian.lib.core.types import HarnessId
 from meridian.lib.launch.harness_env_passthrough import (
@@ -45,11 +46,29 @@ _WINDOWS_BASELINE_ENV_VARS = frozenset(
     }
 )
 
+_NPM_CONFIG_ENV_VARS = frozenset(
+    {
+        "NPM_CONFIG_USERCONFIG",
+        "NPM_CONFIG_CACHE",
+        "NPM_CONFIG_PREFIX",
+        "NPM_CONFIG_REGISTRY",
+    }
+)
+
 _NODE_RUNTIME_ENV_VARS = frozenset(
     {
         "PNPM_HOME",
+        "NODE_OPTIONS",
+    }
+) | _NPM_CONFIG_ENV_VARS
+
+_COREPACK_RUNTIME_ENV_VARS = frozenset(
+    {
+        "COREPACK_ENABLE_DOWNLOAD_PROMPT",
     }
 )
+
+_NPM_CONFIG_URL_SCRUB_VARS = frozenset({"NPM_CONFIG_REGISTRY"})
 
 _CHILD_ENV_ALLOWLIST = frozenset(
     {
@@ -63,9 +82,29 @@ _CHILD_ENV_ALLOWLIST = frozenset(
         "PYTHONPATH",
         "VIRTUAL_ENV",
     }
-) | _NETWORK_TLS_ENV_VARS | _WINDOWS_BASELINE_ENV_VARS | _NODE_RUNTIME_ENV_VARS
-_CHILD_ENV_ALLOWLIST_PREFIXES = ("LC_", "XDG_", "UV_", "NODE_", "NPM_CONFIG_", "COREPACK_")
+) | (
+    _NETWORK_TLS_ENV_VARS
+    | _WINDOWS_BASELINE_ENV_VARS
+    | _NODE_RUNTIME_ENV_VARS
+    | _COREPACK_RUNTIME_ENV_VARS
+)
+_CHILD_ENV_ALLOWLIST_PREFIXES = ("LC_", "XDG_", "UV_")
 _CHILD_ENV_SECRET_SUFFIXES = ("_TOKEN", "_KEY", "_SECRET")
+
+
+def _scrub_url_userinfo(value: str) -> str:
+    """Remove embedded HTTP basic-auth credentials from a URL env value."""
+
+    stripped = value.strip()
+    if "://" not in stripped or "@" not in stripped:
+        return value
+    parts = urlsplit(stripped)
+    if parts.username is None and parts.password is None:
+        return value
+    hostname = parts.hostname or ""
+    if parts.port is not None:
+        hostname = f"{hostname}:{parts.port}"
+    return urlunsplit((parts.scheme, hostname, parts.path, parts.query, parts.fragment))
 
 
 def _is_allowlisted_child_env_var(key: str) -> bool:
@@ -161,7 +200,10 @@ def sanitize_child_env(
         if _matches_passthrough(normalized, passthrough) or _is_allowlisted_child_env_var(
             normalized
         ):
-            sanitized[key] = value
+            if normalized in _NPM_CONFIG_URL_SCRUB_VARS:
+                sanitized[key] = _scrub_url_userinfo(value)
+            else:
+                sanitized[key] = value
 
     if env_overrides is not None:
         sanitized.update(env_overrides)

--- a/src/meridian/lib/launch/env_sanitize.py
+++ b/src/meridian/lib/launch/env_sanitize.py
@@ -12,6 +12,45 @@ from meridian.lib.launch.harness_env_passthrough import (
 
 from .constants import BLOCKED_CHILD_ENV_VARS
 
+_NETWORK_TLS_ENV_VARS = frozenset(
+    {
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
+        "NO_PROXY",
+        "SSL_CERT_FILE",
+        "SSL_CERT_DIR",
+        "REQUESTS_CA_BUNDLE",
+        "CURL_CA_BUNDLE",
+        "NODE_EXTRA_CA_CERTS",
+    }
+)
+
+_WINDOWS_BASELINE_ENV_VARS = frozenset(
+    {
+        "USERPROFILE",
+        "APPDATA",
+        "LOCALAPPDATA",
+        "SYSTEMROOT",
+        "SYSTEMDRIVE",
+        "COMSPEC",
+        "PATHEXT",
+        "TEMP",
+        "TMP",
+        "WINDIR",
+        "HOMEDRIVE",
+        "HOMEPATH",
+        "NUMBER_OF_PROCESSORS",
+        "PROCESSOR_ARCHITECTURE",
+    }
+)
+
+_NODE_RUNTIME_ENV_VARS = frozenset(
+    {
+        "PNPM_HOME",
+    }
+)
+
 _CHILD_ENV_ALLOWLIST = frozenset(
     {
         "PATH",
@@ -24,8 +63,8 @@ _CHILD_ENV_ALLOWLIST = frozenset(
         "PYTHONPATH",
         "VIRTUAL_ENV",
     }
-)
-_CHILD_ENV_ALLOWLIST_PREFIXES = ("LC_", "XDG_", "UV_")
+) | _NETWORK_TLS_ENV_VARS | _WINDOWS_BASELINE_ENV_VARS | _NODE_RUNTIME_ENV_VARS
+_CHILD_ENV_ALLOWLIST_PREFIXES = ("LC_", "XDG_", "UV_", "NODE_", "NPM_CONFIG_", "COREPACK_")
 _CHILD_ENV_SECRET_SUFFIXES = ("_TOKEN", "_KEY", "_SECRET")
 
 

--- a/src/meridian/lib/launch/env_sanitize.py
+++ b/src/meridian/lib/launch/env_sanitize.py
@@ -1,0 +1,227 @@
+"""Sanitized child-environment primitives without harness adapter imports."""
+
+from collections.abc import Collection, Mapping
+from dataclasses import dataclass
+from typing import cast
+
+from meridian.lib.core.types import HarnessId
+from meridian.lib.launch.harness_env_passthrough import (
+    HarnessEnvPassthrough,
+    harness_env_passthrough,
+)
+
+from .constants import BLOCKED_CHILD_ENV_VARS
+
+_CHILD_ENV_ALLOWLIST = frozenset(
+    {
+        "PATH",
+        "HOME",
+        "USER",
+        "SHELL",
+        "LANG",
+        "TERM",
+        "TMPDIR",
+        "PYTHONPATH",
+        "VIRTUAL_ENV",
+    }
+)
+_CHILD_ENV_ALLOWLIST_PREFIXES = ("LC_", "XDG_", "UV_")
+_CHILD_ENV_SECRET_SUFFIXES = ("_TOKEN", "_KEY", "_SECRET")
+
+
+def _is_allowlisted_child_env_var(key: str) -> bool:
+    normalized = key.upper()
+    if normalized in _CHILD_ENV_ALLOWLIST:
+        return True
+    return any(normalized.startswith(prefix) for prefix in _CHILD_ENV_ALLOWLIST_PREFIXES)
+
+
+def _looks_like_secret_env_var(key: str) -> bool:
+    normalized = key.upper()
+    return any(normalized.endswith(suffix) for suffix in _CHILD_ENV_SECRET_SUFFIXES)
+
+
+def _matches_passthrough(key: str, passthrough: HarnessEnvPassthrough) -> bool:
+    normalized = key.upper()
+    if normalized in passthrough.exact:
+        return True
+    return any(normalized.startswith(prefix) for prefix in passthrough.prefixes)
+
+
+@dataclass(frozen=True)
+class ChildEnvPolicy:
+    """Project-level child-env policy loaded from ``[spawn]`` config."""
+
+    inherit_full_env: bool = False
+    extra_passthrough: frozenset[str] = frozenset()
+
+
+def collect_child_env_passthrough(
+    *,
+    harness_id: HarnessId,
+    policy: ChildEnvPolicy | None = None,
+    explicit_grants: Collection[str] = (),
+) -> HarnessEnvPassthrough:
+    """Merge harness, config, and explicit env-grant passthrough declarations."""
+
+    harness = harness_env_passthrough(harness_id)
+    extra_exact = {name.upper() for name in explicit_grants}
+    if policy is not None:
+        extra_exact.update(policy.extra_passthrough)
+    return HarnessEnvPassthrough(
+        exact=harness.exact | extra_exact,
+        prefixes=harness.prefixes,
+    )
+
+
+def _normalize_meridian_env(env: dict[str, str]) -> None:
+    """Normalize MERIDIAN_CONTEXT_*_DIR path overrides.
+
+    Trims whitespace and drops blank placeholders.
+    """
+    import re
+
+    context_pattern = re.compile(r"^MERIDIAN_CONTEXT_[A-Z][A-Z0-9_]*_DIR$")
+    to_drop: list[str] = []
+    normalize_keys = ("MERIDIAN_ACTIVE_WORK_DIR", "MERIDIAN_PROJECT_ROOT", "MERIDIAN_TASK_DIR")
+    for key in env:
+        if key not in normalize_keys and not context_pattern.match(key):
+            continue
+        normalized = env[key].strip()
+        if normalized:
+            env[key] = normalized
+        else:
+            to_drop.append(key)
+    for key in to_drop:
+        env.pop(key, None)
+
+
+def sanitize_child_env(
+    base_env: Mapping[str, str],
+    env_overrides: Mapping[str, str] | None,
+    pass_through: Collection[str] | HarnessEnvPassthrough,
+) -> dict[str, str]:
+    """Return a sanitized child environment with explicit pass-through controls."""
+
+    if isinstance(pass_through, HarnessEnvPassthrough):
+        passthrough = pass_through
+    else:
+        passthrough = HarnessEnvPassthrough(
+            exact=frozenset(name.upper() for name in pass_through),
+        )
+    sanitized: dict[str, str] = {}
+
+    for key, value in base_env.items():
+        normalized = key.upper()
+        if normalized.startswith("MERIDIAN_"):
+            continue
+        if _looks_like_secret_env_var(normalized) and not _matches_passthrough(
+            normalized, passthrough
+        ):
+            continue
+        if _matches_passthrough(normalized, passthrough) or _is_allowlisted_child_env_var(
+            normalized
+        ):
+            sanitized[key] = value
+
+    if env_overrides is not None:
+        sanitized.update(env_overrides)
+
+    _normalize_meridian_env(sanitized)
+    return sanitized
+
+
+def inherit_child_env(
+    base_env: Mapping[str, str],
+    env_overrides: Mapping[str, str] | None,
+    *,
+    blocked: Collection[str] = BLOCKED_CHILD_ENV_VARS,
+) -> dict[str, str]:
+    """Return an inherited child environment with targeted non-propagation."""
+
+    blocked_keys = {name.upper() for name in blocked}
+    inherited = {key: value for key, value in base_env.items() if key.upper() not in blocked_keys}
+    if env_overrides is not None:
+        inherited.update(env_overrides)
+    _normalize_meridian_env(inherited)
+    return inherited
+
+
+def build_connection_child_env(
+    *,
+    harness_id: HarnessId,
+    base_env: Mapping[str, str],
+    env_overrides: Mapping[str, str] | None,
+    env_policy: ChildEnvPolicy | None = None,
+    explicit_env_grants: Collection[str] = (),
+    blocked: Collection[str] = BLOCKED_CHILD_ENV_VARS,
+) -> dict[str, str]:
+    """Build sanitized child env for one harness connection transport."""
+
+    if env_policy is not None and env_policy.inherit_full_env:
+        return inherit_child_env(
+            base_env=base_env,
+            env_overrides=env_overrides,
+            blocked=blocked,
+        )
+    passthrough = collect_child_env_passthrough(
+        harness_id=harness_id,
+        policy=env_policy,
+        explicit_grants=explicit_env_grants,
+    )
+    return sanitize_child_env(
+        base_env=base_env,
+        env_overrides=env_overrides,
+        pass_through=passthrough,
+    )
+
+
+def build_meridian_subprocess_env(
+    *,
+    base_env: Mapping[str, str],
+    env_overrides: Mapping[str, str] | None = None,
+    env_policy: ChildEnvPolicy | None = None,
+) -> dict[str, str]:
+    """Build sanitized env for Meridian-to-Meridian subprocesses (e.g. bg workers)."""
+
+    if env_policy is not None and env_policy.inherit_full_env:
+        return inherit_child_env(
+            base_env=base_env,
+            env_overrides=env_overrides,
+            blocked=BLOCKED_CHILD_ENV_VARS,
+        )
+    passthrough = HarnessEnvPassthrough(
+        exact=env_policy.extra_passthrough if env_policy is not None else frozenset(),
+    )
+    return sanitize_child_env(
+        base_env=base_env,
+        env_overrides=env_overrides,
+        pass_through=passthrough,
+    )
+
+
+def child_env_policy_from_config(config: object) -> ChildEnvPolicy:
+    """Extract spawn child-env policy from one ``MeridianConfig`` instance."""
+
+    inherit_full_env = bool(getattr(config, "inherit_full_env", False))
+    raw_passthrough = getattr(config, "env_passthrough", ())
+    extra = frozenset(
+        name.strip().upper()
+        for name in cast("tuple[str, ...]", raw_passthrough or ())
+        if name.strip()
+    )
+    return ChildEnvPolicy(
+        inherit_full_env=inherit_full_env,
+        extra_passthrough=extra,
+    )
+
+
+__all__ = [
+    "ChildEnvPolicy",
+    "build_connection_child_env",
+    "build_meridian_subprocess_env",
+    "child_env_policy_from_config",
+    "collect_child_env_passthrough",
+    "inherit_child_env",
+    "sanitize_child_env",
+]

--- a/src/meridian/lib/launch/harness_env_passthrough.py
+++ b/src/meridian/lib/launch/harness_env_passthrough.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 
 from meridian.lib.core.types import HarnessId
 
-_COMMON_PROVIDER_CREDENTIALS = frozenset(
+_PROVIDER_API_KEYS = frozenset(
     {
         "ANTHROPIC_API_KEY",
         "OPENAI_API_KEY",
@@ -22,6 +22,12 @@ _COMMON_PROVIDER_CREDENTIALS = frozenset(
         "COHERE_API_KEY",
         "GROQ_API_KEY",
         "OPENROUTER_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "NVIDIA_API_KEY",
+        "CEREBRAS_API_KEY",
+        "FIREWORKS_API_KEY",
+        "TOGETHER_API_KEY",
+        "AI_GATEWAY_API_KEY",
     }
 )
 
@@ -34,20 +40,54 @@ _CLAUDE_EXACT = frozenset(
     }
 )
 
-_CODEX_EXACT = frozenset(
+_CODEX_EXACT = _PROVIDER_API_KEYS | frozenset(
     {
-        "OPENAI_API_KEY",
         "OPENAI_BASE_URL",
         "OPENAI_API_BASE",
+    }
+)
+
+_PI_PROVIDER_EXACT = frozenset(
+    {
+        "ANTHROPIC_OAUTH_TOKEN",
+        "ANT_LING_API_KEY",
+        "ZAI_API_KEY",
+        "ZAI_CODING_CN_API_KEY",
+        "MINIMAX_API_KEY",
+        "MOONSHOT_API_KEY",
+        "OPENCODE_API_KEY",
+        "KIMI_API_KEY",
+        "CLOUDFLARE_API_KEY",
+        "CLOUDFLARE_ACCOUNT_ID",
+        "CLOUDFLARE_GATEWAY_ID",
+        "XIAOMI_API_KEY",
+        "XIAOMI_TOKEN_PLAN_CN_API_KEY",
+        "XIAOMI_TOKEN_PLAN_AMS_API_KEY",
+        "XIAOMI_TOKEN_PLAN_SGP_API_KEY",
+        "AWS_PROFILE",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_BEARER_TOKEN_BEDROCK",
+        "AWS_REGION",
+    }
+)
+
+_PI_EXACT = _PROVIDER_API_KEYS | _PI_PROVIDER_EXACT
+
+_OPENCODE_EXACT = _PROVIDER_API_KEYS | frozenset(
+    {
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_BASE_URL",
+        "OPENAI_BASE_URL",
     }
 )
 
 _HARNESS_EXACT: dict[HarnessId, frozenset[str]] = {
     HarnessId.CLAUDE: _CLAUDE_EXACT,
     HarnessId.CODEX: _CODEX_EXACT,
-    HarnessId.OPENCODE: _COMMON_PROVIDER_CREDENTIALS,
+    HarnessId.OPENCODE: _OPENCODE_EXACT,
     HarnessId.CURSOR: frozenset(),
-    HarnessId.PI: _COMMON_PROVIDER_CREDENTIALS,
+    HarnessId.PI: _PI_EXACT,
 }
 
 _HARNESS_PREFIXES: dict[HarnessId, tuple[str, ...]] = {

--- a/src/meridian/lib/launch/harness_env_passthrough.py
+++ b/src/meridian/lib/launch/harness_env_passthrough.py
@@ -1,4 +1,8 @@
-"""Per-harness coordinator env passthrough declarations for child launches."""
+"""Per-harness coordinator env passthrough declarations for child launches.
+
+TODO(P3-bundle-contract): harness-specific env policy belongs under ``harness/``;
+this launch-local data module is interim only to avoid bootstrap import cycles.
+"""
 
 from __future__ import annotations
 
@@ -21,20 +25,37 @@ _COMMON_PROVIDER_CREDENTIALS = frozenset(
     }
 )
 
+_CLAUDE_EXACT = frozenset(
+    {
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_BEDROCK_BASE_URL",
+    }
+)
+
+_CODEX_EXACT = frozenset(
+    {
+        "OPENAI_API_KEY",
+        "OPENAI_BASE_URL",
+        "OPENAI_API_BASE",
+    }
+)
+
 _HARNESS_EXACT: dict[HarnessId, frozenset[str]] = {
-    HarnessId.CLAUDE: frozenset({"ANTHROPIC_API_KEY"}),
-    HarnessId.CODEX: frozenset({"OPENAI_API_KEY"}),
+    HarnessId.CLAUDE: _CLAUDE_EXACT,
+    HarnessId.CODEX: _CODEX_EXACT,
     HarnessId.OPENCODE: _COMMON_PROVIDER_CREDENTIALS,
     HarnessId.CURSOR: frozenset(),
     HarnessId.PI: _COMMON_PROVIDER_CREDENTIALS,
 }
 
 _HARNESS_PREFIXES: dict[HarnessId, tuple[str, ...]] = {
-    HarnessId.CLAUDE: ("CLAUDE_",),
-    HarnessId.CODEX: ("CODEX_",),
+    HarnessId.CLAUDE: ("CLAUDE_", "CLAUDE_CODE_", "ANTHROPIC_VERTEX_"),
+    HarnessId.CODEX: ("CODEX_", "AZURE_OPENAI_", "OPENAI_ORG"),
     HarnessId.OPENCODE: ("OPENCODE_",),
     HarnessId.CURSOR: ("CURSOR_",),
-    HarnessId.PI: ("PI_",),
+    HarnessId.PI: ("PI_", "AZURE_OPENAI_", "OPENAI_ORG"),
 }
 
 

--- a/src/meridian/lib/launch/harness_env_passthrough.py
+++ b/src/meridian/lib/launch/harness_env_passthrough.py
@@ -1,0 +1,58 @@
+"""Per-harness coordinator env passthrough declarations for child launches."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from meridian.lib.core.types import HarnessId
+
+_COMMON_PROVIDER_CREDENTIALS = frozenset(
+    {
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "GOOGLE_API_KEY",
+        "AZURE_OPENAI_API_KEY",
+        "GEMINI_API_KEY",
+        "XAI_API_KEY",
+        "MISTRAL_API_KEY",
+        "COHERE_API_KEY",
+        "GROQ_API_KEY",
+        "OPENROUTER_API_KEY",
+    }
+)
+
+_HARNESS_EXACT: dict[HarnessId, frozenset[str]] = {
+    HarnessId.CLAUDE: frozenset({"ANTHROPIC_API_KEY"}),
+    HarnessId.CODEX: frozenset({"OPENAI_API_KEY"}),
+    HarnessId.OPENCODE: _COMMON_PROVIDER_CREDENTIALS,
+    HarnessId.CURSOR: frozenset(),
+    HarnessId.PI: _COMMON_PROVIDER_CREDENTIALS,
+}
+
+_HARNESS_PREFIXES: dict[HarnessId, tuple[str, ...]] = {
+    HarnessId.CLAUDE: ("CLAUDE_",),
+    HarnessId.CODEX: ("CODEX_",),
+    HarnessId.OPENCODE: ("OPENCODE_",),
+    HarnessId.CURSOR: ("CURSOR_",),
+    HarnessId.PI: ("PI_",),
+}
+
+
+@dataclass(frozen=True)
+class HarnessEnvPassthrough:
+    """Coordinator env keys one harness may inherit beyond the default allowlist."""
+
+    exact: frozenset[str] = frozenset()
+    prefixes: tuple[str, ...] = ()
+
+
+def harness_env_passthrough(harness_id: HarnessId) -> HarnessEnvPassthrough:
+    """Return declared passthrough for one harness."""
+
+    return HarnessEnvPassthrough(
+        exact=_HARNESS_EXACT.get(harness_id, frozenset()),
+        prefixes=_HARNESS_PREFIXES.get(harness_id, ()),
+    )
+
+
+__all__ = ["HarnessEnvPassthrough", "harness_env_passthrough"]

--- a/src/meridian/lib/ops/context.py
+++ b/src/meridian/lib/ops/context.py
@@ -20,6 +20,7 @@ from meridian.lib.core.resolved_context import ResolvedContext
 from meridian.lib.core.util import FormatContext
 from meridian.lib.hooks.builtin.autosync_store import read_status
 from meridian.lib.launch.cwd import resolve_effective_task_dir
+from meridian.lib.ops.depth import with_record_backed_depth
 from meridian.lib.ops.runtime import (
     resolve_runtime_authority_for_read,
     resolve_runtime_authority_for_write,
@@ -256,11 +257,12 @@ def _resolve_runtime_context(
     """Resolve context with explicit roots — no env mutation needed."""
 
     normalized_chat_id = (chat_id or "").strip()
-    return ResolvedContext.from_environment(
+    resolved = ResolvedContext.from_environment(
         explicit_project_root=project_root,
         explicit_runtime_root=runtime_root,
         explicit_chat_id=normalized_chat_id or None,
     )
+    return with_record_backed_depth(resolved)
 
 
 def resolve_active_work_scope(

--- a/src/meridian/lib/ops/depth.py
+++ b/src/meridian/lib/ops/depth.py
@@ -1,0 +1,61 @@
+"""Ops-layer helpers for record-backed Meridian depth."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import replace
+from pathlib import Path
+
+from meridian.lib.core.context import RuntimeContext
+from meridian.lib.core.resolved_context import ResolvedContext
+from meridian.lib.state.depth_resolution import resolve_effective_meridian_depth
+
+
+def effective_meridian_depth(
+    env: Mapping[str, str],
+    *,
+    runtime_root: Path | None,
+) -> int | None:
+    """Return record-backed depth when runtime root is known, else ``None``."""
+
+    if runtime_root is None:
+        return None
+    return resolve_effective_meridian_depth(env, runtime_root=runtime_root)
+
+
+def with_record_backed_depth(
+    resolved: ResolvedContext,
+    env: Mapping[str, str] | None = None,
+) -> ResolvedContext:
+    """Return ``resolved`` with spawn-record depth applied when available."""
+
+    if resolved.runtime_root is None:
+        return resolved
+    source = os.environ if env is None else env
+    depth = resolve_effective_meridian_depth(source, runtime_root=resolved.runtime_root)
+    if depth == resolved.depth:
+        return resolved
+    return replace(resolved, depth=depth)
+
+
+def with_record_backed_runtime_context(
+    ctx: RuntimeContext,
+    env: Mapping[str, str] | None = None,
+) -> RuntimeContext:
+    """Return ``ctx`` with spawn-record depth applied when available."""
+
+    if ctx.runtime_root is None:
+        return ctx
+    source = os.environ if env is None else env
+    depth = resolve_effective_meridian_depth(source, runtime_root=ctx.runtime_root)
+    if depth == ctx.depth:
+        return ctx
+    return ctx.model_copy(update={"depth": depth})
+
+
+__all__ = [
+    "effective_meridian_depth",
+    "with_record_backed_depth",
+    "with_record_backed_runtime_context",
+]

--- a/src/meridian/lib/ops/runtime.py
+++ b/src/meridian/lib/ops/runtime.py
@@ -134,9 +134,11 @@ class ResolvedRoots:
 
 
 def runtime_context(ctx: RuntimeContext | None) -> RuntimeContext:
+    from meridian.lib.ops.depth import with_record_backed_runtime_context
+
     if ctx is not None:
-        return ctx
-    return RuntimeContext.from_environment()
+        return with_record_backed_runtime_context(ctx)
+    return with_record_backed_runtime_context(RuntimeContext.from_environment())
 
 
 def resolve_project_authority(

--- a/src/meridian/lib/ops/spawn/execute.py
+++ b/src/meridian/lib/ops/spawn/execute.py
@@ -16,6 +16,10 @@ from meridian.lib.config.project_paths import resolve_project_config_paths
 from meridian.lib.core.context import RuntimeContext
 from meridian.lib.launch.context import PreparedLaunchSurface
 from meridian.lib.launch.cwd import resolve_task_cwd
+from meridian.lib.launch.env_sanitize import (
+    build_meridian_subprocess_env,
+    child_env_policy_from_config,
+)
 from meridian.lib.launch.request import LaunchArgvIntent, SpawnRequest
 from meridian.lib.platform import IS_WINDOWS
 from meridian.lib.state import spawn_store
@@ -391,13 +395,14 @@ def execute_spawn_background(
     stdout_path = log_dir / BACKGROUND_STDOUT_FILENAME
     stderr_path = log_dir / BACKGROUND_STDERR_FILENAME
 
-    launch_env = dict(os.environ)
-    launch_env.update(
-        _spawn_background_worker_env(
+    launch_env = build_meridian_subprocess_env(
+        base_env=os.environ,
+        env_overrides=_spawn_background_worker_env(
             project_root=execution_contract.control_root,
             work_id=context.work_id,
             autocompact=request.execution_policy.autocompact,
-        )
+        ),
+        env_policy=child_env_policy_from_config(runtime.config),
     )
     try:
         with (

--- a/src/meridian/lib/ops/spawn/execute_init.py
+++ b/src/meridian/lib/ops/spawn/execute_init.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, ConfigDict
 from meridian.lib.bootstrap.services import build_spawn_lifecycle_service_from_roots
 from meridian.lib.config.project_paths import ProjectConfigPaths, resolve_project_config_paths
 from meridian.lib.core.context import RuntimeContext
-from meridian.lib.core.depth import current_meridian_depth, max_depth_reached
+from meridian.lib.core.depth import child_meridian_depth, current_meridian_depth, max_depth_reached
 from meridian.lib.core.domain import Spawn, SpawnStatus
 from meridian.lib.core.launch_policy_snapshot import LaunchPolicySnapshot
 from meridian.lib.core.resolved_context import ResolvedContext
@@ -187,6 +187,7 @@ def build_spawn_reservation(
         chat_id=owner_chat_id,
         owner_chat_id=owner_chat_id,
         parent_id=str(resolved_context.spawn_id) if resolved_context.spawn_id else None,
+        meridian_depth=child_meridian_depth(resolved_context.depth),
         session_metadata=spawn_session_metadata,
         kind="child",
         prompt=request.prompt,

--- a/src/meridian/lib/state/depth_resolution.py
+++ b/src/meridian/lib/state/depth_resolution.py
@@ -1,0 +1,73 @@
+"""Spawn-record-backed Meridian depth resolution."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+
+from meridian.lib.core.depth import (
+    MERIDIAN_DEPTH_ENV,
+    MERIDIAN_SPAWN_ID_ENV,
+    parse_meridian_depth,
+)
+from meridian.lib.core.types import SpawnId
+from meridian.lib.state import spawn_store
+
+
+def depth_from_spawn_ancestry(
+    spawn_id: str | SpawnId,
+    runtime_root: Path,
+) -> int | None:
+    """Return spawn depth from persisted records, or ``None`` when unknown."""
+
+    normalized_spawn_id = str(spawn_id).strip()
+    if not normalized_spawn_id:
+        return None
+
+    record = spawn_store.get_spawn(runtime_root, normalized_spawn_id)
+    if record is None:
+        return None
+    if record.meridian_depth is not None:
+        return record.meridian_depth
+
+    depth = 0
+    current_id = normalized_spawn_id
+    visited: set[str] = set()
+    while current_id:
+        if current_id in visited:
+            return None
+        visited.add(current_id)
+        walk_record = spawn_store.get_spawn(runtime_root, current_id)
+        if walk_record is None:
+            if current_id == normalized_spawn_id:
+                return None
+            return max(depth, record.meridian_depth or 0)
+        parent_id = (walk_record.parent_id or "").strip() or None
+        if parent_id is None:
+            return depth
+        depth += 1
+        current_id = parent_id
+    return depth
+
+
+def resolve_effective_meridian_depth(
+    env: Mapping[str, str],
+    *,
+    runtime_root: Path | None = None,
+) -> int:
+    """Return depth using coordinator records when the caller spawn is known."""
+
+    env_depth = parse_meridian_depth(env.get(MERIDIAN_DEPTH_ENV))
+    spawn_id = (env.get(MERIDIAN_SPAWN_ID_ENV) or "").strip()
+    if not spawn_id or runtime_root is None:
+        return env_depth
+    record_depth = depth_from_spawn_ancestry(spawn_id, runtime_root)
+    if record_depth is None:
+        return env_depth
+    return max(env_depth, record_depth)
+
+
+__all__ = [
+    "depth_from_spawn_ancestry",
+    "resolve_effective_meridian_depth",
+]

--- a/src/meridian/lib/state/spawn/model.py
+++ b/src/meridian/lib/state/spawn/model.py
@@ -54,6 +54,7 @@ class SpawnRecord(BaseModel):
     chat_id: str | None
     owner_chat_id: str | None = None
     parent_id: str | None
+    meridian_depth: int | None = None
     originating_bash_id: str | None = None
     model: str | None
     agent: str | None

--- a/src/meridian/lib/state/spawn/repository.py
+++ b/src/meridian/lib/state/spawn/repository.py
@@ -40,6 +40,7 @@ class StoredSpawnState(BaseModel):
     chat_id: str | None = None
     owner_chat_id: str | None = None
     parent_id: str | None = None
+    meridian_depth: int | None = None
     originating_bash_id: str | None = None
     model: str | None = None
     agent: str | None = None
@@ -114,6 +115,7 @@ def record_to_stored_state(
         chat_id=record.chat_id,
         owner_chat_id=record.owner_chat_id,
         parent_id=record.parent_id,
+        meridian_depth=record.meridian_depth,
         originating_bash_id=record.originating_bash_id,
         model=record.model,
         agent=record.agent,
@@ -171,6 +173,7 @@ def stored_state_to_record(
         chat_id=stored.chat_id,
         owner_chat_id=stored.owner_chat_id,
         parent_id=stored.parent_id,
+        meridian_depth=stored.meridian_depth,
         originating_bash_id=stored.originating_bash_id,
         model=stored.model,
         agent=stored.agent,

--- a/src/meridian/lib/state/spawn_store.py
+++ b/src/meridian/lib/state/spawn_store.py
@@ -243,6 +243,26 @@ class FinalizeOutcome(BaseModel):
     snapshot: SpawnRecord | None
 
 
+def _resolve_spawn_meridian_depth(
+    runtime_root: Path,
+    *,
+    parent_id: str | None,
+    kind: str,
+    meridian_depth: int | None,
+) -> int:
+    if meridian_depth is not None:
+        return max(0, meridian_depth)
+    if kind == "primary":
+        return 0
+    if parent_id:
+        parent = get_spawn(runtime_root, parent_id)
+        if parent is not None and parent.meridian_depth is not None:
+            return parent.meridian_depth + 1
+    from meridian.lib.core.depth import child_meridian_depth, current_meridian_depth
+
+    return child_meridian_depth(current_meridian_depth())
+
+
 def start_spawn(
     runtime_root: Path,
     *,
@@ -271,6 +291,7 @@ def start_spawn(
     runner_pid: int | None = None,
     runner_created_at_epoch: float | None = None,
     launch_policy_snapshot: LaunchPolicySnapshot | None = None,
+    meridian_depth: int | None = None,
     status: SpawnStatus = "running",
     started_at: str | None = None,
     clock: Clock | None = None,
@@ -300,6 +321,12 @@ def start_spawn(
     resolved_launch_policy_snapshot = (
         launch_policy_snapshot or start_metadata.launch_policy_snapshot
     )
+    resolved_meridian_depth = _resolve_spawn_meridian_depth(
+        runtime_root,
+        parent_id=parent_id,
+        kind=kind,
+        meridian_depth=meridian_depth,
+    )
 
     with lock_file(paths.spawns_flock):
         if spawn_id is not None:
@@ -316,6 +343,7 @@ def start_spawn(
             chat_id=chat_id,
             owner_chat_id=owner_chat_id,
             parent_id=parent_id,
+            meridian_depth=resolved_meridian_depth,
             originating_bash_id=os.environ.get("MERIDIAN_PI_BASH_ID") or None,
             model=model,
             agent=agent,

--- a/tests/integration/harness/test_opencode_connection.py
+++ b/tests/integration/harness/test_opencode_connection.py
@@ -627,10 +627,9 @@ async def test_opencode_launch_process_passes_env_overrides_to_managed_backend(
     fake_process = _FakeProcess()
     captured: dict[str, object] = {}
 
-    def _fake_inherit_child_env(
-        _base_env: Mapping[str, str],
-        overrides: dict[str, str],
-    ) -> dict[str, str]:
+    def _fake_build_connection_child_env(**kwargs: object) -> dict[str, str]:
+        overrides = kwargs.get("env_overrides")
+        assert isinstance(overrides, dict)
         captured["overrides"] = dict(overrides)
         return {"MERIDIAN_INHERIT_CALLED": "1", **overrides}
 
@@ -661,7 +660,11 @@ async def test_opencode_launch_process_passes_env_overrides_to_managed_backend(
         )
 
     monkeypatch.setattr(opencode_http, "_find_free_port", lambda _host="127.0.0.1": 17777)
-    monkeypatch.setattr(opencode_http, "inherit_child_env", _fake_inherit_child_env)
+    monkeypatch.setattr(
+        opencode_http,
+        "build_connection_child_env",
+        _fake_build_connection_child_env,
+    )
     monkeypatch.setattr(opencode_http, "launch_managed_backend", _fake_launch_managed_backend)
 
     await connection._launch_process(config, spec)

--- a/tests/integration/launch/test_permissions.py
+++ b/tests/integration/launch/test_permissions.py
@@ -215,12 +215,14 @@ def test_sanitize_child_env_strips_secrets() -> None:
     assert "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE" not in sanitized
 
 
-def test_build_harness_child_env_inherits_allowed_vars_and_blocks_adapter_vars() -> None:
+def test_build_harness_child_env_sanitizes_secrets_and_keeps_harness_credentials() -> None:
     child_env = build_harness_child_env(
         base_env={
             "PATH": "/usr/bin",
-            "UNRELATED_TOKEN": "keep-me",
-            "MISC_VALUE": "keep-too",
+            "FOO_API_KEY": "drop-me",
+            "UNRELATED_TOKEN": "drop-me-too",
+            "MISC_VALUE": "misc",
+            "ANTHROPIC_API_KEY": "allowed-credential",
             "CLAUDECODE": "1",
             "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "67",
             "MERIDIAN_PRIMARY_PROMPT": "stale",
@@ -228,15 +230,20 @@ def test_build_harness_child_env_inherits_allowed_vars_and_blocks_adapter_vars()
         adapter=ClaudeAdapter(),
         run_params=SpawnParams(prompt="test", model=ModelId("claude-sonnet-4-6")),
         permission_config=PermissionConfig(),
-        runtime_env_overrides={"MERIDIAN_DEPTH": "2"},
+        runtime_env_overrides={
+            "MERIDIAN_DEPTH": "2",
+            "MERIDIAN_SPAWN_ID": "p-child",
+        },
     )
 
     assert child_env["PATH"] == "/usr/bin"
-    assert child_env["UNRELATED_TOKEN"] == "keep-me"
-    assert child_env["MISC_VALUE"] == "keep-too"
+    assert child_env["ANTHROPIC_API_KEY"] == "allowed-credential"
     assert child_env["MERIDIAN_DEPTH"] == "2"
-    assert child_env["MERIDIAN_PRIMARY_PROMPT"] == "stale"
+    assert child_env["MERIDIAN_SPAWN_ID"] == "p-child"
     assert child_env["CLAUDE_AUTOCOMPACT_PCT_OVERRIDE"] == "67"
+    assert "FOO_API_KEY" not in child_env
+    assert "UNRELATED_TOKEN" not in child_env
+    assert "MISC_VALUE" not in child_env
     assert "CLAUDECODE" not in child_env
 
 

--- a/tests/unit/core/test_depth_records.py
+++ b/tests/unit/core/test_depth_records.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from meridian.lib.core.depth import (
+from meridian.lib.state.depth_resolution import (
     depth_from_spawn_ancestry,
     resolve_effective_meridian_depth,
 )

--- a/tests/unit/core/test_depth_records.py
+++ b/tests/unit/core/test_depth_records.py
@@ -15,11 +15,13 @@ def _record(
     spawn_id: str,
     *,
     parent_id: str | None = None,
+    meridian_depth: int | None = None,
 ) -> SpawnRecord:
     return SpawnRecord(
         id=spawn_id,
         chat_id="chat-1",
         parent_id=parent_id,
+        meridian_depth=meridian_depth,
         model="gpt-5.4",
         agent="coder",
         agent_path=None,
@@ -99,3 +101,29 @@ def test_resolve_effective_meridian_depth_uses_max_of_env_and_records(
 
     env["MERIDIAN_DEPTH"] = "2"
     assert resolve_effective_meridian_depth(env, runtime_root=runtime_root) == 2
+
+
+def test_depth_from_persisted_record_is_o1_when_ancestors_pruned(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime_root = tmp_path / "runtime"
+    records = {
+        "p-deep": _record("p-deep", parent_id="p-missing", meridian_depth=5),
+    }
+
+    def _fake_get_spawn(_runtime_root: Path, spawn_id: str) -> SpawnRecord | None:
+        return records.get(spawn_id)
+
+    monkeypatch.setattr(
+        "meridian.lib.state.spawn_store.get_spawn",
+        _fake_get_spawn,
+    )
+
+    assert depth_from_spawn_ancestry("p-deep", runtime_root) == 5
+
+    env = {
+        "MERIDIAN_SPAWN_ID": "p-deep",
+        "MERIDIAN_DEPTH": "0",
+    }
+    assert resolve_effective_meridian_depth(env, runtime_root=runtime_root) == 5

--- a/tests/unit/core/test_depth_records.py
+++ b/tests/unit/core/test_depth_records.py
@@ -1,0 +1,101 @@
+"""Depth resolution from spawn ancestry records."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from meridian.lib.core.depth import (
+    depth_from_spawn_ancestry,
+    resolve_effective_meridian_depth,
+)
+from meridian.lib.state.spawn.model import SpawnRecord
+
+
+def _record(
+    spawn_id: str,
+    *,
+    parent_id: str | None = None,
+) -> SpawnRecord:
+    return SpawnRecord(
+        id=spawn_id,
+        chat_id="chat-1",
+        parent_id=parent_id,
+        model="gpt-5.4",
+        agent="coder",
+        agent_path=None,
+        skills=(),
+        skill_paths=(),
+        harness="codex",
+        kind="child",
+        desc="test spawn",
+        work_id=None,
+        harness_session_id=None,
+        launch_mode="foreground",
+        worker_pid=None,
+        runner_pid=None,
+        runner_created_at_epoch=None,
+        status="running",
+        prompt="hello",
+        started_at=None,
+        last_attempt_exited_at=None,
+        last_attempt_exit_code=None,
+        runner_exit_code=None,
+        runner_exit_status=None,
+        runner_exit_error=None,
+        runner_exit_at=None,
+        finished_at=None,
+        exit_code=None,
+        duration_secs=None,
+        total_cost_usd=None,
+        input_tokens=None,
+        output_tokens=None,
+        cache_read_input_tokens=None,
+        cache_creation_input_tokens=None,
+        reasoning_tokens=None,
+        cost_is_estimate=False,
+        error=None,
+        terminal_origin=None,
+    )
+
+
+def test_depth_from_spawn_ancestry_counts_parents(tmp_path: Path, monkeypatch) -> None:
+    runtime_root = tmp_path / "runtime"
+    records = {
+        "p-root": _record("p-root"),
+        "p-child": _record("p-child", parent_id="p-root"),
+        "p-grandchild": _record("p-grandchild", parent_id="p-child"),
+    }
+
+    def _fake_get_spawn(_runtime_root: Path, spawn_id: str) -> SpawnRecord | None:
+        return records.get(spawn_id)
+
+    monkeypatch.setattr(
+        "meridian.lib.state.spawn_store.get_spawn",
+        _fake_get_spawn,
+    )
+
+    assert depth_from_spawn_ancestry("p-root", runtime_root) == 0
+    assert depth_from_spawn_ancestry("p-child", runtime_root) == 1
+    assert depth_from_spawn_ancestry("p-grandchild", runtime_root) == 2
+
+
+def test_resolve_effective_meridian_depth_uses_max_of_env_and_records(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime_root = tmp_path / "runtime"
+    monkeypatch.setattr(
+        "meridian.lib.state.spawn_store.get_spawn",
+        lambda _runtime_root, spawn_id: _record(spawn_id, parent_id="p-root")
+        if spawn_id == "p-child"
+        else _record(spawn_id),
+    )
+
+    env = {
+        "MERIDIAN_SPAWN_ID": "p-child",
+        "MERIDIAN_DEPTH": "0",
+    }
+    assert resolve_effective_meridian_depth(env, runtime_root=runtime_root) == 1
+
+    env["MERIDIAN_DEPTH"] = "2"
+    assert resolve_effective_meridian_depth(env, runtime_root=runtime_root) == 2

--- a/tests/unit/harness/test_connection_control_root.py
+++ b/tests/unit/harness/test_connection_control_root.py
@@ -63,7 +63,11 @@ async def test_claude_connection_launches_subprocess_from_control_root(
         captured["env"] = dict(env)
         return _FakeProcess()
 
-    monkeypatch.setattr(claude_ws, "inherit_child_env", lambda _base, overrides, blocked: overrides)
+    monkeypatch.setattr(
+        claude_ws,
+        "build_connection_child_env",
+        lambda **_kwargs: _kwargs.get("env_overrides") or {},
+    )
     monkeypatch.setattr(claude_ws.asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
     connection = ClaudeConnection()
     monkeypatch.setattr(connection, "_build_command", lambda _config, _spec: ["claude", "--test"])
@@ -108,7 +112,11 @@ async def _capture_codex_launch_cwd(
     async def _noop_cleanup(*, mark_stopped: bool) -> None:
         _ = mark_stopped
 
-    monkeypatch.setattr(codex_ws, "inherit_child_env", lambda _base, overrides: overrides)
+    monkeypatch.setattr(
+        codex_ws,
+        "build_connection_child_env",
+        lambda **_kwargs: _kwargs.get("env_overrides") or {},
+    )
     monkeypatch.setattr(
         codex_ws,
         "project_managed_primary_backend_command",

--- a/tests/unit/harness/test_cursor_subprocess_connection.py
+++ b/tests/unit/harness/test_cursor_subprocess_connection.py
@@ -63,13 +63,11 @@ async def _collect_events(connection: CursorSubprocessConnection) -> list[Harnes
     return [event async for event in connection.events()]
 
 
-def _passthrough_child_env(
-    _base: object,
-    overrides: dict[str, str],
-    blocked: object,
-) -> dict[str, str]:
-    _ = blocked
-    return dict(overrides)
+def _passthrough_child_env(**kwargs: object) -> dict[str, str]:
+    overrides = kwargs.get("env_overrides")
+    if isinstance(overrides, dict):
+        return dict(overrides)
+    return {}
 
 
 @pytest.mark.asyncio
@@ -250,7 +248,7 @@ async def _start_fresh_cursor_spawn(
 
     monkeypatch.setattr(
         cursor_subprocess_module,
-        "inherit_child_env",
+        "build_connection_child_env",
         _passthrough_child_env,
     )
     monkeypatch.setattr(
@@ -313,7 +311,7 @@ async def test_cursor_start_mints_chat_id_and_records_observer(
 
     monkeypatch.setattr(
         cursor_subprocess_module,
-        "inherit_child_env",
+        "build_connection_child_env",
         _passthrough_child_env,
     )
     monkeypatch.setattr(
@@ -369,7 +367,7 @@ async def test_cursor_start_reuses_continue_session_id_without_minting(
 
     monkeypatch.setattr(
         cursor_subprocess_module,
-        "inherit_child_env",
+        "build_connection_child_env",
         _passthrough_child_env,
     )
     monkeypatch.setattr(

--- a/tests/unit/hooks/test_runner_env_argv.py
+++ b/tests/unit/hooks/test_runner_env_argv.py
@@ -59,3 +59,54 @@ def test_external_hook_runs_argv_without_shell(
     assert isinstance(env, dict)
     assert "SECRET_API_KEY" not in env
     assert env["PATH"] == "/usr/bin"
+
+
+def test_external_hook_inherit_full_env_restores_ambient_secrets(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class _FakeProcess:
+        returncode = 0
+
+        def communicate(self, **_kwargs: object) -> tuple[bytes, bytes]:
+            return b"ok", b""
+
+    def _fake_popen(
+        _command: object,
+        *,
+        env: dict[str, str],
+        **_kwargs: object,
+    ) -> _FakeProcess:
+        captured["env"] = env
+        return _FakeProcess()
+
+    monkeypatch.setattr("meridian.lib.hooks.runner.subprocess.Popen", _fake_popen)
+    monkeypatch.setenv("SECRET_API_KEY", "legacy-visible")
+    monkeypatch.setenv("PATH", "/usr/bin")
+
+    hook = Hook(
+        name="legacy-hook",
+        event="spawn.created",
+        source="project",
+        command_argv=("/bin/echo", "hi"),
+    )
+    context = HookContext.from_roots(
+        event_name="spawn.created",
+        event_id=uuid4(),
+        timestamp="2026-01-01T00:00:00Z",
+        project_root=str(tmp_path),
+        runtime_root=str(tmp_path / ".meridian"),
+    )
+    from meridian.lib.launch.env_sanitize import ChildEnvPolicy
+
+    result = ExternalHookRunner(
+        tmp_path,
+        env_policy=ChildEnvPolicy(inherit_full_env=True),
+    ).run(hook, context, timeout_secs=5)
+
+    assert result.success is True
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["SECRET_API_KEY"] == "legacy-visible"

--- a/tests/unit/hooks/test_runner_env_argv.py
+++ b/tests/unit/hooks/test_runner_env_argv.py
@@ -1,0 +1,61 @@
+"""External hook runner argv and env hardening."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import uuid4
+
+from meridian.lib.hooks.runner import ExternalHookRunner
+from meridian.lib.hooks.types import Hook, HookContext
+
+
+def test_external_hook_runs_argv_without_shell(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class _FakeProcess:
+        returncode = 0
+
+        def communicate(self, **_kwargs: object) -> tuple[bytes, bytes]:
+            return b"ok", b""
+
+    def _fake_popen(
+        command: object,
+        *,
+        shell: bool,
+        env: dict[str, str],
+        **_kwargs: object,
+    ) -> _FakeProcess:
+        captured["command"] = command
+        captured["shell"] = shell
+        captured["env"] = env
+        return _FakeProcess()
+
+    monkeypatch.setattr("meridian.lib.hooks.runner.subprocess.Popen", _fake_popen)
+    monkeypatch.setenv("SECRET_API_KEY", "must-not-leak")
+    monkeypatch.setenv("PATH", "/usr/bin")
+
+    hook = Hook(
+        name="argv-hook",
+        event="spawn.created",
+        source="project",
+        command_argv=("/bin/echo", "hi"),
+    )
+    context = HookContext.from_roots(
+        event_name="spawn.created",
+        event_id=uuid4(),
+        timestamp="2026-01-01T00:00:00Z",
+        project_root=str(tmp_path),
+        runtime_root=str(tmp_path / ".meridian"),
+    )
+    result = ExternalHookRunner(tmp_path).run(hook, context, timeout_secs=5)
+
+    assert result.success is True
+    assert captured["shell"] is False
+    assert captured["command"] == ["/bin/echo", "hi"]
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert "SECRET_API_KEY" not in env
+    assert env["PATH"] == "/usr/bin"

--- a/tests/unit/launch/test_env_sanitize_passthrough.py
+++ b/tests/unit/launch/test_env_sanitize_passthrough.py
@@ -163,3 +163,42 @@ def test_pi_node_runtime_prefixes_pass() -> None:
     assert sanitized["PNPM_HOME"] == "/home/tester/.local/share/pnpm"
     assert sanitized["COREPACK_ENABLE_DOWNLOAD_PROMPT"] == "0"
     assert "CUSTOM_TOKEN" not in sanitized
+
+
+def test_npm_config_password_and_credential_registry_not_propagated() -> None:
+    passthrough = collect_child_env_passthrough(harness_id=HarnessId.PI)
+    sanitized = sanitize_child_env(
+        base_env={
+            "PATH": "/usr/bin",
+            "NPM_CONFIG_PASSWORD": "npm-secret",
+            "NPM_CONFIG_REGISTRY": "https://user:pass@registry.example.com",
+            "NPM_CONFIG_CACHE": "/home/tester/.npm",
+            "NPM_CONFIG_USERCONFIG": "/home/tester/.npmrc",
+        },
+        env_overrides=None,
+        pass_through=passthrough,
+    )
+
+    assert "NPM_CONFIG_PASSWORD" not in sanitized
+    assert sanitized["NPM_CONFIG_REGISTRY"] == "https://registry.example.com"
+    assert sanitized["NPM_CONFIG_CACHE"] == "/home/tester/.npm"
+    assert sanitized["NPM_CONFIG_USERCONFIG"] == "/home/tester/.npmrc"
+
+
+def test_node_and_corepack_broad_prefixes_do_not_leak_password_shaped_vars() -> None:
+    sanitized = sanitize_child_env(
+        base_env={
+            "PATH": "/usr/bin",
+            "NODE_OPTIONS": "--max-old-space-size=4096",
+            "NODE_PASSWORD": "drop-me",
+            "COREPACK_ENABLE_DOWNLOAD_PROMPT": "0",
+            "COREPACK_PASSWORD": "drop-me-too",
+        },
+        env_overrides=None,
+        pass_through=harness_env_passthrough(HarnessId.PI),
+    )
+
+    assert sanitized["NODE_OPTIONS"] == "--max-old-space-size=4096"
+    assert sanitized["COREPACK_ENABLE_DOWNLOAD_PROMPT"] == "0"
+    assert "NODE_PASSWORD" not in sanitized
+    assert "COREPACK_PASSWORD" not in sanitized

--- a/tests/unit/launch/test_env_sanitize_passthrough.py
+++ b/tests/unit/launch/test_env_sanitize_passthrough.py
@@ -1,0 +1,131 @@
+"""Regression tests for child-env sanitization allowlists and harness passthrough."""
+
+from __future__ import annotations
+
+import pytest
+
+from meridian.lib.core.types import HarnessId
+from meridian.lib.launch.env_sanitize import (
+    build_connection_child_env,
+    collect_child_env_passthrough,
+    sanitize_child_env,
+)
+from meridian.lib.launch.harness_env_passthrough import harness_env_passthrough
+
+_ALL_HARNESS_IDS = tuple(HarnessId)
+
+
+def _corporate_proxy_env() -> dict[str, str]:
+    return {
+        "PATH": "/usr/bin",
+        "HOME": "/home/tester",
+        "HTTPS_PROXY": "http://proxy.corp:8080",
+        "NO_PROXY": "localhost,.corp",
+        "SSL_CERT_FILE": "/etc/ssl/corp-ca.pem",
+        "http_proxy": "http://proxy.corp:8080",
+    }
+
+
+def test_claude_spawn_keeps_auth_token_and_drops_unrelated_secrets() -> None:
+    base_env = {
+        "PATH": "/usr/bin",
+        "HOME": "/home/tester",
+        "ANTHROPIC_API_KEY": "key-1",
+        "ANTHROPIC_AUTH_TOKEN": "token-1",
+        "ANTHROPIC_BASE_URL": "https://api.example.com",
+        "FOO_API_KEY": "drop-me",
+        "MY_SECRET": "drop-me-too",
+    }
+    child_env = build_connection_child_env(
+        harness_id=HarnessId.CLAUDE,
+        base_env=base_env,
+        env_overrides=None,
+    )
+
+    assert child_env["ANTHROPIC_API_KEY"] == "key-1"
+    assert child_env["ANTHROPIC_AUTH_TOKEN"] == "token-1"
+    assert child_env["ANTHROPIC_BASE_URL"] == "https://api.example.com"
+    assert "FOO_API_KEY" not in child_env
+    assert "MY_SECRET" not in child_env
+
+
+@pytest.mark.parametrize("harness_id", _ALL_HARNESS_IDS)
+def test_corporate_proxy_and_cert_vars_reach_every_harness(harness_id: HarnessId) -> None:
+    child_env = build_connection_child_env(
+        harness_id=harness_id,
+        base_env=_corporate_proxy_env(),
+        env_overrides=None,
+    )
+
+    assert child_env["HTTPS_PROXY"] == "http://proxy.corp:8080"
+    assert child_env["NO_PROXY"] == "localhost,.corp"
+    assert child_env["SSL_CERT_FILE"] == "/etc/ssl/corp-ca.pem"
+    assert child_env["http_proxy"] == "http://proxy.corp:8080"
+
+
+def test_windows_baseline_vars_survive_sanitization() -> None:
+    base_env = {
+        "PATH": "C:\\Windows\\System32",
+        "USERPROFILE": "C:\\Users\\alice",
+        "APPDATA": "C:\\Users\\alice\\AppData\\Roaming",
+        "LOCALAPPDATA": "C:\\Users\\alice\\AppData\\Local",
+        "SystemRoot": "C:\\Windows",
+        "COMSPEC": "C:\\Windows\\System32\\cmd.exe",
+        "PATHEXT": ".COM;.EXE;.BAT",
+        "TEMP": "C:\\Users\\alice\\AppData\\Local\\Temp",
+        "TMP": "C:\\Users\\alice\\AppData\\Local\\Temp",
+        "FOO_API_KEY": "drop-me",
+    }
+    sanitized = sanitize_child_env(
+        base_env=base_env,
+        env_overrides=None,
+        pass_through=harness_env_passthrough(HarnessId.CODEX),
+    )
+
+    assert sanitized["USERPROFILE"] == "C:\\Users\\alice"
+    assert sanitized["APPDATA"] == "C:\\Users\\alice\\AppData\\Roaming"
+    assert sanitized["SystemRoot"] == "C:\\Windows"
+    assert sanitized["COMSPEC"] == "C:\\Windows\\System32\\cmd.exe"
+    assert "FOO_API_KEY" not in sanitized
+
+
+def test_codex_openai_base_url_and_azure_prefix_pass() -> None:
+    passthrough = collect_child_env_passthrough(harness_id=HarnessId.CODEX)
+    sanitized = sanitize_child_env(
+        base_env={
+            "PATH": "/usr/bin",
+            "OPENAI_BASE_URL": "https://api.openai.com/v1",
+            "AZURE_OPENAI_ENDPOINT": "https://example.openai.azure.com",
+            "OPENAI_ORG_ID": "org-123",
+            "RANDOM_API_KEY": "drop-me",
+        },
+        env_overrides=None,
+        pass_through=passthrough,
+    )
+
+    assert sanitized["OPENAI_BASE_URL"] == "https://api.openai.com/v1"
+    assert sanitized["AZURE_OPENAI_ENDPOINT"] == "https://example.openai.azure.com"
+    assert sanitized["OPENAI_ORG_ID"] == "org-123"
+    assert "RANDOM_API_KEY" not in sanitized
+
+
+def test_pi_node_runtime_prefixes_pass() -> None:
+    passthrough = collect_child_env_passthrough(harness_id=HarnessId.PI)
+    sanitized = sanitize_child_env(
+        base_env={
+            "PATH": "/usr/bin",
+            "NODE_OPTIONS": "--max-old-space-size=4096",
+            "NPM_CONFIG_REGISTRY": "https://registry.npmjs.org",
+            "PNPM_HOME": "/home/tester/.local/share/pnpm",
+            "COREPACK_ENABLE_DOWNLOAD_PROMPT": "0",
+            "CUSTOM_TOKEN": "drop-me",
+        },
+        env_overrides=None,
+        pass_through=passthrough,
+    )
+
+    assert sanitized["NODE_OPTIONS"] == "--max-old-space-size=4096"
+    assert sanitized["NPM_CONFIG_REGISTRY"] == "https://registry.npmjs.org"
+    assert sanitized["PNPM_HOME"] == "/home/tester/.local/share/pnpm"
+    assert sanitized["COREPACK_ENABLE_DOWNLOAD_PROMPT"] == "0"
+    assert "CUSTOM_TOKEN" not in sanitized

--- a/tests/unit/launch/test_env_sanitize_passthrough.py
+++ b/tests/unit/launch/test_env_sanitize_passthrough.py
@@ -109,6 +109,40 @@ def test_codex_openai_base_url_and_azure_prefix_pass() -> None:
     assert "RANDOM_API_KEY" not in sanitized
 
 
+def test_pi_provider_api_key_reaches_spawn_and_drops_unrelated_secrets() -> None:
+    child_env = build_connection_child_env(
+        harness_id=HarnessId.PI,
+        base_env={
+            "PATH": "/usr/bin",
+            "DEEPSEEK_API_KEY": "deepseek-key",
+            "FOO_API_KEY": "drop-me",
+            "MY_SECRET": "drop-me-too",
+        },
+        env_overrides=None,
+    )
+
+    assert child_env["DEEPSEEK_API_KEY"] == "deepseek-key"
+    assert "FOO_API_KEY" not in child_env
+    assert "MY_SECRET" not in child_env
+
+
+def test_opencode_auth_token_reaches_spawn_and_drops_unrelated_secrets() -> None:
+    child_env = build_connection_child_env(
+        harness_id=HarnessId.OPENCODE,
+        base_env={
+            "PATH": "/usr/bin",
+            "ANTHROPIC_AUTH_TOKEN": "token-1",
+            "FOO_API_KEY": "drop-me",
+            "MY_SECRET": "drop-me-too",
+        },
+        env_overrides=None,
+    )
+
+    assert child_env["ANTHROPIC_AUTH_TOKEN"] == "token-1"
+    assert "FOO_API_KEY" not in child_env
+    assert "MY_SECRET" not in child_env
+
+
 def test_pi_node_runtime_prefixes_pass() -> None:
     passthrough = collect_child_env_passthrough(harness_id=HarnessId.PI)
     sanitized = sanitize_child_env(

--- a/tests/unit/launch/test_env_sanitize_passthrough.py
+++ b/tests/unit/launch/test_env_sanitize_passthrough.py
@@ -5,14 +5,29 @@ from __future__ import annotations
 import pytest
 
 from meridian.lib.core.types import HarnessId
+from meridian.lib.harness.coordinator_env import (
+    CLAUDE_COORDINATOR_ENV,
+    CODEX_COORDINATOR_ENV,
+    CURSOR_COORDINATOR_ENV,
+    OPENCODE_COORDINATOR_ENV,
+    PI_COORDINATOR_ENV,
+    CoordinatorEnvPassthrough,
+)
 from meridian.lib.launch.env_sanitize import (
     build_connection_child_env,
     collect_child_env_passthrough,
     sanitize_child_env,
 )
-from meridian.lib.launch.harness_env_passthrough import harness_env_passthrough
 
 _ALL_HARNESS_IDS = tuple(HarnessId)
+
+_HARNESS_PASSTHROUGH: dict[HarnessId, CoordinatorEnvPassthrough] = {
+    HarnessId.CLAUDE: CLAUDE_COORDINATOR_ENV,
+    HarnessId.CODEX: CODEX_COORDINATOR_ENV,
+    HarnessId.OPENCODE: OPENCODE_COORDINATOR_ENV,
+    HarnessId.CURSOR: CURSOR_COORDINATOR_ENV,
+    HarnessId.PI: PI_COORDINATOR_ENV,
+}
 
 
 def _corporate_proxy_env() -> dict[str, str]:
@@ -37,7 +52,7 @@ def test_claude_spawn_keeps_auth_token_and_drops_unrelated_secrets() -> None:
         "MY_SECRET": "drop-me-too",
     }
     child_env = build_connection_child_env(
-        harness_id=HarnessId.CLAUDE,
+        harness_passthrough=CLAUDE_COORDINATOR_ENV,
         base_env=base_env,
         env_overrides=None,
     )
@@ -52,7 +67,7 @@ def test_claude_spawn_keeps_auth_token_and_drops_unrelated_secrets() -> None:
 @pytest.mark.parametrize("harness_id", _ALL_HARNESS_IDS)
 def test_corporate_proxy_and_cert_vars_reach_every_harness(harness_id: HarnessId) -> None:
     child_env = build_connection_child_env(
-        harness_id=harness_id,
+        harness_passthrough=_HARNESS_PASSTHROUGH[harness_id],
         base_env=_corporate_proxy_env(),
         env_overrides=None,
     )
@@ -79,7 +94,7 @@ def test_windows_baseline_vars_survive_sanitization() -> None:
     sanitized = sanitize_child_env(
         base_env=base_env,
         env_overrides=None,
-        pass_through=harness_env_passthrough(HarnessId.CODEX),
+        pass_through=CODEX_COORDINATOR_ENV,
     )
 
     assert sanitized["USERPROFILE"] == "C:\\Users\\alice"
@@ -90,7 +105,7 @@ def test_windows_baseline_vars_survive_sanitization() -> None:
 
 
 def test_codex_openai_base_url_and_azure_prefix_pass() -> None:
-    passthrough = collect_child_env_passthrough(harness_id=HarnessId.CODEX)
+    passthrough = collect_child_env_passthrough(harness_passthrough=CODEX_COORDINATOR_ENV)
     sanitized = sanitize_child_env(
         base_env={
             "PATH": "/usr/bin",
@@ -111,7 +126,7 @@ def test_codex_openai_base_url_and_azure_prefix_pass() -> None:
 
 def test_pi_provider_api_key_reaches_spawn_and_drops_unrelated_secrets() -> None:
     child_env = build_connection_child_env(
-        harness_id=HarnessId.PI,
+        harness_passthrough=PI_COORDINATOR_ENV,
         base_env={
             "PATH": "/usr/bin",
             "DEEPSEEK_API_KEY": "deepseek-key",
@@ -128,7 +143,7 @@ def test_pi_provider_api_key_reaches_spawn_and_drops_unrelated_secrets() -> None
 
 def test_opencode_auth_token_reaches_spawn_and_drops_unrelated_secrets() -> None:
     child_env = build_connection_child_env(
-        harness_id=HarnessId.OPENCODE,
+        harness_passthrough=OPENCODE_COORDINATOR_ENV,
         base_env={
             "PATH": "/usr/bin",
             "ANTHROPIC_AUTH_TOKEN": "token-1",
@@ -144,7 +159,7 @@ def test_opencode_auth_token_reaches_spawn_and_drops_unrelated_secrets() -> None
 
 
 def test_pi_node_runtime_prefixes_pass() -> None:
-    passthrough = collect_child_env_passthrough(harness_id=HarnessId.PI)
+    passthrough = collect_child_env_passthrough(harness_passthrough=PI_COORDINATOR_ENV)
     sanitized = sanitize_child_env(
         base_env={
             "PATH": "/usr/bin",
@@ -166,7 +181,7 @@ def test_pi_node_runtime_prefixes_pass() -> None:
 
 
 def test_npm_config_password_and_credential_registry_not_propagated() -> None:
-    passthrough = collect_child_env_passthrough(harness_id=HarnessId.PI)
+    passthrough = collect_child_env_passthrough(harness_passthrough=PI_COORDINATOR_ENV)
     sanitized = sanitize_child_env(
         base_env={
             "PATH": "/usr/bin",
@@ -195,7 +210,7 @@ def test_node_and_corepack_broad_prefixes_do_not_leak_password_shaped_vars() -> 
             "COREPACK_PASSWORD": "drop-me-too",
         },
         env_overrides=None,
-        pass_through=harness_env_passthrough(HarnessId.PI),
+        pass_through=PI_COORDINATOR_ENV,
     )
 
     assert sanitized["NODE_OPTIONS"] == "--max-old-space-size=4096"


### PR DESCRIPTION
## Why

Any spawned harness inherited nearly the full coordinator environment — API keys and tokens included. External hooks ran arbitrary `shell=True` strings from writable config. Spawn depth limits trusted a child-forgeable `MERIDIAN_DEPTH` env var. A security audit flagged all three as escalation/leak paths.

## Goal

Harness children and hooks get a least-privilege environment by default; hook commands can avoid the shell; spawn depth cannot be undercounted by a forged env var.

## Summary

Sanitize-by-default child env with per-harness credential passthrough and config escape hatches; argv-array hook commands (`shell=False`) with string form deprecated; spawn depth persisted on the record for O(1) fail-closed enforcement.

## Resulting Behavior

- A `FOO_API_KEY` / `MY_SECRET` in the coordinator shell no longer reaches a spawned harness. Declared provider creds (`ANTHROPIC_AUTH_TOKEN`, `DEEPSEEK_API_KEY`, …), OS/network/TLS baseline (proxy, cert bundles, Windows process env), and `MERIDIAN_*` still flow. Opt back into full inheritance with `[spawn].inherit_full_env = true` or allowlist extras via `[spawn].env_passthrough`.
- Hooks: `command = ["bash", "scripts/check.sh"]` runs without a shell; string form still works but warns on load. Escape hatches apply to hooks too.
- A worker cannot bypass `--max-depth` by unsetting `MERIDIAN_DEPTH`.

## Changes

- New `launch/env_sanitize.py` + `launch/harness_env_passthrough.py` (exact per-harness provider vars; broad `NPM_CONFIG_`/`NODE_`/`COREPACK_` prefixes replaced with exact names; `NPM_CONFIG_REGISTRY` URL creds scrubbed).
- `hooks/runner.py` + `dispatch.py`: argv commands, threaded `ChildEnvPolicy`.
- `SpawnRecord.meridian_depth` persisted (legacy records read-compatible); `depth.py` uses `max(env, record)`.
- TODO marker: `harness_env_passthrough.py` interim placement in `launch/` (bootstrap import cycle) — moves to a harness-owned home under the P3 bundle contract.

## Work Item

codebase-audit-rewrite

## Verification

`uv run ruff check .` pass; `uv run --extra dev python -m pyright` 0 errors; `uv run pytest-llm` green (Pi extensions built). Two review rounds (p4938, p4945) request-changes fixed; reviewer probes (`ANTHROPIC_AUTH_TOKEN` reaches spawn, `NPM_CONFIG_PASSWORD` dropped, bare secrets dropped) confirmed fail-safe. New regression tests in `tests/unit/launch/test_env_sanitize_passthrough.py`, `tests/unit/hooks/test_runner_env_argv.py`, `tests/unit/core/test_depth_records.py`.

## Knowledge Updates

`docs/configuration.md`, `docs/hooks.md` updated (env policy, argv hooks).

## Spawn Trace

- p4935 coder — implemented hardening
- p4938 reviewer — round-1 review
- p4943 coder — round-1 fixes
- p4945 reviewer — round-2 review
- p4947 coder — round-2 fixes

## Release Label Guide
