### PR TITLE
fix: contain managed primaries on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- Fresh managed Codex sessions identify the active agent in the visible bootstrap
+  message when an agent profile is available.
+
 ### Fixed
 - macOS/BSD managed harness backends now get real crash containment via a detached
   parent-watchdog helper with a readiness handshake and full process-group liveness;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- macOS/BSD managed harness backends now get real crash containment via a detached
+  parent-watchdog helper with a readiness handshake and full process-group liveness;
+  Linux `prctl` and Windows Job Object linkage remain unchanged.
+- Fresh managed Codex sessions now finish their bootstrap turn before TUI handoff,
+  preventing the remote TUI from remaining stuck in `Working` after the bootstrap
+  response and restoring normal idle Ctrl+C exit behavior.
+- Primary process launch now separates process birth from its blocking terminal wait,
+  so managed-primary cancellation can terminate and boundedly drain a known TUI scope
+  instead of polling a child-start callback.
+
 ## [0.3.28] - 2026-07-10
 
 ### Fixed

--- a/docs/codex-tui-passthrough.md
+++ b/docs/codex-tui-passthrough.md
@@ -60,7 +60,8 @@ Meridian handles that by sending a minimal bootstrap turn, then waiting until:
 1. the Codex rollout file contains a matching `session_meta` entry for the project cwd;
 2. the observer receives `turn/completed` for that bootstrap turn.
 
-`Meridian started`
+`Meridian started (agent: reviewer)` when an agent profile is active, otherwise
+`Meridian started`.
 
 This bootstrap is intentionally small and deterministic. Meridian does **not** temporarily override Codex model/reasoning defaults for the bootstrap turn. The session should preserve Codex's own default or last-used settings.
 

--- a/docs/codex-tui-passthrough.md
+++ b/docs/codex-tui-passthrough.md
@@ -55,9 +55,10 @@ That keeps Meridian's system content out of the visible TUI prompt on managed pa
 
 Fresh Codex threads are not immediately attachable after `thread/start`. Codex needs at least one rollout materialized before `codex resume --remote ...` can attach.
 
-Meridian handles that by sending a minimal bootstrap turn, then waiting only
-until the Codex rollout file contains a matching `session_meta` entry for the
-project cwd:
+Meridian handles that by sending a minimal bootstrap turn, then waiting until:
+
+1. the Codex rollout file contains a matching `session_meta` entry for the project cwd;
+2. the observer receives `turn/completed` for that bootstrap turn.
 
 `Meridian started`
 
@@ -88,11 +89,15 @@ The important condition is:
 
 `thread is attachable by the Codex TUI`
 
-Today Meridian uses rollout materialization as that condition. It does not wait
-for `turn/completed`, because full bootstrap response completion is not required
-for TUI attach.
+Rollout materialization makes the thread technically resumable. Meridian also waits
+for the bootstrap turn to complete before handing the websocket endpoint to the TUI.
+Attaching during the bootstrap turn can strand the remote TUI in a stale `Working`
+state after the observer connection is displaced, which also prevents normal idle
+Ctrl+C exit behavior.
 
-If Codex exposes an earlier observable signal like "thread attachable", Meridian should switch to that signal instead of:
+If Codex exposes an atomic "completed turn handoff" signal, Meridian should prefer it
+over coordinating the rollout and completion signals separately. It should not improve
+startup time by:
 
 - changing bootstrap wording
 - lowering reasoning effort temporarily

--- a/src/meridian/lib/harness/codex.py
+++ b/src/meridian/lib/harness/codex.py
@@ -271,6 +271,7 @@ class CodexAdapter(BaseHarnessAdapter[ResolvedLaunchSpec]):
             "mcp_tools",
             "projected_roots",
             "control_root",
+            "agent",
             "adhoc_agent_payload",
             "appended_system_prompt",
             "user_turn_content",
@@ -279,7 +280,6 @@ class CodexAdapter(BaseHarnessAdapter[ResolvedLaunchSpec]):
     _EXPLICITLY_IGNORED_FIELDS: ClassVar[frozenset[str]] = frozenset(
         {
             "skills",
-            "agent",
             "context_from_payload",
             "reference_items",
             "task_cwd",
@@ -382,6 +382,7 @@ class CodexAdapter(BaseHarnessAdapter[ResolvedLaunchSpec]):
             interactive=run.interactive,
             mcp_tools=run.mcp_tools,
             projected_roots=run.projected_roots,
+            agent_name=run.agent,
             base_instructions=run.adhoc_agent_payload.strip() or None,
             developer_instructions=run.appended_system_prompt,
             user_turn_content=run.user_turn_content,

--- a/src/meridian/lib/harness/connections/codex_ws.py
+++ b/src/meridian/lib/harness/connections/codex_ws.py
@@ -76,7 +76,7 @@ from meridian.lib.observability.trace_helpers import (
     trace_state_change,
     trace_wire_send,
 )
-from meridian.lib.platform.detached_process import ParentDeathLink
+from meridian.lib.platform.detached_process import ParentDeathLink, release_parent_death_link
 from meridian.lib.platform.process_scope import (
     ProcessScopeSnapshot,
     ScopedProcessHandle,
@@ -240,6 +240,8 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
         self._current_turn_id: str | None = None
         self._thread_id: str | None = None
         self._main_turn_thread_id: str | None = None
+        self._last_completed_turn_id: str | None = None
+        self._turn_completed_event = asyncio.Event()
         self._tracer: DebugTracer | None = None
         self._cancel_requested = False
         self._signal_in_flight = False
@@ -361,6 +363,8 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
         self._current_turn_id = None
         self._thread_id = None
         self._main_turn_thread_id = None
+        self._last_completed_turn_id = None
+        self._turn_completed_event.clear()
         self._liveness.reset()
         self._cancel_requested = False
         self._signal_in_flight = False
@@ -440,12 +444,6 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
                 # Fresh primary sessions need a bootstrap turn to materialize the
                 # Codex rollout before the TUI can attach. Without this, Codex
                 # cannot resume a fresh thread because no rollout file exists.
-                #
-                # The load-bearing requirement is "thread is attachable", not
-                # "bootstrap response is semantically complete". We gate on
-                # rollout materialization because that is the earliest observed
-                # durable signal that `codex resume --remote` can attach.
-                # Do not optimize this by mutating Codex model/reasoning defaults.
                 self._emit_startup_phase(StartupPhase.INITIALIZING_SESSION)
                 await self._send_bootstrap_turn_and_wait()
 
@@ -847,6 +845,7 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
                 process.kill()
                 await process.wait()
 
+        await asyncio.to_thread(release_parent_death_link, self._parent_death_link)
         self._parent_death_link = None
         self._fail_pending_requests(RuntimeError("Codex connection stopped"))
         await self._clear_stale_hitl_requests(reason="connection_stopped")
@@ -1208,7 +1207,7 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
         attachability gate, not by mutating user-visible Codex defaults.
         """
         thread_id = self._require_thread_id("bootstrap_turn")
-        await self._request(
+        result = await self._request(
             "turn/start",
             {
                 "threadId": thread_id,
@@ -1216,15 +1215,20 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
             },
         )
         await self._wait_for_rollout_materialization()
+        turn_id = (
+            _extract_turn_id(result)
+            or self._current_turn_id
+            or self._last_completed_turn_id
+        )
+        if turn_id is None:
+            raise RuntimeError("Codex bootstrap turn did not provide a turn id")
+        await self._wait_for_turn_completion(turn_id)
 
     async def _wait_for_rollout_materialization(self, timeout_seconds: float = 120.0) -> None:
         """Block until Codex has created an attachable rollout for the thread.
 
-        Fresh primary attach only needs the thread to be resumable by the Codex
-        TUI. The attach-safe signal is a rollout file whose session_meta exists
-        and whose cwd matches this project. We intentionally do not wait for
-        turn/completed and do not change model/effort settings to make bootstrap
-        cheaper.
+        The attach-safe filesystem signal is a rollout file whose session_meta
+        exists and whose cwd matches this project.
         """
         config = self._config
         codex_home = self._codex_home
@@ -1256,6 +1260,31 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
             ws_open = self._ws is not None and _ws_is_open(self._ws)
             if not process_running or not ws_open:
                 raise RuntimeError("Codex connection lost during bootstrap turn")
+
+    async def _wait_for_turn_completion(
+        self,
+        turn_id: str,
+        timeout_seconds: float = 120.0,
+    ) -> None:
+        """Wait until the observer receives completion for the bootstrap turn."""
+
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout_seconds
+        while self._last_completed_turn_id != turn_id:
+            self._turn_completed_event.clear()
+            if self._last_completed_turn_id == turn_id:
+                return
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                raise RuntimeError(
+                    f"Bootstrap turn timed out after {timeout_seconds}s waiting for completion"
+                )
+            try:
+                await asyncio.wait_for(self._turn_completed_event.wait(), timeout=remaining)
+            except TimeoutError as exc:
+                raise RuntimeError(
+                    f"Bootstrap turn timed out after {timeout_seconds}s waiting for completion"
+                ) from exc
 
     async def _bootstrap_thread(self, spec: ResolvedLaunchSpec) -> dict[str, object]:
         method, payload = self._thread_bootstrap_request(spec)
@@ -1294,7 +1323,9 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
             if thread_id is not None:
                 self._main_turn_thread_id = thread_id
         if clears_signal(event, primary_event_scope=self.primary_event_scope):
+            self._last_completed_turn_id = _extract_turn_id(payload) or self._current_turn_id
             self._end_current_turn()
+            self._turn_completed_event.set()
             self._signal_in_flight = False
             self._liveness.signal_request_resolved("cancel")
             return

--- a/src/meridian/lib/harness/connections/codex_ws.py
+++ b/src/meridian/lib/harness/connections/codex_ws.py
@@ -445,7 +445,7 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
                 # Codex rollout before the TUI can attach. Without this, Codex
                 # cannot resume a fresh thread because no rollout file exists.
                 self._emit_startup_phase(StartupPhase.INITIALIZING_SESSION)
-                await self._send_bootstrap_turn_and_wait()
+                await self._send_bootstrap_turn_and_wait(agent_name=spec.agent_name)
 
             self._transition("connected")
             self._liveness.mark_activity()
@@ -1197,7 +1197,7 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
             raise RuntimeError("Codex connection config is unavailable")
         return config.control_root
 
-    async def _send_bootstrap_turn_and_wait(self) -> None:
+    async def _send_bootstrap_turn_and_wait(self, *, agent_name: str | None) -> None:
         """Send a minimal bootstrap turn and wait for completion.
 
         This materializes the Codex rollout file so the TUI can later attach
@@ -1207,11 +1207,15 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
         attachability gate, not by mutating user-visible Codex defaults.
         """
         thread_id = self._require_thread_id("bootstrap_turn")
+        normalized_agent = (agent_name or "").strip()
+        prompt = _BOOTSTRAP_TURN_PROMPT
+        if normalized_agent:
+            prompt = f"{prompt} (agent: {normalized_agent})"
         result = await self._request(
             "turn/start",
             {
                 "threadId": thread_id,
-                "input": _build_text_user_input(_BOOTSTRAP_TURN_PROMPT),
+                "input": _build_text_user_input(prompt),
             },
         )
         await self._wait_for_rollout_materialization()

--- a/src/meridian/lib/harness/connections/managed_backend.py
+++ b/src/meridian/lib/harness/connections/managed_backend.py
@@ -92,7 +92,11 @@ async def launch_managed_backend(
     except (psutil.NoSuchProcess, psutil.AccessDenied):
         birth_time = PROCESS_BIRTH_UNKNOWN_EPOCH
 
-    parent_death_link = link_child_lifetime_to_parent(pid)
+    parent_death_link = (
+        ParentDeathLink(parent_death_linked=False)
+        if subprocess_config.parent_death_linked
+        else link_child_lifetime_to_parent(pid)
+    )
     parent_death_linked = (
         subprocess_config.parent_death_linked or parent_death_link.parent_death_linked
     )

--- a/src/meridian/lib/harness/connections/opencode_http.py
+++ b/src/meridian/lib/harness/connections/opencode_http.py
@@ -69,7 +69,7 @@ from meridian.lib.observability.trace_helpers import (
     trace_wire_recv,
     trace_wire_send,
 )
-from meridian.lib.platform.detached_process import ParentDeathLink
+from meridian.lib.platform.detached_process import ParentDeathLink, release_parent_death_link
 from meridian.lib.platform.process_scope import (
     ProcessScopeSnapshot,
     ScopedProcessHandle,
@@ -1044,6 +1044,7 @@ class OpenCodeConnection(HarnessConnection[ResolvedLaunchSpec]):
                 process.kill()
                 await process.wait()
 
+        await asyncio.to_thread(release_parent_death_link, self._parent_death_link)
         self._parent_death_link = None
         self._base_url = None
         self._session_id = None

--- a/src/meridian/lib/launch/launch_types.py
+++ b/src/meridian/lib/launch/launch_types.py
@@ -99,7 +99,7 @@ class ResolvedLaunchSpec(BaseModel):
     # All are optional and default to their zero values so unused adapters
     # don't need to set them.
 
-    # Claude + OpenCode
+    # Harness-level agent identity. Codex also shows it in the managed bootstrap turn.
     agent_name: str | None = None
     appended_system_prompt: str | None = None
 

--- a/src/meridian/lib/launch/process/.context/CONTEXT.md
+++ b/src/meridian/lib/launch/process/.context/CONTEXT.md
@@ -20,6 +20,15 @@ handles Windows-specific console inheritance. Subprocess is the portable fallbac
 `captures_output_to_artifact` on `ProcessPlatformContract` is authoritative — callers must
 not assume capture based on launcher type alone.
 
+`ProcessLauncher.start()` returns a `RunningProcess` immediately after process birth.
+PID/scope recording happens before `RunningProcess.wait()` begins the blocking terminal
+relay. Keep those phases separate: managed-primary cancellation depends on having a
+concrete process identity before it can wait for exit or terminate the scope.
+`RunningProcess.cancel_wait()` must release its caller-facing wait even when scope
+termination cannot confirm child exit. Managed attach also directly terminates the
+concrete process as a fallback and bridges the synchronous wait through a daemon thread,
+so an uncooperative relay cannot be re-joined by `asyncio.run()` during loop shutdown.
+
 ## Managed Attach vs Black-Box
 
 `_execute_primary_process()` checks `harness_contract.bootstrap.mode`. When mode is

--- a/src/meridian/lib/launch/process/ports.py
+++ b/src/meridian/lib/launch/process/ports.py
@@ -19,9 +19,6 @@ class LaunchedProcess:
     pid: int | None
 
 
-ChildStartedHook = Callable[[int], None]
-
-
 class ProcessBackendId(StrEnum):
     """Named launch backends used for local harness process execution."""
 
@@ -48,6 +45,34 @@ class ProcessPlatformContract:
     platform_family: str
 
 
+class RunningProcess(Protocol):
+    """A started primary process whose blocking exit wait is a separate phase."""
+
+    @property
+    def pid(self) -> int: ...
+
+    def wait(self) -> LaunchedProcess: ...
+
+    def terminate(self) -> None: ...
+
+    def cancel_wait(self) -> None:
+        """Unblock a concurrent wait without assuming the child exited."""
+        ...
+
+
+class ProcessLauncher(Protocol):
+    """Start a primary process and return as soon as its PID is available."""
+
+    def start(
+        self,
+        *,
+        command: tuple[str, ...],
+        cwd: Path,
+        env: dict[str, str],
+        output_log_path: Path | None,
+    ) -> RunningProcess: ...
+
+
 @dataclass(frozen=True)
 class SelectedProcessLauncher:
     """Launcher instance paired with its explicit process/platform contract."""
@@ -56,31 +81,17 @@ class SelectedProcessLauncher:
     contract: ProcessPlatformContract
 
 
-class ProcessLauncher(Protocol):
-    """Protocol for primary process launch strategies."""
-
-    def launch(
-        self,
-        *,
-        command: tuple[str, ...],
-        cwd: Path,
-        env: dict[str, str],
-        output_log_path: Path | None,
-        on_child_started: ChildStartedHook | None = None,
-    ) -> LaunchedProcess: ...
-
-
 ProcessLauncherSelector = Callable[[Path | None], ProcessLauncher]
 
 
 __all__ = [
     "PRIMARY_STDERR_LOG_PATH_ENV",
-    "ChildStartedHook",
     "LaunchedProcess",
     "ProcessBackendId",
     "ProcessLauncher",
     "ProcessLauncherSelector",
     "ProcessPlatformContract",
     "ProcessSurfaceMode",
+    "RunningProcess",
     "SelectedProcessLauncher",
 ]

--- a/src/meridian/lib/launch/process/primary_attach.py
+++ b/src/meridian/lib/launch/process/primary_attach.py
@@ -13,10 +13,11 @@ from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from threading import Lock
+from threading import Lock, Thread
 from typing import Any
 
 import psutil
+import structlog
 
 from meridian.lib.core.types import HarnessId, SpawnId
 from meridian.lib.harness.connections.base import ConnectionConfig, HarnessConnection, HarnessEvent
@@ -33,10 +34,46 @@ from meridian.lib.state.history import HarnessHistoryWriter
 from meridian.lib.state.primary_meta import ActivityState, PrimaryMetadata, write_primary_metadata
 from meridian.lib.state.process_scope_projection import record_scope
 
-from .ports import ProcessLauncher
+from .ports import LaunchedProcess, ProcessLauncher, RunningProcess
 
 TuiCommandBuilder = Callable[[str], tuple[str, ...]]
 MAX_PORT_RETRY_ATTEMPTS = 3
+_TUI_LAUNCH_DRAIN_TIMEOUT_SECONDS = 1.0
+_TUI_WAIT_CANCEL_TIMEOUT_SECONDS = 1.0
+
+logger = structlog.get_logger(__name__)
+
+
+def _start_process_wait(running_process: RunningProcess) -> asyncio.Future[LaunchedProcess]:
+    """Run a synchronous terminal relay without joining it during loop shutdown."""
+
+    loop = asyncio.get_running_loop()
+    result_future: asyncio.Future[LaunchedProcess] = loop.create_future()
+
+    def _publish_result(result: LaunchedProcess) -> None:
+        if not result_future.done():
+            result_future.set_result(result)
+
+    def _publish_error(error: BaseException) -> None:
+        if not result_future.done():
+            result_future.set_exception(error)
+
+    def _wait() -> None:
+        try:
+            result = running_process.wait()
+        except BaseException as exc:
+            with suppress(RuntimeError):
+                loop.call_soon_threadsafe(_publish_error, exc)
+            return
+        with suppress(RuntimeError):
+            loop.call_soon_threadsafe(_publish_result, result)
+
+    Thread(
+        target=_wait,
+        name=f"meridian-primary-wait-{running_process.pid}",
+        daemon=True,
+    ).start()
+    return result_future
 
 
 def _make_scope_snapshot(
@@ -209,6 +246,9 @@ class PrimaryAttachLauncher:
         self._history_writer = HarnessHistoryWriter(self._spawn_dir / "history.jsonl")
         connection_started = False
         session_id: str | None = None
+        running_process: RunningProcess | None = None
+        launch_task: asyncio.Future[LaunchedProcess] | None = None
+        tui_lifecycle_finished = False
         telemetry = _StartupTelemetry()
 
         try:
@@ -245,7 +285,6 @@ class PrimaryAttachLauncher:
 
             telemetry.update(f"Attaching {self._connection.harness_id.value.capitalize()} TUI...")
             command = tuple(self._tui_command_builder(session_id))
-            loop = asyncio.get_running_loop()
             running_callback = on_running if on_running is not None else self._on_running
 
             def _handle_running(pid: int) -> None:
@@ -254,19 +293,19 @@ class PrimaryAttachLauncher:
                 if running_callback is not None:
                     running_callback(pid)
 
-            def _on_child_started(pid: int) -> None:
-                loop.call_soon_threadsafe(_handle_running, pid)
-
-            launch_task = asyncio.create_task(
-                asyncio.to_thread(
-                    self._process_launcher.launch,
-                    command=command,
-                    cwd=cwd,
-                    env=env,
-                    output_log_path=None,
-                    on_child_started=_on_child_started,
-                )
+            running_process = self._process_launcher.start(
+                command=command,
+                cwd=cwd,
+                env=env,
+                output_log_path=None,
             )
+            try:
+                _handle_running(running_process.pid)
+            except Exception:
+                running_process.terminate()
+                await _start_process_wait(running_process)
+                raise
+            launch_task = _start_process_wait(running_process)
             telemetry.clear()
 
             writer_task = self._event_writer_task
@@ -281,22 +320,28 @@ class PrimaryAttachLauncher:
                 if self._connection.harness_id is HarnessId.CODEX:
                     # Codex TUI takes over the observer endpoint after attach;
                     # the displaced observer stream closing is normal.
-                    launched = await launch_task
+                    launched = await asyncio.shield(launch_task)
+                    tui_lifecycle_finished = True
                     return PrimaryAttachOutcome(
                         exit_code=launched.exit_code,
                         session_id=session_id,
                         tui_pid=launched.pid,
                     )
                 await self._connection.stop(reason="event_stream_closed")
-                await self._terminate_tui_scope()
-                launched = await launch_task
+                await self._stop_tui_launch_task(
+                    running_process,
+                    launch_task,
+                    reason="event_stream_closed",
+                )
+                tui_lifecycle_finished = True
                 return PrimaryAttachOutcome(
                     exit_code=1,
                     session_id=session_id,
-                    tui_pid=launched.pid,
+                    tui_pid=running_process.pid,
                 )
 
-            launched = await launch_task
+            launched = await asyncio.shield(launch_task)
+            tui_lifecycle_finished = True
 
             return PrimaryAttachOutcome(
                 exit_code=launched.exit_code,
@@ -314,6 +359,16 @@ class PrimaryAttachLauncher:
                 writer_task.cancel()
                 with suppress(asyncio.CancelledError):
                     await writer_task
+            if (
+                running_process is not None
+                and launch_task is not None
+                and not tui_lifecycle_finished
+            ):
+                await self._stop_tui_launch_task(
+                    running_process,
+                    launch_task,
+                    reason="primary_attach_shutdown",
+                )
             if connection_started:
                 await self._connection.stop()
 
@@ -449,7 +504,45 @@ class PrimaryAttachLauncher:
         self._tui_scope_snapshot = snapshot
         record_scope(runtime_root, self._spawn_id, snapshot)
 
-    async def _terminate_tui_scope(self) -> None:
+    async def _stop_tui_launch_task(
+        self,
+        running_process: RunningProcess,
+        launch_task: asyncio.Future[LaunchedProcess],
+        *,
+        reason: str,
+    ) -> None:
+        await self._terminate_tui_scope(reason=reason)
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(launch_task),
+                timeout=_TUI_LAUNCH_DRAIN_TIMEOUT_SECONDS,
+            )
+        except TimeoutError:
+            logger.warning(
+                "primary_attach.tui_drain_timeout",
+                spawn_id=str(self._spawn_id),
+            )
+            running_process.terminate()
+            running_process.cancel_wait()
+            try:
+                await asyncio.wait_for(
+                    asyncio.shield(launch_task),
+                    timeout=_TUI_WAIT_CANCEL_TIMEOUT_SECONDS,
+                )
+            except TimeoutError:
+                logger.error(
+                    "primary_attach.tui_wait_cancel_timeout",
+                    spawn_id=str(self._spawn_id),
+                )
+                launch_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await launch_task
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            pass
+
+    async def _terminate_tui_scope(self, *, reason: str) -> None:
         snapshot = self._tui_scope_snapshot
         if snapshot is None:
             return
@@ -457,7 +550,7 @@ class PrimaryAttachLauncher:
             terminate_scope_sync,
             snapshot,
             grace_seconds=5.0,
-            reason="event_stream_closed",
+            reason=reason,
         )
 
     def _resolve_backend_port(self) -> int | None:

--- a/src/meridian/lib/launch/process/pty_launcher.py
+++ b/src/meridian/lib/launch/process/pty_launcher.py
@@ -8,12 +8,13 @@ import struct
 import sys
 import threading
 from contextlib import ExitStack, suppress
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, BinaryIO, cast
 
 from meridian.lib.platform import IS_WINDOWS, fcntl, pty, select, termios, tty
 
-from .ports import ChildStartedHook, LaunchedProcess, ProcessLauncher
+from .ports import LaunchedProcess, ProcessLauncher
 
 
 def can_use_pty() -> bool:
@@ -78,6 +79,7 @@ def _copy_primary_pty_output(
     child_pid: int,
     master_fd: int,
     output_log_path: Path | None,
+    wait_cancelled: threading.Event | None = None,
 ) -> int:
     stdin_fd = sys.stdin.fileno()
     stdout_fd = sys.stdout.fileno()
@@ -96,10 +98,12 @@ def _copy_primary_pty_output(
                 output_handle = stack.enter_context(output_log_path.open("wb"))
 
             while True:
+                if wait_cancelled is not None and wait_cancelled.is_set():
+                    return 130
                 fds = [master_fd]
                 if stdin_open:
                     fds.append(stdin_fd)
-                ready, _, _ = select.select(fds, [], [])
+                ready, _, _ = select.select(fds, [], [], 0.1)
 
                 if master_fd in ready:
                     try:
@@ -128,18 +132,45 @@ def _copy_primary_pty_output(
     return os.waitstatus_to_exitcode(status)
 
 
+@dataclass
+class _RunningPtyProcess:
+    pid: int
+    master_fd: int
+    output_log_path: Path | None
+    wait_cancelled: threading.Event = field(default_factory=threading.Event)
+
+    def wait(self) -> LaunchedProcess:
+        try:
+            exit_code = _copy_primary_pty_output(
+                child_pid=self.pid,
+                master_fd=self.master_fd,
+                output_log_path=self.output_log_path,
+                wait_cancelled=self.wait_cancelled,
+            )
+            return LaunchedProcess(exit_code=exit_code, pid=self.pid)
+        finally:
+            with suppress(OSError):
+                os.close(self.master_fd)
+
+    def terminate(self) -> None:
+        with suppress(ProcessLookupError):
+            os.kill(self.pid, signal.SIGTERM)
+
+    def cancel_wait(self) -> None:
+        self.wait_cancelled.set()
+
+
 class PtyProcessLauncher(ProcessLauncher):
     """Unix PTY launcher with optional output capture."""
 
-    def launch(
+    def start(
         self,
         *,
         command: tuple[str, ...],
         cwd: Path,
         env: dict[str, str],
         output_log_path: Path | None,
-        on_child_started: ChildStartedHook | None = None,
-    ) -> LaunchedProcess:
+    ) -> _RunningPtyProcess:
         if IS_WINDOWS:
             raise RuntimeError("PTY launcher is not available on Windows")
 
@@ -159,25 +190,11 @@ class PtyProcessLauncher(ProcessLauncher):
                 os._exit(1)
 
         os.close(slave_fd)
-        try:
-            if on_child_started is not None:
-                try:
-                    on_child_started(child_pid)
-                except Exception:
-                    with suppress(ProcessLookupError):
-                        os.kill(child_pid, signal.SIGTERM)
-                    with suppress(ChildProcessError):
-                        os.waitpid(child_pid, 0)
-                    raise
-            exit_code = _copy_primary_pty_output(
-                child_pid=child_pid,
-                master_fd=master_fd,
-                output_log_path=output_log_path,
-            )
-            return LaunchedProcess(exit_code=exit_code, pid=child_pid)
-        finally:
-            with suppress(OSError):
-                os.close(master_fd)
+        return _RunningPtyProcess(
+            pid=child_pid,
+            master_fd=master_fd,
+            output_log_path=output_log_path,
+        )
 
 
 __all__ = [

--- a/src/meridian/lib/launch/process/runner.py
+++ b/src/meridian/lib/launch/process/runner.py
@@ -330,13 +330,20 @@ def run_primary_process_with_capture(
 ) -> tuple[int, int | None]:
     launcher: ProcessLauncher = launcher_selector(output_log_path)
 
-    launched = launcher.launch(
+    running = launcher.start(
         command=command,
         cwd=cwd,
         env=env,
         output_log_path=output_log_path,
-        on_child_started=on_child_started,
     )
+    try:
+        if on_child_started is not None:
+            on_child_started(running.pid)
+    except Exception:
+        running.terminate()
+        running.wait()
+        raise
+    launched = running.wait()
     return launched.exit_code, launched.pid
 
 

--- a/src/meridian/lib/launch/process/subprocess_launcher.py
+++ b/src/meridian/lib/launch/process/subprocess_launcher.py
@@ -7,14 +7,15 @@ import subprocess
 import sys
 import threading
 from contextlib import suppress
+from dataclasses import dataclass, field
 from pathlib import Path
+from queue import Empty, Full, Queue
 from typing import BinaryIO
 
 from meridian.lib.platform import IS_WINDOWS
 
 from .ports import (
     PRIMARY_STDERR_LOG_PATH_ENV,
-    ChildStartedHook,
     LaunchedProcess,
     ProcessLauncher,
 )
@@ -53,6 +54,7 @@ def _write_chunk_to_stderr(chunk: bytes) -> None:
 def _read_pipe_to_stderr_log(
     stderr_stream: BinaryIO,
     stderr_log_path: Path,
+    wait_cancelled: threading.Event,
 ) -> None:
     stderr_log_path.parent.mkdir(parents=True, exist_ok=True)
     with stderr_log_path.open("ab") as stderr_handle:
@@ -60,36 +62,164 @@ def _read_pipe_to_stderr_log(
             chunk = stderr_stream.read(4096)
             if not chunk:
                 return
+            if wait_cancelled.is_set():
+                return
             stderr_handle.write(chunk)
             stderr_handle.flush()
             _write_chunk_to_stderr(chunk)
 
 
-def _wait_for_process(process: subprocess.Popen[str] | subprocess.Popen[bytes]) -> int:
+def _read_pipe_to_queue(
+    stream: BinaryIO,
+    chunks: Queue[bytes | None],
+    wait_cancelled: threading.Event,
+) -> None:
     try:
-        return process.wait()
-    except KeyboardInterrupt:
-        if process.poll() is None:
-            if IS_WINDOWS:
-                process.terminate()
-            else:
-                process.send_signal(signal.SIGINT)
-            return process.wait()
-        return 130
+        while True:
+            chunk = stream.read(4096)
+            if not chunk or wait_cancelled.is_set():
+                return
+            while not wait_cancelled.is_set():
+                try:
+                    chunks.put(chunk, timeout=0.1)
+                    break
+                except Full:
+                    continue
+    finally:
+        while not wait_cancelled.is_set():
+            try:
+                chunks.put(None, timeout=0.1)
+                break
+            except Full:
+                continue
+
+
+def _wait_for_process(
+    process: subprocess.Popen[str] | subprocess.Popen[bytes],
+    *,
+    wait_cancelled: threading.Event | None = None,
+) -> int:
+    while True:
+        try:
+            if wait_cancelled is None:
+                return process.wait()
+            return process.wait(timeout=0.1)
+        except subprocess.TimeoutExpired:
+            if wait_cancelled is not None and wait_cancelled.is_set():
+                return process.returncode if process.returncode is not None else 130
+        except KeyboardInterrupt:
+            if process.poll() is None:
+                if IS_WINDOWS:
+                    process.terminate()
+                else:
+                    process.send_signal(signal.SIGINT)
+                return process.wait()
+            return 130
+
+
+@dataclass
+class _RunningSubprocess:
+    process: subprocess.Popen[str] | subprocess.Popen[bytes]
+    output_log_path: Path | None
+    stderr_log_path: Path | None
+    wait_cancelled: threading.Event = field(default_factory=threading.Event)
+
+    @property
+    def pid(self) -> int:
+        return self.process.pid
+
+    def terminate(self) -> None:
+        if self.process.poll() is None:
+            self.process.terminate()
+
+    def cancel_wait(self) -> None:
+        self.wait_cancelled.set()
+
+    def wait(self) -> LaunchedProcess:
+        stderr_thread: threading.Thread | None = None
+        if self.output_log_path is None:
+            try:
+                if self.stderr_log_path is not None and self.process.stderr is not None:
+                    stderr_thread = threading.Thread(
+                        target=_read_pipe_to_stderr_log,
+                        args=(
+                            self.process.stderr,
+                            self.stderr_log_path,
+                            self.wait_cancelled,
+                        ),
+                        daemon=True,
+                    )
+                    stderr_thread.start()
+                return LaunchedProcess(
+                    exit_code=_wait_for_process(
+                        self.process,
+                        wait_cancelled=self.wait_cancelled,
+                    ),
+                    pid=self.process.pid,
+                )
+            finally:
+                if stderr_thread is not None and not self.wait_cancelled.is_set():
+                    stderr_thread.join(timeout=1.0)
+                with suppress(Exception):
+                    if (
+                        self.process.stderr is not None
+                        and (stderr_thread is None or not stderr_thread.is_alive())
+                    ):
+                        self.process.stderr.close()
+
+        stdout_thread: threading.Thread | None = None
+        try:
+            with self.output_log_path.open("wb") as output_handle:
+                stdout_stream = self.process.stdout
+                if stdout_stream is not None:
+                    chunks: Queue[bytes | None] = Queue(maxsize=16)
+                    stdout_thread = threading.Thread(
+                        target=_read_pipe_to_queue,
+                        args=(stdout_stream, chunks, self.wait_cancelled),
+                        daemon=True,
+                    )
+                    stdout_thread.start()
+                    while True:
+                        if self.wait_cancelled.is_set():
+                            return LaunchedProcess(exit_code=130, pid=self.process.pid)
+                        try:
+                            chunk = chunks.get(timeout=0.1)
+                        except Empty:
+                            continue
+                        if chunk is None:
+                            break
+                        output_handle.write(chunk)
+                        output_handle.flush()
+                        _write_chunk_to_stdout(chunk)
+            return LaunchedProcess(
+                exit_code=_wait_for_process(
+                    self.process,
+                    wait_cancelled=self.wait_cancelled,
+                ),
+                pid=self.process.pid,
+            )
+        finally:
+            if stdout_thread is not None and not self.wait_cancelled.is_set():
+                stdout_thread.join(timeout=1.0)
+            with suppress(Exception):
+                if (
+                    self.process.stdout is not None
+                    and (stdout_thread is None or not stdout_thread.is_alive())
+                ):
+                    self.process.stdout.close()
 
 
 class SubprocessProcessLauncher(ProcessLauncher):
     """Portable subprocess launcher used when PTY capture is unavailable."""
 
-    def launch(
+    def start(
         self,
         *,
         command: tuple[str, ...],
         cwd: Path,
         env: dict[str, str],
         output_log_path: Path | None,
-        on_child_started: ChildStartedHook | None = None,
-    ) -> LaunchedProcess:
+    ) -> _RunningSubprocess:
         child_env = dict(env)
         stderr_log_path_raw = child_env.pop(PRIMARY_STDERR_LOG_PATH_ENV, "").strip()
         stderr_log_path = Path(stderr_log_path_raw) if stderr_log_path_raw else None
@@ -113,49 +243,11 @@ class SubprocessProcessLauncher(ProcessLauncher):
                 text=False,
                 start_new_session=not IS_WINDOWS,
             )
-        if on_child_started is not None:
-            try:
-                on_child_started(process.pid)
-            except Exception:
-                if process.poll() is None:
-                    process.terminate()
-                    process.wait()
-                raise
-        stderr_thread: threading.Thread | None = None
-        if output_log_path is None:
-            try:
-                if stderr_log_path is not None and process.stderr is not None:
-                    stderr_thread = threading.Thread(
-                        target=_read_pipe_to_stderr_log,
-                        args=(process.stderr, stderr_log_path),
-                        daemon=True,
-                    )
-                    stderr_thread.start()
-                return LaunchedProcess(exit_code=_wait_for_process(process), pid=process.pid)
-            finally:
-                if stderr_thread is not None:
-                    stderr_thread.join(timeout=1.0)
-                with suppress(Exception):
-                    if process.stderr is not None:
-                        process.stderr.close()
-        try:
-            with output_log_path.open("wb") as output_handle:
-                stdout_stream = process.stdout
-                if stdout_stream is not None:
-                    while True:
-                        chunk = stdout_stream.read(4096)
-                        if not chunk:
-                            break
-                        # text=False guarantees bytes; pyright sees union
-                        chunk_bytes = chunk if isinstance(chunk, bytes) else chunk.encode()
-                        output_handle.write(chunk_bytes)
-                        output_handle.flush()
-                        _write_chunk_to_stdout(chunk_bytes)
-            return LaunchedProcess(exit_code=_wait_for_process(process), pid=process.pid)
-        finally:
-            with suppress(Exception):
-                if process.stdout is not None:
-                    process.stdout.close()
+        return _RunningSubprocess(
+            process=process,
+            output_log_path=output_log_path,
+            stderr_log_path=stderr_log_path,
+        )
 
 
 __all__ = ["SubprocessProcessLauncher"]

--- a/src/meridian/lib/launch/process/windows_launcher.py
+++ b/src/meridian/lib/launch/process/windows_launcher.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from meridian.lib.platform import IS_WINDOWS
 
-from .ports import ChildStartedHook, LaunchedProcess, ProcessLauncher
+from .ports import ProcessLauncher, RunningProcess
 from .subprocess_launcher import SubprocessProcessLauncher
 
 logger = logging.getLogger(__name__)
@@ -22,22 +22,20 @@ def can_use_windows_console_launcher() -> bool:
 class WindowsConsoleLauncher(ProcessLauncher):
     """Windows fallback launcher that preserves interactive console semantics."""
 
-    def launch(
+    def start(
         self,
         *,
         command: tuple[str, ...],
         cwd: Path,
         env: dict[str, str],
         output_log_path: Path | None,
-        on_child_started: ChildStartedHook | None = None,
-    ) -> LaunchedProcess:
+    ) -> RunningProcess:
         logger.debug("Windows console-inheritance mode (no PTY capture available)")
-        return SubprocessProcessLauncher().launch(
+        return SubprocessProcessLauncher().start(
             command=command,
             cwd=cwd,
             env=env,
             output_log_path=output_log_path,
-            on_child_started=on_child_started,
         )
 
 

--- a/src/meridian/lib/platform/.context/CONTEXT.md
+++ b/src/meridian/lib/platform/.context/CONTEXT.md
@@ -72,7 +72,14 @@ process_scope/
 ```
 
 **POSIX:** `setsid()` at launch; `os.killpg(pgid, SIGTERM)` on teardown. Catches
-reparented descendants that single-PID kill misses.
+reparented descendants that single-PID kill misses. Linux installs
+`PR_SET_PDEATHSIG` before exec when available. POSIX platforms without a native
+parent-death signal (macOS/BSD, or Linux without `prctl`) launch a detached
+watchdog helper after spawn. The helper acknowledges readiness over an inherited
+pipe before containment is recorded, watches the Meridian launcher by
+birth-validated PID, and terminates the full target process group if the launcher
+disappears first. It remains alive while any non-zombie process-group member exists,
+even if the scope root exits before its descendants.
 
 **Windows:** Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`. When Meridian
 exits, the OS closes the handle and kills all assigned processes automatically.

--- a/src/meridian/lib/platform/detached_process.py
+++ b/src/meridian/lib/platform/detached_process.py
@@ -3,9 +3,9 @@
 Platform contract:
 - **Linux** with ``prctl(PR_SET_PDEATHSIG)``: child receives SIGKILL when this
   process dies (installed in a pre-exec hook before the child execs).
-- **Other POSIX** (macOS, BSD, etc.): no kernel parent-death signal exists;
-  detached backends start in a new session only — callers must treat
-  ``parent_death_linked=False`` as degraded containment.
+- **Other POSIX** (macOS, BSD, Linux without ``prctl``): children start in a
+  new session, then a tiny detached watchdog process terminates the child
+  process group if the Meridian launcher dies first.
 - **Windows**: parent-death linkage is applied post-spawn via a Job Object
   (see ``link_child_lifetime_to_parent``).
 """
@@ -13,24 +13,29 @@ Platform contract:
 from __future__ import annotations
 
 import os
+import select
 import signal
+import subprocess
 import sys
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
+import psutil
 import structlog
 
 from meridian.lib.platform import IS_WINDOWS
+from meridian.lib.platform.process_scope.base import PROCESS_BIRTH_UNKNOWN_EPOCH
 
 logger = structlog.get_logger(__name__)
 
 _PR_SET_PDEATHSIG = 1
+_WATCHDOG_READY_TIMEOUT_SECONDS = 2.0
 
 
 @dataclass(frozen=True)
 class DetachedSubprocessConfig:
-    """Subprocess options and parent-death containment capability."""
+    """Subprocess options and pre-exec parent-death containment capability."""
 
     kwargs: dict[str, Any]
     parent_death_linked: bool
@@ -42,16 +47,18 @@ class ParentDeathLink:
 
     job_name: str | None = None
     job_handle: object | None = None
+    watchdog_process: subprocess.Popen[bytes] | None = None
     parent_death_linked: bool = False
 
 
 def detached_subprocess_config() -> DetachedSubprocessConfig:
-    """Return subprocess options and whether parent-death linkage will be installed.
+    """Return subprocess options and whether pre-exec linkage will be installed.
 
     On Linux with ``prctl``, ``parent_death_linked`` is True and the returned
-    kwargs include a pre-exec hook that sets ``PR_SET_PDEATHSIG``. On other
-    POSIX platforms only ``start_new_session`` is applied and a structured
-    warning is logged. Windows returns empty kwargs; linkage happens post-spawn.
+    kwargs include a pre-exec hook that sets ``PR_SET_PDEATHSIG``. Other POSIX
+    platforms still get ``start_new_session`` so the later watchdog / cleanup
+    path can target a dedicated process group. Windows returns empty kwargs;
+    linkage happens post-spawn.
     """
 
     if IS_WINDOWS:
@@ -66,11 +73,6 @@ def detached_subprocess_config() -> DetachedSubprocessConfig:
             parent_death_linked=True,
         )
 
-    logger.warning(
-        "detached_backend_parent_death_unavailable",
-        platform=sys.platform,
-        containment="start_new_session_only",
-    )
     return DetachedSubprocessConfig(
         kwargs={"start_new_session": True},
         parent_death_linked=False,
@@ -80,20 +82,148 @@ def detached_subprocess_config() -> DetachedSubprocessConfig:
 def link_child_lifetime_to_parent(pid: int) -> ParentDeathLink:
     """Attach an already-started child to this process lifetime when needed."""
 
-    if not IS_WINDOWS:
+    if IS_WINDOWS:
+        from meridian.lib.platform.process_scope.windows_job import assign_to_new_job
+
+        result = assign_to_new_job(pid)
+        if result is None:
+            return ParentDeathLink(parent_death_linked=False)
+        job_name, job_handle = result
+        return ParentDeathLink(
+            job_name=job_name,
+            job_handle=job_handle,
+            parent_death_linked=True,
+        )
+
+    return _start_parent_watchdog(pid)
+
+
+def release_parent_death_link(link: ParentDeathLink | None) -> None:
+    """Release/reap any helper resources associated with a parent-death link."""
+
+    if link is None or link.watchdog_process is None:
+        return
+    try:
+        link.watchdog_process.wait(timeout=1.0)
+    except subprocess.TimeoutExpired:
+        link.watchdog_process.terminate()
+        try:
+            link.watchdog_process.wait(timeout=1.0)
+        except subprocess.TimeoutExpired:
+            link.watchdog_process.kill()
+            link.watchdog_process.wait(timeout=1.0)
+
+
+def _start_parent_watchdog(pid: int) -> ParentDeathLink:
+    parent_pid = os.getpid()
+    parent_created_at = _process_birth_epoch(parent_pid)
+    target_created_at = _process_birth_epoch(pid)
+    target_pgid = _process_group_id(pid)
+    if target_pgid is None:
         return ParentDeathLink(parent_death_linked=False)
 
-    from meridian.lib.platform.process_scope.windows_job import assign_to_new_job
-
-    result = assign_to_new_job(pid)
-    if result is None:
+    try:
+        ready_read_fd, ready_write_fd = os.pipe()
+    except OSError:
+        logger.warning(
+            "detached_backend_parent_watchdog_unavailable",
+            platform=sys.platform,
+            target_pid=pid,
+            exc_info=True,
+        )
         return ParentDeathLink(parent_death_linked=False)
-    job_name, job_handle = result
+    command = (
+        sys.executable,
+        "-m",
+        "meridian.lib.platform.parent_watchdog",
+        "--parent-pid",
+        str(parent_pid),
+        "--parent-created-at",
+        str(parent_created_at),
+        "--target-pid",
+        str(pid),
+        "--target-created-at",
+        str(target_created_at),
+        "--target-pgid",
+        str(target_pgid),
+        "--scope-id",
+        "backend",
+        "--ready-fd",
+        str(ready_write_fd),
+    )
+    try:
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            close_fds=True,
+            pass_fds=(ready_write_fd,),
+            start_new_session=True,
+        )
+    except OSError:
+        os.close(ready_read_fd)
+        os.close(ready_write_fd)
+        logger.warning(
+            "detached_backend_parent_watchdog_unavailable",
+            platform=sys.platform,
+            target_pid=pid,
+            exc_info=True,
+        )
+        return ParentDeathLink(parent_death_linked=False)
+    os.close(ready_write_fd)
+
+    try:
+        ready = _watchdog_reported_ready(ready_read_fd)
+    except OSError:
+        ready = False
+        logger.warning(
+            "detached_backend_parent_watchdog_handshake_failed",
+            platform=sys.platform,
+            target_pid=pid,
+            exc_info=True,
+        )
+    finally:
+        os.close(ready_read_fd)
+    if not ready:
+        returncode = process.poll()
+        release_parent_death_link(ParentDeathLink(watchdog_process=process))
+        logger.warning(
+            "detached_backend_parent_watchdog_unavailable",
+            platform=sys.platform,
+            target_pid=pid,
+            watchdog_returncode=returncode,
+        )
+        return ParentDeathLink(parent_death_linked=False)
+
     return ParentDeathLink(
-        job_name=job_name,
-        job_handle=job_handle,
+        watchdog_process=process,
         parent_death_linked=True,
     )
+
+
+def _watchdog_reported_ready(read_fd: int) -> bool:
+    readable, _, _ = select.select(
+        [read_fd],
+        [],
+        [],
+        _WATCHDOG_READY_TIMEOUT_SECONDS,
+    )
+    return bool(readable and os.read(read_fd, 1) == b"1")
+
+
+def _process_birth_epoch(pid: int) -> float:
+    try:
+        return psutil.Process(pid).create_time()
+    except (psutil.NoSuchProcess, psutil.AccessDenied, OSError):
+        return PROCESS_BIRTH_UNKNOWN_EPOCH
+
+
+def _process_group_id(pid: int) -> int | None:
+    try:
+        return os.getpgid(pid)
+    except OSError:
+        return None
 
 
 def _linux_parent_death_sig_available() -> bool:
@@ -129,4 +259,5 @@ __all__ = [
     "ParentDeathLink",
     "detached_subprocess_config",
     "link_child_lifetime_to_parent",
+    "release_parent_death_link",
 ]

--- a/src/meridian/lib/platform/parent_watchdog.py
+++ b/src/meridian/lib/platform/parent_watchdog.py
@@ -1,0 +1,154 @@
+"""Detached process parent-death watchdog.
+
+Runs as a tiny helper process on POSIX platforms that lack a native
+parent-death signal.  It watches the Meridian launcher process and terminates
+an already-isolated target process scope if the launcher disappears before the
+scope is empty.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import time
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+
+import psutil
+
+from meridian.lib.platform.process_scope import terminate_scope_sync
+from meridian.lib.platform.process_scope.base import (
+    PROCESS_BIRTH_UNKNOWN_EPOCH,
+    ProcessScopeSnapshot,
+    birth_time_unverified,
+)
+
+_DEFAULT_POLL_INTERVAL_SECONDS = 0.5
+_DEFAULT_GRACE_SECONDS = 5.0
+
+
+@dataclass(frozen=True)
+class WatchedProcess:
+    pid: int
+    created_at_epoch: float
+
+
+def process_is_same_birth(process: WatchedProcess) -> bool:
+    """Return True when *process* is alive and still has the recorded birth time."""
+
+    if process.pid <= 0:
+        return False
+    try:
+        actual = psutil.Process(process.pid).create_time()
+    except (psutil.NoSuchProcess, psutil.AccessDenied, OSError):
+        return False
+    if birth_time_unverified(process.created_at_epoch):
+        return True
+    return abs(actual - process.created_at_epoch) <= 1.0
+
+
+def process_scope_is_alive(scope: ProcessScopeSnapshot) -> bool:
+    """Return True while the scope root or one of its process-group members lives."""
+
+    root = WatchedProcess(
+        pid=scope.root_pid,
+        created_at_epoch=scope.root_created_at_epoch,
+    )
+    if process_is_same_birth(root):
+        return True
+    if scope.pgid is None:
+        return False
+
+    for process in psutil.process_iter(["pid", "status"]):
+        try:
+            if process.info["status"] == psutil.STATUS_ZOMBIE:
+                continue
+            if os.getpgid(process.pid) == scope.pgid:
+                return True
+        except (psutil.NoSuchProcess, psutil.AccessDenied, OSError):
+            continue
+    return False
+
+
+def watch_parent_until_exit(
+    *,
+    parent: WatchedProcess,
+    target_scope: ProcessScopeSnapshot,
+    poll_interval_seconds: float = _DEFAULT_POLL_INTERVAL_SECONDS,
+    grace_seconds: float = _DEFAULT_GRACE_SECONDS,
+    parent_alive: Callable[[WatchedProcess], bool] = process_is_same_birth,
+    target_alive: Callable[[ProcessScopeSnapshot], bool] = process_scope_is_alive,
+    terminate_scope: Callable[..., object] = terminate_scope_sync,
+    sleep: Callable[[float], None] = time.sleep,
+) -> int:
+    """Watch *parent* and terminate *target_scope* if the parent dies first."""
+
+    while True:
+        if not target_alive(target_scope):
+            return 0
+        if not parent_alive(parent):
+            terminate_scope(
+                target_scope,
+                grace_seconds=grace_seconds,
+                reason="parent_exit_watchdog",
+            )
+            return 0
+        sleep(max(0.05, poll_interval_seconds))
+
+
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--parent-pid", type=int, required=True)
+    parser.add_argument("--parent-created-at", type=float, required=True)
+    parser.add_argument("--target-pid", type=int, required=True)
+    parser.add_argument("--target-created-at", type=float, required=True)
+    parser.add_argument("--target-pgid", type=int, default=0)
+    parser.add_argument("--scope-id", default="backend")
+    parser.add_argument("--ready-fd", type=int, default=-1)
+    parser.add_argument("--poll-interval", type=float, default=_DEFAULT_POLL_INTERVAL_SECONDS)
+    parser.add_argument("--grace-seconds", type=float, default=_DEFAULT_GRACE_SECONDS)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    target_pgid = args.target_pgid if args.target_pgid > 0 else None
+    target_scope = ProcessScopeSnapshot(
+        scope_id=args.scope_id,
+        owner_policy="spawn_owned",
+        owner_id=f"parent-watchdog:{args.parent_pid}",
+        role="harness_backend",
+        containment="posix_pgid" if target_pgid is not None else "pid_tree_fallback",
+        root_pid=args.target_pid,
+        root_created_at_epoch=args.target_created_at or PROCESS_BIRTH_UNKNOWN_EPOCH,
+        pgid=target_pgid,
+        job_name=None,
+        degraded_reason=None,
+    )
+    if args.ready_fd >= 0:
+        try:
+            os.write(args.ready_fd, b"1")
+        finally:
+            os.close(args.ready_fd)
+    return watch_parent_until_exit(
+        parent=WatchedProcess(
+            pid=args.parent_pid,
+            created_at_epoch=args.parent_created_at or PROCESS_BIRTH_UNKNOWN_EPOCH,
+        ),
+        target_scope=target_scope,
+        poll_interval_seconds=args.poll_interval,
+        grace_seconds=args.grace_seconds,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised by subprocess smoke tests
+    raise SystemExit(main())
+
+
+__all__ = [
+    "WatchedProcess",
+    "main",
+    "process_is_same_birth",
+    "process_scope_is_alive",
+    "watch_parent_until_exit",
+]

--- a/tests/integration/harness/test_managed_backend.py
+++ b/tests/integration/harness/test_managed_backend.py
@@ -23,21 +23,27 @@ from meridian.lib.state.process_scope_projection import read_scopes_from_disk
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("preexec_linked", "post_spawn_linked"),
+    ((True, False), (False, True)),
+)
 async def test_launch_managed_backend_records_scope_with_parent_death_outcome(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    preexec_linked: bool,
+    post_spawn_linked: bool,
 ) -> None:
     spawn_id = SpawnId("spawn-3")
 
     monkeypatch.setattr(
         managed_backend,
         "detached_subprocess_config",
-        lambda: DetachedSubprocessConfig(kwargs={}, parent_death_linked=True),
+        lambda: DetachedSubprocessConfig(kwargs={}, parent_death_linked=preexec_linked),
     )
     monkeypatch.setattr(
         managed_backend,
         "link_child_lifetime_to_parent",
-        lambda _pid: ParentDeathLink(parent_death_linked=False),
+        lambda _pid: ParentDeathLink(parent_death_linked=post_spawn_linked),
     )
 
     handle = await launch_managed_backend(

--- a/tests/integration/launch/test_launch_process_contract.py
+++ b/tests/integration/launch/test_launch_process_contract.py
@@ -9,17 +9,20 @@ These tests do NOT spin up a real harness process.
 from __future__ import annotations
 
 import os
-
-# pyright: reportPrivateUsage=false
 import sys
+import threading
+import time
 from pathlib import Path
 from typing import Any
+
+import pytest
 
 from meridian.lib.core.types import HarnessId, SpawnId
 from meridian.lib.harness.adapter import BootstrapMode
 from meridian.lib.harness.registry import get_default_harness_registry
 from meridian.lib.launch.launch_types import ResolvedLaunchSpec
 from meridian.lib.launch.process import runner as process_runner
+from meridian.lib.launch.process.ports import PRIMARY_STDERR_LOG_PATH_ENV, LaunchedProcess
 from meridian.lib.launch.process.primary_attach import PrimaryAttachError
 from meridian.lib.launch.process.subprocess_launcher import SubprocessProcessLauncher
 from meridian.lib.safety.permissions import UnsafeNoOpPermissionResolver
@@ -27,7 +30,7 @@ from meridian.lib.safety.permissions import UnsafeNoOpPermissionResolver
 
 def test_subprocess_launcher_captures_output_log(tmp_path: Path) -> None:
     output_log_path = tmp_path / "history.jsonl"
-    launched = SubprocessProcessLauncher().launch(
+    running = SubprocessProcessLauncher().start(
         command=(
             sys.executable,
             "-c",
@@ -43,9 +46,41 @@ def test_subprocess_launcher_captures_output_log(tmp_path: Path) -> None:
         env=dict(os.environ),
         output_log_path=output_log_path,
     )
+    launched = running.wait()
 
     assert launched.exit_code == 0
     assert output_log_path.read_text(encoding="utf-8").splitlines() == ["line-1", "line-2"]
+
+
+@pytest.mark.parametrize("capture_output", (False, True))
+def test_subprocess_launcher_cancel_wait_releases_pipe_relays(
+    tmp_path: Path,
+    capture_output: bool,
+) -> None:
+    env = dict(os.environ)
+    output_log_path = tmp_path / "output.log" if capture_output else None
+    if not capture_output:
+        env[PRIMARY_STDERR_LOG_PATH_ENV] = str(tmp_path / "stderr.log")
+    running = SubprocessProcessLauncher().start(
+        command=(sys.executable, "-c", "import time;time.sleep(60)"),
+        cwd=tmp_path,
+        env=env,
+        output_log_path=output_log_path,
+    )
+    results: list[LaunchedProcess] = []
+    wait_thread = threading.Thread(target=lambda: results.append(running.wait()))
+    wait_thread.start()
+    time.sleep(0.05)
+
+    try:
+        running.cancel_wait()
+        wait_thread.join(timeout=0.5)
+
+        assert wait_thread.is_alive() is False
+        assert [result.exit_code for result in results] == [130]
+    finally:
+        running.terminate()
+        running.process.wait(timeout=5.0)
 
 
 def test_execute_primary_process_uses_contract_bootstrap_mode_not_harness_id(

--- a/tests/integration/launch/test_primary_attach.py
+++ b/tests/integration/launch/test_primary_attach.py
@@ -21,7 +21,7 @@ from meridian.lib.harness.connections.base import (
 from meridian.lib.launch.constants import HISTORY_FILENAME, PRIMARY_META_FILENAME
 from meridian.lib.launch.launch_types import ResolvedLaunchSpec
 from meridian.lib.launch.process import primary_attach as primary_attach_module
-from meridian.lib.launch.process.ports import ChildStartedHook, LaunchedProcess, ProcessLauncher
+from meridian.lib.launch.process.ports import LaunchedProcess, ProcessLauncher
 from meridian.lib.launch.process.primary_attach import (
     PortBindError,
     PrimaryAttachError,
@@ -202,15 +202,14 @@ class FakeProcessLauncher(ProcessLauncher):
     output_log_paths: list[Path | None] = field(default_factory=list)
     metadata_seen_at_launch: dict[str, object] | None = None
 
-    def launch(
+    def start(
         self,
         *,
         command: tuple[str, ...],
         cwd: Path,
         env: dict[str, str],
         output_log_path: Path | None,
-        on_child_started: ChildStartedHook | None = None,
-    ) -> LaunchedProcess:
+    ) -> FakeProcessLauncher:
         _ = (cwd, env, output_log_path)
         self.launch_commands.append(command)
         self.output_log_paths.append(output_log_path)
@@ -220,10 +219,17 @@ class FakeProcessLauncher(ProcessLauncher):
             "dict[str, object]",
             json.loads(metadata_path.read_text(encoding="utf-8")),
         )
-        if on_child_started is not None:
-            on_child_started(self.pid)
+        return self
+
+    def wait(self) -> LaunchedProcess:
         time.sleep(self.pause_seconds)
         return LaunchedProcess(exit_code=self.exit_code, pid=self.pid)
+
+    def terminate(self) -> None:
+        return None
+
+    def cancel_wait(self) -> None:
+        return None
 
 
 @dataclass
@@ -232,24 +238,37 @@ class BlockingProcessLauncher(ProcessLauncher):
     pid: int = 5252
     launch_commands: list[tuple[str, ...]] = field(default_factory=list)
     release: threading.Event = field(default_factory=threading.Event)
+    wait_timeout_seconds: float = 5.0
+    terminate_releases: bool = True
+    cancel_wait_releases: bool = True
+    cancel_wait_calls: int = 0
 
-    def launch(
+    def start(
         self,
         *,
         command: tuple[str, ...],
         cwd: Path,
         env: dict[str, str],
         output_log_path: Path | None,
-        on_child_started: ChildStartedHook | None = None,
-    ) -> LaunchedProcess:
+    ) -> BlockingProcessLauncher:
         _ = (cwd, env, output_log_path)
         self.launch_commands.append(command)
         metadata_path = self.spawn_dir / PRIMARY_META_FILENAME
         assert metadata_path.exists()
-        if on_child_started is not None:
-            on_child_started(self.pid)
-        self.release.wait(timeout=5.0)
+        return self
+
+    def wait(self) -> LaunchedProcess:
+        self.release.wait(timeout=self.wait_timeout_seconds)
         return LaunchedProcess(exit_code=143, pid=self.pid)
+
+    def terminate(self) -> None:
+        if self.terminate_releases:
+            self.release.set()
+
+    def cancel_wait(self) -> None:
+        self.cancel_wait_calls += 1
+        if self.cancel_wait_releases:
+            self.release.set()
 
 
 class FailingEventConnection(FakeManagedConnection):
@@ -358,6 +377,106 @@ async def test_primary_attach_event_writer_failure_stops_connection_and_tui(
 
 
 @pytest.mark.asyncio
+async def test_primary_attach_cancellation_stops_blocking_tui_launch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spawn_dir = tmp_path / "spawns" / "p900-cancel"
+    tui_started = asyncio.Event()
+    connection = FakeManagedConnection(events=[], session_id="sess-cancel")
+    process_launcher = BlockingProcessLauncher(spawn_dir=spawn_dir)
+    terminated_scopes: list[str] = []
+
+    def _terminate_scope(scope: Any, *, grace_seconds: float, reason: str) -> None:
+        _ = grace_seconds
+        terminated_scopes.append(f"{scope.scope_id}:{reason}")
+        process_launcher.release.set()
+        return None
+
+    monkeypatch.setattr(primary_attach_module, "terminate_scope_sync", _terminate_scope)
+    launcher = PrimaryAttachLauncher(
+        spawn_id=SpawnId("p900-cancel"),
+        spawn_dir=spawn_dir,
+        connection=connection,
+        tui_command_builder=lambda session_id: ("codex", "resume", session_id),
+        process_launcher=process_launcher,
+        on_running=lambda _pid: tui_started.set(),
+    )
+
+    run_task = asyncio.create_task(
+        launcher.run(
+            config=_build_config(spawn_id=SpawnId("p900-cancel"), control_root=tmp_path),
+            spec=_build_spec(),
+            cwd=tmp_path,
+            env={},
+        )
+    )
+    await tui_started.wait()
+
+    run_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await run_task
+
+    assert connection.stop_reasons == [None]
+    assert terminated_scopes == ["tui:primary_attach_shutdown"]
+    assert _read_metadata(spawn_dir)["tui_pid"] == 5252
+
+
+def test_primary_attach_cancellation_does_not_join_uncooperative_wait_thread(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spawn_dir = tmp_path / "spawns" / "p901-cancel-timeout"
+    tui_started = asyncio.Event()
+    connection = FakeManagedConnection(events=[], session_id="sess-cancel-timeout")
+    process_launcher = BlockingProcessLauncher(
+        spawn_dir=spawn_dir,
+        wait_timeout_seconds=0.3,
+        terminate_releases=False,
+        cancel_wait_releases=False,
+    )
+
+    def _terminate_scope(_scope: Any, *, grace_seconds: float, reason: str) -> None:
+        _ = (grace_seconds, reason)
+
+    monkeypatch.setattr(primary_attach_module, "terminate_scope_sync", _terminate_scope)
+    monkeypatch.setattr(primary_attach_module, "_TUI_LAUNCH_DRAIN_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(primary_attach_module, "_TUI_WAIT_CANCEL_TIMEOUT_SECONDS", 0.05)
+    launcher = PrimaryAttachLauncher(
+        spawn_id=SpawnId("p901-cancel-timeout"),
+        spawn_dir=spawn_dir,
+        connection=connection,
+        tui_command_builder=lambda session_id: ("codex", "resume", session_id),
+        process_launcher=process_launcher,
+        on_running=lambda _pid: tui_started.set(),
+    )
+
+    async def _cancel_after_tui_start() -> None:
+        run_task = asyncio.create_task(
+            launcher.run(
+                config=_build_config(
+                    spawn_id=SpawnId("p901-cancel-timeout"),
+                    control_root=tmp_path,
+                ),
+                spec=_build_spec(),
+                cwd=tmp_path,
+                env={},
+            )
+        )
+        await tui_started.wait()
+        run_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await run_task
+
+    started_at = time.monotonic()
+    asyncio.run(_cancel_after_tui_start())
+
+    assert time.monotonic() - started_at < 0.25
+    assert process_launcher.release.is_set() is False
+    assert connection.stop_reasons == [None]
+
+
+@pytest.mark.asyncio
 async def test_primary_attach_codex_event_stream_closure_does_not_stop_backend_or_tui(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -412,6 +531,135 @@ async def test_primary_attach_codex_event_stream_closure_does_not_stop_backend_o
     assert connection.stop_reasons == [None]
     assert terminated_scopes == []
     assert _read_metadata(spawn_dir)["tui_pid"] == 5252
+
+
+def test_primary_attach_cancellation_after_codex_observer_displacement_cleans_tui(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spawn_dir = tmp_path / "spawns" / "p902-codex-cancel"
+    tui_started = asyncio.Event()
+    stream_closed = asyncio.Event()
+    connection = FailingEventConnection(
+        fail_after_started=tui_started,
+        stream_closed=stream_closed,
+        events=[],
+        session_id="sess-codex-cancel",
+    )
+    process_launcher = BlockingProcessLauncher(spawn_dir=spawn_dir)
+    terminated_scopes: list[str] = []
+
+    def _terminate_scope(scope: Any, *, grace_seconds: float, reason: str) -> None:
+        _ = grace_seconds
+        terminated_scopes.append(f"{scope.scope_id}:{reason}")
+
+    monkeypatch.setattr(primary_attach_module, "terminate_scope_sync", _terminate_scope)
+    monkeypatch.setattr(primary_attach_module, "_TUI_LAUNCH_DRAIN_TIMEOUT_SECONDS", 0.05)
+    launcher = PrimaryAttachLauncher(
+        spawn_id=SpawnId("p902-codex-cancel"),
+        spawn_dir=spawn_dir,
+        connection=connection,
+        tui_command_builder=lambda session_id: ("codex", "resume", session_id),
+        process_launcher=process_launcher,
+        on_running=lambda _pid: tui_started.set(),
+    )
+
+    async def _cancel_after_observer_displacement() -> None:
+        run_task = asyncio.create_task(
+            launcher.run(
+                config=_build_config(
+                    spawn_id=SpawnId("p902-codex-cancel"),
+                    control_root=tmp_path,
+                ),
+                spec=_build_spec(),
+                cwd=tmp_path,
+                env={},
+            )
+        )
+        await stream_closed.wait()
+        async with asyncio.timeout(1.0):
+            while launcher._event_writer_task is not None:
+                await asyncio.sleep(0)
+        run_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await run_task
+
+    asyncio.run(_cancel_after_observer_displacement())
+
+    assert terminated_scopes == ["tui:primary_attach_shutdown"]
+    assert process_launcher.release.is_set()
+    assert connection.stop_reasons == [None]
+
+
+@pytest.mark.asyncio
+async def test_primary_attach_cancellation_during_opencode_drain_retries_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spawn_dir = tmp_path / "spawns" / "p903-opencode-cancel"
+    tui_started = asyncio.Event()
+    stream_closed = asyncio.Event()
+    drain_started = asyncio.Event()
+    connection = FailingEventConnection(
+        fail_after_started=tui_started,
+        stream_closed=stream_closed,
+        events=[],
+        session_id="sess-opencode-cancel",
+        harness_id=HarnessId.OPENCODE,
+    )
+    process_launcher = BlockingProcessLauncher(
+        spawn_dir=spawn_dir,
+        terminate_releases=False,
+    )
+    terminated_scopes: list[str] = []
+
+    def _terminate_scope(scope: Any, *, grace_seconds: float, reason: str) -> None:
+        _ = grace_seconds
+        terminated_scopes.append(f"{scope.scope_id}:{reason}")
+
+    real_shield = asyncio.shield
+
+    def _shield(awaitable: Any) -> asyncio.Future[Any]:
+        drain_started.set()
+        return real_shield(awaitable)
+
+    monkeypatch.setattr(primary_attach_module, "terminate_scope_sync", _terminate_scope)
+    monkeypatch.setattr(primary_attach_module.asyncio, "shield", _shield)
+    monkeypatch.setattr(primary_attach_module, "_TUI_LAUNCH_DRAIN_TIMEOUT_SECONDS", 0.05)
+    launcher = PrimaryAttachLauncher(
+        spawn_id=SpawnId("p903-opencode-cancel"),
+        spawn_dir=spawn_dir,
+        connection=connection,
+        tui_command_builder=lambda session_id: ("opencode", "attach", session_id),
+        process_launcher=process_launcher,
+        on_running=lambda _pid: tui_started.set(),
+    )
+    run_task = asyncio.create_task(
+        launcher.run(
+            config=_build_config(
+                spawn_id=SpawnId("p903-opencode-cancel"),
+                control_root=tmp_path,
+                harness_id=HarnessId.OPENCODE,
+            ),
+            spec=_build_spec(),
+            cwd=tmp_path,
+            env={},
+        )
+    )
+
+    await stream_closed.wait()
+    await drain_started.wait()
+    run_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await run_task
+
+    assert terminated_scopes == [
+        "tui:event_stream_closed",
+        "tui:primary_attach_shutdown",
+    ]
+    assert process_launcher.release.is_set()
+    assert process_launcher.cancel_wait_calls == 1
+    assert connection.stop_reasons == ["event_stream_closed", None]
 
 
 @pytest.mark.asyncio

--- a/tests/platform/test_parent_watchdog.py
+++ b/tests/platform/test_parent_watchdog.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import time
+from contextlib import suppress
+
+import psutil
+
+from meridian.lib.platform.detached_process import (
+    link_child_lifetime_to_parent,
+    release_parent_death_link,
+)
+from meridian.lib.platform.parent_watchdog import (
+    WatchedProcess,
+    process_scope_is_alive,
+    watch_parent_until_exit,
+)
+from meridian.lib.platform.process_scope.base import ProcessScopeSnapshot
+from tests.conftest import posix_only
+
+
+def _process_is_running(pid: int) -> bool:
+    try:
+        return psutil.Process(pid).status() != psutil.STATUS_ZOMBIE
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        return False
+
+
+@posix_only
+def test_parent_death_link_waits_for_watchdog_readiness() -> None:
+    target = subprocess.Popen(
+        (sys.executable, "-c", "import time;time.sleep(60)"),
+        start_new_session=True,
+    )
+    link = None
+    try:
+        link = link_child_lifetime_to_parent(target.pid)
+        assert link.parent_death_linked is True
+        assert link.watchdog_process is not None
+        assert link.watchdog_process.poll() is None
+    finally:
+        target.terminate()
+        target.wait(timeout=5.0)
+        release_parent_death_link(link)
+
+
+@posix_only
+def test_watchdog_terminates_group_after_scope_root_exits() -> None:
+    root = subprocess.Popen(
+        (
+            sys.executable,
+            "-c",
+            (
+                "import subprocess,sys;"
+                "child=subprocess.Popen((sys.executable,'-c','import time;time.sleep(60)'));"
+                "print(child.pid,flush=True)"
+            ),
+        ),
+        stdout=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    child_pid = 0
+    try:
+        root_created_at = psutil.Process(root.pid).create_time()
+        assert root.stdout is not None
+        child_pid = int(root.stdout.readline().strip())
+        pgid = os.getpgid(child_pid)
+        assert pgid == root.pid
+        assert root.wait(timeout=5.0) == 0
+
+        scope = ProcessScopeSnapshot(
+            scope_id="backend",
+            owner_policy="spawn_owned",
+            owner_id="watchdog-test",
+            role="harness_backend",
+            containment="posix_pgid",
+            root_pid=root.pid,
+            root_created_at_epoch=root_created_at,
+            pgid=pgid,
+            job_name=None,
+            degraded_reason=None,
+        )
+        assert process_scope_is_alive(scope) is True
+
+        watch_parent_until_exit(
+            parent=WatchedProcess(pid=-1, created_at_epoch=0.0),
+            target_scope=scope,
+            parent_alive=lambda _parent: False,
+        )
+
+        deadline = time.monotonic() + 5.0
+        while _process_is_running(child_pid) and time.monotonic() < deadline:
+            time.sleep(0.05)
+        assert _process_is_running(child_pid) is False
+    finally:
+        if root.poll() is None:
+            root.terminate()
+            root.wait(timeout=5.0)
+        if child_pid > 0:
+            with suppress(ProcessLookupError):
+                os.kill(child_pid, signal.SIGKILL)

--- a/tests/unit/harness/test_codex_bootstrap_turn.py
+++ b/tests/unit/harness/test_codex_bootstrap_turn.py
@@ -1,10 +1,41 @@
 from __future__ import annotations
 
 import asyncio
+from unittest.mock import AsyncMock
 
 import pytest
 
 from meridian.lib.harness.connections.codex_ws import CodexConnection
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("agent_name", "expected_prompt"),
+    [
+        ("reviewer", "Meridian started (agent: reviewer)"),
+        (None, "Meridian started"),
+        ("  ", "Meridian started"),
+    ],
+)
+async def test_bootstrap_turn_identifies_agent_when_available(
+    agent_name: str | None,
+    expected_prompt: str,
+) -> None:
+    connection = CodexConnection()
+    connection._thread_id = "thread-1"
+    connection._request = AsyncMock(return_value={"turn": {"id": "turn-1"}})  # type: ignore[method-assign]
+    connection._wait_for_rollout_materialization = AsyncMock()  # type: ignore[method-assign]
+    connection._wait_for_turn_completion = AsyncMock()  # type: ignore[method-assign]
+
+    await connection._send_bootstrap_turn_and_wait(agent_name=agent_name)
+
+    connection._request.assert_awaited_once_with(
+        "turn/start",
+        {
+            "threadId": "thread-1",
+            "input": [{"type": "text", "text": expected_prompt}],
+        },
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/harness/test_codex_bootstrap_turn.py
+++ b/tests/unit/harness/test_codex_bootstrap_turn.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from meridian.lib.harness.connections.codex_ws import CodexConnection
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_wait_finishes_only_after_matching_turn_completes() -> None:
+    connection = CodexConnection()
+    wait_task = asyncio.create_task(
+        connection._wait_for_turn_completion("turn-1", timeout_seconds=1.0)
+    )
+
+    connection._update_turn_state(
+        method="turn/started",
+        payload={"threadId": "thread-1", "turn": {"id": "turn-1"}},
+    )
+    await asyncio.sleep(0)
+    assert wait_task.done() is False
+
+    connection._update_turn_state(
+        method="turn/completed",
+        payload={"threadId": "thread-1", "turn": {"id": "turn-1"}},
+    )
+
+    await asyncio.wait_for(wait_task, timeout=1.0)
+    assert connection.current_turn_id is None

--- a/tests/unit/harness/test_codex_projection.py
+++ b/tests/unit/harness/test_codex_projection.py
@@ -33,6 +33,15 @@ from meridian.lib.state.paths import resolve_spawn_log_dir
 from tests.support.launch import stub_bundle_request_and_resolve
 
 
+def test_codex_resolved_spec_preserves_agent_identity() -> None:
+    spec = CodexAdapter().resolve_launch_spec(
+        SpawnParams(prompt="do work", agent="reviewer"),
+        TieredPermissionResolver(config=PermissionConfig()),
+    )
+
+    assert spec.agent_name == "reviewer"
+
+
 def test_codex_subprocess_projection_emits_no_o_without_report_output_path() -> None:
     adapter = CodexAdapter()
     spec = adapter.resolve_launch_spec(

--- a/tests/unit/launch/process/test_windows_launcher.py
+++ b/tests/unit/launch/process/test_windows_launcher.py
@@ -124,38 +124,44 @@ def test_windows_console_launcher_forces_console_inheritance(
     captured: dict[str, object] = {}
     expected = LaunchedProcess(exit_code=12, pid=456)
 
+    class _Running:
+        pid = 456
+
+        def wait(self) -> LaunchedProcess:
+            return expected
+
+        def terminate(self) -> None:
+            return None
+
+        def cancel_wait(self) -> None:
+            return None
+
     class FakeSubprocessProcessLauncher:
-        def launch(
+        def start(
             self,
             *,
             command: tuple[str, ...],
             cwd: Path,
             env: dict[str, str],
             output_log_path: Path | None,
-            on_child_started=None,
-        ) -> LaunchedProcess:
+        ) -> _Running:
             captured["command"] = command
             captured["cwd"] = cwd
             captured["env"] = env
             captured["output_log_path"] = output_log_path
-            if on_child_started is not None:
-                on_child_started(456)
-            return expected
+            return _Running()
 
     monkeypatch.setattr(
         "meridian.lib.launch.process.windows_launcher.SubprocessProcessLauncher",
         FakeSubprocessProcessLauncher,
     )
-    child_started: list[int] = []
-
-    result = WindowsConsoleLauncher().launch(
+    running = WindowsConsoleLauncher().start(
         command=("meridian-harness", "--run"),
         cwd=tmp_path,
         env={"MERIDIAN_TEST": "1"},
         output_log_path=tmp_path / "history.jsonl",
-        on_child_started=child_started.append,
     )
 
     assert captured["output_log_path"] == tmp_path / "history.jsonl"
-    assert child_started == [456]
-    assert result == expected
+    assert running.pid == 456
+    assert running.wait() == expected

--- a/tests/unit/platform/test_detached_process.py
+++ b/tests/unit/platform/test_detached_process.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import signal
+import subprocess
 from typing import Any
 
 import pytest
-from structlog.testing import capture_logs
 
 from meridian.lib.platform import IS_WINDOWS, detached_process
+from meridian.lib.platform.process_scope.base import ProcessScopeSnapshot
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="Linux prctl parent-death preexec is POSIX-only")
@@ -42,23 +43,58 @@ def test_detached_subprocess_config_links_linux_parent_death_preexec(
 def test_detached_subprocess_config_degrades_without_prctl(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    import structlog
-
     monkeypatch.setattr(detached_process, "IS_WINDOWS", False)
     monkeypatch.setattr(detached_process, "_linux_parent_death_sig_available", lambda: False)
 
-    with capture_logs() as logs:
-        detached_process.logger = structlog.get_logger(detached_process.__name__)
-        config = detached_process.detached_subprocess_config()
+    config = detached_process.detached_subprocess_config()
 
     assert config.parent_death_linked is False
     assert config.kwargs == {"start_new_session": True}
     assert "preexec_fn" not in config.kwargs
-    degraded = next(
-        log for log in logs if log["event"] == "detached_backend_parent_death_unavailable"
+
+
+def test_link_child_lifetime_to_parent_posix_starts_watchdog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Popen:
+        pid = 4567
+
+        def __init__(self, command: tuple[str, ...], **kwargs: object) -> None:
+            launched.append((command, kwargs))
+
+    launched: list[tuple[tuple[str, ...], dict[str, object]]] = []
+
+    def _birth_epoch(pid: int) -> float:
+        return float(pid)
+
+    def _pgid(_pid: int) -> int:
+        return 1234
+
+    def _watchdog_ready(_fd: int) -> bool:
+        return True
+
+    monkeypatch.setattr(detached_process, "IS_WINDOWS", False)
+    monkeypatch.setattr(detached_process, "_process_birth_epoch", _birth_epoch)
+    monkeypatch.setattr(detached_process, "_process_group_id", _pgid)
+    monkeypatch.setattr(detached_process, "_watchdog_reported_ready", _watchdog_ready)
+    monkeypatch.setattr(detached_process.subprocess, "Popen", _Popen)
+
+    link = detached_process.link_child_lifetime_to_parent(1234)
+
+    assert link.parent_death_linked is True
+    assert link.watchdog_process is not None
+    assert link.watchdog_process.pid == 4567
+    assert launched
+    command, kwargs = launched[0]
+    assert command[:3] == (
+        detached_process.sys.executable,
+        "-m",
+        "meridian.lib.platform.parent_watchdog",
     )
-    assert degraded["platform"] == detached_process.sys.platform
-    assert degraded["containment"] == "start_new_session_only"
+    assert "--target-pid" in command
+    assert "1234" in command
+    assert kwargs["start_new_session"] is True
+    assert kwargs["stdin"] == subprocess.DEVNULL
 
 
 def test_detached_subprocess_config_links_windows_child_with_job(
@@ -93,8 +129,11 @@ def test_link_child_lifetime_to_parent_reports_windows_job_failure(
 ) -> None:
     from meridian.lib.platform.process_scope import windows_job
 
+    def _assign_failed(_pid: int) -> None:
+        return None
+
     monkeypatch.setattr(detached_process, "IS_WINDOWS", True)
-    monkeypatch.setattr(windows_job, "assign_to_new_job", lambda _pid: None)
+    monkeypatch.setattr(windows_job, "assign_to_new_job", _assign_failed)
 
     link = detached_process.link_child_lifetime_to_parent(999)
 
@@ -106,8 +145,60 @@ def test_link_child_lifetime_to_parent_reports_windows_job_failure(
 def test_link_child_lifetime_to_parent_posix_is_not_linked(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    def _pgid_unavailable(_pid: int) -> None:
+        return None
+
     monkeypatch.setattr(detached_process, "IS_WINDOWS", False)
+    monkeypatch.setattr(detached_process, "_process_group_id", _pgid_unavailable)
 
     link = detached_process.link_child_lifetime_to_parent(4242)
 
     assert link == detached_process.ParentDeathLink(parent_death_linked=False)
+
+
+def test_watchdog_terminates_target_when_parent_dies() -> None:
+    from meridian.lib.platform.parent_watchdog import WatchedProcess, watch_parent_until_exit
+
+    parent = WatchedProcess(pid=1, created_at_epoch=1.0)
+    target_scope = ProcessScopeSnapshot(
+        scope_id="backend",
+        owner_policy="spawn_owned",
+        owner_id="spawn-1",
+        role="harness_backend",
+        containment="posix_pgid",
+        root_pid=2,
+        root_created_at_epoch=2.0,
+        pgid=2,
+        job_name=None,
+        degraded_reason=None,
+    )
+    terminated: list[tuple[ProcessScopeSnapshot, float, str]] = []
+
+    def _parent_alive(_parent: WatchedProcess) -> bool:
+        return False
+
+    def _target_alive(_target: ProcessScopeSnapshot) -> bool:
+        return True
+
+    def _terminate_scope(
+        scope: ProcessScopeSnapshot,
+        *,
+        grace_seconds: float,
+        reason: str,
+    ) -> None:
+        terminated.append((scope, grace_seconds, reason))
+
+    def _sleep(_seconds: float) -> None:
+        return None
+
+    result = watch_parent_until_exit(
+        parent=parent,
+        target_scope=target_scope,
+        parent_alive=_parent_alive,
+        target_alive=_target_alive,
+        terminate_scope=_terminate_scope,
+        sleep=_sleep,
+    )
+
+    assert result == 0
+    assert terminated == [(target_scope, 5.0, "parent_exit_watchdog")]


### PR DESCRIPTION
## Why

macOS has no Linux `PR_SET_PDEATHSIG` equivalent. Managed Codex/OpenCode backends therefore ran in a new session without a real parent-death link and could survive Meridian as PID-1 orphans.

Fresh Codex managed primaries also handed the websocket endpoint to the remote TUI while the bootstrap turn was still active. That could strand the TUI in a phantom `Working` state, making idle Ctrl+C behave like a no-op turn interrupt.

## Goal

Give managed primaries real crash containment on macOS/BSD, hand fresh Codex sessions to the TUI only from a completed bootstrap state, and make attached-TUI shutdown deterministic across cancellation paths.

## Summary

- Added a detached POSIX parent watchdog for platforms without native parent-death signals.
- Added a readiness handshake and birth/PGID-aware full-scope liveness.
- Split primary process birth from blocking terminal wait through `RunningProcess`.
- Made PTY/subprocess waits cancellation-aware and bounded managed-primary cleanup.
- Waited for matching Codex bootstrap `turn/completed` before remote TUI attach.
- Included the resolved agent name in the visible fresh-session bootstrap message.
- Added process-level, cancellation-race, bootstrap-ordering, and cross-platform regression coverage.

## Resulting Behavior

On macOS:

- the degraded `start_new_session_only` warning is gone;
- killing Meridian or its tmux/terminal container terminates the managed app-server, TUI, watchdog, and process-group descendants;
- a fresh managed Codex TUI opens idle after bootstrap and exits normally with one idle Ctrl+C;
- its bootstrap message is `Meridian started (agent: <name>)` when an agent profile is active, and remains `Meridian started` otherwise;
- cancellation cannot be rejoined indefinitely through a blocking terminal relay.

Linux keeps native `prctl(PR_SET_PDEATHSIG)` containment. Windows keeps Job Object containment.

## Changes

- `parent_watchdog.py` watches the launcher's birth-validated PID and the target process scope, acknowledges readiness over an inherited pipe, and delegates cleanup to the existing process-scope terminator.
- Managed backend launch records post-spawn watchdog linkage only after readiness succeeds; Codex/OpenCode cleanup reaps the helper.
- `ProcessLauncher.start()` now returns a `RunningProcess` before blocking wait/terminal relay begins.
- Managed attach shields observational waits, retries canonical cleanup after cancellation, and bounds force-close behavior across Codex and OpenCode branches.
- Codex bootstrap tracks matching turn completion before TUI handoff.
- Codex launch-spec resolution now carries the resolved agent identity to bootstrap message construction.
- Updated platform/process context and Codex passthrough documentation.

Known unrelated issue found during regression probing: a late background-subagent cancellation can lose to a newly written control-frame report and finalize as succeeded. Process cleanup still converged; this PR does not change terminal-state precedence.

## Work Item

N/A — direct primary-session macOS containment fix.

## Verification

- `uv run ruff check .` — passed.
- `uv run --extra dev python -m pyright` — 0 errors; 7 pre-existing CLI warnings.
- Focused platform/harness/launch gate — 52 passed.
- Agent-bootstrap delta gate — 45 passed, including adapter identity propagation and message fallback coverage.
- Post-rebase combined gate against `v0.3.28` — 67 passed; Ruff passed and Pyright remained at 0 errors.
- GitHub CI — changelog, lint, fast, full, compatibility, and Windows gates all passed.
- Real macOS tmux verification:
  - bootstrap completion preceded TUI birth;
  - one idle Ctrl+C exited with code 0;
  - tmux death removed backend/TUI/watchdog with no persistent PID-1 orphan;
  - a real `gpt-dev` launch displayed `Meridian started (agent: gpt-dev)`, reached idle, exited cleanly, and left no probe processes;
  - real background subagent spawn, `spawn wait`, report, and transcript passed.
- Independent final review: approved after the OpenCode drain-cancellation race test was synchronized to the exact bounded-drain state.
- Bootstrap-message review initially caught missing adapter-to-spec agent propagation; the corrected production path was re-reviewed and approved.

Full `pytest-llm` reached 1,127+ passes but is not green in this checkout for two unrelated existing environment failures: `/tmp` vs `/private/tmp` path resolution in `test_snapshot_round_trip_preserves_all_profile_fields`, and a missing generated Pi extension artifact in `test_blocking_spawn_compose_once_then_bind_only_execute`.

## Knowledge Updates

- Updated `src/meridian/lib/platform/.context/CONTEXT.md` with watchdog readiness and process-group liveness.
- Updated `src/meridian/lib/launch/process/.context/CONTEXT.md` with the start/wait/cancel contract.
- Updated `docs/codex-tui-passthrough.md` with the completed-bootstrap handoff requirement.
- Added `CHANGELOG.md` entries under `[Unreleased]`.

## Spawn Trace

- p8 reviewer — initial structural/process-lifecycle review.
- p9 prober — initial macOS tmux containment and Ctrl+C verification.
- p10 prober — background subagent spawn/wait/cancel regression.
- p11 prober — isolated Ctrl+C root cause and bootstrap-handoff A/B test.
- p12, p13, p15, p16 reviewers — iterative cancellation and relay correctness review.
- p14 prober — final macOS tmux containment, Ctrl+C, and subagent regression.
- p17 reviewer — final race-test synchronization approval.
- p19 reviewer — agent-bootstrap delta review; caught missing production identity propagation.
- p20 reviewer — approved the corrected adapter-to-bootstrap path.
- p21 prober — real macOS tmux verification of the named-agent bootstrap message and cleanup.

## Release Label Guide

Set one release label: `release:patch`.

## Post-Merge Automation

After merge, CI will perform the repository's normal labeled patch release flow.

## Cleanup

After merge, clean the worktree with `scripts/prune-worktrees.sh`.
