### PR TITLE
fix: restore rollout materialization as Codex bootstrap readiness boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Codex managed-primary bootstrap no longer waits for turn completion — rollout
+  materialization is the readiness gate again. Rich context (`--work`,
+  `--prompt-file`, `--from`) caused 120s timeout when the model began real work
+  during bootstrap.
+
 ## [0.3.40] - 2026-07-18
 
 ### Fixed

--- a/src/meridian/lib/harness/connections/codex_ws.py
+++ b/src/meridian/lib/harness/connections/codex_ws.py
@@ -242,8 +242,6 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
         self._current_turn_id: str | None = None
         self._thread_id: str | None = None
         self._main_turn_thread_id: str | None = None
-        self._last_completed_turn_id: str | None = None
-        self._turn_completed_event = asyncio.Event()
         self._tracer: DebugTracer | None = None
         self._cancel_requested = False
         self._signal_in_flight = False
@@ -365,8 +363,6 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
         self._current_turn_id = None
         self._thread_id = None
         self._main_turn_thread_id = None
-        self._last_completed_turn_id = None
-        self._turn_completed_event.clear()
         self._liveness.reset()
         self._cancel_requested = False
         self._signal_in_flight = False
@@ -1207,20 +1203,25 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
         return config.control_root
 
     async def _send_bootstrap_turn_and_wait(self, *, agent_name: str | None) -> None:
-        """Send a minimal bootstrap turn and wait for completion.
+        """Send a bootstrap turn and wait for the rollout to become attachable.
 
         This materializes the Codex rollout file so the TUI can later attach
         to this thread. The bootstrap prompt is deterministic and minimal.
-        Meridian intentionally leaves the thread's normal model/effort
-        semantics alone; bootstrap should be made cheaper by improving the
-        attachability gate, not by mutating user-visible Codex defaults.
+
+        The load-bearing requirement is "thread is attachable", not "bootstrap
+        response is semantically complete". We gate on rollout materialization
+        because that is the earliest observed durable signal that
+        ``codex resume --remote`` can attach. We intentionally do NOT wait for
+        ``turn/completed`` — the model may begin real work (reading context,
+        calling tools) and take arbitrarily long. The TUI handles in-progress
+        turns fine.
         """
         thread_id = self._require_thread_id("bootstrap_turn")
         normalized_agent = (agent_name or "").strip()
         prompt = _BOOTSTRAP_TURN_PROMPT
         if normalized_agent:
             prompt = f"{prompt} (agent: {normalized_agent})"
-        result = await self._request(
+        await self._request(
             "turn/start",
             {
                 "threadId": thread_id,
@@ -1228,14 +1229,6 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
             },
         )
         await self._wait_for_rollout_materialization()
-        turn_id = (
-            _extract_turn_id(result)
-            or self._current_turn_id
-            or self._last_completed_turn_id
-        )
-        if turn_id is None:
-            raise RuntimeError("Codex bootstrap turn did not provide a turn id")
-        await self._wait_for_turn_completion(turn_id)
 
     async def _wait_for_rollout_materialization(self, timeout_seconds: float = 120.0) -> None:
         """Block until Codex has created an attachable rollout for the thread.
@@ -1274,31 +1267,6 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
             if not process_running or not ws_open:
                 raise RuntimeError("Codex connection lost during bootstrap turn")
 
-    async def _wait_for_turn_completion(
-        self,
-        turn_id: str,
-        timeout_seconds: float = 120.0,
-    ) -> None:
-        """Wait until the observer receives completion for the bootstrap turn."""
-
-        loop = asyncio.get_running_loop()
-        deadline = loop.time() + timeout_seconds
-        while self._last_completed_turn_id != turn_id:
-            self._turn_completed_event.clear()
-            if self._last_completed_turn_id == turn_id:
-                return
-            remaining = deadline - loop.time()
-            if remaining <= 0:
-                raise RuntimeError(
-                    f"Bootstrap turn timed out after {timeout_seconds}s waiting for completion"
-                )
-            try:
-                await asyncio.wait_for(self._turn_completed_event.wait(), timeout=remaining)
-            except TimeoutError as exc:
-                raise RuntimeError(
-                    f"Bootstrap turn timed out after {timeout_seconds}s waiting for completion"
-                ) from exc
-
     async def _bootstrap_thread(self, spec: ResolvedLaunchSpec) -> dict[str, object]:
         method, payload = self._thread_bootstrap_request(spec)
         return await self._request(method, payload)
@@ -1336,9 +1304,7 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
             if thread_id is not None:
                 self._main_turn_thread_id = thread_id
         if clears_signal(event, primary_event_scope=self.primary_event_scope):
-            self._last_completed_turn_id = _extract_turn_id(payload) or self._current_turn_id
             self._end_current_turn()
-            self._turn_completed_event.set()
             self._signal_in_flight = False
             self._liveness.signal_request_resolved("cancel")
             return

--- a/tests/unit/harness/test_codex_bootstrap_turn.py
+++ b/tests/unit/harness/test_codex_bootstrap_turn.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 from unittest.mock import AsyncMock
 
 import pytest
@@ -25,7 +24,6 @@ async def test_bootstrap_turn_identifies_agent_when_available(
     connection._thread_id = "thread-1"
     connection._request = AsyncMock(return_value={"turn": {"id": "turn-1"}})  # type: ignore[method-assign]
     connection._wait_for_rollout_materialization = AsyncMock()  # type: ignore[method-assign]
-    connection._wait_for_turn_completion = AsyncMock()  # type: ignore[method-assign]
 
     await connection._send_bootstrap_turn_and_wait(agent_name=agent_name)
 
@@ -39,23 +37,20 @@ async def test_bootstrap_turn_identifies_agent_when_available(
 
 
 @pytest.mark.asyncio
-async def test_bootstrap_wait_finishes_only_after_matching_turn_completes() -> None:
+async def test_bootstrap_does_not_wait_for_turn_completion() -> None:
+    """Rollout materialization is the readiness boundary, not turn completion.
+
+    The bootstrap turn may trigger real model work (tool calls, reasoning)
+    that takes arbitrarily long. Waiting for turn/completed caused a 120s
+    timeout regression when rich context was present (see #452).
+    """
     connection = CodexConnection()
-    wait_task = asyncio.create_task(
-        connection._wait_for_turn_completion("turn-1", timeout_seconds=1.0)
-    )
+    connection._thread_id = "thread-1"
+    connection._request = AsyncMock(return_value={"turn": {"id": "turn-1"}})  # type: ignore[method-assign]
+    connection._wait_for_rollout_materialization = AsyncMock()  # type: ignore[method-assign]
 
-    connection._update_turn_state(
-        method="turn/started",
-        payload={"threadId": "thread-1", "turn": {"id": "turn-1"}},
-    )
-    await asyncio.sleep(0)
-    assert wait_task.done() is False
+    await connection._send_bootstrap_turn_and_wait(agent_name="gpt-dev")
 
-    connection._update_turn_state(
-        method="turn/completed",
-        payload={"threadId": "thread-1", "turn": {"id": "turn-1"}},
-    )
-
-    await asyncio.wait_for(wait_task, timeout=1.0)
-    assert connection.current_turn_id is None
+    # Only rollout materialization should be awaited, not turn completion
+    connection._wait_for_rollout_materialization.assert_awaited_once()
+    assert not hasattr(connection, "_wait_for_turn_completion")


### PR DESCRIPTION
## Why

Codex managed-primary sessions with rich context (`--work`, `--prompt-file`,
`--from`) hang for 120s and fail with `Bootstrap turn timed out`. The model
begins real implementation work (15+ tool calls observed) during what should
be a fast bootstrap turn, exceeding the hardcoded timeout.

## Goal

Codex managed-primary bootstrap completes in seconds regardless of context
richness.

## Summary

Restores rollout materialization as the bootstrap readiness gate, reverting
the semantic change from `44bf9389` that added `_wait_for_turn_completion()`.
The original code had an explicit comment: *"We intentionally do not wait for
turn/completed"* — that comment was deleted and the wait was added.

## Resulting Behavior

`meridian -a gpt-dev --work <slug> --prompt-file <brief> --from <session>`
starts in seconds on Codex instead of hanging for 120s. The TUI attaches to
the in-progress bootstrap turn.

## Changes

- Deleted `_wait_for_turn_completion()`, `_last_completed_turn_id`,
  `_turn_completed_event` — all dead after the revert
- Restored the design comment explaining why turn completion is NOT the
  readiness boundary
- Updated test to assert bootstrap does NOT wait for turn completion

No behavior change for spawns (non-primary paths don't use bootstrap turns).

## Work Item

workstream-roadmap (ad-hoc fix during fleet coordination)

## Verification

- 1624 tests pass (0 errors, 23 warnings — all pre-existing)
- `test_bootstrap_does_not_wait_for_turn_completion` asserts the contract
- Ruff + Pyright clean (0 errors)
- Manual: needs Codex primary launch with rich context to confirm

## Knowledge Updates

No colocated doc changes needed — the fix restores documented intent that
was accidentally deleted.

## Spawn Trace

- p5521 investigator — root-caused the bootstrap timeout (Codex)
- p5523 prober — gathered runtime evidence from crash artifacts (Codex)
- p5526 investigator — parallel investigation (Claude)

## Release Label

`release:patch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)