### PR TITLE
fix(spawn): fail-closed depth via persisted meridian_depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Security
+- Spawn depth limits use persisted per-record `meridian_depth` so forged `MERIDIAN_DEPTH` cannot bypass `--max-depth`; first concrete piece of coordinator-enforced delegation limits.
+
 ## [0.3.24] - 2026-07-04
 
 ### Changed

--- a/src/meridian/lib/core/lifecycle.py
+++ b/src/meridian/lib/core/lifecycle.py
@@ -297,6 +297,7 @@ class SpawnLifecycleService:
                 worker_pid=reservation.worker_pid,
                 runner_pid=reservation.runner_pid,
                 launch_policy_snapshot=reservation.launch_policy_snapshot,
+                meridian_depth=reservation.meridian_depth,
                 status=reservation.status,
                 started_at=reservation.started_at,
                 clock=reservation.clock,

--- a/src/meridian/lib/core/resolved_context.py
+++ b/src/meridian/lib/core/resolved_context.py
@@ -61,6 +61,7 @@ class ResolvedContext:
         explicit_chat_id: str | None = None,
         explicit_project_root: Path | None = None,
         explicit_runtime_root: Path | None = None,
+        explicit_depth: int | None = None,
         backend: ContextBackend | None = None,
         context_config: ContextConfig | None = None,
     ) -> Self:
@@ -100,7 +101,11 @@ class ResolvedContext:
             work_id_raw = os.getenv("MERIDIAN_ACTIVE_WORK_ID", "").strip()
             work_dir_raw = os.getenv("MERIDIAN_ACTIVE_WORK_DIR", "").strip()
 
-        depth = parse_meridian_depth(depth_raw)
+        depth = (
+            max(0, explicit_depth)
+            if explicit_depth is not None
+            else parse_meridian_depth(depth_raw)
+        )
 
         project_root = (
             explicit_project_root

--- a/src/meridian/lib/core/spawn_lifecycle.py
+++ b/src/meridian/lib/core/spawn_lifecycle.py
@@ -31,6 +31,7 @@ class SpawnReservation:
     prompt: str
     owner_chat_id: str | None = None
     parent_id: str | None = None
+    meridian_depth: int | None = None
     kind: str = "child"
     metadata: SpawnStartMetadata | None = None
     desc: str | None = None

--- a/src/meridian/lib/launch/__init__.py
+++ b/src/meridian/lib/launch/__init__.py
@@ -96,6 +96,7 @@ def launch_primary(
     from meridian.lib.catalog.catalog_session import CatalogSession
     from meridian.lib.config.project_root import resolve_project_root_resolution
     from meridian.lib.core.context import resolve_runtime_context
+    from meridian.lib.ops.depth import with_record_backed_depth
     from meridian.lib.ops.runtime import resolve_runtime_root_for_read
 
     from .context import (
@@ -111,9 +112,11 @@ def launch_primary(
     resolved_project_root = resolve_project_root_resolution(project_root).project_root
     explicit_work_id = _explicit_work_id_for_launch(request)
     runtime_root_for_context = resolve_runtime_root_for_read(resolved_project_root)
-    runtime_context = resolve_runtime_context(
-        project_root=resolved_project_root,
-        runtime_root=runtime_root_for_context,
+    runtime_context = with_record_backed_depth(
+        resolve_runtime_context(
+            project_root=resolved_project_root,
+            runtime_root=runtime_root_for_context,
+        )
     )
     inherit_ambient_work = request.session_mode.value != "resume"
     inherited_task_dir = (

--- a/src/meridian/lib/launch/context.py
+++ b/src/meridian/lib/launch/context.py
@@ -172,6 +172,9 @@ class ChildEnvContext:
             explicit_runtime_root=resolved_runtime_root,
             context_config=context_config,
         )
+        from meridian.lib.ops.depth import with_record_backed_depth
+
+        resolved = with_record_backed_depth(resolved)
         return cls(resolved=resolved)
 
     @property

--- a/src/meridian/lib/ops/context.py
+++ b/src/meridian/lib/ops/context.py
@@ -20,6 +20,7 @@ from meridian.lib.core.resolved_context import ResolvedContext
 from meridian.lib.core.util import FormatContext
 from meridian.lib.hooks.builtin.autosync_store import read_status
 from meridian.lib.launch.cwd import resolve_effective_task_dir
+from meridian.lib.ops.depth import with_record_backed_depth
 from meridian.lib.ops.runtime import (
     resolve_runtime_authority_for_read,
     resolve_runtime_authority_for_write,
@@ -256,11 +257,12 @@ def _resolve_runtime_context(
     """Resolve context with explicit roots — no env mutation needed."""
 
     normalized_chat_id = (chat_id or "").strip()
-    return ResolvedContext.from_environment(
+    resolved = ResolvedContext.from_environment(
         explicit_project_root=project_root,
         explicit_runtime_root=runtime_root,
         explicit_chat_id=normalized_chat_id or None,
     )
+    return with_record_backed_depth(resolved)
 
 
 def resolve_active_work_scope(

--- a/src/meridian/lib/ops/depth.py
+++ b/src/meridian/lib/ops/depth.py
@@ -1,0 +1,61 @@
+"""Ops-layer helpers for record-backed Meridian depth."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import replace
+from pathlib import Path
+
+from meridian.lib.core.context import RuntimeContext
+from meridian.lib.core.resolved_context import ResolvedContext
+from meridian.lib.state.depth_resolution import resolve_effective_meridian_depth
+
+
+def effective_meridian_depth(
+    env: Mapping[str, str],
+    *,
+    runtime_root: Path | None,
+) -> int | None:
+    """Return record-backed depth when runtime root is known, else ``None``."""
+
+    if runtime_root is None:
+        return None
+    return resolve_effective_meridian_depth(env, runtime_root=runtime_root)
+
+
+def with_record_backed_depth(
+    resolved: ResolvedContext,
+    env: Mapping[str, str] | None = None,
+) -> ResolvedContext:
+    """Return ``resolved`` with spawn-record depth applied when available."""
+
+    if resolved.runtime_root is None:
+        return resolved
+    source = os.environ if env is None else env
+    depth = resolve_effective_meridian_depth(source, runtime_root=resolved.runtime_root)
+    if depth == resolved.depth:
+        return resolved
+    return replace(resolved, depth=depth)
+
+
+def with_record_backed_runtime_context(
+    ctx: RuntimeContext,
+    env: Mapping[str, str] | None = None,
+) -> RuntimeContext:
+    """Return ``ctx`` with spawn-record depth applied when available."""
+
+    if ctx.runtime_root is None:
+        return ctx
+    source = os.environ if env is None else env
+    depth = resolve_effective_meridian_depth(source, runtime_root=ctx.runtime_root)
+    if depth == ctx.depth:
+        return ctx
+    return ctx.model_copy(update={"depth": depth})
+
+
+__all__ = [
+    "effective_meridian_depth",
+    "with_record_backed_depth",
+    "with_record_backed_runtime_context",
+]

--- a/src/meridian/lib/ops/runtime.py
+++ b/src/meridian/lib/ops/runtime.py
@@ -134,9 +134,11 @@ class ResolvedRoots:
 
 
 def runtime_context(ctx: RuntimeContext | None) -> RuntimeContext:
+    from meridian.lib.ops.depth import with_record_backed_runtime_context
+
     if ctx is not None:
-        return ctx
-    return RuntimeContext.from_environment()
+        return with_record_backed_runtime_context(ctx)
+    return with_record_backed_runtime_context(RuntimeContext.from_environment())
 
 
 def resolve_project_authority(

--- a/src/meridian/lib/ops/spawn/execute_init.py
+++ b/src/meridian/lib/ops/spawn/execute_init.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, ConfigDict
 from meridian.lib.bootstrap.services import build_spawn_lifecycle_service_from_roots
 from meridian.lib.config.project_paths import ProjectConfigPaths, resolve_project_config_paths
 from meridian.lib.core.context import RuntimeContext
-from meridian.lib.core.depth import current_meridian_depth, max_depth_reached
+from meridian.lib.core.depth import child_meridian_depth, current_meridian_depth, max_depth_reached
 from meridian.lib.core.domain import Spawn, SpawnStatus
 from meridian.lib.core.launch_policy_snapshot import LaunchPolicySnapshot
 from meridian.lib.core.resolved_context import ResolvedContext
@@ -187,6 +187,7 @@ def build_spawn_reservation(
         chat_id=owner_chat_id,
         owner_chat_id=owner_chat_id,
         parent_id=str(resolved_context.spawn_id) if resolved_context.spawn_id else None,
+        meridian_depth=child_meridian_depth(resolved_context.depth),
         session_metadata=spawn_session_metadata,
         kind="child",
         prompt=request.prompt,

--- a/src/meridian/lib/state/depth_resolution.py
+++ b/src/meridian/lib/state/depth_resolution.py
@@ -1,0 +1,73 @@
+"""Spawn-record-backed Meridian depth resolution."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+
+from meridian.lib.core.depth import (
+    MERIDIAN_DEPTH_ENV,
+    MERIDIAN_SPAWN_ID_ENV,
+    parse_meridian_depth,
+)
+from meridian.lib.core.types import SpawnId
+from meridian.lib.state import spawn_store
+
+
+def depth_from_spawn_ancestry(
+    spawn_id: str | SpawnId,
+    runtime_root: Path,
+) -> int | None:
+    """Return spawn depth from persisted records, or ``None`` when unknown."""
+
+    normalized_spawn_id = str(spawn_id).strip()
+    if not normalized_spawn_id:
+        return None
+
+    record = spawn_store.get_spawn(runtime_root, normalized_spawn_id)
+    if record is None:
+        return None
+    if record.meridian_depth is not None:
+        return record.meridian_depth
+
+    depth = 0
+    current_id = normalized_spawn_id
+    visited: set[str] = set()
+    while current_id:
+        if current_id in visited:
+            return None
+        visited.add(current_id)
+        walk_record = spawn_store.get_spawn(runtime_root, current_id)
+        if walk_record is None:
+            if current_id == normalized_spawn_id:
+                return None
+            return max(depth, record.meridian_depth or 0)
+        parent_id = (walk_record.parent_id or "").strip() or None
+        if parent_id is None:
+            return depth
+        depth += 1
+        current_id = parent_id
+    return depth
+
+
+def resolve_effective_meridian_depth(
+    env: Mapping[str, str],
+    *,
+    runtime_root: Path | None = None,
+) -> int:
+    """Return depth using coordinator records when the caller spawn is known."""
+
+    env_depth = parse_meridian_depth(env.get(MERIDIAN_DEPTH_ENV))
+    spawn_id = (env.get(MERIDIAN_SPAWN_ID_ENV) or "").strip()
+    if not spawn_id or runtime_root is None:
+        return env_depth
+    record_depth = depth_from_spawn_ancestry(spawn_id, runtime_root)
+    if record_depth is None:
+        return env_depth
+    return max(env_depth, record_depth)
+
+
+__all__ = [
+    "depth_from_spawn_ancestry",
+    "resolve_effective_meridian_depth",
+]

--- a/src/meridian/lib/state/spawn/model.py
+++ b/src/meridian/lib/state/spawn/model.py
@@ -54,6 +54,7 @@ class SpawnRecord(BaseModel):
     chat_id: str | None
     owner_chat_id: str | None = None
     parent_id: str | None
+    meridian_depth: int | None = None
     originating_bash_id: str | None = None
     model: str | None
     agent: str | None

--- a/src/meridian/lib/state/spawn/repository.py
+++ b/src/meridian/lib/state/spawn/repository.py
@@ -40,6 +40,7 @@ class StoredSpawnState(BaseModel):
     chat_id: str | None = None
     owner_chat_id: str | None = None
     parent_id: str | None = None
+    meridian_depth: int | None = None
     originating_bash_id: str | None = None
     model: str | None = None
     agent: str | None = None
@@ -114,6 +115,7 @@ def record_to_stored_state(
         chat_id=record.chat_id,
         owner_chat_id=record.owner_chat_id,
         parent_id=record.parent_id,
+        meridian_depth=record.meridian_depth,
         originating_bash_id=record.originating_bash_id,
         model=record.model,
         agent=record.agent,
@@ -171,6 +173,7 @@ def stored_state_to_record(
         chat_id=stored.chat_id,
         owner_chat_id=stored.owner_chat_id,
         parent_id=stored.parent_id,
+        meridian_depth=stored.meridian_depth,
         originating_bash_id=stored.originating_bash_id,
         model=stored.model,
         agent=stored.agent,

--- a/src/meridian/lib/state/spawn_store.py
+++ b/src/meridian/lib/state/spawn_store.py
@@ -243,6 +243,26 @@ class FinalizeOutcome(BaseModel):
     snapshot: SpawnRecord | None
 
 
+def _resolve_spawn_meridian_depth(
+    runtime_root: Path,
+    *,
+    parent_id: str | None,
+    kind: str,
+    meridian_depth: int | None,
+) -> int:
+    if meridian_depth is not None:
+        return max(0, meridian_depth)
+    if kind == "primary":
+        return 0
+    if parent_id:
+        parent = get_spawn(runtime_root, parent_id)
+        if parent is not None and parent.meridian_depth is not None:
+            return parent.meridian_depth + 1
+    from meridian.lib.core.depth import child_meridian_depth, current_meridian_depth
+
+    return child_meridian_depth(current_meridian_depth())
+
+
 def start_spawn(
     runtime_root: Path,
     *,
@@ -271,6 +291,7 @@ def start_spawn(
     runner_pid: int | None = None,
     runner_created_at_epoch: float | None = None,
     launch_policy_snapshot: LaunchPolicySnapshot | None = None,
+    meridian_depth: int | None = None,
     status: SpawnStatus = "running",
     started_at: str | None = None,
     clock: Clock | None = None,
@@ -300,6 +321,12 @@ def start_spawn(
     resolved_launch_policy_snapshot = (
         launch_policy_snapshot or start_metadata.launch_policy_snapshot
     )
+    resolved_meridian_depth = _resolve_spawn_meridian_depth(
+        runtime_root,
+        parent_id=parent_id,
+        kind=kind,
+        meridian_depth=meridian_depth,
+    )
 
     with lock_file(paths.spawns_flock):
         if spawn_id is not None:
@@ -316,6 +343,7 @@ def start_spawn(
             chat_id=chat_id,
             owner_chat_id=owner_chat_id,
             parent_id=parent_id,
+            meridian_depth=resolved_meridian_depth,
             originating_bash_id=os.environ.get("MERIDIAN_PI_BASH_ID") or None,
             model=model,
             agent=agent,

--- a/tests/unit/core/test_depth_records.py
+++ b/tests/unit/core/test_depth_records.py
@@ -1,0 +1,129 @@
+"""Depth resolution from spawn ancestry records."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from meridian.lib.state.depth_resolution import (
+    depth_from_spawn_ancestry,
+    resolve_effective_meridian_depth,
+)
+from meridian.lib.state.spawn.model import SpawnRecord
+
+
+def _record(
+    spawn_id: str,
+    *,
+    parent_id: str | None = None,
+    meridian_depth: int | None = None,
+) -> SpawnRecord:
+    return SpawnRecord(
+        id=spawn_id,
+        chat_id="chat-1",
+        parent_id=parent_id,
+        meridian_depth=meridian_depth,
+        model="gpt-5.4",
+        agent="coder",
+        agent_path=None,
+        skills=(),
+        skill_paths=(),
+        harness="codex",
+        kind="child",
+        desc="test spawn",
+        work_id=None,
+        harness_session_id=None,
+        launch_mode="foreground",
+        worker_pid=None,
+        runner_pid=None,
+        runner_created_at_epoch=None,
+        status="running",
+        prompt="hello",
+        started_at=None,
+        last_attempt_exited_at=None,
+        last_attempt_exit_code=None,
+        runner_exit_code=None,
+        runner_exit_status=None,
+        runner_exit_error=None,
+        runner_exit_at=None,
+        finished_at=None,
+        exit_code=None,
+        duration_secs=None,
+        total_cost_usd=None,
+        input_tokens=None,
+        output_tokens=None,
+        cache_read_input_tokens=None,
+        cache_creation_input_tokens=None,
+        reasoning_tokens=None,
+        cost_is_estimate=False,
+        error=None,
+        terminal_origin=None,
+    )
+
+
+def test_depth_from_spawn_ancestry_counts_parents(tmp_path: Path, monkeypatch) -> None:
+    runtime_root = tmp_path / "runtime"
+    records = {
+        "p-root": _record("p-root"),
+        "p-child": _record("p-child", parent_id="p-root"),
+        "p-grandchild": _record("p-grandchild", parent_id="p-child"),
+    }
+
+    def _fake_get_spawn(_runtime_root: Path, spawn_id: str) -> SpawnRecord | None:
+        return records.get(spawn_id)
+
+    monkeypatch.setattr(
+        "meridian.lib.state.spawn_store.get_spawn",
+        _fake_get_spawn,
+    )
+
+    assert depth_from_spawn_ancestry("p-root", runtime_root) == 0
+    assert depth_from_spawn_ancestry("p-child", runtime_root) == 1
+    assert depth_from_spawn_ancestry("p-grandchild", runtime_root) == 2
+
+
+def test_resolve_effective_meridian_depth_uses_max_of_env_and_records(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime_root = tmp_path / "runtime"
+    monkeypatch.setattr(
+        "meridian.lib.state.spawn_store.get_spawn",
+        lambda _runtime_root, spawn_id: _record(spawn_id, parent_id="p-root")
+        if spawn_id == "p-child"
+        else _record(spawn_id),
+    )
+
+    env = {
+        "MERIDIAN_SPAWN_ID": "p-child",
+        "MERIDIAN_DEPTH": "0",
+    }
+    assert resolve_effective_meridian_depth(env, runtime_root=runtime_root) == 1
+
+    env["MERIDIAN_DEPTH"] = "2"
+    assert resolve_effective_meridian_depth(env, runtime_root=runtime_root) == 2
+
+
+def test_depth_from_persisted_record_is_o1_when_ancestors_pruned(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime_root = tmp_path / "runtime"
+    records = {
+        "p-deep": _record("p-deep", parent_id="p-missing", meridian_depth=5),
+    }
+
+    def _fake_get_spawn(_runtime_root: Path, spawn_id: str) -> SpawnRecord | None:
+        return records.get(spawn_id)
+
+    monkeypatch.setattr(
+        "meridian.lib.state.spawn_store.get_spawn",
+        _fake_get_spawn,
+    )
+
+    assert depth_from_spawn_ancestry("p-deep", runtime_root) == 5
+
+    env = {
+        "MERIDIAN_SPAWN_ID": "p-deep",
+        "MERIDIAN_DEPTH": "0",
+    }
+    assert resolve_effective_meridian_depth(env, runtime_root=runtime_root) == 5


### PR DESCRIPTION
## Why

Spawn depth limiting read `MERIDIAN_DEPTH` from the child-controlled environment, so a worker could unset or lower it to escape `--max-depth` (e.g. run unbounded nested spawns). Extracted from the now-closed #357 as the one genuinely useful, orthogonal piece.

## Goal

Depth authority comes from coordinator-owned spawn records, not a forgeable env var — a worker cannot undercount its own depth.

## Summary

Persist effective `meridian_depth` on the spawn record at creation (primary = 0, child = parent + 1). Depth checks use `max(env, record)`, so a forged-low `MERIDIAN_DEPTH` cannot bypass the limit. `core/depth.py` stays pure (env parsing + math); record-backed resolution lives in `state/depth_resolution.py` and is applied at ops/launch boundaries.

## Resulting Behavior

A spawn whose record carries `meridian_depth=5` is treated as depth 5 even if its environment says `MERIDIAN_DEPTH=0`. Legacy records without the field fall back to the prior env/ancestry behavior. No change for normal (non-adversarial) spawns.

## Changes

- `state/spawn/model.py`, `state/spawn/repository.py`, `core/spawn_lifecycle.py` — `meridian_depth: int | None = None` on record/stored/reservation (legacy-compatible).
- `state/spawn_store.py`, `ops/spawn/execute_init.py` — compute + persist depth at creation.
- `state/depth_resolution.py` (new), `ops/depth.py` (new) — record-backed resolution + `with_record_backed_depth()` boundary helpers.
- `core/depth.py` stays pure; `core/resolved_context.py` gains an `explicit_depth` param and does NOT read spawn records.

## Relationship to the delegation/capability model

`max_depth` is a ceiling axis in the capability-cap design (`design/capability-caps.md`). This is the first concrete piece of coordinator-enforced delegation limits — the same pattern (authoritative, record-backed, not env-forgeable) generalizes to sandbox/approval ceilings later.

## Work Item

codebase-audit-rewrite

## Verification

`git grep 'from meridian.lib.state' src/meridian/lib/core/` clean (core stays pure); `uv run ruff check .` pass; `uv run --extra dev python -m pyright` 0 errors; `uv run pytest tests/unit/core/test_depth_records.py` 3 passed; `uv run pytest-llm` 1358 passed. Diff is depth-only (15 files, zero env/hook changes).

## Spawn Trace

- p4957 coder — clean extraction from the closed #357 branch

## Release Label Guide
