### PR TITLE
deps: bump mars-agents to 0.10.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Bump mars-agents to 0.10.5 so packages with same-named agents install
+  together through collision-driven source suffixes instead of failing with a
+  duplicate-provider error.
+
 ## [0.3.29] - 2026-07-10
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "cyclopts>=3.0",
   "fastapi>=0.115",
   "markdown-it-py>=4.0",
-  "mars-agents==0.10.3",
+  "mars-agents==0.10.5",
   "mcp>=1.0",
   "pathspec>=1.1.0",
   "psutil>=7.2.2",

--- a/uv.lock
+++ b/uv.lock
@@ -666,15 +666,15 @@ wheels = [
 
 [[package]]
 name = "mars-agents"
-version = "0.10.3"
+version = "0.10.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3e/11/34cb52bfb2a2d1e20d11bb1b4711deb0be933583d1ed70def6aed6cd0395/mars_agents-0.10.3.tar.gz", hash = "sha256:ca36feca3f4345fb0f00c0b02b374e08c84713d588661d4f3b69c166d73735ca", size = 708683, upload-time = "2026-07-06T01:35:12.077Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/b5/951623d8b8bf26116448ab0f78290f3b62eb89849da7a2147ab1a125936c/mars_agents-0.10.5.tar.gz", hash = "sha256:ef027e2de948cb2817667df504cfeee78e5e01a59a9ff4628798482741e46f10", size = 716091, upload-time = "2026-07-10T08:07:56.905Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/53/4de8cfbaae3e135c2b1d3bc26e0a907ca4fdd625b9217a6f07526d137952/mars_agents-0.10.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4fc9b218e768d864bfc7730c8f5939e4afb38e75ddde7ae8d90c1f6b7268507d", size = 3467571, upload-time = "2026-07-06T01:35:03.557Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/58/cdbf0ef8687f47e07b3e2de4408ef52f615bc0c30f5bc048a11d7814da14/mars_agents-0.10.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b55e02b790070a7cf1abb970c62a01e62adcef5d042e3e786d9ef5750e4d3efd", size = 3323114, upload-time = "2026-07-06T01:35:05.22Z" },
-    { url = "https://files.pythonhosted.org/packages/49/f5/464ef9f8b70cfecaa8334c6165bb8b6166d232d10686289e76c5f5b8698c/mars_agents-0.10.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7659800e78e96633e69afcb84b1bb014aff20727da7eee6700afdad993bf6625", size = 3368784, upload-time = "2026-07-06T01:35:06.827Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/2c/9c56d225417806c608797f63f24a7bd2cf8fd964fc286d9ef76177b010f6/mars_agents-0.10.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:caba0cf4a98da6ba8f75ca8eef16f08f0953a91fcc77c39d67494fda6b6df808", size = 3592163, upload-time = "2026-07-06T01:35:08.631Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/06/3848f9dbef1226533a49683f46462810c07a379b55b9a27b39609919fe3d/mars_agents-0.10.3-py3-none-win_amd64.whl", hash = "sha256:31d6c28449e4ef741c498edfcf2f1dd5cefd8eb8fbf134cf1ac7cae745b5fce3", size = 3541943, upload-time = "2026-07-06T01:35:10.108Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e0/7fe41506a417ec73ed2d6ffe8404c4d2f70a835f9d4f222391dbd71b9eeb/mars_agents-0.10.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f597ecb02677f7f0b1597c6642c2d200f6235b4e3450ad2022e1b197304fc290", size = 3482301, upload-time = "2026-07-10T08:07:48.323Z" },
+    { url = "https://files.pythonhosted.org/packages/43/03/b7c8930d0644766767fddedd97e9a093c21862c86f0cfd3fa6c3e5f9d739/mars_agents-0.10.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1bd4badd33e8ac62b8eb029f623469394a3f98a7415895935b99835fffe61dc6", size = 3329416, upload-time = "2026-07-10T08:07:50.38Z" },
+    { url = "https://files.pythonhosted.org/packages/06/78/46f4442562cf18820247b29363284e645f0f439c492218491cb11b7766fc/mars_agents-0.10.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5761bc14d33a75983f3e404ca781762b8ca8d446af7d61af12a4c37f92244307", size = 3299337, upload-time = "2026-07-10T08:07:51.882Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/b2/22b9845702adce3396698420850a7b42d707694f2adbd6122a9ed30beed1/mars_agents-0.10.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:654dda45910aafaf72cc0f17a055728144a3891139ddcbd083d27e22ad01abad", size = 3524201, upload-time = "2026-07-10T08:07:53.289Z" },
+    { url = "https://files.pythonhosted.org/packages/85/9d/048248f6b0334ab92c2dceb2352fdd39753b18ba4236dbb6d819eea83fed/mars_agents-0.10.5-py3-none-win_amd64.whl", hash = "sha256:141723ef616a45cb43eefcfd35e3b0b4a8b1d67dae4ee12fd105977462b707cc", size = 3557743, upload-time = "2026-07-10T08:07:55.13Z" },
 ]
 
 [[package]]
@@ -766,7 +766,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'app'", specifier = ">=0.28" },
     { name = "jinja2", marker = "extra == 'templates'", specifier = ">=3.1" },
     { name = "markdown-it-py", specifier = ">=4.0" },
-    { name = "mars-agents", specifier = "==0.10.3" },
+    { name = "mars-agents", specifier = "==0.10.5" },
     { name = "mcp", specifier = ">=1.0" },
     { name = "pathspec", specifier = ">=1.1.0" },
     { name = "psutil", specifier = ">=7.2.2" },


### PR DESCRIPTION
## Why

Meridian 0.3.29 pins Mars 0.10.3, so `meridian mars add haowjy/creative-writing-skills` still fails when `meridian-dev-workflow` is installed because both packages provide `web-researcher`.

## Goal

Bundle the released Mars collision fix so same-named agents install with source-qualified names and package-local references remain correct.

## Summary

Bump the exact `mars-agents` dependency and universal lock from 0.10.3 to 0.10.5.

## Resulting Behavior

Adding `creative-writing-skills` to a project that already uses `meridian-dev-workflow` succeeds. Mars installs `web-researcher__creative-writing-skills` and `web-researcher__meridian-dev-workflow`, then rewrites each package's orchestrator references to its own agent.

## Changes

- Pin `mars-agents==0.10.5` in project metadata.
- Refresh only the Mars package record and requirement in `uv.lock`.
- Record the collision behavior fix in `CHANGELOG.md`.

## Work Item

npm-provenance-publish

## Verification

- `uv lock --check`
- `uv run ruff check .`
- `uv run pytest-llm` — 1376 passed, 2 platform skips
- `uv run --extra dev python -m pyright` — 0 errors
- Pre-push gate — lint, type check, 1376 tests, and wheel/sdist build passed
- `uv run meridian mars --version` — `mars 0.10.5`
- Fresh sequential package-add smoke test — both adds exited 0; both suffixed agents and rewritten references verified
- Reviewer p5029 — approved with no findings
- Prober p5030 — functional runtime verification passed

## Knowledge Updates

No architecture or context update required. The dependency behavior is recorded in `CHANGELOG.md`. A pre-existing, non-blocking `mars doctor` bootstrap hashing bug discovered during probing is tracked as haowjy/mars-agents#128.

## Spawn Trace

- p5029 reviewer — dependency, lockfile, platform-wheel, and changelog review
- p5030 prober — exact sequential package-add runtime verification

## Cleanup

No debug files or tracked build artifacts remain. The worktree will be pruned after merge and release verification.
