### PR TITLE
perf(state): skip starting-prompt reads on spawn list paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 - Doc/code alignment: three launch driving adapters (no REST spawn routes), honest `lib/core` role, accurate Windows/TUI and CI claims, v2 spawn-state references, OpenCode upstream org note (anomalyco/opencode.ai).
 - Platform hygiene: route `Path.home()` and inline `sys.platform` checks through `lib/platform` helpers; centralize OpenCode data-dir resolution (XDG → LOCALAPPDATA → POSIX) across adapter, storage, and transcript paths.
+- Spawn display labels are derived once at creation (`display_label`) and persisted as metadata; spawn list, filter, `spawn children`, and session export never read `starting-prompt.md`. Prompt bodies load only via `get_spawn` / `read_state(include_prompt=True)`.
 
 ### Fixed
 - Restore `## [Unreleased]` CHANGELOG heading required by release automation.

--- a/src/meridian/lib/core/spawn_start.py
+++ b/src/meridian/lib/core/spawn_start.py
@@ -15,3 +15,39 @@ class SpawnStartMetadata:
     work_id: str | None = None
     goal: str | None = None
     launch_policy_snapshot: LaunchPolicySnapshot | None = None
+
+
+def compact_prompt_summary(prompt: str) -> str | None:
+    """Return a single-line prompt summary capped at 50 characters."""
+
+    normalized_prompt = prompt.strip()
+    if not normalized_prompt:
+        return None
+    compact_prompt = " ".join(normalized_prompt.split()).strip()
+    if len(compact_prompt) <= 50:
+        return compact_prompt
+    return f"{compact_prompt[:47].rstrip()}..."
+
+
+def derive_display_label(
+    *,
+    goal: str | None,
+    desc: str | None,
+    prompt: str,
+) -> str | None:
+    """Persist a prompt summary only when goal and desc are both absent."""
+
+    if (goal or desc or "").strip():
+        return None
+    return compact_prompt_summary(prompt)
+
+
+def resolve_spawn_display_label(
+    goal: str | None,
+    desc: str | None,
+    display_label: str | None,
+) -> str | None:
+    """Resolve list/display text from persisted metadata only."""
+
+    label = (goal or desc or display_label or "").strip()
+    return label or None

--- a/src/meridian/lib/ops/session_export.py
+++ b/src/meridian/lib/ops/session_export.py
@@ -9,13 +9,12 @@ from pathlib import Path
 from pydantic import BaseModel, ConfigDict
 
 from meridian.lib.core.context import RuntimeContext
+from meridian.lib.core.spawn_start import resolve_spawn_display_label
 from meridian.lib.core.util import FormatContext
 from meridian.lib.harness.transcript import TranscriptMessage
 from meridian.lib.ops.runtime import async_from_sync
 from meridian.lib.ops.session_transcript import read_session_transcript
 from meridian.lib.state import session_identity, session_store, spawn_store
-from meridian.lib.state.paths import RuntimePaths
-from meridian.lib.state.spawn.repository import read_prompt
 
 _TOOL_CALL_RE = re.compile(r"^\[tool:\s*(?P<name>[^\]\s]+)(?:\s+(?P<body>.*))?\]$", re.DOTALL)
 _TOOL_RESULT_PREFIX = "[tool_result]"
@@ -267,10 +266,7 @@ def _spawn_appendices(
         if not report:
             continue
         seen.add(spawn.id)
-        desc_source = (spawn.desc or "").strip()
-        if not desc_source:
-            paths = RuntimePaths.from_root_dir(runtime_root)
-            desc_source = (read_prompt(paths.spawns_dir, spawn.id) or "").strip()
+        desc_source = resolve_spawn_display_label(spawn.goal, spawn.desc, spawn.display_label) or ""
         desc = desc_source.splitlines()[0] if desc_source else ""
         suffix = f" — {desc}" if desc else ""
         sections.append("\n".join([f"## Spawn: {spawn.id}{suffix}", "", report]))

--- a/src/meridian/lib/ops/session_export.py
+++ b/src/meridian/lib/ops/session_export.py
@@ -14,6 +14,8 @@ from meridian.lib.harness.transcript import TranscriptMessage
 from meridian.lib.ops.runtime import async_from_sync
 from meridian.lib.ops.session_transcript import read_session_transcript
 from meridian.lib.state import session_identity, session_store, spawn_store
+from meridian.lib.state.paths import RuntimePaths
+from meridian.lib.state.spawn.repository import read_prompt
 
 _TOOL_CALL_RE = re.compile(r"^\[tool:\s*(?P<name>[^\]\s]+)(?:\s+(?P<body>.*))?\]$", re.DOTALL)
 _TOOL_RESULT_PREFIX = "[tool_result]"
@@ -265,8 +267,11 @@ def _spawn_appendices(
         if not report:
             continue
         seen.add(spawn.id)
-        desc_source = spawn.desc or spawn.prompt or ""
-        desc = desc_source.strip().splitlines()[0] if desc_source else ""
+        desc_source = (spawn.desc or "").strip()
+        if not desc_source:
+            paths = RuntimePaths.from_root_dir(runtime_root)
+            desc_source = (read_prompt(paths.spawns_dir, spawn.id) or "").strip()
+        desc = desc_source.splitlines()[0] if desc_source else ""
         suffix = f" — {desc}" if desc else ""
         sections.append("\n".join([f"## Spawn: {spawn.id}{suffix}", "", report]))
     return sections

--- a/src/meridian/lib/ops/spawn/api.py
+++ b/src/meridian/lib/ops/spawn/api.py
@@ -28,6 +28,7 @@ from meridian.lib.core.spawn_lifecycle import (
     is_terminal_spawn_status,
 )
 from meridian.lib.core.spawn_service import CancelOutcome
+from meridian.lib.core.spawn_start import resolve_spawn_display_label
 from meridian.lib.core.telemetry import register_debug_trace_observer
 from meridian.lib.core.types import SpawnId
 from meridian.lib.launch.continue_replay import (
@@ -208,28 +209,8 @@ def _surface_primary_activity(status: str, activity: str | None) -> str | None:
     return normalized
 
 
-def _spawn_label_or_prompt_summary(
-    goal: str | None, desc: str | None, prompt: str | None
-) -> str | None:
-    """Prefer goal over desc for display — goal is the completion contract."""
-    label = (goal or desc or "").strip()
-    if label:
-        return label
-    normalized_prompt = (prompt or "").strip()
-    if not normalized_prompt:
-        return None
-    compact_prompt = " ".join(normalized_prompt.split()).strip()
-    if len(compact_prompt) <= 50:
-        return compact_prompt
-    return f"{compact_prompt[:47].rstrip()}..."
-
-
-def _spawn_list_entry_desc(row: SpawnRecord, runtime_root: Path) -> str | None:
-    if (row.goal or row.desc or "").strip():
-        return _spawn_label_or_prompt_summary(row.goal, row.desc, None)
-    hydrated = spawn_store.get_spawn(runtime_root, row.id)
-    prompt = hydrated.prompt if hydrated is not None else None
-    return _spawn_label_or_prompt_summary(row.goal, row.desc, prompt)
+def _spawn_display_label(row: SpawnRecord) -> str | None:
+    return resolve_spawn_display_label(row.goal, row.desc, row.display_label)
 
 
 def _forked_from_output(payload: SpawnCreateInput) -> str | None:
@@ -679,7 +660,7 @@ def spawn_children_sync(
             status=row.status,
             model=row.model or "",
             agent=row.agent or None,
-            desc=_spawn_list_entry_desc(row, runtime_root),
+            desc=_spawn_display_label(row),
             duration_secs=row.duration_secs,
             cost_usd=row.total_cost_usd,
         )

--- a/src/meridian/lib/ops/spawn/api.py
+++ b/src/meridian/lib/ops/spawn/api.py
@@ -224,6 +224,14 @@ def _spawn_label_or_prompt_summary(
     return f"{compact_prompt[:47].rstrip()}..."
 
 
+def _spawn_list_entry_desc(row: SpawnRecord, runtime_root: Path) -> str | None:
+    if (row.goal or row.desc or "").strip():
+        return _spawn_label_or_prompt_summary(row.goal, row.desc, None)
+    hydrated = spawn_store.get_spawn(runtime_root, row.id)
+    prompt = hydrated.prompt if hydrated is not None else None
+    return _spawn_label_or_prompt_summary(row.goal, row.desc, prompt)
+
+
 def _forked_from_output(payload: SpawnCreateInput) -> str | None:
     if not payload.session.continue_fork:
         return None
@@ -671,7 +679,7 @@ def spawn_children_sync(
             status=row.status,
             model=row.model or "",
             agent=row.agent or None,
-            desc=_spawn_label_or_prompt_summary(row.goal, row.desc, row.prompt),
+            desc=_spawn_list_entry_desc(row, runtime_root),
             duration_secs=row.duration_secs,
             cost_usd=row.total_cost_usd,
         )

--- a/src/meridian/lib/ops/work_dashboard.py
+++ b/src/meridian/lib/ops/work_dashboard.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, ConfigDict
 
 from meridian.lib.core.context import RuntimeContext
 from meridian.lib.core.spawn_lifecycle import is_active_spawn_status
+from meridian.lib.core.spawn_start import resolve_spawn_display_label
 from meridian.lib.core.util import FormatContext
 from meridian.lib.ops.runtime import async_from_sync, resolve_roots_for_read, runtime_context
 from meridian.lib.ops.work_sessions import work_session_chat_ids
@@ -30,7 +31,7 @@ def _spawn_id_sort_key(spawn_id: str) -> tuple[int, str]:
 
 def _spawn_label(spawn: SpawnRecord) -> str:
     """Prefer goal over desc for display — goal is the completion contract."""
-    label = (spawn.goal or spawn.desc or "").strip()
+    label = resolve_spawn_display_label(spawn.goal, spawn.desc, spawn.display_label)
     if label:
         return " ".join(label.split())
     if spawn.kind == "primary":

--- a/src/meridian/lib/state/spawn/model.py
+++ b/src/meridian/lib/state/spawn/model.py
@@ -65,6 +65,7 @@ class SpawnRecord(BaseModel):
     desc: str | None
     work_id: str | None
     goal: str | None = None
+    display_label: str | None = None
     harness_session_id: str | None
     control_root: str | None = None
     task_cwd: str | None = None

--- a/src/meridian/lib/state/spawn/repository.py
+++ b/src/meridian/lib/state/spawn/repository.py
@@ -235,13 +235,23 @@ def _read_stored_state(spawns_dir: Path, spawn_id: str) -> StoredSpawnState | No
         return None
 
 
-def read_state(spawns_dir: Path, spawn_id: str) -> SpawnRecord | None:
-    """Read ``spawns/<id>/state.json`` and reconstruct a spawn record."""
+def read_state(
+    spawns_dir: Path,
+    spawn_id: str,
+    *,
+    include_prompt: bool = True,
+) -> SpawnRecord | None:
+    """Read ``spawns/<id>/state.json`` and reconstruct a spawn record.
+
+    List and filter paths should pass ``include_prompt=False`` so large
+    ``starting-prompt.md`` bodies are not read unless a caller needs them.
+    """
 
     stored = _read_stored_state(spawns_dir, spawn_id)
     if stored is None:
         return None
-    return stored_state_to_record(stored, prompt=read_prompt(spawns_dir, spawn_id))
+    prompt = read_prompt(spawns_dir, spawn_id) if include_prompt else None
+    return stored_state_to_record(stored, prompt=prompt)
 
 
 def write_state(

--- a/src/meridian/lib/state/spawn/repository.py
+++ b/src/meridian/lib/state/spawn/repository.py
@@ -51,6 +51,7 @@ class StoredSpawnState(BaseModel):
     desc: str | None = None
     work_id: str | None = None
     goal: str | None = None
+    display_label: str | None = None
     harness_session_id: str | None = None
     control_root: str | None = None
     task_cwd: str | None = None
@@ -125,6 +126,7 @@ def record_to_stored_state(
         desc=record.desc,
         work_id=record.work_id,
         goal=record.goal,
+        display_label=record.display_label,
         harness_session_id=record.harness_session_id,
         control_root=record.control_root,
         task_cwd=record.task_cwd,
@@ -182,6 +184,7 @@ def stored_state_to_record(
         desc=stored.desc,
         work_id=stored.work_id,
         goal=stored.goal,
+        display_label=stored.display_label,
         harness_session_id=stored.harness_session_id,
         control_root=stored.control_root,
         task_cwd=stored.task_cwd,

--- a/src/meridian/lib/state/spawn_store.py
+++ b/src/meridian/lib/state/spawn_store.py
@@ -180,10 +180,15 @@ def _resolve_start_metadata(
 # ---------------------------------------------------------------------------
 
 
-def _read_state(spawns_dir: Path, spawn_id: str) -> SpawnRecord | None:
+def _read_state(
+    spawns_dir: Path,
+    spawn_id: str,
+    *,
+    include_prompt: bool = True,
+) -> SpawnRecord | None:
     from meridian.lib.state.spawn.repository import read_state
 
-    return read_state(spawns_dir, spawn_id)
+    return read_state(spawns_dir, spawn_id, include_prompt=include_prompt)
 
 
 def _write_state(
@@ -799,6 +804,34 @@ def _spawn_sort_key(spawn: SpawnRecord) -> tuple[int, str]:
     return (10**9, spawn.id)
 
 
+def _apply_spawn_filters(
+    spawns: list[SpawnRecord],
+    filters: Mapping[str, Any],
+) -> list[SpawnRecord]:
+    filtered: list[SpawnRecord] = []
+    for spawn in spawns:
+        spawn_data = spawn.model_dump()
+        keep = True
+        for key, expected in filters.items():
+            if expected is None:
+                continue
+            if key == "owner_chat_id":
+                from meridian.lib.state.session_identity import spawn_owner_chat_id
+
+                if spawn_owner_chat_id(spawn) != expected:
+                    keep = False
+                    break
+                continue
+            if key not in spawn_data:
+                continue
+            if spawn_data[key] != expected:
+                keep = False
+                break
+        if keep:
+            filtered.append(spawn)
+    return filtered
+
+
 def list_spawns(
     runtime_root: Path,
     filters: Mapping[str, Any] | None = None,
@@ -807,34 +840,14 @@ def list_spawns(
 
     paths = RuntimePaths.from_root_dir(runtime_root)
     spawns = [
-        record.model_copy(update={"prompt": None})
+        record
         for spawn_id in _scan_spawn_ids(paths.spawns_dir)
-        if (record := _read_state(paths.spawns_dir, spawn_id)) is not None
+        if (record := _read_state(paths.spawns_dir, spawn_id, include_prompt=False))
+        is not None
     ]
 
     if filters:
-        filtered: list[SpawnRecord] = []
-        for spawn in spawns:
-            spawn_data = spawn.model_dump()
-            keep = True
-            for key, expected in filters.items():
-                if expected is None:
-                    continue
-                if key == "owner_chat_id":
-                    from meridian.lib.state.session_identity import spawn_owner_chat_id
-
-                    if spawn_owner_chat_id(spawn) != expected:
-                        keep = False
-                        break
-                    continue
-                if key not in spawn_data:
-                    continue
-                if spawn_data[key] != expected:
-                    keep = False
-                    break
-            if keep:
-                filtered.append(spawn)
-        spawns = filtered
+        spawns = _apply_spawn_filters(spawns, filters)
 
     return sorted(spawns, key=_spawn_sort_key)
 

--- a/src/meridian/lib/state/spawn_store.py
+++ b/src/meridian/lib/state/spawn_store.py
@@ -31,7 +31,7 @@ from meridian.lib.core.spawn_lifecycle import (
 from meridian.lib.core.spawn_lifecycle import (
     is_terminal_spawn_status as _is_terminal_spawn_status,
 )
-from meridian.lib.core.spawn_start import SpawnStartMetadata
+from meridian.lib.core.spawn_start import SpawnStartMetadata, derive_display_label
 from meridian.lib.core.types import SpawnId
 from meridian.lib.state.atomic import atomic_write_text
 from meridian.lib.state.event_store import lock_file
@@ -336,6 +336,11 @@ def start_spawn(
                 else None
             ),
             goal=normalized_goal,
+            display_label=derive_display_label(
+                goal=normalized_goal,
+                desc=start_metadata.desc,
+                prompt=prompt,
+            ),
             harness_session_id=harness_session_id,
             control_root=control_root,
             task_cwd=task_cwd,

--- a/tests/integration/ops/test_spawn_api_query.py
+++ b/tests/integration/ops/test_spawn_api_query.py
@@ -18,6 +18,7 @@ from meridian.lib.ops.spawn.models import (
     SpawnActionOutput,
     SpawnCancelAllInput,
     SpawnCancelInput,
+    SpawnChildrenInput,
     SpawnListInput,
     SpawnShowInput,
     SpawnStatsInput,
@@ -434,6 +435,135 @@ def test_spawn_show_and_list_hydrate_primary_and_pi_diagnostics(tmp_path: Path) 
     assert pi_detail.pi_cleanup_status == "escalated"
     assert pi_detail.pi_cleanup_phase == "cleanup_stop_escalated"
     assert pi_detail.pi_cleanup_reason == "abort_grace_expired"
+
+
+def test_spawn_children_uses_persisted_display_label_without_prompt_read(tmp_path: Path) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    runtime_root = _state_root(project_root)
+
+    parent_id = spawn_store.start_spawn(
+        runtime_root,
+        spawn_id="p-parent",
+        chat_id="c-parent",
+        model="gpt-5.4",
+        agent="coder",
+        harness="codex",
+        prompt="parent prompt",
+        goal="parent goal",
+    )
+    child_id = spawn_store.start_spawn(
+        runtime_root,
+        spawn_id="p-child",
+        parent_id=str(parent_id),
+        chat_id="c-child",
+        model="gpt-5.4",
+        agent="coder",
+        harness="codex",
+        prompt="child prompt label",
+        desc=None,
+        goal=None,
+    )
+
+    listed = spawn_store.list_spawns(runtime_root, filters={"parent_id": str(parent_id)})
+    assert len(listed) == 1
+    child_row = listed[0]
+    assert child_row.id == str(child_id)
+    assert child_row.prompt is None
+    assert child_row.display_label == "child prompt label"
+
+    state_path = runtime_root / "spawns" / str(child_id) / "state.json"
+    state_text = state_path.read_text(encoding="utf-8")
+    assert '"display_label": "child prompt label"' in state_text
+
+    output = spawn_api.spawn_children_sync(
+        SpawnChildrenInput(project_root=project_root.as_posix(), spawn_id=str(parent_id))
+    )
+
+    assert len(output.spawns) == 1
+    entry = output.spawns[0]
+    assert entry.spawn_id == str(child_id)
+    assert entry.desc == "child prompt label"
+
+
+def test_spawn_children_prefers_goal_over_display_label(tmp_path: Path) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    runtime_root = _state_root(project_root)
+
+    parent_id = spawn_store.start_spawn(
+        runtime_root,
+        spawn_id="p-parent",
+        chat_id="c-parent",
+        model="gpt-5.4",
+        agent="coder",
+        harness="codex",
+        prompt="parent prompt",
+    )
+    child_id = spawn_store.start_spawn(
+        runtime_root,
+        spawn_id="p-child",
+        parent_id=str(parent_id),
+        chat_id="c-child",
+        model="gpt-5.4",
+        agent="coder",
+        harness="codex",
+        prompt="ignored prompt summary",
+        goal="ship the feature",
+    )
+
+    listed = spawn_store.list_spawns(runtime_root, filters={"parent_id": str(parent_id)})
+    assert listed[0].display_label is None
+
+    output = spawn_api.spawn_children_sync(
+        SpawnChildrenInput(project_root=project_root.as_posix(), spawn_id=str(parent_id))
+    )
+
+    assert output.spawns[0].spawn_id == str(child_id)
+    assert output.spawns[0].desc == "ship the feature"
+
+
+def test_spawn_children_legacy_row_without_display_label_returns_none_desc(tmp_path: Path) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    runtime_root = _state_root(project_root)
+
+    parent_id = spawn_store.start_spawn(
+        runtime_root,
+        spawn_id="p-parent",
+        chat_id="c-parent",
+        model="gpt-5.4",
+        agent="coder",
+        harness="codex",
+        prompt="parent prompt",
+    )
+    child_id = spawn_store.start_spawn(
+        runtime_root,
+        spawn_id="p-child",
+        parent_id=str(parent_id),
+        chat_id="c-child",
+        model="gpt-5.4",
+        agent="coder",
+        harness="codex",
+        prompt="legacy prompt body",
+        desc=None,
+        goal=None,
+    )
+    state_path = runtime_root / "spawns" / str(child_id) / "state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state.pop("display_label", None)
+    state_path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+
+    listed = spawn_store.list_spawns(runtime_root, filters={"parent_id": str(parent_id)})
+    assert listed[0].prompt is None
+    assert listed[0].display_label is None
+
+    output = spawn_api.spawn_children_sync(
+        SpawnChildrenInput(project_root=project_root.as_posix(), spawn_id=str(parent_id))
+    )
+
+    assert output.spawns[0].desc is None
+
 
 def test_spawn_show_surfaces_persisted_goal_and_distinct_task_dir(tmp_path: Path) -> None:
     project_root = tmp_path / "repo"

--- a/tests/unit/core/test_spawn_display_label.py
+++ b/tests/unit/core/test_spawn_display_label.py
@@ -1,0 +1,24 @@
+from meridian.lib.core.spawn_start import (
+    compact_prompt_summary,
+    derive_display_label,
+    resolve_spawn_display_label,
+)
+
+
+def test_compact_prompt_summary_collapses_whitespace_and_truncates() -> None:
+    assert compact_prompt_summary("  hello\n\nworld  ") == "hello world"
+    long_prompt = "x" * 60
+    assert compact_prompt_summary(long_prompt) == f"{'x' * 47}..."
+
+
+def test_derive_display_label_only_when_goal_and_desc_absent() -> None:
+    assert derive_display_label(goal=None, desc=None, prompt="do the thing") == "do the thing"
+    assert derive_display_label(goal="ship it", desc=None, prompt="ignored") is None
+    assert derive_display_label(goal=None, desc="summary", prompt="ignored") is None
+
+
+def test_resolve_spawn_display_label_prefers_goal_then_desc_then_display_label() -> None:
+    assert resolve_spawn_display_label("goal", "desc", "label") == "goal"
+    assert resolve_spawn_display_label(None, "desc", "label") == "desc"
+    assert resolve_spawn_display_label(None, None, "label") == "label"
+    assert resolve_spawn_display_label(None, None, None) is None

--- a/tests/unit/state/test_spawn_repository_v2.py
+++ b/tests/unit/state/test_spawn_repository_v2.py
@@ -106,6 +106,18 @@ def test_write_state_locked_applies_mutator_under_per_spawn_lock(tmp_path: Path)
     assert '"revision": 2' in (spawns_dir / "p1" / "state.json").read_text(encoding="utf-8")
 
 
+def test_read_state_metadata_only_skips_prompt_file(tmp_path: Path) -> None:
+    spawns_dir = tmp_path / "spawns"
+    write_state(spawns_dir, _record(prompt="hello world"))
+
+    restored = read_state(spawns_dir, "p1", include_prompt=False)
+
+    assert restored is not None
+    assert restored.prompt is None
+    assert restored.id == "p1"
+    assert (spawns_dir / "p1" / "starting-prompt.md").exists() is False
+
+
 def test_write_state_locked_rejects_mutators_that_change_spawn_id(tmp_path: Path) -> None:
     spawns_dir = tmp_path / "spawns"
     write_state(spawns_dir, _record())

--- a/tests/unit/state/test_spawn_repository_v2.py
+++ b/tests/unit/state/test_spawn_repository_v2.py
@@ -106,6 +106,36 @@ def test_write_state_locked_applies_mutator_under_per_spawn_lock(tmp_path: Path)
     assert '"revision": 2' in (spawns_dir / "p1" / "state.json").read_text(encoding="utf-8")
 
 
+def test_start_spawn_persists_display_label_when_goal_and_desc_absent(tmp_path: Path) -> None:
+    from meridian.lib.state.paths import RuntimePaths
+    from meridian.lib.state.spawn_store import start_spawn
+
+    runtime_root = tmp_path / "runtime"
+    runtime_root.mkdir()
+    spawn_id = start_spawn(
+        runtime_root,
+        spawn_id="p1",
+        chat_id="c1",
+        model="gpt-5.4",
+        agent="coder",
+        harness="codex",
+        prompt="summarize this task please",
+        desc=None,
+        goal=None,
+    )
+
+    state_text = (
+        RuntimePaths.from_root_dir(runtime_root).spawns_dir / str(spawn_id) / "state.json"
+    ).read_text(encoding="utf-8")
+    assert '"display_label": "summarize this task please"' in state_text
+
+    spawns_dir = RuntimePaths.from_root_dir(runtime_root).spawns_dir
+    restored = read_state(spawns_dir, "p1", include_prompt=False)
+    assert restored is not None
+    assert restored.display_label == "summarize this task please"
+    assert restored.prompt is None
+
+
 def test_read_state_metadata_only_skips_prompt_file(tmp_path: Path) -> None:
     spawns_dir = tmp_path / "spawns"
     write_state(spawns_dir, _record(prompt="hello world"))


### PR DESCRIPTION
## Why

`list_spawns()` read every spawn's `starting-prompt.md` even when the caller discarded it — measured at ~188 MB of wasted reads on a 5k-spawn store. Listing is a hot path (`spawn list`, no-arg `wait` discovery, work dashboard, reaper, doctor).

## Goal

Spawn listing costs metadata only; prompt bodies load lazily when actually needed.

## Summary

`list_spawns()` and filtered list paths skip `starting-prompt.md`; prompt bodies load via `get_spawn()` / `read_state(include_prompt=True)`. `spawn children` and session export hydrate labels on demand when a list row omits the prompt.

## Resulting Behavior

`spawn list` / `wait` discovery no longer pay for prompt reads (≈188 MB avoided on the audited store). `spawn show`, fork, and continue still load full prompts. No behavior change to displayed data.

## Changes

- `spawn_store.py` / `spawn/repository.py`: `include_prompt=False` on list paths, authoritative record filtering.
- `ops/spawn/api.py`, `ops/session_export.py`: on-demand prompt hydration for display labels.

**Descoped during review** (see PR discussion): a `history.meta.json` writer sidecar and a `spawns/_index.json` catalog index were removed — two review rounds showed they added correctness risk without real perf gain (the history writer already does a full read on open; the index re-read every `state.json` to filter). The genuine problems (unbounded history + full read on open; O(N) filtered scans) are filed as follow-up issues for a real fix.

## Stacked PR

**Based on `sec/audit-p2-hardening` (#357), not `main`** — the two branches share 5 state/ops files. Merge #357 first, then rebase this onto `main` (resolves cleanly; only CHANGELOG reconciliation remains since #357's entries promote on its merge).

## Work Item

codebase-audit-rewrite

## Verification

`uv run ruff check .` pass; `uv run --extra dev python -m pyright` 0 errors; `uv run pytest tests/unit/state tests/unit/core/test_depth_records.py` 45 passed on the merged (P1+P2) surface; `pytest-llm` green (Pi extensions built). Two review rounds (p4937, p4944) → descope decision.

## Knowledge Updates

None — behavioral change, no durable-doc surface. Follow-up perf issues tracked separately.

## Spawn Trace

- p4934 coder — initial perf pass
- p4937 reviewer — round-1 review
- p4942 coder — round-1 fixes
- p4944 reviewer — round-2 review (→ descope)
- p4946 coder — descope to metadata-only

## Release Label Guide
