### PR TITLE
Harden Claude/Codex/OpenCode death & inject contracts (zoom-out of #443)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 - Retire dead Pi notification/subspawn lifecycle machinery: the real Pi runtime never emits `meridian.notification.*` / `meridian.subspawn.*` events, so the pending-notification ledger and `pi_notification_timeout` gating are removed. Tracked-work wake continues via persisted-descendant discovery, the direct `meridian-spawn-watch` follow-up turn, and `last-notification.json` epoch gating. (#440)
+- Codex resident spawns: a resolved terminal outcome (including a succeeded turn) is no longer overwritten by a late generic connection-close when the backend dies; backend death with tracked children now reports `backend_dead_while_awaiting_done` instead of the raw WebSocket-close message.
+- OpenCode process death now preserves the subprocess exit code and stderr in the terminal outcome instead of collapsing to a generic `connection_closed_without_terminal_event`.
+- Claude connection death now emits a canonical `error/connectionClosed` event carrying exit code and stderr, so death diagnostics survive terminal classification.
+- OpenCode `response.completed` removed from the accepted event taxonomy — the real runtime never emits it.
 
 ## [0.3.35] - 2026-07-17
 

--- a/src/meridian/lib/harness/.context/CONTEXT.md
+++ b/src/meridian/lib/harness/.context/CONTEXT.md
@@ -175,7 +175,7 @@ specific evidence already recorded.
 
 | Harness | Unexpected death delivered to the drain |
 |---|---|
-| Claude | Non-zero subprocess exit at stdout EOF yields `error/connectionClosed` with the exit code in `message`, then the iterator ends. Stdout reader failure yields the same event with the read error. Stderr remains in `stderr.log`; it is not copied into the event. |
+| Claude | Non-zero subprocess exit at stdout EOF yields `error/connectionClosed` with the exit code and captured stderr excerpt when present, then the iterator ends. Stdout reader failure yields the same event with the read error. |
 | Codex | Unexpected WebSocket reader failure or liveness timeout queues `error/connectionClosed`, then queue EOF. A clean WebSocket close queues EOF without a terminal event. Startup process exit is raised before draining and includes exit code plus the captured stderr excerpt when present. |
 | OpenCode | A detected backend process exit yields `error/connectionClosed` with the exit code and captured stderr excerpt when present, then the SSE iterator ends. SSE liveness failure without a detected process exit currently ends without a terminal event. |
 | Cursor | Non-zero subprocess exit at stdout EOF yields `error/connectionClosed` with the exit code, then the iterator ends. Exit code zero is the success boundary and ends without a terminal event. |

--- a/src/meridian/lib/harness/.context/CONTEXT.md
+++ b/src/meridian/lib/harness/.context/CONTEXT.md
@@ -166,6 +166,40 @@ The drain loop persists all child events before classification; scope filtering 
 decides whether an event can end the parent turn, clear a pending signal, update the
 parent activity state, or contribute to the parent report.
 
+### Connection Death Shape
+
+A connection must deliver its most diagnostic terminal evidence before iterator EOF.
+If a harness has a specific terminal classification and a later generic close event,
+the specific classification wins; generic transport failure must not shadow more
+specific evidence already recorded.
+
+| Harness | Unexpected death delivered to the drain |
+|---|---|
+| Claude | Non-zero subprocess exit at stdout EOF yields `error/connectionClosed` with the exit code in `message`, then the iterator ends. Stdout reader failure yields the same event with the read error. Stderr remains in `stderr.log`; it is not copied into the event. |
+| Codex | Unexpected WebSocket reader failure or liveness timeout queues `error/connectionClosed`, then queue EOF. A clean WebSocket close queues EOF without a terminal event. Startup process exit is raised before draining and includes exit code plus the captured stderr excerpt when present. |
+| OpenCode | A detected backend process exit yields `error/connectionClosed` with the exit code and captured stderr excerpt when present, then the SSE iterator ends. SSE liveness failure without a detected process exit currently ends without a terminal event. |
+| Cursor | Non-zero subprocess exit at stdout EOF yields `error/connectionClosed` with the exit code, then the iterator ends. Exit code zero is the success boundary and ends without a terminal event. |
+| Pi | Non-zero subprocess exit yields `error/connectionClosed` with the exit code and captured stderr when present, then the iterator ends. Pi completion remains subject to its quiescence profile rather than raw EOF. |
+
+Tests for death classification must preserve that ordering: process exit and its code
+become observable before fake iterator exhaustion. Clean EOF is a different contract.
+
+### Inject Acknowledgment
+
+`send_user_message()` success is a transport-level delivery claim, not proof that the
+model observed or executed the message.
+
+| Harness | What a successful return means |
+|---|---|
+| Claude | The NDJSON user frame was written to subprocess stdin and `drain()` completed. Claude sends no correlated acknowledgment; busy-turn acceptance remains an open runtime question. |
+| Codex | The app-server returned a successful JSON-RPC result for `turn/steer` or `turn/start`. A JSON-RPC error raises instead of becoming a harness terminal event. |
+| OpenCode | A session-message HTTP endpoint returned an accepted success status. This does not prove that an assistant turn was scheduled or executed. |
+| Cursor | Unsupported; `send_user_message()` raises. |
+| Pi | The matching prompt-command RPC response reported success. Initial prompt delivery is intentionally not acknowledgment-blocking. |
+
+The generic control endpoint acknowledges only after the applicable connection method
+returns. Do not describe that acknowledgment as semantic execution evidence.
+
 Codex keeps a conservative unscoped fallback: if a `turn/completed` event has no
 thread ID, it still counts as terminal for the parent. OpenCode does not use that
 fallback once the parent session is known, because its global SSE stream can emit

--- a/src/meridian/lib/harness/connections/claude_ws.py
+++ b/src/meridian/lib/harness/connections/claude_ws.py
@@ -10,6 +10,7 @@ import signal
 from asyncio.subprocess import PIPE, Process
 from collections.abc import AsyncIterator
 from io import BufferedWriter
+from pathlib import Path
 from typing import TYPE_CHECKING, Final, cast
 
 if TYPE_CHECKING:
@@ -51,6 +52,7 @@ logger = logging.getLogger(__name__)
 _PROCESS_KILL_GRACE_SECONDS: Final[float] = 10.0
 _STDOUT_READLINE_LIMIT: Final[int] = 128 * 1024 * 1024  # 128 MiB
 _VERSION_CHECK_TIMEOUT_SECONDS: Final[float] = 5.0
+_STDERR_MAX_BYTES: Final[int] = 16 * 1024
 _TESTED_VERSION_PREFIXES: Final[tuple[str, ...]] = ("1.", "2.")
 _HARNESS_NAME: Final[str] = HarnessId.CLAUDE.value
 _BLOCKED_CHILD_ENV_VARS: Final[frozenset[str]] = frozenset(
@@ -104,6 +106,7 @@ class ClaudeConnection(HarnessConnection[ResolvedLaunchSpec]):
         self._send_lock = asyncio.Lock()
         self._stop_lock = asyncio.Lock()
         self._stderr_handle: BufferedWriter | None = None
+        self._stderr_log_path: Path | None = None
         self._protocol_validated = False
         self._event_stream_started = False
         self._tracer: DebugTracer | None = None
@@ -245,6 +248,9 @@ class ClaudeConnection(HarnessConnection[ResolvedLaunchSpec]):
                         return_code = await process.wait()
                     if return_code != 0 and self._state not in {"stopping", "stopped"}:
                         detail = f"Claude subprocess exited with code {return_code}."
+                        stderr_excerpt = self._read_stderr_excerpt()
+                        if stderr_excerpt:
+                            detail = f"{detail}\n\nClaude subprocess stderr:\n{stderr_excerpt}"
                         self._mark_failed(detail)
                         yield self._error_event(detail)
                     return
@@ -351,6 +357,7 @@ class ClaudeConnection(HarnessConnection[ResolvedLaunchSpec]):
         spawn_dir.mkdir(parents=True, exist_ok=True)
 
         stderr_path = spawn_dir / "stderr.log"
+        self._stderr_log_path = stderr_path
         self._stderr_handle = stderr_path.open("ab")
 
         command = self._build_command(config, spec)
@@ -447,6 +454,20 @@ class ClaudeConnection(HarnessConnection[ResolvedLaunchSpec]):
         if self._stderr_handle is not None:
             self._stderr_handle.close()
             self._stderr_handle = None
+        self._stderr_log_path = None
+
+    def _read_stderr_excerpt(self) -> str:
+        if self._stderr_handle is not None:
+            self._stderr_handle.flush()
+        path = self._stderr_log_path
+        if path is None or not path.exists():
+            return ""
+        with path.open("rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            end_offset = handle.tell()
+            handle.seek(max(0, end_offset - _STDERR_MAX_BYTES), os.SEEK_SET)
+            data = handle.read()
+        return data.decode("utf-8", errors="replace").strip()
 
     def _parse_stdout_line(self, line: str) -> list[HarnessEvent]:
         """Parse one line of NDJSON from Claude stdout into HarnessEvent objects."""
@@ -484,9 +505,12 @@ class ClaudeConnection(HarnessConnection[ResolvedLaunchSpec]):
         ]
 
     def _error_event(self, message: str, raw_text: str | None = None) -> HarnessEvent:
-        payload: dict[str, object] = {"type": "error", "message": message}
+        payload: dict[str, object] = {
+            "type": "error/connectionClosed",
+            "message": message,
+        }
         return HarnessEvent(
-            event_type="error",
+            event_type="error/connectionClosed",
             payload=payload,
             harness_id=_HARNESS_NAME,
             raw_text=raw_text,

--- a/src/meridian/lib/harness/connections/opencode_http.py
+++ b/src/meridian/lib/harness/connections/opencode_http.py
@@ -402,6 +402,11 @@ class OpenCodeConnection(HarnessConnection[ResolvedLaunchSpec]):
         sse_data_lines: list[str] = []
 
         while self._state in ("connected", "stopping"):
+            if self._process_exited():
+                event = self._process_exit_event()
+                if event is not None:
+                    yield event
+                return
             if self._liveness.evaluate() in (
                 LivenessDecision.BACKEND_DEAD,
                 LivenessDecision.STREAM_STALLED,
@@ -412,14 +417,16 @@ class OpenCodeConnection(HarnessConnection[ResolvedLaunchSpec]):
                 )
                 self._set_failed()
                 return
-            if self._process_exited():
-                self._set_failed()
-                return
 
             self._liveness.mark_activity_if_idle()
             try:
                 response = await self._liveness.wait_for_activity(self._open_event_stream())
             except EventStreamLivenessTimeout:
+                if self._process_exited():
+                    event = self._process_exit_event()
+                    if event is not None:
+                        yield event
+                    return
                 logger.warning(
                     "OpenCode event stream liveness timeout after %.1fs without events",
                     self._LIVENESS_TIMEOUT_SECONDS,
@@ -430,7 +437,9 @@ class OpenCodeConnection(HarnessConnection[ResolvedLaunchSpec]):
                 if self._state in ("stopping", "stopped"):
                     return
                 if self._process_exited():
-                    self._set_failed()
+                    event = self._process_exit_event()
+                    if event is not None:
+                        yield event
                     return
                 logger.warning("OpenCode event stream dropped; reconnecting: %s", exc)
                 await asyncio.sleep(self._EVENT_RETRY_DELAY_SECONDS)
@@ -444,6 +453,11 @@ class OpenCodeConnection(HarnessConnection[ResolvedLaunchSpec]):
                             response.content.read(4096)
                         )
                     except EventStreamLivenessTimeout:
+                        if self._process_exited():
+                            event = self._process_exit_event()
+                            if event is not None:
+                                yield event
+                            return
                         logger.warning(
                             "OpenCode event stream liveness timeout after %.1fs without events",
                             self._LIVENESS_TIMEOUT_SECONDS,
@@ -1076,6 +1090,24 @@ class OpenCodeConnection(HarnessConnection[ResolvedLaunchSpec]):
         if process is None:
             return False
         return process.returncode is not None
+
+    def _process_exit_event(self) -> HarnessEvent | None:
+        if self._state in {"stopping", "stopped"}:
+            return None
+        process = self._process
+        return_code = process.returncode if process is not None else None
+        if return_code is None:
+            raise RuntimeError("OpenCode process-exit event requested before process exit")
+        detail = f"OpenCode subprocess exited with code {return_code}."
+        stderr_excerpt = self._read_startup_stderr_excerpt()
+        if stderr_excerpt:
+            detail = f"{detail}\n\nOpenCode subprocess stderr:\n{stderr_excerpt}"
+        self._set_failed()
+        return HarnessEvent(
+            event_type="error/connectionClosed",
+            payload={"type": "error/connectionClosed", "message": detail},
+            harness_id=self.harness_id.value,
+        )
 
     def _set_failed(self) -> None:
         if self._state == "failed":

--- a/src/meridian/lib/harness/extractors/opencode.py
+++ b/src/meridian/lib/harness/extractors/opencode.py
@@ -389,7 +389,7 @@ def _extract_opencode_usage(artifacts: ArtifactStore, spawn_id: SpawnId) -> Toke
             .strip()
             .lower()
         )
-        if event_type not in {"session.idle", "message.updated", "response.completed"}:
+        if event_type not in {"session.idle", "message.updated"}:
             continue
         usage = _try_parse_opencode_usage(payload)
         if usage is not None:

--- a/src/meridian/lib/harness/semantics.py
+++ b/src/meridian/lib/harness/semantics.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
+from enum import StrEnum
 from typing import TYPE_CHECKING, Literal, cast
 
 from meridian.lib.core.domain import SpawnStatus
@@ -18,12 +19,18 @@ if TYPE_CHECKING:
 ActivityState = Literal["turn_active", "idle"]
 
 
+class TerminalOutcomeCause(StrEnum):
+    """Typed cause used only when completion policy may refine an outcome."""
+
+    REPLACEABLE_TRANSPORT_CLOSE = "replaceable_transport_close"
+
+
 @dataclass(frozen=True)
 class TerminalEventOutcome:
     status: SpawnStatus
     exit_code: int
     error: str | None = None
-    generic_connection_close: bool = False
+    cause: TerminalOutcomeCause | None = None
 
 
 @dataclass(frozen=True)
@@ -122,11 +129,16 @@ def terminal_outcome(
 
     if event.event_type == "error/connectionClosed":
         error = _stringify_terminal_error(event.payload.get("message")) or "connection_closed"
+        cause = (
+            TerminalOutcomeCause.REPLACEABLE_TRANSPORT_CLOSE
+            if event.harness_id == HarnessId.CODEX.value
+            else None
+        )
         return TerminalEventOutcome(
             status="failed",
             exit_code=1,
             error=error,
-            generic_connection_close=True,
+            cause=cause,
         )
 
     if event.harness_id == HarnessId.CLAUDE.value and event.event_type == "result":

--- a/src/meridian/lib/harness/semantics.py
+++ b/src/meridian/lib/harness/semantics.py
@@ -23,6 +23,7 @@ class TerminalEventOutcome:
     status: SpawnStatus
     exit_code: int
     error: str | None = None
+    generic_connection_close: bool = False
 
 
 @dataclass(frozen=True)
@@ -125,6 +126,7 @@ def terminal_outcome(
             status="failed",
             exit_code=1,
             error=error,
+            generic_connection_close=True,
         )
 
     if event.harness_id == HarnessId.CLAUDE.value and event.event_type == "result":

--- a/src/meridian/lib/streaming/.context/CONTEXT.md
+++ b/src/meridian/lib/streaming/.context/CONTEXT.md
@@ -120,6 +120,13 @@ otherwise an authoritative stop outcome (from `stop_spawn()`) wins; otherwise th
 drain classification stands. Publication is idempotent — `terminal_published` on
 `SpawnSession` guards against double publication.
 
+Resident completion also resolves transport death before that publication barrier.
+When a successful turn is being held for persisted descendant work and the backend
+then emits a generic `error/connectionClosed`, the resident profile publishes
+`backend_dead_while_awaiting_done` rather than the transport's incidental close
+message. Harness-specific terminal failures remain authoritative. A success already
+recorded for publication is still protected by the generic success-first barrier.
+
 ### Subscriber Queue Backpressure
 
 The subscriber queue (`maxsize=1000`) drops non-sentinel events on `QueueFull`

--- a/src/meridian/lib/streaming/resident_drain.py
+++ b/src/meridian/lib/streaming/resident_drain.py
@@ -49,6 +49,12 @@ if TYPE_CHECKING:
 
 logger = structlog.get_logger()
 
+_BACKEND_DEAD_WHILE_AWAITING_DONE = TerminalEventOutcome(
+    status="failed",
+    exit_code=1,
+    error="backend_dead_while_awaiting_done",
+)
+
 
 class _ResidentCompletionEvidence:
     """Assess the reconciled, transitive persisted descendant tree."""
@@ -167,11 +173,7 @@ class _ResidentCompletionProfile:
         if intentional_stop:
             return state.candidate
         if self._resident_health_status() == LivenessDecision.BACKEND_DEAD:
-            return TerminalEventOutcome(
-                status="failed",
-                exit_code=1,
-                error="backend_dead_while_awaiting_done",
-            )
+            return _BACKEND_DEAD_WHILE_AWAITING_DONE
         return TerminalEventOutcome(
             status="failed",
             exit_code=1,
@@ -225,6 +227,15 @@ class _ResidentCompletionProfile:
             return ProfileDecision(action="clear", emit_turn_boundary=action.emit_turn_boundary)
         if outcome.status != "succeeded":
             self.clear()
+            if (
+                context.candidate is not None
+                and outcome.generic_connection_close
+                and self._resident_health_status() == LivenessDecision.BACKEND_DEAD
+            ):
+                return ProfileDecision(
+                    action="fail",
+                    outcome=_BACKEND_DEAD_WHILE_AWAITING_DONE,
+                )
             return ProfileDecision(action="fail", outcome=outcome)
         if context.directives.rearm:
             self._mark_rearmed(context.now)

--- a/src/meridian/lib/streaming/resident_drain.py
+++ b/src/meridian/lib/streaming/resident_drain.py
@@ -10,7 +10,7 @@ import structlog
 
 from meridian.lib.core.types import SpawnId
 from meridian.lib.harness.connections.liveness import LivenessDecision
-from meridian.lib.harness.semantics import TerminalEventOutcome
+from meridian.lib.harness.semantics import TerminalEventOutcome, TerminalOutcomeCause
 from meridian.lib.state import spawn_store
 from meridian.lib.state.spawn_signals import consume_resident_signals
 from meridian.lib.streaming.completion_contracts import (
@@ -229,7 +229,7 @@ class _ResidentCompletionProfile:
             self.clear()
             if (
                 context.candidate is not None
-                and outcome.generic_connection_close
+                and outcome.cause is TerminalOutcomeCause.REPLACEABLE_TRANSPORT_CLOSE
                 and self._resident_health_status() == LivenessDecision.BACKEND_DEAD
             ):
                 return ProfileDecision(

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -28,18 +28,21 @@ tests/smoke/        Markdown guides for manual CLI verification.
 For spawn state, prefer v2 state helpers (`create_lifecycle_service`,
 `spawn_store.get_spawn`) or direct `state.json` assertions.
 
-### Pi Fake Fidelity
+### Fake Fidelity
 
-`tests/support/pi.py` provides `FakePiConnection` and `PiDrainScenario`. Real Pi
-RPC connections emit an `error/connectionClosed` event with the Pi subprocess exit
-code before the event iterator reaches EOF. Test fakes must model this when testing
-exit classification. Use the fidelity helpers:
+When exit classification depends on event ordering, fakes must reproduce the real
+connection's pre-EOF death shape. A non-zero subprocess exit is not clean iterator
+exhaustion: the exit code becomes an `error/connectionClosed` event before the
+iterator ends. This invariant applies to every adapter that synthesizes such an
+event. Do not replace it with direct `handle_stream_exit(None)` calls; that skips the
+precedence path where a generic process-exit failure is recorded before stream exit.
 
-- `pi_process_exit_event(return_code)` — builds the `error/connectionClosed`
-  event with the canonical `Pi subprocess exited with code <N>.` message.
-- `write_pi_bash_record(runtime_root, spawn_id)` — writes managed-bash disk
-  evidence for Pi private work that is not a Meridian spawn row.
+Worked helpers:
 
-Do not test Pi exit classification using only clean iterator exhaustion or direct
-`handle_stream_exit(None)` — that shape avoids the real precedence path where the
-generic process-exit failure arrives before stream exit.
+- `tests/support/pi.py`: `pi_process_exit_event(return_code)` builds Pi's canonical
+  close event, and `write_pi_bash_record(...)` supplies managed-bash disk evidence.
+- `tests/support/opencode.py`: `FakeOpenCodeProcess.exit(return_code)` makes backend
+  death observable while the OpenCode event iterator is still active.
+
+Add fidelity only for a real behavior under test. Do not pre-build alternate close,
+timeout, or reader-error scenarios without a contract they protect.

--- a/tests/integration/harness/test_opencode_connection.py
+++ b/tests/integration/harness/test_opencode_connection.py
@@ -18,6 +18,7 @@ from meridian.lib.harness.connections.base import (
     HarnessEvent,
 )
 from meridian.lib.harness.connections.opencode_http import OpenCodeConnection
+from meridian.lib.harness.semantics import terminal_outcome
 from meridian.lib.launch.launch_types import ResolvedLaunchSpec
 from meridian.lib.platform.detached_process import ParentDeathLink
 from meridian.lib.platform.process_scope import ProcessScopeSnapshot, ScopedProcessHandle
@@ -27,26 +28,10 @@ from meridian.lib.safety.permissions import (
 from meridian.lib.state.paths import resolve_spawn_log_dir
 from tests.support.async_determinism import AsyncDeterminism
 from tests.support.fakes import FakeClock
+from tests.support.opencode import FakeOpenCodeProcess
 
 OPENCODE_ACTIVITY_IDLE_EVENT = "session.idle"
 OPENCODE_ACTIVITY_ERROR_EVENT = "session.error"
-
-
-class _FakeProcess:
-    def __init__(self) -> None:
-        self.pid = 9001
-        self.returncode: int | None = None
-
-    def terminate(self) -> None:
-        self.returncode = 0
-
-    def kill(self) -> None:
-        self.returncode = -9
-
-    async def wait(self) -> int:
-        if self.returncode is None:
-            self.returncode = 0
-        return self.returncode
 
 
 class _StartProbeOpenCodeConnection(OpenCodeConnection):
@@ -80,7 +65,7 @@ class _StartProbeOpenCodeConnection(OpenCodeConnection):
     async def _launch_process(self, config: ConnectionConfig, spec: ResolvedLaunchSpec) -> None:
         _ = config, spec
         self.startup_events.append("launch")
-        self._process = _FakeProcess()
+        self._process = FakeOpenCodeProcess()
 
     async def _wait_for_ready(self, *, timeout_seconds: float) -> None:
         if self._get_responses is not None:
@@ -143,17 +128,39 @@ class _SseResponse:
         self.closed = True
 
 
+class _ProcessDeathSseContent:
+    def __init__(self, process: FakeOpenCodeProcess, return_code: int) -> None:
+        self._process = process
+        self._return_code = return_code
+        self._sent_event = False
+
+    async def read(self, _size: int) -> bytes:
+        if not self._sent_event:
+            self._sent_event = True
+            return b'{"type":"session.updated","sessionID":"sess-liveness"}\n'
+        self._process.exit(self._return_code)
+        return b""
+
+
+class _ProcessDeathSseResponse:
+    def __init__(self, process: FakeOpenCodeProcess, return_code: int) -> None:
+        self.content = _ProcessDeathSseContent(process, return_code)
+
+    def close(self) -> None:
+        return None
+
+
 class _LivenessProbeOpenCodeConnection(OpenCodeConnection):
     def __init__(
         self,
-        responses: list[_SseResponse | Exception],
+        responses: list[_SseResponse | _ProcessDeathSseResponse | Exception],
         *,
         block_open: bool = False,
     ) -> None:
         super().__init__()
         self._state = "connected"
         self._session_id = "sess-liveness"
-        self._process = _FakeProcess()
+        self._process = FakeOpenCodeProcess()
         self._responses = iter(responses)
         self._block_open = block_open
         self.open_count = 0
@@ -233,6 +240,40 @@ async def test_opencode_events_fail_after_liveness_timeout_without_events(
     assert events == []
     assert connection.open_count > 1
     assert connection.state == "failed"
+
+
+@pytest.mark.asyncio
+async def test_opencode_process_death_emits_terminal_outcome_with_exit_diagnostics(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    process = FakeOpenCodeProcess()
+    response = _ProcessDeathSseResponse(process, return_code=17)
+    connection = _LivenessProbeOpenCodeConnection(responses=[response])
+    connection._process = process
+    connection._stderr_log_path = tmp_path / "stderr.log"
+    connection._stderr_log_path.write_text("fatal backend detail\n", encoding="utf-8")
+    connection._stderr_read_offset = 0
+
+    monkeypatch.setattr(OpenCodeConnection, "_EVENT_RETRY_DELAY_SECONDS", 0.0)
+
+    events = await _collect_opencode_events(connection)
+
+    assert [event.event_type for event in events] == [
+        "session.updated",
+        "error/connectionClosed",
+    ]
+    outcome = terminal_outcome(
+        events[-1],
+        primary_event_scope=connection.primary_event_scope,
+    )
+    assert outcome is not None
+    assert outcome.status == "failed"
+    assert outcome.error == (
+        "OpenCode subprocess exited with code 17.\n\n"
+        "OpenCode subprocess stderr:\n"
+        "fatal backend detail"
+    )
 
 
 @pytest.mark.asyncio
@@ -324,7 +365,7 @@ def test_opencode_health_fails_when_event_liveness_expires(
 ) -> None:
     connection = OpenCodeConnection()
     connection._state = "connected"
-    connection._process = _FakeProcess()
+    connection._process = FakeOpenCodeProcess()
     connection._last_health_ok = True
 
     monkeypatch.setattr(OpenCodeConnection, "_LIVENESS_TIMEOUT_SECONDS", 1.0)
@@ -432,7 +473,7 @@ async def test_opencode_launch_process_passes_env_overrides_to_managed_backend(
     spec = ResolvedLaunchSpec(
         permission_resolver=UnsafeNoOpPermissionResolver(_suppress_warning=True),
     )
-    fake_process = _FakeProcess()
+    fake_process = FakeOpenCodeProcess()
     captured: dict[str, object] = {}
 
     def _fake_inherit_child_env(
@@ -493,7 +534,7 @@ def _set_startup_failure(
     connection._stderr_log_path = spawn_dir / "stderr.log"
     connection._stderr_log_path.write_text(text, encoding="utf-8")
     connection._stderr_read_offset = 0
-    connection._process = _FakeProcess()
+    connection._process = FakeOpenCodeProcess()
     connection._process.returncode = 1
     connection._config = config
 

--- a/tests/integration/streaming/test_resident_drain.py
+++ b/tests/integration/streaming/test_resident_drain.py
@@ -68,6 +68,31 @@ async def test_codex_terminal_success_without_live_children_finalizes_immediatel
 
 
 @pytest.mark.asyncio
+async def test_codex_backend_death_with_pending_success_preserves_resident_reason(
+    tmp_path: Path,
+) -> None:
+    spawn_id = SpawnId("p1")
+    start_row(tmp_path, str(spawn_id), HarnessId.CODEX, None)
+    start_row(tmp_path, "p2", HarnessId.CODEX, str(spawn_id))
+    connection = FakeResidentConnection(HarnessId.CODEX)
+    manager = await start_manager(tmp_path, connection, spawn_id=spawn_id)
+    subscriber = manager.subscribe(spawn_id)
+    assert subscriber is not None
+
+    connection.emit(resident_event(HarnessId.CODEX, "turn/completed", {}))
+    await next_turn_boundary(subscriber)
+    connection.fail_backend("no close frame received or sent")
+
+    try:
+        outcome = await manager.wait_for_completion(spawn_id)
+        assert outcome is not None
+        assert outcome.status == "failed"
+        assert outcome.error == "backend_dead_while_awaiting_done"
+    finally:
+        await manager.stop_spawn(spawn_id)
+
+
+@pytest.mark.asyncio
 async def test_opencode_terminal_success_without_live_children_finalizes_immediately(
     tmp_path: Path,
 ) -> None:

--- a/tests/integration/streaming/test_resident_drain_coordinator.py
+++ b/tests/integration/streaming/test_resident_drain_coordinator.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from meridian.lib.core.types import HarnessId, SpawnId
+from meridian.lib.harness.semantics import TerminalEventOutcome
+from meridian.lib.state import spawn_store
+from meridian.lib.streaming import descendant_evidence as descendant_evidence_module
+from meridian.lib.streaming.drain_policy import (
+    DrainAction,
+)
+from meridian.lib.streaming.resident_drain import ResidentDrainCoordinator
+from tests.support.fakes import FakeClock
+from tests.support.pi import start_row
+from tests.support.resident_drain import (
+    FakeResidentConnection,
+    awaiting_done_coordinator,
+    coordinator_with_clock,
+    descendant_cancellation_from_roots,
+    resident_event,
+)
+
+
+async def _execute_latched_cleanup(
+    coordinator: ResidentDrainCoordinator,
+    outcome: TerminalEventOutcome | None,
+) -> None:
+    exit_decision = await coordinator.handle_stream_exit(outcome)
+    request = exit_decision.post_publication_cleanup
+    assert request is not None
+    await coordinator.execute_post_publication_cleanup(request)
+
+@pytest.mark.asyncio
+async def test_terminal_done_fails_closed_when_descendant_evidence_unreadable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from meridian.lib.state.spawn_signals import write_spawn_signal
+    from meridian.lib.streaming import resident_drain as resident_drain_module
+
+    start_row(tmp_path, "p1", HarnessId.CODEX, None)
+    clock = FakeClock(start=100.0)
+    monkeypatch.setattr(resident_drain_module.time, "monotonic", clock.monotonic)
+    connection = FakeResidentConnection(HarnessId.CODEX)
+    coordinator = ResidentDrainCoordinator.for_connection(
+        runtime_root=tmp_path,
+        spawn_id=SpawnId("p1"),
+        receiver=connection,
+        resident_backend=connection.resident_backend,
+        deadline_seconds=30.0,
+        poll_seconds=0.01,
+        rearm_budget=None,
+        cancel_descendants=descendant_cancellation_from_roots(tmp_path, tmp_path),
+    )
+    write_spawn_signal(tmp_path, "p1", "done")
+
+    def _raise_evidence_read_failure(*_args: object) -> None:
+        raise OSError("descendant evidence unavailable")
+
+    monkeypatch.setattr(
+        descendant_evidence_module.spawn_store,
+        "list_spawns",
+        _raise_evidence_read_failure,
+    )
+    terminal = TerminalEventOutcome(status="succeeded", exit_code=0)
+
+    decision = await coordinator.handle_terminal_event(
+        resident_event(HarnessId.CODEX, "turn/completed", {}),
+        terminal,
+        DrainAction(terminate=True, emit_turn_boundary=False),
+    )
+
+    assert decision.recorded_outcome is None
+    assert decision.emit_turn_boundary is True
+    assert connection.fake_resident_backend.awaiting_done_values == [True]
+
+    clock.advance(30.0)
+    expired = await coordinator.handle_timeout()
+
+    assert expired.recorded_outcome is not None
+    assert expired.recorded_outcome.status == "failed"
+    assert expired.recorded_outcome.exit_code == 1
+    assert expired.recorded_outcome.error == "resident_evidence_unreadable"
+
+@pytest.mark.asyncio
+async def test_terminal_done_completes_when_descendant_evidence_recovers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from meridian.lib.state.spawn_signals import write_spawn_signal
+    from meridian.lib.streaming import resident_drain as resident_drain_module
+
+    clock = FakeClock(start=100.0)
+    monkeypatch.setattr(resident_drain_module.time, "monotonic", clock.monotonic)
+    start_row(tmp_path, "p1", HarnessId.CODEX, None)
+    connection = FakeResidentConnection(HarnessId.CODEX)
+    coordinator = ResidentDrainCoordinator.for_connection(
+        runtime_root=tmp_path,
+        spawn_id=SpawnId("p1"),
+        receiver=connection,
+        resident_backend=connection.resident_backend,
+        deadline_seconds=30.0,
+        poll_seconds=0.01,
+        rearm_budget=None,
+        cancel_descendants=descendant_cancellation_from_roots(tmp_path, tmp_path),
+    )
+    evidence_readable = False
+    list_spawns = descendant_evidence_module.spawn_store.list_spawns
+
+    def _read_descendants(runtime_root: Path) -> object:
+        if not evidence_readable:
+            raise OSError("descendant evidence unavailable")
+        return list_spawns(runtime_root)
+
+    monkeypatch.setattr(
+        descendant_evidence_module.spawn_store,
+        "list_spawns",
+        _read_descendants,
+    )
+    write_spawn_signal(tmp_path, "p1", "done")
+    terminal = TerminalEventOutcome(status="succeeded", exit_code=0)
+
+    waiting = await coordinator.handle_terminal_event(
+        resident_event(HarnessId.CODEX, "turn/completed", {}),
+        terminal,
+        DrainAction(terminate=True, emit_turn_boundary=False),
+    )
+    evidence_readable = True
+    recovered = await coordinator.handle_timeout()
+
+    assert waiting.recorded_outcome is None
+    assert recovered.recorded_outcome == terminal
+
+@pytest.mark.asyncio
+async def test_active_followup_turn_stays_resident_honors_done_and_defers_poll(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from meridian.lib.state.spawn_signals import write_spawn_signal
+    from meridian.lib.streaming import resident_drain as resident_drain_module
+
+    clock = FakeClock(start=100.0)
+    monkeypatch.setattr(resident_drain_module.time, "monotonic", clock.monotonic)
+    start_row(tmp_path, "p1", HarnessId.CODEX, None)
+    start_row(tmp_path, "p2", HarnessId.CODEX, "p1")
+    connection = FakeResidentConnection(HarnessId.CODEX)
+    coordinator = ResidentDrainCoordinator.for_connection(
+        runtime_root=tmp_path,
+        spawn_id=SpawnId("p1"),
+        receiver=connection,
+        resident_backend=connection.resident_backend,
+        deadline_seconds=3300.0,
+        poll_seconds=5.0,
+        rearm_budget=None,
+        cancel_descendants=descendant_cancellation_from_roots(tmp_path, tmp_path),
+    )
+    terminal = TerminalEventOutcome(status="succeeded", exit_code=0)
+    waiting = await coordinator.handle_terminal_event(
+        resident_event(HarnessId.CODEX, "turn/completed", {}),
+        terminal,
+        DrainAction(terminate=True, emit_turn_boundary=False),
+    )
+    assert waiting.emit_turn_boundary is True
+    spawn_store.finalize_spawn(tmp_path, SpawnId("p2"), "succeeded", 0, origin="runner")
+    write_spawn_signal(tmp_path, "p1", "rearm")
+    rearmed = await coordinator.handle_timeout()
+    assert rearmed.recorded_outcome is None
+    assert coordinator.next_timeout() == pytest.approx(5.0)
+    assert connection.fake_resident_backend.injected_messages == []
+
+    clock.advance(270.0)
+    nudged = await coordinator.handle_timeout()
+    assert nudged.recorded_outcome is None
+    assert len(connection.fake_resident_backend.injected_messages) == 1
+    injected = connection.fake_resident_backend.injected_messages[0]
+    assert "meridian spawn done" in injected
+    assert "meridian spawn rearm" in injected
+
+    coordinator.observe_activity_transition("turn_active")
+
+    assert coordinator.next_timeout() == pytest.approx(5.0)
+    assert connection.fake_resident_backend.awaiting_done_values == [True, False]
+
+    write_spawn_signal(tmp_path, "p1", "done")
+    decision = await coordinator.handle_timeout()
+
+    assert decision.recorded_outcome == terminal
+    assert coordinator.next_timeout() is None
+    assert connection.fake_resident_backend.awaiting_done_values == [True, False, False]
+
+@pytest.mark.asyncio
+async def test_active_followup_turn_still_enforces_deadline(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from meridian.lib.streaming import resident_drain as resident_drain_module
+
+    clock = FakeClock(start=0.0)
+    monkeypatch.setattr(resident_drain_module.time, "monotonic", clock.monotonic)
+    start_row(tmp_path, "p1", HarnessId.CODEX, None)
+    connection = FakeResidentConnection(HarnessId.CODEX)
+    coordinator = await coordinator_with_clock(tmp_path, connection, clock, deadline_seconds=10.0)
+    coordinator.observe_activity_transition("turn_active")
+
+    clock.advance(10.0)
+    decision = await coordinator.handle_timeout()
+
+    assert decision.recorded_outcome is not None
+    assert decision.recorded_outcome.status == "timed_out"
+    assert decision.recorded_outcome.error == "resident_deadline_expired"
+
+@pytest.mark.asyncio
+async def test_deadline_returns_timed_out_when_descendant_reap_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from meridian.lib.bootstrap import services as bootstrap_services
+    from meridian.lib.streaming import resident_drain as resident_drain_module
+
+    clock = FakeClock(start=0.0)
+    monkeypatch.setattr(resident_drain_module.time, "monotonic", clock.monotonic)
+    start_row(tmp_path, "p1", HarnessId.CODEX, None)
+    connection = FakeResidentConnection(HarnessId.CODEX)
+    coordinator = await coordinator_with_clock(tmp_path, connection, clock, deadline_seconds=10.0)
+    cleanup_calls = 0
+
+    class _FailingService:
+        async def cancel_descendants(self, root_id: SpawnId) -> set[str]:
+            nonlocal cleanup_calls
+            _ = root_id
+            cleanup_calls += 1
+            raise RuntimeError("teardown failed")
+
+    monkeypatch.setattr(
+        bootstrap_services,
+        "build_spawn_application_service_from_roots",
+        lambda _project_root, _runtime_root: _FailingService(),
+    )
+    clock.advance(10.0)
+
+    decision = await coordinator.handle_timeout()
+
+    assert decision.recorded_outcome is not None
+    assert decision.recorded_outcome.status == "timed_out"
+    assert decision.recorded_outcome.error == "resident_deadline_expired"
+    assert cleanup_calls == 0
+    await _execute_latched_cleanup(coordinator, decision.recorded_outcome)
+    assert cleanup_calls == 1
+
+    later_decision = await coordinator.handle_timeout()
+    assert later_decision.recorded_outcome is None
+    assert cleanup_calls == 1
+
+@pytest.mark.asyncio
+async def test_deadline_reap_cancels_active_descendant_cli_spawns(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from meridian.lib.bootstrap import services as bootstrap_services
+    from meridian.lib.state.spawn_tree import active_descendants
+    from meridian.lib.streaming import resident_drain as resident_drain_module
+
+    clock = FakeClock(start=0.0)
+    monkeypatch.setattr(resident_drain_module.time, "monotonic", clock.monotonic)
+    start_row(tmp_path, "p1", HarnessId.CODEX, None)
+    start_row(tmp_path, "p2", HarnessId.OPENCODE, "p1")
+    start_row(tmp_path, "p3", HarnessId.OPENCODE, "p1")
+    spawn_store.finalize_spawn(tmp_path, SpawnId("p3"), "succeeded", 0, origin="runner")
+    connection = FakeResidentConnection(HarnessId.CODEX)
+    coordinator = await coordinator_with_clock(tmp_path, connection, clock, deadline_seconds=10.0)
+    cancelled: list[str] = []
+
+    class _FakeService:
+        async def cancel_descendants(self, root_id: SpawnId) -> set[str]:
+            reaped_ids: set[str] = set()
+            for descendant in active_descendants(tmp_path, root_id):
+                reaped_ids.add(descendant.id)
+                cancelled.append(descendant.id)
+                spawn_store.finalize_spawn(
+                    tmp_path,
+                    descendant.id,
+                    "cancelled",
+                    130,
+                    origin="cancel",
+                    error="cancelled",
+                )
+            return reaped_ids
+
+    monkeypatch.setattr(
+        bootstrap_services,
+        "build_spawn_application_service_from_roots",
+        lambda _project_root, _runtime_root: _FakeService(),
+    )
+    clock.advance(10.0)
+
+    decision = await coordinator.handle_timeout()
+
+    assert decision.recorded_outcome is not None
+    assert decision.recorded_outcome.status == "timed_out"
+    assert cancelled == []
+    await _execute_latched_cleanup(coordinator, decision.recorded_outcome)
+    assert cancelled == ["p2"]
+    child = spawn_store.get_spawn(tmp_path, SpawnId("p2"))
+    assert child is not None
+    assert child.status == "cancelled"
+    already_terminal = spawn_store.get_spawn(tmp_path, SpawnId("p3"))
+    assert already_terminal is not None
+    assert already_terminal.status == "succeeded"
+
+@pytest.mark.asyncio
+async def test_done_signal_is_honored_with_tracked_child_outstanding(
+    tmp_path: Path,
+) -> None:
+    from meridian.lib.state.spawn_signals import write_spawn_signal
+
+    start_row(tmp_path, "p1", HarnessId.OPENCODE, None)
+    start_row(tmp_path, "p2", HarnessId.CODEX, "p1")
+    connection = FakeResidentConnection(HarnessId.OPENCODE)
+    coordinator = await awaiting_done_coordinator(tmp_path, connection)
+
+    write_spawn_signal(tmp_path, "p1", "done")
+    decision = await coordinator.handle_timeout()
+
+    assert decision.recorded_outcome is not None
+    assert decision.recorded_outcome.status == "succeeded"
+    assert connection.fake_resident_backend.injected_messages == []

--- a/tests/integration/streaming/test_resident_drain_manager.py
+++ b/tests/integration/streaming/test_resident_drain_manager.py
@@ -10,42 +10,24 @@ from meridian.lib.bootstrap.services import prepare_for_runtime_write
 from meridian.lib.core.context import RuntimeContext
 from meridian.lib.core.types import HarnessId, SpawnId
 from meridian.lib.harness.common import extract_codex_report
-from meridian.lib.harness.semantics import TerminalEventOutcome
 from meridian.lib.ops.spawn.models import SpawnSignalInput
 from meridian.lib.state import spawn_store
 from meridian.lib.state.artifact_store import LocalStore
-from meridian.lib.streaming import descendant_evidence as descendant_evidence_module
 from meridian.lib.streaming.drain_policy import (
-    DrainAction,
     PersistentDrainPolicy,
 )
-from meridian.lib.streaming.resident_drain import ResidentDrainCoordinator
 from tests.support.async_determinism import (
     AsyncDeterminism,
     assert_still_pending,
     wait_until,
 )
-from tests.support.fakes import FakeClock
 from tests.support.pi import start_row
 from tests.support.resident_drain import (
     FakeResidentConnection,
-    awaiting_done_coordinator,
-    coordinator_with_clock,
-    descendant_cancellation_from_roots,
     next_turn_boundary,
     resident_event,
     start_manager,
 )
-
-
-async def _execute_latched_cleanup(
-    coordinator: ResidentDrainCoordinator,
-    outcome: TerminalEventOutcome | None,
-) -> None:
-    exit_decision = await coordinator.handle_stream_exit(outcome)
-    request = exit_decision.post_publication_cleanup
-    assert request is not None
-    await coordinator.execute_post_publication_cleanup(request)
 
 
 @pytest.mark.asyncio
@@ -65,7 +47,6 @@ async def test_codex_terminal_success_without_live_children_finalizes_immediatel
         assert outcome.status == "succeeded"
     finally:
         await manager.stop_spawn(spawn_id)
-
 
 @pytest.mark.asyncio
 async def test_codex_backend_death_with_pending_success_preserves_resident_reason(
@@ -91,6 +72,35 @@ async def test_codex_backend_death_with_pending_success_preserves_resident_reaso
     finally:
         await manager.stop_spawn(spawn_id)
 
+@pytest.mark.asyncio
+async def test_opencode_process_death_with_pending_success_preserves_exit_diagnostics(
+    tmp_path: Path,
+) -> None:
+    spawn_id = SpawnId("p1")
+    start_row(tmp_path, str(spawn_id), HarnessId.OPENCODE, None)
+    start_row(tmp_path, "p2", HarnessId.CODEX, str(spawn_id))
+    connection = FakeResidentConnection(HarnessId.OPENCODE)
+    manager = await start_manager(tmp_path, connection, spawn_id=spawn_id)
+    subscriber = manager.subscribe(spawn_id)
+    assert subscriber is not None
+
+    connection.emit(resident_event(HarnessId.OPENCODE, "session.idle", {}))
+    await next_turn_boundary(subscriber)
+    diagnostic = (
+        "OpenCode subprocess exited with code 17.\n\n"
+        "OpenCode subprocess stderr:\n"
+        "fatal backend detail"
+    )
+    connection.fail_backend(diagnostic)
+
+    try:
+        outcome = await manager.wait_for_completion(spawn_id)
+        assert outcome is not None
+        assert outcome.status == "failed"
+        assert outcome.error == diagnostic
+        assert outcome.error != "backend_dead_while_awaiting_done"
+    finally:
+        await manager.stop_spawn(spawn_id)
 
 @pytest.mark.asyncio
 async def test_opencode_terminal_success_without_live_children_finalizes_immediately(
@@ -110,7 +120,6 @@ async def test_opencode_terminal_success_without_live_children_finalizes_immedia
         assert True not in connection.fake_resident_backend.awaiting_done_values
     finally:
         await manager.stop_spawn(spawn_id)
-
 
 @pytest.mark.asyncio
 async def test_opencode_child_session_idle_does_not_finalize_parent(
@@ -152,7 +161,6 @@ async def test_opencode_child_session_idle_does_not_finalize_parent(
     finally:
         await manager.stop_spawn(spawn_id)
 
-
 @pytest.mark.asyncio
 async def test_opencode_child_session_error_does_not_fail_parent(
     tmp_path: Path,
@@ -189,7 +197,6 @@ async def test_opencode_child_session_error_does_not_fail_parent(
         assert outcome.status == "succeeded"
     finally:
         await manager.stop_spawn(spawn_id)
-
 
 @pytest.mark.parametrize(
     "harness_id,event_type",
@@ -230,7 +237,6 @@ async def test_resident_persistent_policy_emits_boundary_and_stays_alive(
     finally:
         await manager.stop_spawn(spawn_id)
 
-
 @pytest.mark.asyncio
 async def test_opencode_terminal_success_resides_until_child_finishes(
     tmp_path: Path,
@@ -267,7 +273,6 @@ async def test_opencode_terminal_success_resides_until_child_finishes(
     finally:
         await manager.stop_spawn(spawn_id)
 
-
 @pytest.mark.asyncio
 async def test_resident_reconciles_finalizing_child_with_durable_report_as_done(
     tmp_path: Path,
@@ -294,7 +299,6 @@ async def test_resident_reconciles_finalizing_child_with_durable_report_as_done(
     finally:
         await manager.stop_spawn(spawn_id)
 
-
 @pytest.mark.asyncio
 async def test_resident_still_waits_on_genuinely_active_finalizing_child(
     tmp_path: Path,
@@ -320,7 +324,6 @@ async def test_resident_still_waits_on_genuinely_active_finalizing_child(
     finally:
         await manager.stop_spawn(spawn_id)
 
-
 @pytest.mark.asyncio
 async def test_done_signal_at_terminalresident_event_wins_over_outstanding_child(
     tmp_path: Path,
@@ -344,110 +347,6 @@ async def test_done_signal_at_terminalresident_event_wins_over_outstanding_child
         assert True not in connection.fake_resident_backend.awaiting_done_values
     finally:
         await manager.stop_spawn(spawn_id)
-
-
-@pytest.mark.asyncio
-async def test_terminal_done_fails_closed_when_descendant_evidence_unreadable(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from meridian.lib.state.spawn_signals import write_spawn_signal
-    from meridian.lib.streaming import resident_drain as resident_drain_module
-
-    start_row(tmp_path, "p1", HarnessId.CODEX, None)
-    clock = FakeClock(start=100.0)
-    monkeypatch.setattr(resident_drain_module.time, "monotonic", clock.monotonic)
-    connection = FakeResidentConnection(HarnessId.CODEX)
-    coordinator = ResidentDrainCoordinator.for_connection(
-        runtime_root=tmp_path,
-        spawn_id=SpawnId("p1"),
-        receiver=connection,
-        resident_backend=connection.resident_backend,
-        deadline_seconds=30.0,
-        poll_seconds=0.01,
-        rearm_budget=None,
-        cancel_descendants=descendant_cancellation_from_roots(tmp_path, tmp_path),
-    )
-    write_spawn_signal(tmp_path, "p1", "done")
-
-    def _raise_evidence_read_failure(*_args: object) -> None:
-        raise OSError("descendant evidence unavailable")
-
-    monkeypatch.setattr(
-        descendant_evidence_module.spawn_store,
-        "list_spawns",
-        _raise_evidence_read_failure,
-    )
-    terminal = TerminalEventOutcome(status="succeeded", exit_code=0)
-
-    decision = await coordinator.handle_terminal_event(
-        resident_event(HarnessId.CODEX, "turn/completed", {}),
-        terminal,
-        DrainAction(terminate=True, emit_turn_boundary=False),
-    )
-
-    assert decision.recorded_outcome is None
-    assert decision.emit_turn_boundary is True
-    assert connection.fake_resident_backend.awaiting_done_values == [True]
-
-    clock.advance(30.0)
-    expired = await coordinator.handle_timeout()
-
-    assert expired.recorded_outcome is not None
-    assert expired.recorded_outcome.status == "failed"
-    assert expired.recorded_outcome.exit_code == 1
-    assert expired.recorded_outcome.error == "resident_evidence_unreadable"
-
-
-@pytest.mark.asyncio
-async def test_terminal_done_completes_when_descendant_evidence_recovers(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from meridian.lib.state.spawn_signals import write_spawn_signal
-    from meridian.lib.streaming import resident_drain as resident_drain_module
-
-    clock = FakeClock(start=100.0)
-    monkeypatch.setattr(resident_drain_module.time, "monotonic", clock.monotonic)
-    start_row(tmp_path, "p1", HarnessId.CODEX, None)
-    connection = FakeResidentConnection(HarnessId.CODEX)
-    coordinator = ResidentDrainCoordinator.for_connection(
-        runtime_root=tmp_path,
-        spawn_id=SpawnId("p1"),
-        receiver=connection,
-        resident_backend=connection.resident_backend,
-        deadline_seconds=30.0,
-        poll_seconds=0.01,
-        rearm_budget=None,
-        cancel_descendants=descendant_cancellation_from_roots(tmp_path, tmp_path),
-    )
-    evidence_readable = False
-    list_spawns = descendant_evidence_module.spawn_store.list_spawns
-
-    def _read_descendants(runtime_root: Path) -> object:
-        if not evidence_readable:
-            raise OSError("descendant evidence unavailable")
-        return list_spawns(runtime_root)
-
-    monkeypatch.setattr(
-        descendant_evidence_module.spawn_store,
-        "list_spawns",
-        _read_descendants,
-    )
-    write_spawn_signal(tmp_path, "p1", "done")
-    terminal = TerminalEventOutcome(status="succeeded", exit_code=0)
-
-    waiting = await coordinator.handle_terminal_event(
-        resident_event(HarnessId.CODEX, "turn/completed", {}),
-        terminal,
-        DrainAction(terminate=True, emit_turn_boundary=False),
-    )
-    evidence_readable = True
-    recovered = await coordinator.handle_timeout()
-
-    assert waiting.recorded_outcome is None
-    assert recovered.recorded_outcome == terminal
-
 
 @pytest.mark.asyncio
 async def test_spawn_done_op_releases_resident_wait_via_environment_default(
@@ -485,7 +384,6 @@ async def test_spawn_done_op_releases_resident_wait_via_environment_default(
         assert outcome.status == "succeeded"
     finally:
         await manager.stop_spawn(spawn_id)
-
 
 @pytest.mark.asyncio
 async def test_spawn_rearm_op_extends_resident_deadline(
@@ -580,7 +478,6 @@ async def test_spawn_rearm_op_extends_resident_deadline(
     finally:
         await manager.stop_spawn(spawn_id)
 
-
 @pytest.mark.asyncio
 async def test_resident_wait_fans_out_turn_boundary_to_subscriber(tmp_path: Path) -> None:
     spawn_id = SpawnId("p1")
@@ -603,7 +500,6 @@ async def test_resident_wait_fans_out_turn_boundary_to_subscriber(tmp_path: Path
             )
     finally:
         await manager.stop_spawn(spawn_id)
-
 
 @pytest.mark.asyncio
 async def test_child_written_before_terminalresident_event_is_processed_prevents_early_finalize(
@@ -630,7 +526,6 @@ async def test_child_written_before_terminalresident_event_is_processed_prevents
         assert outcome.status == "succeeded"
     finally:
         await manager.stop_spawn(spawn_id)
-
 
 @pytest.mark.asyncio
 async def test_resident_stream_close_with_dead_backend_fails_while_child_running(
@@ -666,7 +561,6 @@ async def test_resident_stream_close_with_dead_backend_fails_while_child_running
     finally:
         await manager.stop_spawn(spawn_id)
 
-
 @pytest.mark.asyncio
 async def test_resident_stream_close_with_stalled_backend_is_not_dead_outcome(
     tmp_path: Path,
@@ -700,7 +594,6 @@ async def test_resident_stream_close_with_stalled_backend_is_not_dead_outcome(
         assert outcome.error == "stream_closed_while_awaiting_done"
     finally:
         await manager.stop_spawn(spawn_id)
-
 
 @pytest.mark.asyncio
 async def test_codex_resident_deadline_waits_then_reaps_live_child(
@@ -773,7 +666,6 @@ async def test_codex_resident_deadline_waits_then_reaps_live_child(
     finally:
         await manager.stop_spawn(spawn_id)
 
-
 @pytest.mark.asyncio
 async def test_codex_resident_finalization_preserves_artifact_report(tmp_path: Path) -> None:
     spawn_id = SpawnId("p1")
@@ -813,202 +705,3 @@ async def test_codex_resident_finalization_preserves_artifact_report(tmp_path: P
         )
     finally:
         await manager.stop_spawn(spawn_id)
-
-
-@pytest.mark.asyncio
-async def test_active_followup_turn_stays_resident_honors_done_and_defers_poll(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from meridian.lib.state.spawn_signals import write_spawn_signal
-    from meridian.lib.streaming import resident_drain as resident_drain_module
-
-    clock = FakeClock(start=100.0)
-    monkeypatch.setattr(resident_drain_module.time, "monotonic", clock.monotonic)
-    start_row(tmp_path, "p1", HarnessId.CODEX, None)
-    start_row(tmp_path, "p2", HarnessId.CODEX, "p1")
-    connection = FakeResidentConnection(HarnessId.CODEX)
-    coordinator = ResidentDrainCoordinator.for_connection(
-        runtime_root=tmp_path,
-        spawn_id=SpawnId("p1"),
-        receiver=connection,
-        resident_backend=connection.resident_backend,
-        deadline_seconds=3300.0,
-        poll_seconds=5.0,
-        rearm_budget=None,
-        cancel_descendants=descendant_cancellation_from_roots(tmp_path, tmp_path),
-    )
-    terminal = TerminalEventOutcome(status="succeeded", exit_code=0)
-    waiting = await coordinator.handle_terminal_event(
-        resident_event(HarnessId.CODEX, "turn/completed", {}),
-        terminal,
-        DrainAction(terminate=True, emit_turn_boundary=False),
-    )
-    assert waiting.emit_turn_boundary is True
-    spawn_store.finalize_spawn(tmp_path, SpawnId("p2"), "succeeded", 0, origin="runner")
-    write_spawn_signal(tmp_path, "p1", "rearm")
-    rearmed = await coordinator.handle_timeout()
-    assert rearmed.recorded_outcome is None
-    assert coordinator.next_timeout() == pytest.approx(5.0)
-    assert connection.fake_resident_backend.injected_messages == []
-
-    clock.advance(270.0)
-    nudged = await coordinator.handle_timeout()
-    assert nudged.recorded_outcome is None
-    assert len(connection.fake_resident_backend.injected_messages) == 1
-    injected = connection.fake_resident_backend.injected_messages[0]
-    assert "meridian spawn done" in injected
-    assert "meridian spawn rearm" in injected
-
-    coordinator.observe_activity_transition("turn_active")
-
-    assert coordinator.next_timeout() == pytest.approx(5.0)
-    assert connection.fake_resident_backend.awaiting_done_values == [True, False]
-
-    write_spawn_signal(tmp_path, "p1", "done")
-    decision = await coordinator.handle_timeout()
-
-    assert decision.recorded_outcome == terminal
-    assert coordinator.next_timeout() is None
-    assert connection.fake_resident_backend.awaiting_done_values == [True, False, False]
-
-
-@pytest.mark.asyncio
-async def test_active_followup_turn_still_enforces_deadline(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from meridian.lib.streaming import resident_drain as resident_drain_module
-
-    clock = FakeClock(start=0.0)
-    monkeypatch.setattr(resident_drain_module.time, "monotonic", clock.monotonic)
-    start_row(tmp_path, "p1", HarnessId.CODEX, None)
-    connection = FakeResidentConnection(HarnessId.CODEX)
-    coordinator = await coordinator_with_clock(tmp_path, connection, clock, deadline_seconds=10.0)
-    coordinator.observe_activity_transition("turn_active")
-
-    clock.advance(10.0)
-    decision = await coordinator.handle_timeout()
-
-    assert decision.recorded_outcome is not None
-    assert decision.recorded_outcome.status == "timed_out"
-    assert decision.recorded_outcome.error == "resident_deadline_expired"
-
-
-@pytest.mark.asyncio
-async def test_deadline_returns_timed_out_when_descendant_reap_fails(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from meridian.lib.bootstrap import services as bootstrap_services
-    from meridian.lib.streaming import resident_drain as resident_drain_module
-
-    clock = FakeClock(start=0.0)
-    monkeypatch.setattr(resident_drain_module.time, "monotonic", clock.monotonic)
-    start_row(tmp_path, "p1", HarnessId.CODEX, None)
-    connection = FakeResidentConnection(HarnessId.CODEX)
-    coordinator = await coordinator_with_clock(tmp_path, connection, clock, deadline_seconds=10.0)
-    cleanup_calls = 0
-
-    class _FailingService:
-        async def cancel_descendants(self, root_id: SpawnId) -> set[str]:
-            nonlocal cleanup_calls
-            _ = root_id
-            cleanup_calls += 1
-            raise RuntimeError("teardown failed")
-
-    monkeypatch.setattr(
-        bootstrap_services,
-        "build_spawn_application_service_from_roots",
-        lambda _project_root, _runtime_root: _FailingService(),
-    )
-    clock.advance(10.0)
-
-    decision = await coordinator.handle_timeout()
-
-    assert decision.recorded_outcome is not None
-    assert decision.recorded_outcome.status == "timed_out"
-    assert decision.recorded_outcome.error == "resident_deadline_expired"
-    assert cleanup_calls == 0
-    await _execute_latched_cleanup(coordinator, decision.recorded_outcome)
-    assert cleanup_calls == 1
-
-    later_decision = await coordinator.handle_timeout()
-    assert later_decision.recorded_outcome is None
-    assert cleanup_calls == 1
-
-
-@pytest.mark.asyncio
-async def test_deadline_reap_cancels_active_descendant_cli_spawns(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from meridian.lib.bootstrap import services as bootstrap_services
-    from meridian.lib.state.spawn_tree import active_descendants
-    from meridian.lib.streaming import resident_drain as resident_drain_module
-
-    clock = FakeClock(start=0.0)
-    monkeypatch.setattr(resident_drain_module.time, "monotonic", clock.monotonic)
-    start_row(tmp_path, "p1", HarnessId.CODEX, None)
-    start_row(tmp_path, "p2", HarnessId.OPENCODE, "p1")
-    start_row(tmp_path, "p3", HarnessId.OPENCODE, "p1")
-    spawn_store.finalize_spawn(tmp_path, SpawnId("p3"), "succeeded", 0, origin="runner")
-    connection = FakeResidentConnection(HarnessId.CODEX)
-    coordinator = await coordinator_with_clock(tmp_path, connection, clock, deadline_seconds=10.0)
-    cancelled: list[str] = []
-
-    class _FakeService:
-        async def cancel_descendants(self, root_id: SpawnId) -> set[str]:
-            reaped_ids: set[str] = set()
-            for descendant in active_descendants(tmp_path, root_id):
-                reaped_ids.add(descendant.id)
-                cancelled.append(descendant.id)
-                spawn_store.finalize_spawn(
-                    tmp_path,
-                    descendant.id,
-                    "cancelled",
-                    130,
-                    origin="cancel",
-                    error="cancelled",
-                )
-            return reaped_ids
-
-    monkeypatch.setattr(
-        bootstrap_services,
-        "build_spawn_application_service_from_roots",
-        lambda _project_root, _runtime_root: _FakeService(),
-    )
-    clock.advance(10.0)
-
-    decision = await coordinator.handle_timeout()
-
-    assert decision.recorded_outcome is not None
-    assert decision.recorded_outcome.status == "timed_out"
-    assert cancelled == []
-    await _execute_latched_cleanup(coordinator, decision.recorded_outcome)
-    assert cancelled == ["p2"]
-    child = spawn_store.get_spawn(tmp_path, SpawnId("p2"))
-    assert child is not None
-    assert child.status == "cancelled"
-    already_terminal = spawn_store.get_spawn(tmp_path, SpawnId("p3"))
-    assert already_terminal is not None
-    assert already_terminal.status == "succeeded"
-
-
-@pytest.mark.asyncio
-async def test_done_signal_is_honored_with_tracked_child_outstanding(
-    tmp_path: Path,
-) -> None:
-    from meridian.lib.state.spawn_signals import write_spawn_signal
-
-    start_row(tmp_path, "p1", HarnessId.OPENCODE, None)
-    start_row(tmp_path, "p2", HarnessId.CODEX, "p1")
-    connection = FakeResidentConnection(HarnessId.OPENCODE)
-    coordinator = await awaiting_done_coordinator(tmp_path, connection)
-
-    write_spawn_signal(tmp_path, "p1", "done")
-    decision = await coordinator.handle_timeout()
-
-    assert decision.recorded_outcome is not None
-    assert decision.recorded_outcome.status == "succeeded"
-    assert connection.fake_resident_backend.injected_messages == []

--- a/tests/support/opencode.py
+++ b/tests/support/opencode.py
@@ -1,0 +1,25 @@
+"""OpenCode process fakes that preserve connection death ordering."""
+
+from __future__ import annotations
+
+
+class FakeOpenCodeProcess:
+    """Minimal process fake whose non-zero exit is observable before event EOF."""
+
+    def __init__(self) -> None:
+        self.pid = 9001
+        self.returncode: int | None = None
+
+    def exit(self, return_code: int) -> None:
+        self.returncode = return_code
+
+    def terminate(self) -> None:
+        self.returncode = 0
+
+    def kill(self) -> None:
+        self.returncode = -9
+
+    async def wait(self) -> int:
+        if self.returncode is None:
+            self.returncode = 0
+        return self.returncode

--- a/tests/support/resident_drain.py
+++ b/tests/support/resident_drain.py
@@ -147,6 +147,19 @@ class FakeResidentConnection(HarnessConnection[ResolvedLaunchSpec]):
     def close_stream(self) -> None:
         self.resident_events.put_nowait(None)
 
+    def fail_backend(self, message: str) -> None:
+        """Reproduce a resident transport failure before iterator exhaustion."""
+
+        self.mark_failed()
+        self.emit(
+            HarnessEvent(
+                event_type="error/connectionClosed",
+                payload={"message": message},
+                harness_id=self.harness_id.value,
+            )
+        )
+        self.close_stream()
+
     def mark_failed(self) -> None:
         self._state = "failed"
         self._resident_backend.status = LivenessDecision.BACKEND_DEAD

--- a/tests/unit/harness/test_claude_connection.py
+++ b/tests/unit/harness/test_claude_connection.py
@@ -1,0 +1,56 @@
+"""Claude streaming connection event-shape tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from meridian.lib.harness.connections.claude_ws import ClaudeConnection
+from meridian.lib.harness.semantics import terminal_outcome
+
+
+class _FakeStdout:
+    async def readline(self) -> bytes:
+        return b""
+
+
+class _ExitedProcess:
+    def __init__(self, returncode: int) -> None:
+        self.returncode = returncode
+        self.stdout = _FakeStdout()
+
+    async def wait(self) -> int:
+        return self.returncode
+
+
+@pytest.mark.asyncio
+async def test_claude_process_death_emits_diagnostic_event_before_eof(
+    tmp_path: Path,
+) -> None:
+    stderr_path = tmp_path / "stderr.log"
+    stderr_path.write_text("fatal claude backend detail\n", encoding="utf-8")
+    connection = ClaudeConnection()
+    connection._state = "connected"  # pyright: ignore[reportPrivateUsage]
+    connection._process = cast("object", _ExitedProcess(17))  # type: ignore[assignment]
+    connection._stderr_log_path = stderr_path  # pyright: ignore[reportPrivateUsage]
+    events = connection.events()
+
+    event = await anext(events)
+
+    assert event.event_type == "error/connectionClosed"
+    assert event.payload == {
+        "type": "error/connectionClosed",
+        "message": (
+            "Claude subprocess exited with code 17.\n\n"
+            "Claude subprocess stderr:\n"
+            "fatal claude backend detail"
+        ),
+    }
+    outcome = terminal_outcome(event)
+    assert outcome is not None
+    assert outcome.status == "failed"
+    assert outcome.error == event.payload["message"]
+    with pytest.raises(StopAsyncIteration):
+        await anext(events)

--- a/tests/unit/harness/test_extract_opencode_report.py
+++ b/tests/unit/harness/test_extract_opencode_report.py
@@ -6,7 +6,10 @@ import json
 from pathlib import Path
 
 from meridian.lib.core.types import ArtifactKey, SpawnId
-from meridian.lib.harness.extractors.opencode import OPENCODE_EXTRACTOR
+from meridian.lib.harness.extractors.opencode import (
+    OPENCODE_EXTRACTOR,
+    _extract_opencode_usage,
+)
 from meridian.lib.harness.opencode_report import extract_opencode_report
 from meridian.lib.harness.opencode_storage import resolve_opencode_storage_root
 from meridian.lib.launch.constants import HISTORY_FILENAME
@@ -30,6 +33,20 @@ def _artifact_store_from_history_lines(
 ) -> _MemoryArtifactStore:
     encoded = "\n".join(json.dumps(line) for line in lines).encode("utf-8")
     return _MemoryArtifactStore({f"{spawn_id}/{HISTORY_FILENAME}": encoded})
+
+
+def test_opencode_usage_ignores_unproduced_response_completed_event() -> None:
+    spawn_id = SpawnId("p-opencode-phantom-event")
+    encoded = json.dumps(
+        {
+            "type": "response.completed",
+            "usage": {"input_tokens": 123, "output_tokens": 45},
+        }
+    ).encode("utf-8")
+    store = _MemoryArtifactStore({f"{spawn_id}/output.jsonl": encoded})
+
+    assert _extract_opencode_usage(store, spawn_id).input_tokens is None
+    assert _extract_opencode_usage(store, spawn_id).output_tokens is None
 
 
 def test_extract_opencode_report_reads_last_assistant_text_from_wrapped_history() -> None:


### PR DESCRIPTION
## Why
PR #443 hardened Pi's drain/terminal contracts. A zoom-out audit (work item `harness-hardening-audit`) asked whether the same defect classes exist for the other harnesses. Real-runtime probing (Claude 2.1.212, Codex 0.144.4, OpenCode 1.17.13) confirmed three do.

## Goal
Bring Claude/Codex/OpenCode death and inject contracts up to the Pi standard: no specific terminal reason shadowed by a generic close, no lost death diagnostics, no phantom events in the taxonomy.

## Summary
- **Codex resident shadowing (the #433 analogue):** a resolved terminal outcome — including a *succeeded* turn — was overwritten by a late generic `error/connectionClosed` when the backend died. Fixed with a typed `TerminalOutcomeCause.REPLACEABLE_TRANSPORT_CLOSE` set only for the Codex close shape, routed through the existing #443 publication barrier (`resolve_terminal_outcome`). Backend death with tracked children now reports `backend_dead_while_awaiting_done`.
- **OpenCode process death** now preserves subprocess exit code + stderr instead of collapsing to `connection_closed_without_terminal_event`.
- **Claude connection death** now emits a canonical `error/connectionClosed` carrying exit code + stderr, so diagnostics survive classification.
- **OpenCode `response.completed`** removed from the accepted taxonomy — the real runtime never emits it.
- Generalized the "Fake Fidelity" rule beyond Pi and added cross-harness death-shape + inject-ack contracts.

## Resulting Behavior
Codex spawns no longer report a spurious `no close frame received or sent` failure after a successful turn when the backend is later killed. OpenCode and Claude terminal failures carry the real exit code and stderr. The OpenCode phantom event no longer parses.

## Changes
`semantics.py` (typed close cause), `resident_drain.py`, `connections/opencode_http.py`, `connections/claude_ws.py`, `extractors/opencode.py`, harness `.context/CONTEXT.md`, `tests/AGENTS.md`; regression tests incl. a negative OpenCode-preservation test; `test_resident_drain.py` split into `_manager`/`_coordinator`.

## Work Item
`harness-hardening-audit` (zoom-out of #443).

## Verification
Real-Pi/Claude/Codex/OpenCode probes (verdicts in work item). Each fix has a pre-fix-failing regression test. `uv run pytest-llm`: **1584 passed, 2 skipped**. Ruff clean, pyright 0 errors. One thermo-nuclear review round (found the Codex-fires-for-OpenCode regression + Claude false-contract; both fixed) + independent regression re-verification.

## Knowledge Updates
Colocated `.context/` death-shape + inject-ack contracts added; KB reconciliation (`concepts/harness-abstraction.md`) running separately.

## Spawn Trace
explorers p5428–p5431 (audit) · coder p5433/p5453/p5468 · prober p5434 · reviewer p5464
