### PR TITLE
docs: align all documentation with POSIX-first platform stance

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,7 +6,7 @@
 git clone https://github.com/haowjy/meridian-cli.git
 cd meridian-cli
 uv sync --extra dev
-scripts/setup-hooks.sh        # Windows: scripts/setup-hooks.ps1
+scripts/setup-hooks.sh
 ```
 
 `setup-hooks` sets `core.hooksPath = .githooks`. Git cannot install hooks on
@@ -104,33 +104,20 @@ When this matters:
 For the full local preflight used by pre-push and release preparation:
 
 ```bash
-# macOS / Linux
 scripts/preflight.sh
-
-# Windows (PowerShell)
-scripts\preflight.ps1
 ```
 
 Fast mode (lint only):
 
 ```bash
-# macOS / Linux
 scripts/preflight.sh fast
-
-# Windows (PowerShell)
-scripts\preflight.ps1 fast
 ```
 
 Pre-push gate (lint + type check + all tests, with optional `--quick` to skip smoke tests):
 
 ```bash
-# macOS / Linux
 scripts/check.sh
 scripts/check.sh --quick
-
-# Windows (PowerShell)
-scripts\check.ps1
-scripts\check.ps1 -quick
 ```
 
 Individual checks:
@@ -200,33 +187,11 @@ scripts/prune-worktrees.sh --yes        # execute
 uv run meridian --help
 ```
 
-## Windows Support
+## Platform Support
 
-Windows is a supported platform. Spawn, state, and coordination layers run
-natively on Windows. The primary interactive TUI and PTY-based session capture
-require WSL — see Deferred items below.
-
-### CI
-
-A `windows-gate` job in `.github/workflows/meridian-ci.yml` runs on `windows-latest` on every push, executing `uv run pytest -n 0 -m "not slow"` serially (xdist worker startup can hang on Windows before pytest emits output).
-
-### Developer scripts
-
-PowerShell mirrors exist for the standard developer workflow:
-
-| Task | POSIX | Windows |
-|------|-------|---------|
-| Setup git hooks | `scripts/setup-hooks.sh` | `scripts\setup-hooks.ps1` |
-| Pre-push gate | `scripts/check.sh` | `scripts\check.ps1` |
-| Full preflight | `scripts/preflight.sh` | `scripts\preflight.ps1` |
-| Prune worktrees | `scripts/prune-worktrees.sh` | `scripts\prune-worktrees.ps1` |
-
-### Deferred items
-
-The following are explicitly out of scope and not implemented:
-
-- **ConPTY / terminal passthrough**: Primary-session TUI capture for Claude Code and Codex session-ID extraction relies on PTY semantics. Windows ConPTY support is not implemented — harness features that depend on PTY capture may not work correctly natively on Windows. WSL is the supported path for primary-session use on Windows.
-- **Full bash script parity**: Only the scripts listed above have PowerShell mirrors. `scripts/quality-issues.sh` and other helpers remain POSIX-only.
+Linux and macOS are supported. WSL is supported as a Linux environment. Native
+Windows was never made to work and is not planned; existing Windows branches and
+scripts are untested, best-effort legacy code.
 
 ## Workspace conventions
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,8 +76,7 @@ Read-only commands (`meridian spawn list`, `meridian config show`, etc.) do not 
 High-churn runtime state lives outside the repo, keyed by project UUID so the repo can be moved or renamed without losing history.
 
 ```text
-~/.meridian/                       # Unix/macOS default (see MERIDIAN_HOME)
-%LOCALAPPDATA%\meridian\           # Windows default
+~/.meridian/                       # Linux/macOS default (see MERIDIAN_HOME)
   projects/
     <uuid>/                        # one dir per project
       sessions.jsonl
@@ -191,7 +190,7 @@ Workspace config defines filesystem roots projected into harness launches. See
 ## Hooks
 
 Hooks are configured in any Meridian config file. See [hooks.md](hooks.md) for
-schema, event names, builtins, and cross-platform guidance.
+schema, event names, builtins, and shell behavior guidance.
 
 ## Context
 

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -33,7 +33,7 @@ resolved logical task cwd; it is not inherited.
 | `MERIDIAN_TASK_DIR` | Inherited source-edit directory; set/clear via `meridian task-dir` |
 | `MERIDIAN_TASK_CWD` | Bind-time alias for the child's resolved task cwd (not inherited) |
 | `MERIDIAN_CONFIG` | User config overlay path |
-| `MERIDIAN_HOME` | Override user state root (default `~/.meridian/` on Unix/macOS, `%LOCALAPPDATA%\meridian\` on Windows) |
+| `MERIDIAN_HOME` | Override user state root (default `~/.meridian/`) |
 | `MERIDIAN_RUNTIME_DIR` | Override the runtime state root. Absolute path = use as-is; relative path = resolve relative to repo root. Repo-owned default paths (`kb/`, `work/`, `archive/work/`) always stay in `.meridian/` regardless of this setting. |
 | `MERIDIAN_FS_DIR` | Resolved shared filesystem path for the current repo state root |
 | `MERIDIAN_ACTIVE_WORK_ID` | Active attached work item slug, when one exists |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,7 +15,7 @@ Meridian is a coordination layer — it needs at least one harness installed to 
 
 **Cursor** runs as a subprocess harness via `cursor agent`. Models are checked at spawn time — run `meridian mars models list --live` to confirm which cursor models are runnable on your installation.
 
-**Platform**: macOS, Linux, Windows, WSL.
+**Platform**: macOS, Linux, and Linux under WSL. Native Windows is not supported.
 
 ## Performance Tip: Keep Prompt Cache Warm
 

--- a/docs/harness-integration.md
+++ b/docs/harness-integration.md
@@ -406,13 +406,8 @@ for structured data — it's diagnostic only.
 **cwd**: Launch in `config.task_cwd` (the agent's working directory) when provided,
 falling back to `config.control_root`.
 
-**Process cancellation**: On `send_cancel()`, send SIGINT (POSIX) or
-`process.terminate()` (Windows). Wait up to 5 seconds for graceful shutdown,
-then SIGKILL/`process.kill()`.
-
-**Windows**: Use `asyncio.create_subprocess_exec()` with `PIPE` for stdin/stdout.
-On Windows, `signal.SIGINT` is not supported — use `process.terminate()` instead.
-Check `IS_WINDOWS` from `meridian.lib.platform`.
+**Process cancellation**: On `send_cancel()`, send SIGINT. Wait up to 5 seconds
+for graceful shutdown, then SIGKILL/`process.kill()`.
 
 **Env propagation**: Inherit parent env, apply adapter env overrides, block
 `MERIDIAN_ACTIVE_WORK_ID` and `MERIDIAN_ACTIVE_WORK_DIR` from child scope.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -87,25 +87,17 @@ If you omit `name` for a builtin hook, Meridian may synthesize a stable name fro
 
 ### Shell Behavior
 
-Hook `command` strings are executed via the platform default shell: `sh -c` on POSIX (Linux/macOS) and `cmd.exe /c` on Windows. This is standard Python `subprocess(shell=True)` behavior. Inline commands that rely on bash syntax — `&&`, `||`, `$()`, `[[`, or POSIX-only tools — will fail on Windows because `cmd.exe` does not understand them.
-
-For hooks that must run on both platforms, use a script file with an appropriate extension:
+Hook `command` strings are executed via `sh -c`. For non-trivial shell logic,
+use a script file instead of embedding it in TOML:
 
 ```toml
-# POSIX — shell script
 [[hooks]]
 name    = "check"
 command = "./scripts/check.sh"
 event   = "spawn.finalized"
-
-# Windows — batch file or PowerShell
-[[hooks]]
-name    = "check"
-command = "powershell -File scripts/check.ps1"
-event   = "spawn.finalized"
 ```
 
-If you only target one platform, inline commands are fine. If portability matters, point `command` at a script file rather than embedding shell syntax in TOML.
+Inline commands are fine when they remain short and readable.
 
 ### `repo` → `remote` Migration
 

--- a/docs/plans/thermo-nuclear-audit.md
+++ b/docs/plans/thermo-nuclear-audit.md
@@ -160,9 +160,8 @@ lock_split_brain true    # holder kept the old inode locked; second process lock
 Three divergent lock implementations exist; `session_store.py:307-343` privately
 implements the correct fstat-vs-stat revalidation loop, proving the codebase
 already pays for the fix. Corrected remedy (both panels): revalidation alone is
-insufficient and "only unlink while held" is not portable to Windows — give
-locks stable identities outside destructible directories (or never unlink lock
-files), then consolidate all three implementations into one parameterized
+insufficient — give locks stable identities outside destructible directories (or
+never unlink lock files), then consolidate all three implementations into one parameterized
 primitive preserving plugin timeout/shared-mode semantics. Deleting a lock file
 then degrades to a retry instead of a mutual-exclusion breach, regardless of
 caller discipline. The atomic-write half of the cluster ([48]/[65]/[66]) is the

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -56,7 +56,7 @@ from meridian.plugin_api import get_project_home, get_user_home
 # Resolve the per-machine state root for the current project
 runtime_root = get_project_home()
 
-# Resolve the user-level Meridian state root (~/.meridian or %LOCALAPPDATA%\meridian)
+# Resolve the user-level Meridian state root (~/.meridian by default)
 user_root = get_user_home()
 ```
 
@@ -110,7 +110,8 @@ command = "notify-send 'spawn done'"
 event   = "spawn.finalized"
 ```
 
-**Shell behavior:** The `command` string is passed to the platform default shell — `sh -c` on POSIX and `cmd.exe /c` on Windows. Inline bash syntax will not work on Windows. For cross-platform hooks, point `command` at a script file (`.sh`, `.ps1`, or `.bat`) rather than embedding shell syntax inline.
+**Shell behavior:** The `command` string is passed to `sh -c`. For non-trivial
+shell logic, point `command` at a script file rather than embedding it inline.
 
 A Python builtin-style hook using the plugin API (for hooks distributed as packages):
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -213,7 +213,9 @@ If multi-repo filesystem access is required, use a harness that supports workspa
 
 ## Spawn artifacts
 
-Each spawn writes artifacts to the user-level runtime directory, under `~/.meridian/projects/<uuid>/spawns/<spawn_id>/` on POSIX (or `%LOCALAPPDATA%\meridian\projects\<uuid>\spawns\<spawn_id>\` on Windows). Use `meridian spawn show ID` to read them without navigating the path directly.
+Each spawn writes artifacts under
+`~/.meridian/projects/<uuid>/spawns/<spawn_id>/`. Use `meridian spawn show ID`
+to read them without navigating the path directly.
 
 | File | Contents |
 | ---- | -------- |

--- a/src/meridian/AGENTS.md
+++ b/src/meridian/AGENTS.md
@@ -99,7 +99,7 @@ orphaned spawns.
 ## Related
 
 - `CLAUDE.md` → `AGENTS.md` — safety rules, design constraints, dev commands
-- `.context/CONTEXT.md` — design philosophy, logging, cross-platform paths
+- `.context/CONTEXT.md` — design philosophy, logging, path handling
 - `lib/launch/AGENTS.md` — composition seam; three driving adapters
 - `lib/harness/AGENTS.md` — translation pipeline; SpawnParams accounting
 - `lib/state/AGENTS.md` — file layout; atomic write invariants

--- a/src/meridian/lib/artifact/AGENTS.md
+++ b/src/meridian/lib/artifact/AGENTS.md
@@ -32,9 +32,10 @@ in-memory handle between commands.
 - **`tailscale serve --set-path` forwards the full path.** `_serve_dir.py` strips
   the `/<slug>` prefix in `translate_path` so root-serving backends resolve. Strip
   in path translation, not URL rewriting, so directory redirects keep the prefix.
-- **No parent-death linkage.** `launch_http_server` uses `start_new_session=True`
-  (POSIX) / `DETACHED_PROCESS` (Windows) with no `pdeathsig`. Adding linkage breaks
-  the feature: TTL + lazy GC *is* the cleanup mechanism.
+- **No parent-death linkage.** `launch_http_server` uses
+  `start_new_session=True`. The legacy native-Windows branch requests
+  `DETACHED_PROCESS` and is untested. Adding linkage breaks the feature: TTL +
+  lazy GC *is* the cleanup mechanism.
 - **Validate the slug at every trust boundary** before any Tailscale subprocess.
   A malformed/empty slug would produce `--set-path=/ off` and clobber a root
   handler. `is_valid_slug` runs at registration, teardown, URL build, and load.

--- a/src/meridian/lib/harness/.context/CONTEXT.md
+++ b/src/meridian/lib/harness/.context/CONTEXT.md
@@ -186,10 +186,10 @@ assistant text while building `report.md`. Child task text remains visible throu
 ### Claude: PTY Capture for Primary Session ID
 
 Claude's TUI emits its session ID to stdout only when stdout is a TTY. Meridian
-uses `pty.openpty()` (POSIX) to observe this output without the harness knowing
-it's captured. This is the minimum-intrusive mechanism for an otherwise unobservable
-value. Windows does not support PTY — Claude primary uses a fallback detection path
-(`session_detection.py`) on Windows.
+uses `pty.openpty()` to observe this output without the harness knowing it's
+captured. This is the minimum-intrusive mechanism for an otherwise unobservable
+value. The legacy native-Windows branch attempts a fallback detection path
+(`session_detection.py`) and is untested.
 
 ### Claude: Native Agent Routing Boundary
 

--- a/src/meridian/lib/harness/extractors/.context/CONTEXT.md
+++ b/src/meridian/lib/harness/extractors/.context/CONTEXT.md
@@ -57,15 +57,15 @@ files and matches against `child_cwd`:
 - **Pi**: scans `~/.meridian/meridian-pi/sessions/` for `*.jsonl` files whose first line
   is a `session` event with matching `cwd`. The Pi session directory is configurable via
   `PI_CODING_AGENT_SESSION_DIR` env var. Session files use `--` as path separator
-  (e.g., `home--jimyao--gitrepos--myproject--.jsonl`). On Windows, cwd matching is
-  case-insensitive.
+  (e.g., `home--jimyao--gitrepos--myproject--.jsonl`). The legacy native-Windows
+  branch uses case-insensitive cwd matching and is untested.
 
 ### Pi Session CWD Encoding
 
 Pi session files encode the cwd as a slugified path: `/` replaced with `--`, with a
 trailing `--`. The extractor normalizes both the launch cwd and the file-derived cwd
 through `_safe_resolve()` → `replace("\\", "/")` → `rstrip("/")` before comparison.
-This ensures path identity comparison works on both POSIX and Windows.
+This keeps persisted path identity comparisons separator-stable.
 
 This path is inherently racy — it relies on the harness having written files by the
 time this runs. The 15-minute window for OpenCode and the mtime-sorted scan for Claude/

--- a/src/meridian/lib/launch/process/.context/CONTEXT.md
+++ b/src/meridian/lib/launch/process/.context/CONTEXT.md
@@ -10,12 +10,14 @@ Selection order when output capture is requested (`output_log_path` is set):
 2. `SubprocessProcessLauncher` (PIPE_CAPTURE, captures to artifact) — fallback
 
 Selection order when no capture is needed (`output_log_path` is None):
-1. `WindowsConsoleLauncher` (NATIVE_INHERIT, no capture) — if `can_use_windows_console_launcher()`
+1. `WindowsConsoleLauncher` (NATIVE_INHERIT, no capture) — legacy, untested;
+   selected if `can_use_windows_console_launcher()`
 2. `PtyProcessLauncher` (PTY_MEDIATED, no capture) — elif `can_use_pty()`
 3. `SubprocessProcessLauncher` (NATIVE_INHERIT, no capture) — fallback
 
-The PTY launcher is preferred for POSIX interactive TUI harnesses. Windows console launcher
-handles Windows-specific console inheritance. Subprocess is the portable fallback.
+The PTY launcher is preferred for POSIX interactive TUI harnesses. The legacy
+Windows console launcher attempts native console inheritance; the subprocess
+launcher is the fallback.
 
 `captures_output_to_artifact` on `ProcessPlatformContract` is authoritative — callers must
 not assume capture based on launcher type alone.

--- a/src/meridian/lib/launch/process/AGENTS.md
+++ b/src/meridian/lib/launch/process/AGENTS.md
@@ -14,7 +14,7 @@ run_harness_process()
     │
     ├── session_scope()            ← open/close session store entry
     ├── lifecycle_service.start()  ← create spawn row
-    ├── select_process_backend()   ← pick {PTY, subprocess, Windows console}
+    ├── select_process_backend()   ← pick {PTY, subprocess, legacy Windows console}
     │
     ├── _execute_via_managed_attach()   ← PrimaryAttachLauncher path
     │       └── fallback on PrimaryAttachError → _execute_via_blackbox()
@@ -25,7 +25,7 @@ run_harness_process()
 ```
 
 **Backend selection rules:**
-- Windows: `WindowsConsoleLauncher`
+- Legacy native-Windows branch (untested): `WindowsConsoleLauncher`
 - POSIX + TTY available: `PtyProcessLauncher`
 - POSIX + no TTY (CI, piped): `SubprocessProcessLauncher`
 

--- a/src/meridian/lib/platform/.context/CONTEXT.md
+++ b/src/meridian/lib/platform/.context/CONTEXT.md
@@ -1,7 +1,7 @@
 # lib/platform/ — Context
 
-Centralizes all OS-specific code. Windows is a first-class product requirement —
-validate Windows behavior for any change touching paths, processes, or locking.
+Centralizes all OS-specific code. Linux and macOS are supported. Native-Windows
+branches are legacy, untested, and must not be expanded.
 
 ## Contracts
 
@@ -9,17 +9,17 @@ validate Windows behavior for any change touching paths, processes, or locking.
 
 POSIX-only stdlib modules (`fcntl`, `pty`, `termios`, `tty`) and Windows-only
 modules (`msvcrt`) must not be imported at module top-level outside `lib/platform/`.
-Two patterns are approved:
+Existing OS-specific boundaries use two patterns:
 
 **Pattern A — Deferred proxy** (shared use from multiple callers):
 ```python
-from meridian.lib.platform import fcntl, pty   # safe on Windows — forwards on first use
+from meridian.lib.platform import fcntl, pty   # deferred until first use
 ```
 These are `DeferredUnixModule` instances defined in `unix_modules.py` and re-exported
-from `__init__.py`. They raise `ImportError` on Windows only when actually called,
-not at import time.
+from `__init__.py`. The legacy native-Windows branch defers `ImportError` until a
+proxy is called; this branch is untested.
 
-**Pattern B — Function-local import** (single call site, Windows-only):
+**Pattern B — Function-local import** (existing Windows-only call site):
 ```python
 def _acquire_windows_lock(handle):
     import msvcrt as _msvcrt   # Windows-only, scoped to Windows code path
@@ -33,14 +33,15 @@ Never add a new top-level `import fcntl` or `import msvcrt` outside this module.
 from meridian.lib.platform import IS_WINDOWS, IS_POSIX
 ```
 
-Prefer these over `sys.platform == "win32"` comparisons anywhere in the codebase.
-Inline `sys.platform` checks are a refactor trigger.
+Do not add or expand native-Windows branches. Keep necessary OS detection
+centralized here; when maintaining an existing branch, prefer these over inline
+`sys.platform` comparisons.
 
 ### Home Directory
 
-`get_home_path()` checks `HOME` env var first, falls back to `Path.home()`. On
-Windows, `Path.home()` ignores `HOME` and queries Windows APIs — breaking test
-isolation. Always use `get_home_path()`, never `Path.home()` directly.
+`get_home_path()` checks `HOME` first, then falls back to `Path.home()`. Always
+use it instead of `Path.home()` directly so path resolution remains explicit and
+testable.
 
 ## File Locking (`locking.py`)
 
@@ -52,9 +53,9 @@ outermost `__exit__`.
 
 **POSIX:** `fcntl.flock(LOCK_EX)` — blocking until acquired.
 
-**Windows:** `msvcrt.locking(LK_NBLCK, 1)` with 50ms retry loop. Requires a
-non-zero-length file; implementation writes a guard byte and fsyncs before the first
-lock attempt. Always locks exactly 1 byte at offset 0.
+**Legacy Windows branch (untested):** `msvcrt.locking(LK_NBLCK, 1)` with a 50ms
+retry loop. It requires a non-zero-length file, writes a guard byte, and locks one
+byte at offset 0.
 
 `try_lock_file(path)` is non-blocking and yields `None` if the lock is already held.
 
@@ -81,8 +82,9 @@ birth-validated PID, and terminates the full target process group if the launche
 disappears first. It remains alive while any non-zombie process-group member exists,
 even if the scope root exits before its descendants.
 
-**Windows:** Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`. When Meridian
-exits, the OS closes the handle and kills all assigned processes automatically.
+**Legacy Windows branch (untested):** Job Object setup exists, but scoped
+termination currently routes to the psutil fallback because Job Object handle
+threading is not wired through.
 
 **Invariants:**
 - Scope snapshot must be persisted **before** `connection.stop()` — both connections
@@ -94,17 +96,17 @@ exits, the OS closes the handle and kills all assigned processes automatically.
 `terminate.py` is a backward-compat shim that delegates to `process_scope/fallback.py`.
 Existing callers (`runner_helpers.py`) work unchanged.
 
-## Windows Signal Behavior
+## Legacy Windows Signal Behavior (Untested)
 
 Three deviations from POSIX that cause silent failures if ignored:
 
 **`os.kill(pid, SIGINT)` is unreliable.** CPython maps it to `GenerateConsoleCtrlEvent(CTRL_C_EVENT)`,
-which only works when the target shares the same console process group. Subprocesses
-launched with `CREATE_NEW_PROCESS_GROUP` never receive it. Use `process.terminate()`
-on Windows instead.
+which only works when the target shares the same console process group. Existing
+branches use `process.terminate()` instead.
 
 **`loop.add_signal_handler()` is a no-op on Windows.** `asyncio.ProactorEventLoop`
-doesn't implement it. Use `signal.signal()` + `loop.call_soon_threadsafe()` instead:
+doesn't implement it. Existing branches use `signal.signal()` +
+`loop.call_soon_threadsafe()` instead:
 ```python
 def _handle(signum, frame):
     loop.call_soon_threadsafe(shutdown_event.set)
@@ -113,5 +115,4 @@ signal.signal(signal.SIGINT, _handle)   # must call from main thread
 
 **`os.kill(pid, SIGTERM)` works but is not graceful.** CPython maps it to
 `TerminateProcess()` — unconditional kill, no signal handler runs. It does not
-silently fail. Use `psutil.Process(pid).terminate()` for equivalent cross-platform
-behavior.
+silently fail. Existing branches use `psutil.Process(pid).terminate()` instead.

--- a/src/meridian/lib/platform/AGENTS.md
+++ b/src/meridian/lib/platform/AGENTS.md
@@ -4,9 +4,8 @@ All platform-specific OS code lives here. Everything else in the codebase should
 be platform-agnostic — if you're writing `sys.platform == "win32"` outside this
 module, that's a refactor trigger.
 
-Windows is a first-class product target. Validate Windows behavior for any change
-touching paths, processes, locking, or signal handling. Do not ship code that only
-works on POSIX.
+Meridian is POSIX-first: Linux and macOS are supported. Existing native-Windows
+branches are untested, best-effort legacy code; do not add or expand them.
 
 ## Mental Model
 
@@ -17,34 +16,35 @@ Two layers:
 
 2. **Process containment** (`process_scope/`) — ensures the full subprocess tree
    Meridian starts is killed on spawn completion, cancel, or crash. Three backends:
-   POSIX group kill, Windows Job Object, and a psutil fallback.
+   POSIX group kill, a legacy Windows Job Object branch, and a psutil fallback.
 
-## Import Rule: Never Import POSIX Modules Outside This Package
+## Import Rule: Keep OS-Specific Imports in This Package
 
 `fcntl`, `pty`, `termios`, `tty` are POSIX-only. `msvcrt` is Windows-only. Either:
 
 - **Deferred proxy** (shared callers): `from meridian.lib.platform import fcntl, pty`
-  — these are `DeferredUnixModule` instances that fail only when *called* on Windows,
-  not at import time.
-- **Function-local import** (single Windows-only path): `import msvcrt as _msvcrt`
-  inside the function that needs it.
+  — these are `DeferredUnixModule` instances that defer unsupported-module errors
+  until first use; the legacy native-Windows behavior is untested.
+- **Function-local import** (existing Windows-only path):
+  `import msvcrt as _msvcrt` inside the function that needs it.
 
 Never add a top-level `import fcntl` or `import msvcrt` outside this module.
 
 ## Key Rules
 
-**Use `IS_WINDOWS`/`IS_POSIX` for all OS detection.** Not `sys.platform == "win32"`.
-Inline `sys.platform` comparisons are a refactor trigger.
+**Do not add or expand native-Windows branches.** Keep necessary OS detection
+centralized here; when maintaining an existing branch, use
+`IS_WINDOWS`/`IS_POSIX`, not inline `sys.platform` comparisons.
 
-**Use `get_home_path()`, never `Path.home()`.** On Windows, `Path.home()` ignores
-the `HOME` env var and queries Windows APIs, breaking test isolation.
+**Use `get_home_path()`, never `Path.home()`.** The helper honors `HOME`, which
+keeps path resolution explicit and testable.
 
 **File locking (`locking.py`) has reentrancy semantics.** A thread that already holds
 the lock re-enters safely. The OS lock releases only when the outermost `__exit__` runs.
-On Windows, the implementation writes a guard byte and fsyncs before the first lock
-attempt — the file must be non-zero-length.
+The legacy Windows branch writes a guard byte and fsyncs before the first lock
+attempt; this behavior is untested.
 
-**Windows signal behavior diverges from POSIX in three ways that cause silent failures:**
+**Legacy Windows signal branches are untested.** Their intended behavior is:
 - `os.kill(pid, SIGINT)` is unreliable — use `process.terminate()` instead.
 - `loop.add_signal_handler()` is a no-op on ProactorEventLoop — use `signal.signal()` + `loop.call_soon_threadsafe()`.
 - `os.kill(pid, SIGTERM)` maps to `TerminateProcess()` — unconditional kill, no handler runs.
@@ -65,7 +65,7 @@ Existing callers work unchanged; new code should use `ScopedProcessHandle`.
 ## Entry Points
 
 - `__init__.py` — `IS_WINDOWS`, `IS_POSIX`, `get_home_path()`, deferred POSIX proxies
-- `locking.py` — `lock_file()`, `try_lock_file()`: cross-platform exclusive file locking
+- `locking.py` — `lock_file()`, `try_lock_file()`: advisory exclusive file locking
 - `process_scope/` — `ScopedProcessHandle`, `ProcessScopeSnapshot`, platform backends
 
 ## Depth

--- a/src/meridian/lib/platform/process_scope/.context/CONTEXT.md
+++ b/src/meridian/lib/platform/process_scope/.context/CONTEXT.md
@@ -55,7 +55,7 @@ the function still attempts `os.killpg()`. If the group has also dissolved
 (`ProcessLookupError`), a secondary full-table scan by PGID runs to catch orphaned
 processes that stayed in the group after reparenting (PROC-004 sweep).
 
-### Windows: Job Object Handle Lifetime
+### Legacy Windows Branch (Untested): Job Object Handle Lifetime
 
 `assign_to_new_job(pid)` returns `(job_name, job_handle)`. The handle **must
 stay alive** until the scope should be released — `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`

--- a/src/meridian/lib/platform/process_scope/AGENTS.md
+++ b/src/meridian/lib/platform/process_scope/AGENTS.md
@@ -6,6 +6,9 @@ Single-PID kill is not enough — reparented children escape it.
 
 Three backends behind one API seam (`ScopedProcessHandle.terminate()`):
 
+The Windows backend is legacy, untested code retained behind the platform seam;
+do not extend it as product support.
+
 | `containment` | Backend | Mechanism |
 |---|---|---|
 | `posix_pgid` | `posix.py` | `os.killpg()` — kills the entire process group |
@@ -39,7 +42,7 @@ that have reparented to PID 1. `SIGTERM` to the root PID only reaches the root �
 it's already dead, reparented children escape entirely. Use POSIX containment when
 available; psutil fallback is accepted as degraded.
 
-## Windows Job Object Handle Lifetime
+## Legacy Windows Job Object Handle Lifetime
 
 `assign_to_new_job(pid)` returns `(job_name, job_handle)`. The handle must stay alive —
 `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` kills all job members when the handle is garbage

--- a/src/meridian/lib/safety/.context/CONTEXT.md
+++ b/src/meridian/lib/safety/.context/CONTEXT.md
@@ -40,7 +40,8 @@ Injected env vars available to guardrail scripts:
 - `MERIDIAN_GUARDRAIL_REPORT_PATH` — optional report path
 
 **Command resolution:**
-- Windows: `.cmd`/`.bat` → `cmd.exe /d /c`; `.ps1` → `powershell.exe -NoProfile -NonInteractive -File`
+- Legacy native-Windows branch (untested): `.cmd`/`.bat` → `cmd.exe /d /c`;
+  `.ps1` → `powershell.exe -NoProfile -NonInteractive -File`
 - POSIX: executable bit → direct; else `bash <script>`; fallback on `OSError` → retry with `bash`
 
 Exit code conventions: non-zero → `GuardrailFailure`; timeout → 124; `OSError` → 127.

--- a/src/meridian/lib/state/.context/CONTEXT.md
+++ b/src/meridian/lib/state/.context/CONTEXT.md
@@ -80,8 +80,8 @@ All state files are written through `atomic.py`:
   write.
 - `atomic_publish_dir()`: require a nonexistent destination, rename a complete
   same-volume directory into place, then fsync the destination parent.
-- `append_text_line()`: opens in binary mode so `\n` is never translated to `\r\n`
-  on Windows. JSONL byte offsets must be stable across platforms.
+- `append_text_line()`: opens in binary mode so JSONL newline encoding and byte
+  offsets remain stable.
 
 Never write state files with plain `open()` + `write()`. Crash in the middle of a
 plain write leaves a partial file; partial state.json will fail Pydantic validation
@@ -183,7 +183,8 @@ the terminal state. The managed tier used depends on how much metadata is readab
 
 Use `platform.locking.lock_file(path)` for all cross-process locking:
 - POSIX: `fcntl.flock(LOCK_EX)` — advisory, kernel-backed
-- Windows: `msvcrt.locking()` with retry loop (50 ms sleep)
+- Legacy native-Windows branch (untested): `msvcrt.locking()` with retry loop
+  (50 ms sleep)
 
 Thread-local reentrancy: a thread that already holds the lock can re-enter on the
 same path without deadlocking. Do not use `threading.Lock` or `fcntl` directly —
@@ -202,15 +203,14 @@ worktrees. Archiving or reopening a work item clears `pending`.
 **Path separator normalization**: `WorktreeMetadata.path` and `.repo_path` normalize
 backslash separators to POSIX (forward slash) at the Pydantic validation boundary via
 `@field_validator(..., mode="before")`. The coercion function `_coerce_worktree_metadata()`
-also detects separator normalization and marks legacy records for rewrite. This ensures
-stored metadata is stable when written on Windows and read elsewhere.
+also detects separator normalization and marks legacy records for rewrite. This keeps
+stored metadata separator-stable.
 
 ### User-Level Storage for New Features
 
 New features that need user-level storage (git clones, cache, custom data) go under
 `get_user_home()` from `user_paths.py`. Do not hardcode `~/.meridian/` or introduce
-new `LOCALAPPDATA` / `XDG_DATA_HOME` branches. `get_user_home()` handles all
-platform variants correctly.
+new OS-specific home-directory branches.
 
 ### Anti-Patterns
 

--- a/src/meridian/lib/state/AGENTS.md
+++ b/src/meridian/lib/state/AGENTS.md
@@ -60,8 +60,8 @@ All state writes go through `atomic.py`. Never write state files with plain `ope
   exists — never a partial write.
 - `atomic_publish_dir()` — rename a complete same-volume stage into a destination
   that must not exist, then fsync the publication parent.
-- `append_text_line()` — binary mode so `\n` is never translated to `\r\n` on
-  Windows. JSONL byte offsets must be stable across platforms.
+- `append_text_line()` — binary mode so JSONL newline encoding and byte offsets
+  remain stable.
 
 A crash in the middle of a plain `open()` write leaves a partial file; partial
 `state.json` fails Pydantic validation on next read.
@@ -118,7 +118,7 @@ spawn ID allocation, initial row publication, and abandoned-stage GC. Later muta
 use `write_state_locked()` (`state.lock`).
 
 **Don't hardcode `~/.meridian/`** — use `get_user_home()` from `user_paths.py`.
-It handles `MERIDIAN_HOME`, Windows `%LOCALAPPDATA%`, and POSIX `~` correctly.
+It honors `MERIDIAN_HOME` and centralizes home resolution.
 
 ## Depth
 

--- a/src/meridian/lib/streaming/.context/CONTEXT.md
+++ b/src/meridian/lib/streaming/.context/CONTEXT.md
@@ -146,13 +146,15 @@ Inject flows through the control socket:
 
 ```
 meridian spawn inject <id> --message "..."
-  → control.sock (POSIX) or control.sock.port (Windows)
+  → control.sock
   → ControlSocketServer._handle_client()
   → SpawnManager.inject()
     → ControlActionCoordinator.run_action()  — serializes concurrent actions
     → _record_inbound()                       — appends to inbound.jsonl
     → connection.send_user_message(message)
 ```
+
+The legacy native-Windows branch uses `control.sock.port` and is untested.
 
 All control actions (inject, interrupt, permission reply, user input reply) are
 serialized through `ControlActionCoordinator`. Concurrent actions queue behind it —

--- a/src/meridian/lib/streaming/.context/pi-drain.md
+++ b/src/meridian/lib/streaming/.context/pi-drain.md
@@ -124,8 +124,8 @@ policy:
 - **POSIX**: iterates captured process group IDs, sends `SIGTERM` via `os.killpg()`,
   waits 250ms, confirms liveness with `os.killpg(pgid, 0)`, then sends `SIGKILL` if
   still alive
-- **Windows/fallback**: uses `terminate_tree_sync()` from
-  `meridian.lib.platform.process_scope.fallback`
+- **Legacy native-Windows branch (untested) / fallback**: uses
+  `terminate_tree_sync()` from `meridian.lib.platform.process_scope.fallback`
 
 If no process metadata is available, a warning is logged but no cleanup is attempted —
 the processes are orphaned. Canonical persisted-descendant cancellation still runs first,

--- a/src/meridian/plugin_api/AGENTS.md
+++ b/src/meridian/plugin_api/AGENTS.md
@@ -12,7 +12,7 @@ External plugins follow the same rule: import `Hook`, `HookContext`, etc. from `
 
 - `types.py` — `Hook`, `HookContext`, `HookResult`, `HookEventName`, `HookOutcome`, `FailurePolicy` — the hook contract types
 - `state.py` — `get_project_home()`, `get_user_home()` — state root access
-- `fs.py` — `file_lock()` — cross-platform file locking for plugins
+- `fs.py` — `file_lock()` — advisory file locking for plugins
 - `git.py` — `resolve_clone_path()` — git clone path helpers
 - `config.py` — `get_user_config()` — user config access
 


### PR DESCRIPTION
## Why

The 2026-07-17 platform decision (root AGENTS.md, 924cae1d): POSIX-first — native Windows was never made to work and is not planned. The rest of the tree still claimed native Windows support (DEVELOPMENT.md 'Windows is a supported platform', PowerShell mirror tables, subsystem AGENTS.md/.context portability claims).

## Summary

Doc-only sweep, 25 files, +107/−144: deletes the DEVELOPMENT.md Windows Support section and PowerShell command mirrors; reframes platform/, state/, streaming/, launch/ AGENTS.md + .context portability language to the honest stance (existing `os.name` branches: untested, best-effort); keeps WSL guidance (WSL is Linux).

Out of scope (reported, untouched): `lib/ops/context.py` code comment claiming Windows first-class; `uv.lock` Win32 wheels; CI windows-gate lane (being handled in the #375 lane — demoted to non-blocking).

## Verification

Doc-only (`git diff --check` clean; `meridian kg check` green on all changed files). Two adversarial review rounds during the sweep; findings fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)