### PR TITLE
docs: reconcile qi-layer guidance with current architecture (audit xc-docs lane)

### DIFF
--- a/src/meridian/AGENTS.md
+++ b/src/meridian/AGENTS.md
@@ -6,7 +6,7 @@ their work.
 
 ## Layered Architecture
 
-The package is structured in concentric layers. Surfaces (CLI, MCP server, REST)
+The package is structured in concentric layers. Active surfaces (CLI and MCP server)
 call into policy (`ops/`), which drives mechanism (`launch/`, `harness/`),
 which reads/writes state (`state/`). Data flows inward; nothing from mechanism
 calls back into surfaces.
@@ -49,7 +49,7 @@ config entry. If adding a feature requires editing 10 files, the abstraction is 
 |---|---|
 | `lib/ops/` | Policy: spawn lifecycle, session, work, config operations |
 | `lib/launch/` | Composition seam: `SpawnRequest` → `LaunchContext` → process |
-| `lib/harness/` | Per-harness adapters: Claude, Codex, OpenCode |
+| `lib/harness/` | Per-harness adapters: Claude, Codex, Cursor, OpenCode, Pi |
 | `lib/state/` | All disk I/O: spawn store, session store, atomic writes |
 | `lib/core/` | Domain types, spawn lifecycle state machine |
 | `lib/platform/` | OS abstractions: locking, process scope, signals |
@@ -62,12 +62,13 @@ config entry. If adding a feature requires editing 10 files, the abstraction is 
 | `lib/hooks/` | Hook dispatch, config layering, built-in hooks |
 | `lib/extensions/` | Extension command registry |
 | `lib/artifact/` | Detached static-artifact serving over Tailscale (`artifact serve/list/stop/gc`); no daemon — file is authority |
-
 | `lib/observability/` | Spawn-scoped JSONL tracing |
-| `lib/mermaid/` | Mermaid diagram validation |
-| `lib/kg/` | Markdown link checking |
+| `lib/telemetry/` | Process telemetry routing, sinks, lifecycle correlation, and retention |
+| `lib/mermaid/` | Mermaid syntax validation and style checks |
+| `lib/kg/` | KB document-graph analysis (links, conflicts, flags) |
 | `lib/bootstrap/` | Startup preparation stages |
 | `lib/markdown/` | Markdown parsing utilities |
+| `lib/utils/` | Dependency-free shared utility helpers |
 
 ## Entry Points
 

--- a/src/meridian/cli/.context/CONTEXT.md
+++ b/src/meridian/cli/.context/CONTEXT.md
@@ -51,14 +51,13 @@ Four independent mechanisms reduce startup latency:
 4. **Heavy module deferral** — `primary_launch` and `mars_passthrough` imported
    inside handler functions, not at module scope.
 
-**Measured impact:** `main.py` module-import time 460ms → 156ms; root
-`--help` latency 140ms → 54ms.
+Together these mechanisms keep startup and help paths from importing command
+implementations they do not need.
 
 ## Help Profile Selection
 
 Human vs agent mode selects a `HelpProfile` at app-build time from the
-command catalog — no runtime mutation of shared `App` objects. Do not call
-`apply_agent_help_supplements()` (archived pattern).
+command catalog — no runtime mutation of shared `App` objects.
 
 ## Project Root Resolution
 
@@ -96,16 +95,8 @@ This flag belongs on creation/bootstrap commands (`meridian`, `spawn create`,
   established. Used by config/inspection commands that degrade gracefully.
 - `exit_no_established_project()` — the single CLI-edge `SystemExit(1)`.
 
-### Footgun killed
-
-Before #338, `require_established_project_root()` raised `SystemExit` (a
-`BaseException`) directly. `maybe_bootstrap_runtime_state()` in `bootstrap.py`
-wrapped bootstrap in `except Exception`, which silently swallowed the
-`SystemExit` — causing confusing downstream crashes instead of the intended
-"No Meridian project found" message.
-
-The fix: `resolve_cli_project_root()` never raises. The no-project exit is an
-explicit decision *outside* the `except Exception` guard.
+`resolve_cli_project_root()` never raises. The no-project exit is an explicit
+decision outside any `except Exception` guard.
 
 ## `to_cli_output()` Dispatch
 
@@ -124,10 +115,8 @@ the small protocol to produce its wire-shaped output.
 - **Bare `meridian init`** (no flags) → calls `config_init_sync` directly to
   bootstrap the project config only.
 
-There is no passthrough path in this command. `resolve_init_link_mars_command`
-was deleted when `init_ops` took over the `--link` case — do not recreate it.
-Auto-link is the default behavior; there are no confirmation prompts in the init
-flow, so `--yes` has no meaning here and was removed.
+There is no passthrough path in this command; do not add one. Auto-link is the
+default behavior, and the init flow has no confirmation prompts or `--yes` option.
 
 ## Session Initiation Argument Handling
 
@@ -220,10 +209,12 @@ argv
 
 ## Related KB
 
-→ [concepts/session-initiation.md](../../../../../../../.meridian/git/haowjy-meridian-cli-kb/kb/concepts/session-initiation.md) — four-mode session initiation semantics, identity lock, bare flag inference, and `--from` placement
-→ [decisions/launch.md](../../../../../../../.meridian/git/haowjy-meridian-cli-kb/kb/decisions/launch.md) — rationale for the launch-mode split and argv normalization
+KB lives at `$MERIDIAN_CONTEXT_KB_DIR` (see `meridian context kb`):
 
-## Spawn Output Mode Changes (spawn-return-report)
+- `$MERIDIAN_CONTEXT_KB_DIR/concepts/session-initiation.md` — four-mode session initiation semantics, identity lock, bare flag inference, and `--from` placement
+- `$MERIDIAN_CONTEXT_KB_DIR/decisions/launch.md` — rationale for the launch-mode split and argv normalization
+
+## Spawn Output Contract
 
 ### Catalog default_output_mode for spawn
 
@@ -233,7 +224,7 @@ Rule: if you add a new spawn subcommand, default to `"json"` unless it surfaces 
 
 ### `--metadata` flag
 
-Added to `_spawn_create` and `_spawn_wait` handlers. In text mode, shows detailed inline accounting (model, harness, exit code, duration, cost, tokens, report path) while still including report body and transcript pointer.
+`_spawn_create` and `_spawn_wait` accept `--metadata`. In text mode it shows detailed inline accounting (model, harness, exit code, duration, cost, tokens, report path) while still including report body and transcript pointer.
 
 Pattern: compact default → `--metadata` inline accounting → `spawn show` full record.
 

--- a/src/meridian/cli/AGENTS.md
+++ b/src/meridian/cli/AGENTS.md
@@ -70,4 +70,4 @@ argv
 - `../lib/core/resolved_context.py` — `ResolvedContext` for primary launch
 
 → [.context/CONTEXT.md](.context/CONTEXT.md) — invocation class table, lazy import strategy, session initiation argument handling, app_tree circular-import pattern, help profile selection
-→ [KB: architecture/startup-pipeline.md](/home/jimyao/.meridian/git/meridian-flow-docs/kb/architecture/startup-pipeline.md)
+→ KB: `$MERIDIAN_CONTEXT_KB_DIR/architecture/startup-pipeline.md` (see `meridian context kb`)

--- a/src/meridian/lib/bootstrap/.context/CONTEXT.md
+++ b/src/meridian/lib/bootstrap/.context/CONTEXT.md
@@ -75,4 +75,4 @@ commands use the cwd-derived root.
 
 ## Related KB
 
-→ [KB: architecture/startup-pipeline.md](/home/jimyao/.meridian/git/meridian-flow-docs/kb/architecture/startup-pipeline.md)
+→ KB: `$MERIDIAN_CONTEXT_KB_DIR/architecture/startup-pipeline.md` (see `meridian context kb`)

--- a/src/meridian/lib/bootstrap/AGENTS.md
+++ b/src/meridian/lib/bootstrap/AGENTS.md
@@ -74,4 +74,4 @@ RuntimeWriteContext(RuntimeReadContext)
 - `../lib/ops/runtime.py` — `RuntimeAuthoritySnapshot`
 
 → [.context/CONTEXT.md](.context/CONTEXT.md) — resolve/ensure split detail, context hierarchy, entrypoint shapes, post-parse bootstrap pattern
-→ [KB: architecture/startup-pipeline.md](/home/jimyao/.meridian/git/meridian-flow-docs/kb/architecture/startup-pipeline.md)
+→ KB: `$MERIDIAN_CONTEXT_KB_DIR/architecture/startup-pipeline.md` (see `meridian context kb`)

--- a/src/meridian/lib/catalog/.context/CONTEXT.md
+++ b/src/meridian/lib/catalog/.context/CONTEXT.md
@@ -107,4 +107,4 @@ aliases resolve correctly from the file; auto-resolve aliases are skipped.
 
 ## Related KB
 
-- [KB: Model Resolution](../../../../../../../../.meridian/git/meridian-flow-docs/kb/concepts/model-resolution/overview.md) — full resolution pipeline design
+- `$MERIDIAN_CONTEXT_KB_DIR/concepts/model-resolution/overview.md` — full resolution pipeline design (see `meridian context kb`)

--- a/src/meridian/lib/config/.context/CONTEXT.md
+++ b/src/meridian/lib/config/.context/CONTEXT.md
@@ -135,4 +135,4 @@ debuggable errors.
 
 ## Related KB
 
-- [KB: Config Precedence](../../../../../../../../.meridian/git/meridian-flow-docs/kb/concepts/config-precedence.md) — full precedence chain and per-spawn vs project config distinction
+- `$MERIDIAN_CONTEXT_KB_DIR/concepts/config-precedence.md` — full precedence chain and per-spawn vs project config distinction (see `meridian context kb`)

--- a/src/meridian/lib/context/.context/CONTEXT.md
+++ b/src/meridian/lib/context/.context/CONTEXT.md
@@ -10,7 +10,7 @@ other named context directories.
 
 `_resolve_path()` supports two placeholders:
 
-- `{project}` — replaced by the project's stable ID (from `.meridian/project_id`).
+- `{project}` — replaced by the project's stable ID (from `.meridian/id`).
   Returns `None` if `{project}` is present but no project ID is available (fresh
   project). Callers must handle `None` — `resolve_context_paths()` falls back to
   `.meridian/work` or `.meridian/kb`.
@@ -63,4 +63,4 @@ includes paths even when env vars are already set.
 
 ## Related KB
 
-- [KB: Context Resolution](../../../../../../../../.meridian/git/meridian-flow-docs/kb/concepts/context-resolution.md) — cross-cutting context design
+- `$MERIDIAN_CONTEXT_KB_DIR/concepts/context-resolution.md` — cross-cutting context design (see `meridian context kb`)

--- a/src/meridian/lib/context/AGENTS.md
+++ b/src/meridian/lib/context/AGENTS.md
@@ -17,7 +17,7 @@ is `MERIDIAN_CONTEXT_{NAME}_DIR`. `context_env_key(name)` derives the var name.
 ## Key Rules
 
 **`{project}` placeholder resolves to `None` if no project ID is available.** A fresh
-project without `.meridian/project_id` produces `None` for any path containing
+project without `.meridian/id` produces `None` for any path containing
 `{project}`. `resolve_context_paths()` handles this gracefully with fallbacks, but
 if you call `_resolve_path()` directly, you must handle `None` returns.
 

--- a/src/meridian/lib/core/.context/CONTEXT.md
+++ b/src/meridian/lib/core/.context/CONTEXT.md
@@ -7,7 +7,7 @@ over `str` / `int`. Zero runtime cost; mypy catches pass-the-wrong-id bugs
 statically. Use them on function signatures wherever spawn or model IDs are
 passed — don't accept `str` when you mean `SpawnId`.
 
-`HarnessId` and `TransportId` are defined here; the former `harness/ids.py` shim was deleted.
+`HarnessId` and `TransportId` are defined here.
 
 ## RuntimeOverrides and Merge Semantics (`overrides.py`)
 
@@ -152,11 +152,6 @@ the root process is still alive with a matching creation time. Returns `False`
 This is a fail-safe for leak prevention (PROC-007): a `session_owned` scope whose
 root has already died must be reclaimed, not silently preserved forever.
 
-### Deleted: `reclaim_stale_session_scopes()`
-
-This function was removed — it had zero callers and was fully superseded by
-`reclaim_session_owned_scopes_for_chat()`. Do not reference it.
-
 ## Spawn Lifecycle Decisions (`spawn_lifecycle.py`)
 
 `spawn_lifecycle.py` owns lifecycle resolution rules — pure stateless functions shared by the
@@ -221,7 +216,9 @@ the terminal state for read-path reconciliation. Durable completion → `succeed
 
 ## Related KB
 
-→ [KB: codebase/guide.md](/home/jimyao/.meridian/git/meridian-flow-docs/kb/codebase/guide.md) — core module orientation and codebase navigation
-→ [KB: concepts/config-precedence.md](/home/jimyao/.meridian/git/meridian-flow-docs/kb/concepts/config-precedence.md)
-→ [KB: architecture/state-system.md](/home/jimyao/.meridian/git/meridian-flow-docs/kb/architecture/state-system.md)
+KB lives at `$MERIDIAN_CONTEXT_KB_DIR` (see `meridian context kb`):
+
+- `$MERIDIAN_CONTEXT_KB_DIR/codebase/guide.md` — core module orientation and codebase navigation
+- `$MERIDIAN_CONTEXT_KB_DIR/concepts/config-precedence.md`
+- `$MERIDIAN_CONTEXT_KB_DIR/architecture/state-system.md`
 → [platform/process_scope/.context/CONTEXT.md](../../platform/process_scope/.context/CONTEXT.md) — mechanism layer (dispatch, backends, PID reuse guard)

--- a/src/meridian/lib/core/AGENTS.md
+++ b/src/meridian/lib/core/AGENTS.md
@@ -58,9 +58,8 @@ cancel()          → finalize(status='cancelled')
 ## Related
 
 - `../state/` — spawn store consumed by `SpawnLifecycleService`
-- `../harness/ids.py` — `HarnessId` (re-exported via core types)
+- `types.py` — `HarnessId`
 - `../launch/` — uses `SpawnApplicationService` and `ResolvedContext`
 
 → [.context/CONTEXT.md](.context/CONTEXT.md) — ID type details, override merge semantics, `OutputSink` swap pattern, depth rationale, child env key enforcement
-→ [KB: codebase/core-primitives.md](/home/jimyao/.meridian/git/meridian-flow-docs/kb/codebase/core-primitives.md)
-→ [KB: concepts/config-precedence.md](/home/jimyao/.meridian/git/meridian-flow-docs/kb/concepts/config-precedence.md)
+→ KB: `$MERIDIAN_CONTEXT_KB_DIR/concepts/config-precedence.md` (see `meridian context kb`)

--- a/src/meridian/lib/extensions/.context/CONTEXT.md
+++ b/src/meridian/lib/extensions/.context/CONTEXT.md
@@ -31,7 +31,9 @@ Op-style handlers (single Pydantic input model) use `ExtensionCommandSpec.from_o
 
 ## Surface Rules
 
-`ExtensionSurface`: `CLI`, `MCP`, `HTTP`. A command may expose any subset via `spec.surfaces`.
+`ExtensionSurface` declares `CLI`, `MCP`, and `HTTP`. CLI and MCP are active.
+HTTP remains in command specs, but no HTTP dispatcher or app server exists, so it
+is a dormant surface rather than a runnable endpoint.
 
 **Non-first-party commands cannot expose `CLI` or `MCP`** — enforced at `registry.register()`. This is a hard constraint, not a default. Attempting to register a non-first-party command with CLI or MCP surfaces raises `ValueError`.
 
@@ -43,9 +45,10 @@ Op-style handlers (single Pydantic input model) use `ExtensionCommandSpec.from_o
 
 **Surface-aware defaults** (applied by `ExtensionInvocationContextBuilder.build()` when `with_capabilities()` is not called explicitly):
 - `CLI` and `MCP` → `ExtensionCapabilities.denied()` (all False)
-- `HTTP` → `ExtensionCapabilities.elevated()` (all True)
+- dormant `HTTP` → `ExtensionCapabilities.elevated()` (all True)
 
-This reflects that the app server is a trusted orchestration boundary. CLI/MCP callers are unprivileged by default.
+CLI/MCP callers are unprivileged by default. The HTTP default is retained policy
+for a possible app-server return; no active boundary currently uses it.
 
 ## Registry Singleton
 
@@ -55,6 +58,6 @@ This reflects that the app server is a trusted orchestration boundary. CLI/MCP c
 
 ## Rationale
 
-Before the extension system, commands had parallel implementations for CLI/MCP and HTTP. The KB page documents the full history:
+One spec keeps surface implementations from diverging. The full design lives in:
 
-→ [KB: concepts/extension-system.md](/home/jimyao/.meridian/git/meridian-flow-docs/kb/concepts/extension-system.md)
+→ `$MERIDIAN_CONTEXT_KB_DIR/concepts/extension-system.md` (see `meridian context kb`)

--- a/src/meridian/lib/extensions/AGENTS.md
+++ b/src/meridian/lib/extensions/AGENTS.md
@@ -1,13 +1,15 @@
 # lib/extensions — Unified Command System
 
-Three surfaces (CLI, MCP, HTTP) read from one registry. You define a command once — as an `ExtensionCommandSpec` — and it appears on all surfaces it opts into. Surfaces are not separate implementations; they're access policies on the same spec.
+CLI and MCP read from one registry. `ExtensionSurface.HTTP` remains declared in
+specs, but no HTTP dispatcher or app server exists, so it is a dormant surface.
+Surfaces are access policies on one `ExtensionCommandSpec`, not separate implementations.
 
 ## Mental Model
 
 Every invokable operation is a spec. The spec declares: which surfaces can call it, what args it accepts (Pydantic model), what capabilities it requires, whether it needs a running app server, and an async handler. The dispatcher runs a validation pipeline before calling the handler — no handler ever receives invalid args or runs on an unauthorized surface.
 
 ```
-Caller (CLI | MCP | HTTP)
+Caller (CLI | MCP; HTTP is declared but dormant)
   └── ExtensionCommandDispatcher.dispatch(fqid, args, context, services)
         1. Registry lookup → not_found
         2. Trust check → trust_violation (third-party blocked)
@@ -23,10 +25,12 @@ Errors at any stage return `ExtensionErrorResult` — the dispatcher never raise
 
 ## Key Rules
 
-- **Add a command = write one spec.** Define a Pydantic args model, write an async handler `(args: dict, context, services) → ExtensionResult`, construct `ExtensionCommandSpec`, register it. It appears on all listed surfaces automatically.
+- **Add a command = write one spec.** Define a Pydantic args model, write an async handler `(args: dict, context, services) → ExtensionResult`, construct `ExtensionCommandSpec`, register it. Registration records every listed surface; active adapters expose only CLI and MCP.
 - **Non-first-party commands cannot use CLI or MCP surfaces.** Enforced at `registry.register()` — raises `ValueError`. Not a soft policy.
 - **`cli_group` and `cli_name` are all-or-nothing.** Both set or both None. A spec with only one will fail construction.
-- **HTTP callers get elevated capabilities by default; CLI/MCP callers get denied.** The app server is a trusted orchestration boundary. This is applied by `ExtensionInvocationContextBuilder.build()` when `with_capabilities()` is not called explicitly.
+- **CLI/MCP callers get denied capabilities by default.** The dormant HTTP context
+  default remains elevated in `ExtensionInvocationContextBuilder.build()`, but no
+  active HTTP boundary constructs it.
 - **Use `ExtensionCommandSpec.from_op()` for single-model handlers.** The factory wraps the op into the 3-arg signature. Don't implement `(args: dict, context, services)` manually for op-style handlers.
 
 ## Entry Points
@@ -40,11 +44,12 @@ Errors at any stage return `ExtensionErrorResult` — the dispatcher never raise
 
 ## Anti-Patterns
 
-- Don't add parallel CLI and HTTP implementations of the same operation. One spec, multiple surfaces.
+- Don't treat `ExtensionSurface.HTTP` membership as a runnable endpoint. The HTTP
+  surface is declared for a possible app-server return, not currently dispatched.
 - Don't catch and swallow exceptions in handlers — return `ExtensionErrorResult` instead. The dispatcher records the error code; exceptions become `handler_error`.
 - Don't call `build_first_party_registry()` in application code — it creates a fresh instance. Use `get_first_party_registry()` for the singleton.
 
 ## Depth
 
 → [.context/CONTEXT.md](.context/CONTEXT.md) — dispatcher pipeline detail, capability model, surface rules, registry singleton, manifest hash
-→ [KB: concepts/extension-system.md](/home/jimyao/.meridian/git/meridian-flow-docs/kb/concepts/extension-system.md)
+→ KB: `$MERIDIAN_CONTEXT_KB_DIR/concepts/extension-system.md` (see `meridian context kb`)

--- a/src/meridian/lib/harness/.context/CONTEXT.md
+++ b/src/meridian/lib/harness/.context/CONTEXT.md
@@ -33,7 +33,7 @@ read back. Process exit signals completion. Used for non-streaming spawns.
 
 **Connection path** (`lib/harness/connections/`): starts a long-lived process then
 connects bidirectionally. Events flow through the `SpawnManager` drain loop. Used
-for streaming app server.
+for streaming execution.
 
 Per-harness mapping:
 - Claude subprocess: `claude -p --output-format stream-json --verbose -`
@@ -71,14 +71,6 @@ the accounting guard will run on a partial registration set and fail.
 
 Every `SpawnParams` field must appear in each adapter's `consumed_fields` **or**
 `explicitly_ignored_fields`. Enforced at import time by `launch_spec.py:_enforce_spawn_params_accounting()`. Adding a field to `SpawnParams` without updating all adapters → `ImportError` on startup. This is not documentation — it is enforcement.
-
-Currently ignored fields:
-- Claude ignores `task_cwd`, `context_from_payload`, `reference_items`
-- Codex ignores `skills`, `agent`, `task_cwd`, `context_from_payload`, `reference_items`
-- Cursor ignores `skills`, `agent`, `adhoc_agent_payload`, `control_root`,
-  `appended_system_prompt`, `user_turn_content`,
-  `context_from_payload`, `reference_items`, `continue_harness_session_id`,
-  `continue_fork`, `effort`
 
 The spawn report path is no longer a `SpawnParams` field. It is derived once in
 `bind_launch_context` from `resolve_spawn_log_dir(project_root, spawn_id)`; the
@@ -254,13 +246,9 @@ override). If the parent process already exported this var, Meridian deep-merges
 new workspace entries into the parent config rather than suppressing projection.
 Suppression would silently drop workspace roots inherited from the spawner.
 
-The implementation (`project_workspace_roots()`, `OPENCODE_CONFIG_CONTENT_ENV`)
-lives in `launch/workspace_projection.py`, not in `harness/`. It was moved there
-to break a circular import in Python 3.14: `harness/__init__` → `opencode.py` →
-`opencode_http.py` → `workspace_projection` as a harness submodule, while harness
-was still initializing. The module only depends on `core.types` — it never depended
-on harness internals. `opencode_http.py` now imports `OPENCODE_CONFIG_CONTENT_ENV`
-from `meridian.lib.launch.workspace_projection`.
+`OPENCODE_CONFIG_CONTENT_ENV` lives in `launch/workspace_projection.py` to keep
+the bootstrap dependency direction acyclic; see
+[launch context](../../launch/.context/CONTEXT.md).
 
 ### Cursor: Subprocess-Only, Read-Only stdout
 
@@ -292,9 +280,9 @@ notification markers). The drain loop delegates this policy to
 `PiDrainCoordinator`, which only lets an `agent_end` success candidate finalize
 after the quiescence check passes.
 
-This is the first harness where "done" is not synonymous with "process exited."
-All other harnesses (Claude, Codex, OpenCode) use process exit or an explicit
-terminal event as the completion boundary.
+Pi completes by quiescence rather than a terminal event. Resident Codex and
+OpenCode also hold terminal-event completion until their persisted descendant
+trees drain; plain subprocess harnesses complete on exit or a terminal event.
 
 ### Pi: Runtime Compatibility Probing
 
@@ -377,7 +365,7 @@ accounting invariant treats any uncovered field as a bug, not a warning.
 ## Related .context/
 
 - [../../state/.context/CONTEXT.md](../../state/.context/CONTEXT.md) — artifact store that `SpawnExtractor` reads from; atomic write primitives
-- [../../launch/.context/CONTEXT.md](../../launch/.context/CONTEXT.md) — composition seam, four driving adapters, prepare/bind split, invariants
+- [../../launch/.context/CONTEXT.md](../../launch/.context/CONTEXT.md) — composition seam, three driving adapters, prepare/bind split, invariants
 - [../../../pi_runtime/.context/CONTEXT.md](../../../pi_runtime/.context/CONTEXT.md) — Pi TypeScript extensions, build pipeline, managed-bash / meridian-spawn-watch split
 - [Pi integration](pi-integration.md) — Pi adapter, runtime, and quiescence details
 - [Session transcripts](session-transcripts.md) — harness-neutral transcript normalization and providers

--- a/src/meridian/lib/harness/AGENTS.md
+++ b/src/meridian/lib/harness/AGENTS.md
@@ -5,9 +5,7 @@ Mechanism side of the policy/mechanism split. Translates harness-agnostic
 domain types. `ops/` and `launch/` work with domain types — harness specifics stay
 here.
 
-**OpenCode upstream status:** Development moved from the archived
-``opencode-ai/opencode`` repository to ``anomalyco/opencode`` (opencode.ai). The
-Meridian OpenCode adapter targets current opencode.ai CLI releases.
+The Meridian OpenCode adapter targets current opencode.ai CLI releases.
 
 ## Translation Pipeline
 

--- a/src/meridian/lib/harness/connections/.context/CONTEXT.md
+++ b/src/meridian/lib/harness/connections/.context/CONTEXT.md
@@ -32,10 +32,8 @@ connection validates this (`_validate_initial_prompt_requirement()`) and enforce
 (`_FIRST_STDOUT_AFTER_INITIAL_PROMPT_TIMEOUT_SECONDS`).
 
 **`opencode_http.py` imports `OPENCODE_CONFIG_CONTENT_ENV` from
-`meridian.lib.launch.workspace_projection`** — a cross-layer dependency on `launch/`
-rather than `harness/`. This is intentional: `workspace_projection.py` was moved to
-`launch/` to break a circular bootstrap dependency. Connections modules may import
-shared constants from `launch/` when those constants live there by architecture necessity.
+`meridian.lib.launch.workspace_projection`** to preserve the required bootstrap
+dependency direction; see [launch context](../../../launch/.context/CONTEXT.md).
 
 ## Contracts
 

--- a/src/meridian/lib/harness/extractors/AGENTS.md
+++ b/src/meridian/lib/harness/extractors/AGENTS.md
@@ -29,7 +29,7 @@ helper in `base.py` handles the per-harness key lookup.
 
 **Protocol is runtime-checkable.** `HarnessExtractor` extends `SpawnExtractor` as a
 `Protocol` — runtime `isinstance()` checks work. Add new methods to the Protocol
-and to all three implementations together.
+and to every implementation together.
 
 ## Entry Points
 

--- a/src/meridian/lib/hooks/.context/CONTEXT.md
+++ b/src/meridian/lib/hooks/.context/CONTEXT.md
@@ -69,4 +69,4 @@ Within an event, hooks are sorted by:
 
 ## Related KB
 
-→ [KB: concepts/hooks-and-plugins.md](/home/jimyao/.meridian/git/meridian-flow-docs/kb/concepts/hooks-and-plugins.md)
+→ KB: `$MERIDIAN_CONTEXT_KB_DIR/concepts/hooks-and-plugins.md` (see `meridian context kb`)

--- a/src/meridian/lib/hooks/AGENTS.md
+++ b/src/meridian/lib/hooks/AGENTS.md
@@ -39,4 +39,4 @@ Override key is `(name, event)` — a higher-priority row with the same key repl
 ## Depth
 
 → [.context/CONTEXT.md](.context/CONTEXT.md) — config layering, event classes, failure behavior, plugin API boundary, context transport schema
-→ [KB: concepts/hooks-and-plugins.md](/home/jimyao/.meridian/git/meridian-flow-docs/kb/concepts/hooks-and-plugins.md)
+→ KB: `$MERIDIAN_CONTEXT_KB_DIR/concepts/hooks-and-plugins.md` (see `meridian context kb`)

--- a/src/meridian/lib/kg/.context/CONTEXT.md
+++ b/src/meridian/lib/kg/.context/CONTEXT.md
@@ -42,7 +42,7 @@ Use `build_check` for validation gates (broken links + content issues). Use `bui
 
 ## Related KB
 
-→ [KB: codebase/tools.md](/home/jimyao/.meridian/git/meridian-flow-docs/kb/codebase/tools.md)
+→ KB: `$MERIDIAN_CONTEXT_KB_DIR/codebase/tools.md` (see `meridian context kb`)
 
 ## Lateral Links
 

--- a/src/meridian/lib/launch/.context/CONTEXT.md
+++ b/src/meridian/lib/launch/.context/CONTEXT.md
@@ -8,7 +8,7 @@ All launch state composition happens inside `build_launch_context()` in `context
 No driving adapter composes argv, env, or permissions independently. This is a hard
 invariant — violation means two places can diverge silently.
 
-`build_launch_context()` is now a backward-compat wrapper over a two-phase pipeline:
+`build_launch_context()` is a backward-compat wrapper over a two-phase pipeline:
 
 ```
 SpawnRequest + LaunchRuntime
@@ -264,38 +264,26 @@ or configured KB root). The path after `kb:` must be relative and must not escap
 the KB root. Example: `kb:architecture/launch-system.md`.
 
 **`@` prefix is unsupported** — attempting to use it raises a `ValueError` directing
-the user to use `kb:` instead. This was a legacy convention that has been removed.
+the user to use `kb:` instead.
 
 Directory references (`-f <dir>`) render as a tree structure with blocked directories
 (`.git`, `node_modules`, `.meridian`, etc.) and blocked suffixes (`.pyc`, `.egg-info`)
 excluded. File references include content inline if under 100KB; larger or binary
 files produce a warning instead.
 
-### Worktree Path Assignment vs Managed Ownership
+### Work Item Task Directories
 
-Work items track worktree paths through `WorktreeMetadata` in `work_store.py`,
-which separates **path assignment** from **managed git-worktree ownership**:
-
-- **`managed=True`**: provisioned by `work start` via `provision_for_start()`.
-  Lifecycle operations (cleanup on done/delete, rename, restore on reopen) apply.
-- **`managed=False`**: set manually via `work set-worktree`. The path is recorded
-  but lifecycle operations skip it — `cleanup_for_done()`, `cleanup_for_delete()`,
-  and `rename_worktree()` all return `skipped_manual` for unmanaged worktrees.
-
-This separation allows users to point a work item at an existing directory without
-meridian treating it as a disposable git worktree. Shared worktree references
-(multiple work items pointing at the same path) also block destructive lifecycle
-operations via the `shared_with` guard.
+Launch uses a work item's `task_dir` as its logical task cwd. Persisted
+`WorktreeMetadata` is state/display metadata only; launch does not provision or
+manage git worktrees.
 
 ### Workspace Projection
 
-`workspace_projection.py` in this module owns `project_workspace_roots()` and
-`OPENCODE_CONFIG_CONTENT_ENV`. It was moved here from `harness/` to eliminate a
-circular import in Python 3.14 bootstrap (`harness/__init__` → `opencode.py` →
-`opencode_http.py` → `workspace_projection` as a harness submodule while harness
-was still initializing). The module only depends on `core.types` — never on harness
-internals. `harness/connections/opencode_http.py` imports `OPENCODE_CONFIG_CONTENT_ENV`
-from this module.
+`workspace_projection.py` owns `project_workspace_roots()` and
+`OPENCODE_CONFIG_CONTENT_ENV`. Keeping this dependency-light module in `launch/`
+prevents `harness` bootstrap from importing back into a partially initialized
+harness package. It depends only on `core.types`, never on harness internals;
+`harness/connections/opencode_http.py` imports the env constant from here.
 
 Two steps inside `bind_launch_context()`:
 
@@ -337,8 +325,7 @@ finally:
 
 The inner try/finally ensures scope reclamation runs even if `stop_session` raises.
 `reclaim_session_owned_scopes_for_chat` terminates any process scopes the session owns
-(e.g., managed primary backends) that were not released during normal teardown — this
-was the missing step that caused session_owned scopes to persist as orphans.
+(e.g., managed primary backends) that were not released during normal teardown.
 
 **Callers must not add manual scope cleanup after `session_scope`** — reclamation is
 guaranteed by the context manager. Adding cleanup outside it creates a race between the
@@ -352,8 +339,8 @@ test injection; in production it always points to `reclaim_session_owned_scopes_
 `resolve_task_context_inputs()` in `context.py` is the single seam for assembling
 user-turn context blocks from `--from` refs and `-f` reference files:
 
-The full four-mode session-initiation model and its rationale live in
-[concepts/session-initiation.md](../../../../../../../../.meridian/git/haowjy-meridian-cli-kb/kb/concepts/session-initiation.md).
+The full four-mode session-initiation model and its rationale live at
+`$MERIDIAN_CONTEXT_KB_DIR/concepts/session-initiation.md` (see `meridian context kb`).
 This code-local note records only the launch seam and the fields it threads.
 
 ```python
@@ -372,9 +359,7 @@ def resolve_task_context_inputs(
 ```
 
 Both `_resolve_spawn_prepare_projection()` and `_resolve_primary_projection()` call
-this function. Before this seam existed, `_resolve_primary_projection()` hardcoded
-`reference_items=()` and `prior_output=""` — primary launch always had empty user-turn
-context even when `LaunchRequest.context_from` was populated.
+this function so both launch paths receive the same user-turn context inputs.
 
 **Content ordering** inside the assembled user turn:
 
@@ -388,18 +373,17 @@ context even when `LaunchRequest.context_from` was populated.
 (from `--from` on both spawn and primary surfaces). It is populated by the CLI layer
 from `ForkModeResolution.resolved_context_from` and passed through to
 `SpawnRequest.context_from` via `build_primary_spawn_request()` in `plan.py`.
-Before this field existed, primary launch silently dropped `--from` refs.
 
 **Do not unify `_resolve_spawn_prepare_projection()` and `_resolve_primary_projection()`.**
 Only the user-turn context resolution step is shared. The two projections differ in
 supplemental documents, agent profile body handling, report instruction, completion
 contract, session seeding, and passthrough arg normalization. `resolve_task_context_inputs()`
-is the only extraction authorized by this change.
+is the only shared extraction between them.
 
 #### Why User-Turn, Not System Prompt
 
 Prior context is rendered into the user turn, not the system prompt. The full
-rationale lives in [concepts/session-initiation.md](../../../../../../../../.meridian/git/haowjy-meridian-cli-kb/kb/concepts/session-initiation.md);
+rationale lives at `$MERIDIAN_CONTEXT_KB_DIR/concepts/session-initiation.md`;
 at this layer, the rule is simply to keep `--from` blocks in user-turn context
 blocks and out of `SystemInstruction`.
 

--- a/src/meridian/lib/launch/AGENTS.md
+++ b/src/meridian/lib/launch/AGENTS.md
@@ -180,5 +180,5 @@ See [.context/CONTEXT.md](.context/CONTEXT.md#why-user-turn-not-system-prompt) f
 
 - `../ops/spawn/AGENTS.md` — policy layer that drives this layer
 - `../harness/AGENTS.md` — mechanism layer this calls for `project_content()`, `build_launch_argv()`
-- KB `architecture/launch-system.md` — full four-adapter diagram
+- KB `architecture/launch-system.md` — launch adapter architecture
 - KB `concepts/spawn-lifecycle.md` — spawn status machine, crash recovery

--- a/src/meridian/lib/launch/process/.context/CONTEXT.md
+++ b/src/meridian/lib/launch/process/.context/CONTEXT.md
@@ -82,5 +82,5 @@ primary CLI's prepare-once/bind-twice optimization path.
 
 ## Lateral Links
 
-→ [../../.context/CONTEXT.md](../../.context/CONTEXT.md) — composition seam, four driving adapters, invariants I-1/I-4/I-10
+→ [../../.context/CONTEXT.md](../../.context/CONTEXT.md) — composition seam, three driving adapters, invariants I-1/I-4/I-10
 → [../../streaming/.context/CONTEXT.md](../../streaming/.context/CONTEXT.md) — streaming spawn execution (sibling path)

--- a/src/meridian/lib/launch/process/AGENTS.md
+++ b/src/meridian/lib/launch/process/AGENTS.md
@@ -63,7 +63,7 @@ the distinction is whether Meridian controls the turn or just observes.
 
 ## Related
 
-- [../.context/CONTEXT.md](../.context/CONTEXT.md) — launch/ layer; four driving adapters;
+- [../.context/CONTEXT.md](../.context/CONTEXT.md) — launch/ layer; three driving adapters;
   invariants I-1 through I-13.
 - [../streaming/.context/CONTEXT.md](../streaming/.context/CONTEXT.md) — streaming spawn
   path; sibling to this package.

--- a/src/meridian/lib/markdown/.context/CONTEXT.md
+++ b/src/meridian/lib/markdown/.context/CONTEXT.md
@@ -27,7 +27,7 @@ Don't import `markdown_it` directly in other modules. Route through `extract_fil
 
 ## Related KB
 
-→ [KB: codebase/tools.md](/home/jimyao/.meridian/git/meridian-flow-docs/kb/codebase/tools.md)
+→ KB: `$MERIDIAN_CONTEXT_KB_DIR/codebase/tools.md` (see `meridian context kb`)
 
 ## Lateral Links
 

--- a/src/meridian/lib/mermaid/.context/CONTEXT.md
+++ b/src/meridian/lib/mermaid/.context/CONTEXT.md
@@ -38,4 +38,4 @@ The `style/` submodule is a separate concern from syntax validation. It checks s
 
 ## Related KB
 
-→ [KB: codebase/tools.md](/home/jimyao/.meridian/git/meridian-flow-docs/kb/codebase/tools.md)
+→ KB: `$MERIDIAN_CONTEXT_KB_DIR/codebase/tools.md` (see `meridian context kb`)

--- a/src/meridian/lib/observability/.context/CONTEXT.md
+++ b/src/meridian/lib/observability/.context/CONTEXT.md
@@ -49,4 +49,4 @@ for ops/launch/harness modules, `logging.getLogger(__name__)` for catalog/config
 
 ## Related KB
 
-→ [KB: codebase/observability.md](/home/jimyao/.meridian/git/meridian-flow-docs/kb/codebase/observability.md)
+→ KB: `$MERIDIAN_CONTEXT_KB_DIR/codebase/observability.md` (see `meridian context kb`)

--- a/src/meridian/lib/observability/AGENTS.md
+++ b/src/meridian/lib/observability/AGENTS.md
@@ -34,4 +34,4 @@ The four helper functions (`trace_wire_recv`, `trace_wire_send`, `trace_state_ch
 - `../core/logging.py` — `configure_logging()` controls structlog (separate from tracer)
 
 → [.context/CONTEXT.md](.context/CONTEXT.md) — disable-on-failure contract, output routing, truncation limits
-→ [KB: codebase/observability.md](/home/jimyao/.meridian/git/meridian-flow-docs/kb/codebase/observability.md)
+→ KB: `$MERIDIAN_CONTEXT_KB_DIR/codebase/observability.md` (see `meridian context kb`)

--- a/src/meridian/lib/ops/.context/CONTEXT.md
+++ b/src/meridian/lib/ops/.context/CONTEXT.md
@@ -2,11 +2,11 @@
 
 ## Architecture
 
-`ops/` sits between surfaces (CLI commands, MCP tools, REST routes) and mechanisms
+`ops/` sits between active surfaces (CLI commands and MCP tools) and mechanisms
 (`launch/`, `state/`, `harness/`). It owns *what* to do, not *how* to run a process.
 
 ```
-CLI / MCP / REST
+CLI / MCP
       │
       ▼
 ops/          ← policy: access control, input validation, lifecycle sequencing
@@ -18,8 +18,8 @@ ops/          ← policy: access control, input validation, lifecycle sequencing
 
 ### ops/spawn/ — The Spawn Policy Layer
 
-`ops/spawn/` is the second of four driving adapters into `lib/launch/`. It owns
-the foreground and background spawn paths for child spawns (not primary sessions).
+The spawn subprocess is the second of three driving adapters into `lib/launch/`.
+`ops/spawn/` owns foreground and background child-spawn paths (not primary sessions).
 
 **SpawnApplicationService** (in `lib/bootstrap/services.py`, built by `build_spawn_application_service()`)
 is the policy coordinator that `ops/spawn/api.py` instantiates. It sits above
@@ -32,7 +32,7 @@ Layer 5: SpawnLifecycleService       ← sole state writer (spawn_store)
 ```
 
 Key `SpawnApplicationService` methods:
-- `prepare_spawn()` — resolve-before-persist; REST and streaming-serve entry point
+- `prepare_spawn()` — resolve-before-persist entry point for streaming-serve
 - `cancel()` — surface-neutral cancel pipeline; managed-primary, signal, finalizing races
 - `complete_spawn()` — idempotent terminal seam; acquires per-spawn lock internally
 - `archive()` — validates terminal state, emits exactly one `spawn.archived`
@@ -59,11 +59,10 @@ This is safe because `complete_spawn()` is idempotent.
 ### Resolve-Before-Persist Pattern
 
 The spawn subprocess path creates the row *before* calling `build_launch_context()`.
-This is a known gap — it differs from the REST/streaming-serve paths which use
+This is a known gap — it differs from streaming-serve, which uses
 resolve-before-persist (`build_launch_context()` first, row creation only on success).
-Row-creation order unification is tracked as follow-up work.
 
-For the REST path, `SpawnApplicationService.prepare_spawn()` enforces:
+For streaming-serve, `SpawnApplicationService.prepare_spawn()` enforces:
 - **SEAM-1**: No spawn row on resolution failure
 - **SEAM-2**: Row metadata always reflects resolved model/agent/harness
 - **SEAM-3**: `ConnectionConfig.env_overrides` populated from `LaunchContext.env_overrides`
@@ -74,40 +73,6 @@ For the REST path, `SpawnApplicationService.prepare_spawn()` enforces:
 `LaunchArgvIntent.REQUIRED`. This is the only execution path that needs a real
 argv — it populates `cli_command` for dry-run display. All actual execution paths
 use `SPEC_ONLY`. Do not set `REQUIRED` on execution paths.
-
-### Worktree Lifecycle Protection
-
-`ops/worktree_lifecycle.py` is the raw git worktree layer — it owns creation,
-restoration, cleanup, and crash recovery. It is intentionally limited to git/worktree
-concerns and returns structured results for callers to persist elsewhere.
-
-`ops/worktree_ensure.py` sits above it and provides high-level ensure semantics used
-by `work_worktree.py` and spawn logic. The split is: lifecycle owns raw git operations,
-ensure owns state management and idempotency.
-
-Managed worktree creation writes a `mars.local.toml` guard with
-`[settings] targets = []` when the worktree is newly created. This prevents
-repo-local `meridian mars sync` from materializing harness targets inside each
-worktree. Existing `mars.local.toml` files are user-owned and preserved.
-
-**Destructive operations guard against three conditions:**
-
-1. **Manual worktrees** (`managed=False`): paths set via `work set-worktree` are never
-   removed or moved by `cleanup_for_done()`, `cleanup_for_delete()`, or `rename_worktree()`.
-   These return `skipped_manual` — the user owns the directory lifecycle.
-2. **Shared references**: when multiple work items reference the same worktree path,
-   cleanup returns `shared_reference` with the list of other item names. The worktree
-   is not removed while another item depends on it.
-3. **Unpushed commits** (done, not force): `cleanup_for_done()` checks for unpushed
-   commits before removal unless `--force` is passed. `cleanup_for_delete()` skips
-   this check — delete is already a destructive operation.
-
-**Worktree rename** (`rename_worktree()`) moves both the directory and the git branch
-to match the new work slug. Fails if the worktree is shared, missing, or not managed.
-
-**Crash recovery** (`recover_pending()`) handles interrupted `work start` between
-`git worktree add` and metadata write. If the worktree directory exists, it heals
-the record; otherwise it clears the pending flag.
 
 ### ops/init_ops.py — Init Orchestration
 
@@ -132,45 +97,6 @@ directories (containing `SKILL.md`), agents as files, so the scan uses
 type (e.g., `{"agents": [...], "skills": [...]}`). This avoids coupling Python
 to the mars JSON report shape — new content types (hooks, MCP servers, etc.) are
 automatically counted without Python model changes.
-
-### ops/worktree_ensure.py — Managed Worktree Orchestration
-
-`worktree_ensure.py` sits above `worktree_lifecycle.py` and provides high-level
-ensure semantics with state management, dry-run support, and session-scoped temporary
-worktrees. Used by `work_worktree.py` and `spawn/api.py`.
-
-**Key contracts:**
-
-`ensure_work_item_worktree()` is idempotent — calling twice returns `already_available`
-on the second call. Once managed metadata (repo_path + name) is persisted, subsequent
-calls reuse it regardless of `--repo` or cwd. Accepts dry-run mode and `allow_missing_dry_run`
-for work items that don't exist yet. Returns `WorktreeEnsureResult` with status, metadata,
-repo_root, canonical_path, and optional warning.
-
-`ensure_temporary_worktree()` provides session-scoped isolation keyed by spawn_id/chat_id
-(via `_temporary_key(ctx)` → `worktree-temp/` store). Uses same pending/rollback discipline:
-set pending before git, clear on failure, upgrade to ready on success.
-
-`get_temporary_worktree_status()` is read-only; heals pending-but-dir-exists records.
-
-Repo resolution (`_resolve_target_repo()`, `_resolve_repo_root()`) supports path selectors,
-workspace aliases, and cwd-based inference. Dry-run mode uses `.git` marker scanning
-without running git commands.
-
-Managed path policy: `_canonical_target()` derives `<repo>.worktrees/<name>`. Non-canonical
-paths are detected as drift and fail clearly.
-
-### ops/work_worktree.py — Work Worktree Command Orchestration
-
-`work_worktree.py` orchestrates `meridian work worktree` command logic. Accepts
-`WorkWorktreeInput` (work_id, ensure, repo, chat_id, project_root), returns
-`WorkWorktreeOutput` with worktree path, branch, name, repo_root, managed status,
-exists flag, temporary flag, ensured flag, message, and warning.
-
-Routes based on whether a work item is active: calls `ensure_work_item_worktree()`
-if present, else delegates to `ensure_temporary_worktree()`. When `ensure=False`,
-returns status-only response (no-op) if path already exists. When work_id is empty
-and no active work item, uses temporary worktree path.
 
 ### session_target.py / session_transcript.py — Ordered Transcript Sources
 
@@ -313,7 +239,7 @@ discovery stays in ops and artifact presence checking stays in the store.
 
 ## Related KB
 
-- `architecture/launch-system.md` — full four-adapter diagram; ops/spawn is adapter #2
+- `architecture/launch-system.md` — launch adapter architecture; ops/spawn is adapter #2 of three
 - `concepts/spawn-lifecycle.md` — spawn status machine ops surfaces expose
 - `architecture/spawn-finalization.md` — `SpawnApplicationService.complete_spawn()`,
   `CompleteSpawnOutcome`, per-spawn lock

--- a/src/meridian/lib/ops/AGENTS.md
+++ b/src/meridian/lib/ops/AGENTS.md
@@ -5,7 +5,7 @@ ops calls into `launch/`, `state/`, and `harness/`. Owns *what* to do — access
 control, input validation, lifecycle sequencing — not *how* to run a process.
 
 ```
-CLI / MCP / REST
+CLI / MCP
       │
       ▼
 ops/          ← policy: depth checks, work attachment, validate, route
@@ -20,14 +20,14 @@ inside ops/, that logic belongs in `launch/`.
 
 ## ops/spawn/ — The Core Subpackage
 
-The second of four driving adapters into `lib/launch/`. Owns foreground and
-background spawn paths for child spawns (not primary sessions).
+The spawn subprocess is the second of three driving adapters into `lib/launch/`.
+This package owns foreground and background child-spawn paths (not primary sessions).
 → [spawn/AGENTS.md](spawn/AGENTS.md)
 
 **SpawnApplicationService** (built by `build_spawn_application_service()` in
 `lib/bootstrap/services.py`) is the policy coordinator. Its key methods:
 
-- `prepare_spawn()` — resolve-before-persist; REST and streaming-serve entry point.
+- `prepare_spawn()` — resolve-before-persist entry point for streaming-serve.
   No row created on resolution failure (SEAM-1).
 - `cancel()` — surface-neutral cancel pipeline: managed-primary, signal, finalizing races.
 - `complete_spawn()` — idempotent terminal seam; acquires per-spawn lock internally.
@@ -80,10 +80,10 @@ references. All `--from` / `-f` operations route through this.
 
 ## Resolve-Before-Persist vs Row-First
 
-- **REST/streaming-serve** (via `SpawnApplicationService.prepare_spawn()`): resolution
+- **Streaming-serve** (via `SpawnApplicationService.prepare_spawn()`): resolution
   first, row created only on success. This is the clean path.
 - **Spawn subprocess** (`execute.py`): row created before calling `build_launch_context()`.
-  Known gap — unification with REST path is tracked as follow-up work.
+  This is a known gap; do not copy it into new paths.
 
 ## Anti-Patterns
 
@@ -106,4 +106,4 @@ use `SPEC_ONLY`.
 - `spawn/AGENTS.md` — spawn policy subpackage depth
 - `../launch/AGENTS.md` — mechanism layer ops/spawn drives
 - `../state/AGENTS.md` — state stores ops reads from
-- KB `architecture/launch-system.md` — four-adapter diagram; ops/spawn is adapter #2
+- KB `architecture/launch-system.md` — launch adapter architecture; ops/spawn is adapter #2 of three

--- a/src/meridian/lib/ops/spawn/.context/CONTEXT.md
+++ b/src/meridian/lib/ops/spawn/.context/CONTEXT.md
@@ -108,7 +108,7 @@ the **only** execution path that builds a real argv — used for `--dry-run` dis
 `cli_command` in `SpawnActionOutput`. All actual execution paths use `SPEC_ONLY`. Do not add
 `REQUIRED` elsewhere.
 
-## Compose-once handoff (foreground + REST)
+## Compose-once handoff (foreground + streaming-serve)
 
 `prepare.py` returns `SpawnCreateArtifacts(request, prepared)` after `compose_spawn_launch_surface`.
 Blocking CLI execute passes `prepared` into `launch_prepared_spawn` for **bind-only** when session/fork
@@ -116,8 +116,9 @@ did not change policy inputs (`_spawn_request_needs_recompose`). Full re-compose
 mutation. Dry-run create uses `dry_run=True` on compose; real spawns use `dry_run=False` (not CLI
 `--dry-run` alone).
 
-REST `SpawnApplicationService.prepare` composes once, reserves `spawn_id`, then bind-only with final
-`MERIDIAN_SPAWN_ID` overrides. `streaming_serve` reuses `PreparedSpawn.launch_context` — no third compose.
+`SpawnApplicationService.prepare_spawn()` composes once for streaming-serve,
+reserves `spawn_id`, then binds with final `MERIDIAN_SPAWN_ID` overrides.
+`streaming_serve` reuses `PreparedSpawn.launch_context` — no third compose.
 
 ## Background Spawn Trust Model (Phase 3A)
 

--- a/src/meridian/lib/ops/spawn/AGENTS.md
+++ b/src/meridian/lib/ops/spawn/AGENTS.md
@@ -72,7 +72,7 @@ not as a harmless absence.
 
 **Don't create spawn rows before calling `build_launch_context()` on new code paths.**
 The existing subprocess path does this (known gap); don't replicate the pattern. New
-paths should use resolve-before-persist (REST/streaming model).
+paths should use the resolve-before-persist streaming-serve model.
 
 **Don't set `LaunchArgvIntent.REQUIRED` on execution paths.** Only `prepare.py` gets
 a real argv — execution paths use `SPEC_ONLY`.

--- a/src/meridian/lib/platform/.context/CONTEXT.md
+++ b/src/meridian/lib/platform/.context/CONTEXT.md
@@ -115,7 +115,3 @@ signal.signal(signal.SIGINT, _handle)   # must call from main thread
 `TerminateProcess()` — unconditional kill, no signal handler runs. It does not
 silently fail. Use `psutil.Process(pid).terminate()` for equivalent cross-platform
 behavior.
-
-## Related KB
-
-- [KB: Platform Abstractions](../../../../../../../../.meridian/git/meridian-flow-docs/kb/codebase/platform-abstractions.md) — cross-cutting platform design

--- a/src/meridian/lib/platform/process_scope/.context/CONTEXT.md
+++ b/src/meridian/lib/platform/process_scope/.context/CONTEXT.md
@@ -95,4 +95,4 @@ but weaker than group kill or Job Object containment.
 - [`../AGENTS.md`](../AGENTS.md) — module entry points
 - [`../.context/CONTEXT.md`](../.context/CONTEXT.md) — parent platform invariants
 - [`../../../core/.context/CONTEXT.md`](../../../core/.context/CONTEXT.md) — process_cleanup.py, which owns policy decisions and calls terminate_scope_sync()
-- KB: [architecture/process-scope.md](/home/jimyao/.meridian/git/meridian-flow-docs/kb/architecture/process-scope.md)
+- KB: `$MERIDIAN_CONTEXT_KB_DIR/architecture/process-scope.md` (see `meridian context kb`)

--- a/src/meridian/lib/platform/process_scope/AGENTS.md
+++ b/src/meridian/lib/platform/process_scope/AGENTS.md
@@ -64,4 +64,4 @@ POSIX orphan sweep (PROC-004), Windows handle threading status, fallback snapsho
 
 ## Related
 
-- KB: [architecture/process-scope.md](/home/jimyao/.meridian/git/meridian-flow-docs/kb/architecture/process-scope.md)
+- KB: `$MERIDIAN_CONTEXT_KB_DIR/architecture/process-scope.md` (see `meridian context kb`)

--- a/src/meridian/lib/safety/.context/CONTEXT.md
+++ b/src/meridian/lib/safety/.context/CONTEXT.md
@@ -90,7 +90,3 @@ The dependency graph must remain:
 
 Do not add direct top-level imports between these modules and `harness.*` or `launch.*`.
 The lazy import in `extract_cost_usd_from_json_line` is load-bearing.
-
-## Related KB
-
-- [KB: Safety Subsystem](../../../../../../../../.meridian/git/meridian-flow-docs/kb/codebase/safety-subsystem.md) — cross-cutting safety design

--- a/src/meridian/lib/state/.context/CONTEXT.md
+++ b/src/meridian/lib/state/.context/CONTEXT.md
@@ -10,8 +10,6 @@ State splits across two roots:
 .meridian/                          ← repo-local, committed scaffolding
   id                                — project UUID / three-word ID
   id.lock                           — exclusive lock for UUID generation
-  work-items/<slug>.json            — mutable JSON per work item
-  work-items.rename.intent.json     — crash-safe rename intent (transient)
 
 ~/.meridian/projects/<id>/          ← user runtime, never committed
   sessions.jsonl                    — all session events, append-only
@@ -21,7 +19,6 @@ State splits across two roots:
   spawn-id-counter                  — monotonic p1, p2, …
   spawns/
     .staging/<unique>/              — complete unpublished spawn row
-    v2-format.json                  — v2 migration marker
     <id>/
       state.json                    — authoritative spawn state (v2)
       state.lock                    — per-spawn exclusive lock for external writers
@@ -31,8 +28,10 @@ State splits across two roots:
       inbound.jsonl                 — injected user messages
       control.sock                  — active-session control socket
   artifacts/                        — LocalStore blob store
-  worktree-temp/                    — session-scoped temporary worktree records
-    <safe-key>.json                 — TemporaryWorktreeRecord per session context
+
+<context.work root>/<slug>/         ← context-resolved, not repo-local
+  __status.json                     — mutable per-work-item metadata
+  prompts/ handoffs/ …              — work artifacts
 ```
 
 The project ID in `.meridian/id` is the key that maps to
@@ -41,16 +40,8 @@ runtime history.
 
 ### Spawn State: V2 Per-Spawn Files
 
-Since 2026-05, spawn state lives in individual `state.json` files under
-`spawns/<id>/`, not a global `spawns.jsonl` event log.
-
-Why: the global log had grown to 189 MB / 35,000 events. Every status read was
-O(n) replay of the entire file. Primary launch had degraded to 12–13 seconds.
-Per-spawn `state.json` makes reads O(1). After migration: 0.67s launch time.
-
-Migration from the legacy global `spawns.jsonl` to per-spawn `state.json` is complete.
-All active installations use v2. The `spawns.jsonl` path still exists in `RuntimePaths`
-as a field but is unused by the spawn store.
+Spawn state lives in individual `spawns/<id>/state.json` files so status reads are
+O(1) instead of replaying an O(n) global event log.
 
 ### Session State
 
@@ -137,25 +128,22 @@ on the same spawn. Terminal statuses are `succeeded`, `failed`, `cancelled`, and
 `failed`. The reaper checks authority before finalizing — it will not overwrite a
 spawn that the runner already terminated with a higher-authority origin.
 
-### Reaper Behavior
+### Reconciliation Behavior
 
-`reaper.py:reap_spawns()` runs on every read path (list, show, wait, dashboard) but
-only when `MERIDIAN_DEPTH` is absent, empty, or `"0"`. Nested processes and
-malformed depth values fail closed (no reap side effects).
+`reaper.py:reconcile_spawns()` is a read-only batch projection used by list, stats,
+reference-discovery, and dashboard callers. For each active row it calls
+`peek_reconciled_active_spawn()`, which may return an in-memory terminal view but
+does not persist state, terminate process scopes, or check process depth.
 
-Liveness check sequence per active spawn:
-1. Skip if status is already terminal.
-2. Skip if not a root-side-effect process (`is_root_side_effect_process()`).
-3. Skip if heartbeat age < 120s (recently alive).
-4. If status = `finalizing`: prefer durable report / cancel precedence and recorded
-   `runner_exit_status`; if neither proves a terminal outcome and activity is stale,
-   mark failed (`orphan_finalization`).
-5. If `runner_exit_status` is already recorded outside `finalizing`, preserve the
-   runner's terminal tuple after the short post-runner-exit grace.
-6. If status = `running` or `queued`: check if `runner_pid` is alive (using
-   `liveness.py:is_process_alive()` with PID reuse guard via recorded start time).
-   If dead, check completion/cancel precedence, recent activity, startup grace, and
-   finally mark failed (`orphan_run` or `missing_runner_pid`).
+`reconcile_active_spawn()` is the mutating repair operation used by doctor orphan-run
+repair. It fails closed unless `is_root_side_effect_process()` is true, applies the
+same reconciliation decision rules, cleans recorded orphan scopes, and persists a
+terminal result through the locked external-writer path.
+
+Shared liveness decisions skip recent activity and live runner PIDs; prefer durable
+report completion, cancel precedence, and recorded runner terminal tuples; and
+otherwise classify stale active rows as orphan failures after startup/finalization
+grace periods. PID checks use the recorded creation time to guard against reuse.
 
 `spawn_report_has_durable_completion(runtime_root, spawn_id)` reads `report.md` and returns True
 for non-empty report content that is not a terminal control frame (`cancelled`/`error`
@@ -165,9 +153,8 @@ and cancel convergence paths.
 `_completion_or_cancel_decision()` centralizes durable-completion-vs-cancel precedence
 for the reaper: if a durable report exists, the spawn resolves `succeeded` regardless
 of cancel intent; otherwise pending cancel intent resolves `cancelled` with the intent's
-exit code and error. This replaces the earlier pattern of returning
-`FinalizeSucceededFromReport` or `_finalize_from_cancel_intent_decision()` directly —
-violating the rule can let a late cancel downgrade a completed spawn.
+exit code and error. Call this helper rather than branching on completion and cancel
+independently; a late cancel must not downgrade a completed spawn.
 
 **Managed-primary orphan cleanup:**
 
@@ -202,50 +189,15 @@ Thread-local reentrancy: a thread that already holds the lock can re-enter on th
 same path without deadlocking. Do not use `threading.Lock` or `fcntl` directly —
 the platform module handles both OS and thread-reentrancy.
 
-### Work Item Store Pattern
+`work_scope.py` resolves each work directory; `work_store.py` stores its mutable
+metadata atomically in `<context.work root>/<slug>/__status.json`.
 
-Work items use a different pattern from spawns: **one mutable JSON file per item**
-under `work-items/<slug>.json`. Mutable JSON is appropriate here because work items
-are correlated with a directory that moves on rename — event-sourcing would add
-complexity without benefit.
+### WorktreeMetadata
 
-Rename is crash-safe: `work-items.rename.intent.json` is written before any rename
-begins. Leftover intent is replayed on startup/reconciliation.
-
-### Temporary Worktree Store Pattern
-
-`temp_worktree_store.py` stores session-scoped managed worktree records keyed by
-spawn_id or chat_id. Path: `~/.meridian/projects/<uuid>/worktree-temp/<safe-key>.json`.
-
-`TemporaryWorktreeRecord` fields: key, repo_path, worktree_name, worktree_path, branch,
-status (pending|ready), managed, updated_at. Status field supports crash recovery:
-`pending` means provisioning was interrupted; `ready` means available.
-`get_temporary_worktree_status()` in `ops/worktree_ensure.py` heals pending-but-dir-exists
-records by updating status to ready.
-
-API: `get_temporary_worktree()`, `put_temporary_worktree()`, `clear_temporary_worktree()`.
-All writes use `atomic_write_text()`.
-
-### WorktreeMetadata: Path Assignment vs Managed Ownership
-
-`WorktreeMetadata` in `work_store.py` separates **path assignment** from **managed
-git-worktree ownership** via the `managed` flag:
-
-- **`managed=True`**: worktree was provisioned by `work start` through
-  `provision_for_start()`. The lifecycle layer (`ops/worktree_lifecycle.py`) owns
-  cleanup on done/delete, rename, and restore on reopen.
-- **`managed=False`**: path was set manually via `work set-worktree`. Lifecycle
-  operations skip it — `cleanup_for_done()`, `cleanup_for_delete()`, and
-  `rename_worktree()` all return `skipped_manual` for unmanaged worktrees.
-
-This separation prevents destructive lifecycle operations from removing or moving
-directories that the user explicitly pointed a work item at. Shared worktree
-references (multiple items referencing the same path) also block cleanup via the
-`shared_with` guard in `cleanup_for_done()` and `cleanup_for_delete()`.
-
-The `pending` flag supports crash recovery: set before `git worktree add`, cleared
-after. `recover_pending()` in `worktree_lifecycle.py` heals or clears interrupted
-provisions.
+`WorktreeMetadata` in `work_store.py` preserves path, branch, repository, name,
+pending, and managed fields in work-item status. Current code reads the path and
+pending flag for dashboard display but does not provision, rename, or clean up git
+worktrees. Archiving or reopening a work item clears `pending`.
 
 **Path separator normalization**: `WorktreeMetadata.path` and `.repo_path` normalize
 backslash separators to POSIX (forward slash) at the Pydantic validation boundary via
@@ -281,7 +233,7 @@ later individual mutations creates unnecessary contention. Use `write_state_lock
 > KB lives at `$MERIDIAN_CONTEXT_KB_DIR` (see `meridian context kb`).
 
 - `$MERIDIAN_CONTEXT_KB_DIR/architecture/state-system.md` — full dual-root layout,
-  v2 migration rationale, session state, work item store, read vs write resolution
+  per-spawn state, session state, work item storage, and read vs write resolution
 - `$MERIDIAN_CONTEXT_KB_DIR/architecture/spawn-finalization.md` — terminal write
   authority lattice, how finalization interacts with the reaper
 ## Related .context/

--- a/src/meridian/lib/state/AGENTS.md
+++ b/src/meridian/lib/state/AGENTS.md
@@ -30,17 +30,13 @@ can move or be renamed without losing runtime history.
 
 Work items live under the `[context.work]` root (default
 `{user_home}/context/<id>/work/<slug>/`), resolved by `work_scope.py` /
-`work_store.py` — **never** the project repo. The legacy
-`.meridian/work-items/<slug>.json` layout is gone; see `docs/configuration.md`
-for context-path resolution.
+`work_store.py` — **never** the project repo. See `docs/configuration.md` for
+context-path resolution.
 
 ## Spawn State: V2 Per-Spawn Files
 
 Spawn state lives in individual `state.json` files (`spawns/<id>/state.json`),
-not a global event log. The legacy `spawns.jsonl` grew to 189 MB / 35,000 events;
-every status read was O(n) replay. Per-spawn `state.json` makes reads O(1). All
-active installations use v2 — the global log path still exists in `RuntimePaths`
-but is unused.
+not a global event log, so status reads stay O(1) instead of replaying O(n) events.
 
 ## Two Write Tiers
 
@@ -82,18 +78,16 @@ Use the correct resolver — they have different side effects:
 Using `*_for_write()` on a read path creates `.meridian/id` in untouched checkouts,
 triggering project setup side effects in CI.
 
-## Reaper Behavior
+## Reconciliation Behavior
 
-`reaper.py:reap_spawns()` runs on every read path but only at root depth
-(`MERIDIAN_DEPTH` absent or `"0"`). Nested processes skip reaping — no side effects.
+`reaper.py:reconcile_spawns()` gives list, stats, reference, and dashboard callers
+a read-only projection of stale active rows. It may return an in-memory terminal
+status but never persists state or terminates processes, and it is safe at any depth.
 
-Liveness sequence per active spawn:
-1. Skip if already terminal.
-2. Skip if heartbeat age < 120s.
-3. `finalizing` with durable report → mark succeeded.
-4. `finalizing` without durable report or recorded runner terminal tuple → mark failed (`orphan_finalization`).
-5. `running`/`queued` with dead PID (checked with start-time reuse guard) → mark failed (`orphan_run`).
-6. Timeouts are terminal `timed_out`, a failure class distinct from generic `failed`.
+`reconcile_active_spawn()` is the side-effectful repair path. It runs from doctor
+background repair, fails closed outside root depth, cleans recorded orphan process
+scopes, and persists the terminal outcome through the locked external-writer path.
+Both paths share the liveness and completion decision rules in `reaper.py`.
 
 ## Entry Points
 
@@ -102,7 +96,8 @@ Liveness sequence per active spawn:
 - `spawn_store.py` — `SpawnStore`. Main interface for listing, creating, updating spawns.
 - `session_store.py` — Session event log.
 - `atomic.py` — atomic write primitives. All state writes use these.
-- `reaper.py` — `reap_spawns()`. Orphan detection on read paths.
+- `reaper.py` — read-only `reconcile_spawns()` projection and root-only
+  `reconcile_active_spawn()` repair.
 
 ## Spawn Subpackage
 
@@ -127,8 +122,8 @@ It handles `MERIDIAN_HOME`, Windows `%LOCALAPPDATA%`, and POSIX `~` correctly.
 
 ## Depth
 
-→ [.context/CONTEXT.md](.context/CONTEXT.md) — full dual-root layout, v2 state format,
-   monotonic ID generation, terminal write authority lattice, work item crash-safe rename.
+→ [.context/CONTEXT.md](.context/CONTEXT.md) — full dual-root layout, per-spawn state,
+   monotonic ID generation, terminal write authority lattice, and worktree metadata.
 
 ## Related
 

--- a/src/meridian/lib/state/spawn/.context/CONTEXT.md
+++ b/src/meridian/lib/state/spawn/.context/CONTEXT.md
@@ -158,5 +158,5 @@ as an orphan failure even if artifacts exist.
 
 - [`../AGENTS.md`](../AGENTS.md) — entry points
 - [`../.context/CONTEXT.md`](../.context/CONTEXT.md) — parent state module contracts
-- KB [`architecture/spawn-finalization.md`](../../../../../../../../.meridian/git/haowjy-meridian-cli-kb/kb/architecture/spawn-finalization.md) — finalization authority lattice, `runner_exit_*` invariant, and reaper contract
-- KB [`architecture/state-system.md`](../../../../../../../../.meridian/git/haowjy-meridian-cli-kb/kb/architecture/state-system.md) — v2 state layout, per-spawn locking, and reconciliation model
+- `$MERIDIAN_CONTEXT_KB_DIR/architecture/spawn-finalization.md` — finalization authority lattice, `runner_exit_*` invariant, and reaper contract
+- `$MERIDIAN_CONTEXT_KB_DIR/architecture/state-system.md` — per-spawn state layout, locking, and reconciliation model

--- a/src/meridian/lib/streaming/.context/CONTEXT.md
+++ b/src/meridian/lib/streaming/.context/CONTEXT.md
@@ -109,12 +109,11 @@ The subscriber queue (`maxsize=1000`) drops non-sentinel events on `QueueFull`
 with telemetry. The terminal `None` sentinel is **never dropped** — on full queue,
 the implementation evicts one item to force the sentinel through.
 
-### SpawnManager Singleton Pattern
+### SpawnManager Lifetime
 
-One `SpawnManager` lives for the app server lifetime. Spawn CLI paths create a
-short-lived instance per run. Do not share manager instances between runs — the
-session dict is not concurrency-safe across multiple concurrent `start_spawn` calls
-from different event loops.
+Each streaming run creates a short-lived `SpawnManager`. Do not share manager
+instances between runs — the session dict is not concurrency-safe across multiple
+concurrent `start_spawn` calls from different event loops.
 
 ### Terminal Publication and Recovery
 

--- a/src/meridian/server/AGENTS.md
+++ b/src/meridian/server/AGENTS.md
@@ -8,7 +8,8 @@ The server exposes two MCP tools:
 - `extension_list_commands` — lists available extension commands
 - `extension_invoke` — invokes a command by fqid
 
-Invocations route through the same `ExtensionCommandDispatcher` used by CLI and HTTP. Surface checks in the dispatcher enforce what's callable via MCP.
+Invocations route through the same `ExtensionCommandDispatcher` used by CLI.
+Surface checks in the dispatcher enforce what's callable via MCP.
 
 ## Key Behaviors
 


### PR DESCRIPTION
## Why

The thermo-nuclear audit's documentation lane (issue #389) audited all 38 `AGENTS.md` + `.context/*.md` trees under `src/meridian/` against the qi-layer standard and found systemic hygiene rot: 24 dead KB links pointing at a nonexistent repo, a ghost REST/app-server architecture documented across 4 subsystems ("four driving adapters" vs the real three), a deleted work-item store documented as current truth, stale per-adapter field enumerations contradicted by the code, and calcified migration diaries. Stale qi-layer docs are load-bearing failures here — agents orient from these files before touching code.

## Goal

Every AGENTS.md/.context claim matches the current code; every line is load-bearing (no session bleed, no reference-dumps posing as intent); CLAUDE.md mirrors intact.

## Summary

Applied all 17 verified findings from the audit's `xc-docs` lane, in place:

- Replaced 24 dead `meridian-flow-docs` KB links with the `$MERIDIAN_CONTEXT_KB_DIR/<page>` prose convention; deleted 3 references whose target pages exist in no repo
- Purged ghost REST/app-server architecture: three driving adapters everywhere; HTTP surface documented as declared-but-dormant
- Removed the legacy work-item store section (`work-items/<slug>.json`, rename-intent replay, `v2-format.json`) — documented the real `<work root>/<slug>/__status.json` layout
- Replaced 6 checkout-depth-dependent deep-relative KB links
- Deleted stale per-adapter ignored-field enumerations (the import-time accounting guard is the authority); fixed dead `harness/ids.py` link; corrected `.meridian/project_id` → `.meridian/id`; corrected Pi-vs-resident completion semantics; repaired the package-index table
- Compressed migration diaries (state 189MB/35k-event narrative, CLI benchmark/PR-#338 stories) to one-line rationale
- Removed references to deleted `reap_spawns()` / `temp_worktree_store.py`

## Resulting Behavior

Agents orienting from any subsystem AGENTS.md/.context get claims that match `main` — no dead links, no ghost architecture, no deleted APIs presented as current. Net −170 lines of prose.

## Changes

41 doc files changed, 170 insertions(+), 340 deletions(-). Zero source-code changes; zero CLAUDE.md mirror changes needed. Follow-up flagged (out of scope): KB-repo pages `architecture/launch-system.md`, `concepts/extension-system.md`, `architecture/state-system.md` still carry the old REST/four-adapter narratives.

## Work Item

thermo-nuclear-audit

## Verification

- `meridian qi claude-md-fix src/meridian` — Created 0, skipped 38, conflicts 0
- `meridian kg check src/meridian` — no issues (114 files, 133 links)
- `uv run ruff check .` — clean; `git diff --check` — clean
- Every staleness fix re-verified against current code before rewriting (runtime probe confirmed `__status.json` layout, 5 extractors, dormant HTTP, absent managed-worktree APIs)
- Pre-push preflight (full test suite) passed

## Knowledge Updates

This PR *is* the knowledge update. KB-repo follow-ups flagged above.

## Spawn Trace

- p5283 gpt-dev — applied all xc-docs findings, docs-only commit
- (finder) audit workflow lane `xc-docs` — produced the verified findings worklist

🤖 Generated with [Claude Code](https://claude.com/claude-code)
