### PR TITLE
Spawn lifecycle: deny at submission, honest Codex terminal status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Denied headless harness spawns fail at submission with the policy error,
+  before any spawn row exists. Previously `--bg` reported "submitted" and
+  the denial surfaced seconds later as a generic launch failure. (#442)
+- Codex turns that fail (e.g. unsupported model 400) now record a failed
+  spawn with the upstream error, not `succeeded` with exit 0. Interrupted
+  turns record `cancelled`/exit 130. (#448)
+- Succeeded terminal outcomes can no longer carry an error or nonzero exit
+  code — invalid combinations are rejected at construction.
+
 ## [0.3.44] - 2026-07-23
 
 ### Fixed

--- a/src/meridian/lib/harness/.context/CONTEXT.md
+++ b/src/meridian/lib/harness/.context/CONTEXT.md
@@ -160,7 +160,9 @@ qualify by `event.harness_id`.
 
 Key mappings:
 - Claude: `result` event with `is_error=True` → failed; `subtype in ("", "success")` and `terminal_reason in ("", "completed")` → succeeded
-- Codex: main-thread `turn/completed` → succeeded; `meridian/error/connectionClosed` → failed
+- Codex: main-thread `turn/completed` resolves nested `turn.status` — `completed`/absent
+  → succeeded/0, `failed` → failed/1 with upstream error, `interrupted` → cancelled/130,
+  unknown → failed/1 diagnostic; `meridian/error/connectionClosed` → failed
 - OpenCode: parent-session `session.idle` → succeeded; parent-session `session.error` → failed
 - Cursor: `meridian/error/connectionClosed` → failed; no explicit success event — stdout EOF
   + process exit code 0 is the success boundary (see `CursorSubprocessConnection.events()`).

--- a/src/meridian/lib/harness/codex.py
+++ b/src/meridian/lib/harness/codex.py
@@ -538,9 +538,14 @@ def _resolve_codex_terminal(event: RawHarnessEvent) -> TerminalEventOutcome | No
             event,
             cause=TerminalOutcomeCause.REPLACEABLE_TRANSPORT_CLOSE,
         )
+    if event.event_type != "turn/completed":
+        return None
+
     turn = event.payload.get("turn")
     turn_payload = cast("dict[str, object]", turn) if isinstance(turn, dict) else None
     turn_status = turn_payload.get("status") if turn_payload is not None else None
+    if turn_payload is None or turn_status == "completed":
+        return TerminalEventOutcome(status=SpawnStatus.SUCCEEDED, exit_code=0)
     if turn_status == "failed":
         assert turn_payload is not None
         error: object = turn_payload.get("error")
@@ -552,21 +557,19 @@ def _resolve_codex_terminal(event: RawHarnessEvent) -> TerminalEventOutcome | No
             error=stringify_terminal_error(preferred_error)
             or stringify_terminal_error(cast("object", error)),
         )
-    if event.event_type == "turn/completed":
-        if turn_payload is None or turn_status == "completed":
-            return TerminalEventOutcome(status=SpawnStatus.SUCCEEDED, exit_code=0)
-        if turn_status == "interrupted":
-            return TerminalEventOutcome(
-                status=SpawnStatus.CANCELLED,
-                exit_code=130,
-                error="interrupted",
-            )
+    if turn_status == "interrupted":
         return TerminalEventOutcome(
-            status=SpawnStatus.FAILED,
-            exit_code=1,
-            error=f"unexpected_codex_turn_status:{turn_status}",
+            status=SpawnStatus.CANCELLED,
+            exit_code=130,
+            error="interrupted",
         )
-    return None
+    # A status-less turn is malformed. Fail loudly: false failures are visible;
+    # hidden failures are not. A missing turn remains success for older payloads.
+    return TerminalEventOutcome(
+        status=SpawnStatus.FAILED,
+        exit_code=1,
+        error=f"unexpected_codex_turn_status:{turn_status}",
+    )
 
 
 CODEX_SEMANTICS = HarnessSemantics(

--- a/src/meridian/lib/harness/codex.py
+++ b/src/meridian/lib/harness/codex.py
@@ -70,6 +70,7 @@ from meridian.lib.harness.semantics import (
     TerminalEventOutcome,
     TerminalOutcomeCause,
     connection_closed_outcome,
+    stringify_terminal_error,
 )
 from meridian.lib.launch.composition import (
     ComposedLaunchContent,
@@ -537,6 +538,20 @@ def _resolve_codex_terminal(event: RawHarnessEvent) -> TerminalEventOutcome | No
             event,
             cause=TerminalOutcomeCause.REPLACEABLE_TRANSPORT_CLOSE,
         )
+    turn = event.payload.get("turn")
+    turn_payload = cast("dict[str, object]", turn) if isinstance(turn, dict) else None
+    if turn_payload is not None and turn_payload.get("status") == "failed":
+        error: object = turn_payload.get("error")
+        error_payload = cast("dict[str, object]", error) if isinstance(error, dict) else None
+        preferred_error = error_payload.get("message") if error_payload is not None else None
+        return TerminalEventOutcome(
+            status=SpawnStatus.FAILED,
+            exit_code=1,
+            error=stringify_terminal_error(preferred_error)
+            or stringify_terminal_error(cast("object", error)),
+        )
+    if event.event_type == "turn/completed":
+        return TerminalEventOutcome(status=SpawnStatus.SUCCEEDED, exit_code=0)
     return None
 
 
@@ -550,7 +565,10 @@ CODEX_SEMANTICS = HarnessSemantics(
         ),
         MERIDIAN_CONNECTION_CLOSED_EVENT: EventSemantics(),
     },
-    payload_resolvers={MERIDIAN_CONNECTION_CLOSED_EVENT: _resolve_codex_terminal},
+    payload_resolvers={
+        "turn/completed": _resolve_codex_terminal,
+        MERIDIAN_CONNECTION_CLOSED_EVENT: _resolve_codex_terminal,
+    },
     scoped_events=frozenset({"turn/started", "turn/completed"}),
     scope_id_resolver=extract_codex_thread_id,
 )

--- a/src/meridian/lib/harness/codex.py
+++ b/src/meridian/lib/harness/codex.py
@@ -540,7 +540,9 @@ def _resolve_codex_terminal(event: RawHarnessEvent) -> TerminalEventOutcome | No
         )
     turn = event.payload.get("turn")
     turn_payload = cast("dict[str, object]", turn) if isinstance(turn, dict) else None
-    if turn_payload is not None and turn_payload.get("status") == "failed":
+    turn_status = turn_payload.get("status") if turn_payload is not None else None
+    if turn_status == "failed":
+        assert turn_payload is not None
         error: object = turn_payload.get("error")
         error_payload = cast("dict[str, object]", error) if isinstance(error, dict) else None
         preferred_error = error_payload.get("message") if error_payload is not None else None
@@ -551,7 +553,19 @@ def _resolve_codex_terminal(event: RawHarnessEvent) -> TerminalEventOutcome | No
             or stringify_terminal_error(cast("object", error)),
         )
     if event.event_type == "turn/completed":
-        return TerminalEventOutcome(status=SpawnStatus.SUCCEEDED, exit_code=0)
+        if turn_payload is None or turn_status == "completed":
+            return TerminalEventOutcome(status=SpawnStatus.SUCCEEDED, exit_code=0)
+        if turn_status == "interrupted":
+            return TerminalEventOutcome(
+                status=SpawnStatus.CANCELLED,
+                exit_code=130,
+                error="interrupted",
+            )
+        return TerminalEventOutcome(
+            status=SpawnStatus.FAILED,
+            exit_code=1,
+            error=f"unexpected_codex_turn_status:{turn_status}",
+        )
     return None
 
 

--- a/src/meridian/lib/harness/semantics.py
+++ b/src/meridian/lib/harness/semantics.py
@@ -33,6 +33,12 @@ class TerminalEventOutcome:
     error: str | None = None
     cause: TerminalOutcomeCause | None = None
 
+    def __post_init__(self) -> None:
+        if self.status == SpawnStatus.SUCCEEDED and (
+            self.exit_code != 0 or self.error is not None
+        ):
+            raise ValueError("succeeded terminal outcomes require exit_code=0 and no error")
+
 
 @dataclass(frozen=True)
 class PrimaryEventScope:

--- a/src/meridian/lib/launch/context.py
+++ b/src/meridian/lib/launch/context.py
@@ -635,6 +635,41 @@ def _resolve_deny_headless_harnesses(
     return tuple(load_config(project_paths.project_root).deny_headless_harnesses)
 
 
+def _enforce_headless_harness_policy(
+    *,
+    request: SpawnRequest,
+    harness: SubprocessHarness,
+    runtime: LaunchRuntime,
+    project_paths: ProjectConfigPaths,
+) -> None:
+    """Reject denied headless harnesses before a spawn can be persisted."""
+
+    if (
+        runtime.composition_surface != LaunchCompositionSurface.SPAWN_PREPARE
+        or harness.id.value not in _resolve_deny_headless_harnesses(runtime, project_paths)
+    ):
+        return
+
+    parent_harness = os.getenv("_MERIDIAN_HARNESS", "")
+    if parent_harness == harness.id.value:
+        agent_hint = (
+            f' Use your native Agent(subagent_type="{request.agent}") tool'
+            " to delegate instead."
+            if request.agent
+            else " Use your native Agent() tool to delegate instead."
+        )
+    else:
+        agent_hint = (
+            " Use a different model with '-m <model>' to route to an allowed harness,"
+            " or override with '--harness <harness>'."
+        )
+    raise ValueError(
+        f"Headless spawns on the '{harness.id.value}' harness are denied by "
+        f"'[spawn] deny_headless_harnesses' in meridian.toml."
+        f"{agent_hint}"
+    )
+
+
 def _missing_continue_session_error(source_ref: str | None) -> str:
     normalized_source = (source_ref or "").strip()
     if normalized_source:
@@ -1592,6 +1627,12 @@ def prepare_launch_surface(
             )
         }
     )
+    _enforce_headless_harness_policy(
+        request=resolved_request,
+        harness=harness,
+        runtime=runtime,
+        project_paths=project_paths,
+    )
     return PreparedLaunchSurface(
         request=resolved_request,
         harness=harness,
@@ -1877,30 +1918,13 @@ def bind_launch_context(
         if tools != resolved_request.tools:
             resolved_request = resolved_request.model_copy(update={"tools": tools})
 
-    if (
-        runtime.composition_surface == LaunchCompositionSurface.SPAWN_PREPARE
-        and harness.id.value in _resolve_deny_headless_harnesses(runtime, project_paths)
-    ):
-        parent_harness = os.getenv("_MERIDIAN_HARNESS", "")
-        if parent_harness == harness.id.value:
-            # Caller is on the same harness that's denied — suggest native delegation.
-            agent_hint = (
-                f' Use your native Agent(subagent_type="{resolved_request.agent}") tool'
-                " to delegate instead."
-                if resolved_request.agent
-                else " Use your native Agent() tool to delegate instead."
-            )
-        else:
-            # Caller is on a different harness — suggest switching model/harness.
-            agent_hint = (
-                " Use a different model with '-m <model>' to route to an allowed harness,"
-                " or override with '--harness <harness>'."
-            )
-        raise ValueError(
-            f"Headless spawns on the '{harness.id.value}' harness are denied by "
-            f"'[spawn] deny_headless_harnesses' in meridian.toml."
-            f"{agent_hint}"
-        )
+    # Defense in depth for persisted worker requests that bypassed preparation.
+    _enforce_headless_harness_policy(
+        request=resolved_request,
+        harness=harness,
+        runtime=runtime,
+        project_paths=project_paths,
+    )
 
     is_primary_launch = runtime.composition_surface == LaunchCompositionSurface.PRIMARY
     inject_task_cwd_instruction = directory_context.should_inject_task_cwd_instruction(

--- a/tests/integration/launch/test_launch_resolution_spawn_prepare.py
+++ b/tests/integration/launch/test_launch_resolution_spawn_prepare.py
@@ -484,6 +484,7 @@ def test_spawn_prepare_headless_deny_error_names_denied_harness(
         model="gpt-5.4",
         harness=HarnessId.CODEX,
     )
+    monkeypatch.delenv("_MERIDIAN_HARNESS", raising=False)
 
     with pytest.raises(ValueError) as exc_info:
         build_launch_context(

--- a/tests/integration/ops/test_spawn_api_create.py
+++ b/tests/integration/ops/test_spawn_api_create.py
@@ -6,6 +6,7 @@ Query/list/cancel/wait tests live in test_spawn_api_query.py.
 """
 
 import json
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -17,16 +18,98 @@ import meridian.lib.ops.spawn.pre_init as pre_init_module
 from meridian.lib.bootstrap.services import prepare_for_runtime_write
 from meridian.lib.core.context import RuntimeContext
 from meridian.lib.core.types import HarnessId
+from meridian.lib.launch import bundle_adapter
+from meridian.lib.launch.launch_types import ResolvedExecutionPolicy
 from meridian.lib.ops.spawn.models import SpawnCreateInput
-from meridian.lib.state import work_repository, work_store
+from meridian.lib.state import spawn_store, work_repository, work_store
 from meridian.lib.state.paths import resolve_project_paths
 from meridian.lib.telemetry import init_telemetry
 from tests.support.fakes import RecordingTelemetrySink, wait_for_telemetry
-from tests.support.launch import stub_bundle_request_and_resolve
+from tests.support.launch import FakeBundleResult, stub_bundle_request_and_resolve
 
 
 def _noop_setup_telemetry(**_kwargs: object) -> None:
     pass
+
+
+def test_background_headless_deny_rejects_before_reservation_without_affecting_allowed_spawn(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    (project_root / ".git").mkdir()
+    (project_root / "mars.toml").write_text("", encoding="utf-8")
+    (project_root / "meridian.toml").write_text(
+        '[spawn]\ndeny_headless_harnesses = ["codex"]\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("MERIDIAN_HOME", (tmp_path / "home").as_posix())
+    prepared = prepare_for_runtime_write(project_root)
+    worker_launches: list[tuple[object, ...]] = []
+    real_popen = subprocess.Popen
+
+    def _resolve_bundle(
+        request: bundle_adapter.BundleRequest,
+        *,
+        harness_registry: object,
+    ) -> FakeBundleResult:
+        _ = harness_registry
+        harness = HarnessId(request.harness_override or "codex")
+        model = request.model_override or "test-model"
+        return FakeBundleResult(
+            model=model,
+            model_token=model,
+            harness=harness,
+            harness_model=model,
+            execution_policy=ResolvedExecutionPolicy(),
+            provenance={"model_source": "cli", "harness_source": "cli"},
+        )
+
+    class _FakePopen:
+        pid = 42424
+
+    def _launch_worker(*args: object, **kwargs: object) -> object:
+        command = args[0] if args else kwargs.get("args")
+        if isinstance(command, tuple) and "meridian.lib.ops.spawn.execute_bg" in command:
+            worker_launches.append((*args, kwargs))
+            return _FakePopen()
+        return real_popen(*args, **kwargs)
+
+    monkeypatch.setattr(bundle_adapter, "request_and_resolve", _resolve_bundle)
+    monkeypatch.setattr(subprocess, "Popen", _launch_worker)
+
+    denied = spawn_api.spawn_create_sync(
+        SpawnCreateInput(
+            prompt="denied",
+            model="gpt-5.4",
+            harness="codex",
+            project_root=project_root.as_posix(),
+            background=True,
+        ),
+        prepared=prepared,
+    )
+    allowed = spawn_api.spawn_create_sync(
+        SpawnCreateInput(
+            prompt="allowed",
+            model="gemini-2.5-pro",
+            harness="opencode",
+            project_root=project_root.as_posix(),
+            background=True,
+        ),
+        prepared=prepared,
+    )
+
+    assert denied.status == "failed"
+    assert denied.spawn_id is None
+    assert denied.message is not None
+    assert "Headless spawns on the 'codex' harness are denied" in denied.message
+    assert allowed.status == "running"
+    assert allowed.spawn_id is not None
+    assert len(worker_launches) == 1
+    assert prepared.runtime_root is not None
+    rows = spawn_store.list_spawns(prepared.runtime_root).records
+    assert [row.id for row in rows] == [allowed.spawn_id]
 
 
 def test_spawn_create_dry_run_resolves_project_root_from_explicit_path(

--- a/tests/integration/ops/test_spawn_api_create.py
+++ b/tests/integration/ops/test_spawn_api_create.py
@@ -22,7 +22,7 @@ from meridian.lib.launch import bundle_adapter
 from meridian.lib.launch.launch_types import ResolvedExecutionPolicy
 from meridian.lib.ops.spawn.models import SpawnCreateInput
 from meridian.lib.state import spawn_store, work_repository, work_store
-from meridian.lib.state.paths import resolve_project_paths
+from meridian.lib.state.paths import resolve_project_paths, resolve_spawn_log_dir
 from meridian.lib.telemetry import init_telemetry
 from tests.support.fakes import RecordingTelemetrySink, wait_for_telemetry
 from tests.support.launch import FakeBundleResult, stub_bundle_request_and_resolve
@@ -110,6 +110,33 @@ def test_background_headless_deny_rejects_before_reservation_without_affecting_a
     assert prepared.runtime_root is not None
     rows = spawn_store.list_spawns(prepared.runtime_root).records
     assert [row.id for row in rows] == [allowed.spawn_id]
+    spawns_dir = prepared.runtime_root / "spawns"
+    assert [
+        path.name
+        for path in spawns_dir.iterdir()
+        if path.is_dir() and not path.name.startswith(".")
+    ] == [allowed.spawn_id]
+    assert list((spawns_dir / ".staging").iterdir()) == []
+
+    allowed_log_dir = resolve_spawn_log_dir(
+        project_root,
+        allowed.spawn_id,
+        runtime_root=prepared.runtime_root,
+    )
+    params = json.loads((allowed_log_dir / "params.json").read_text(encoding="utf-8"))
+    assert params["model"] == "gemini-2.5-pro"
+    assert params["harness"] == "opencode"
+    assert params["prompt_length"] == len("allowed")
+
+    worker_request = json.loads(
+        (allowed_log_dir / "bg-worker-request.json").read_text(encoding="utf-8")
+    )
+    assert worker_request["request"]["prompt"] == "allowed"
+    assert worker_request["request"]["harness"] == "opencode"
+
+    launch_command = worker_launches[0][0]
+    assert isinstance(launch_command, tuple)
+    assert launch_command[launch_command.index("--spawn-id") + 1] == allowed.spawn_id
 
 
 def test_spawn_create_dry_run_resolves_project_root_from_explicit_path(

--- a/tests/integration/ops/test_spawn_continue.py
+++ b/tests/integration/ops/test_spawn_continue.py
@@ -28,6 +28,10 @@ def _state_root(project_root: Path) -> Path:
         '[settings]\ntargets = [".claude", ".codex", ".opencode"]\n',
         encoding="utf-8",
     )
+    (project_root / "meridian.toml").write_text(
+        "[spawn]\ndeny_headless_harnesses = []\n",
+        encoding="utf-8",
+    )
     runtime_root = resolve_project_runtime_root_for_write(project_root)
     runtime_root.mkdir(parents=True, exist_ok=True)
     return runtime_root

--- a/tests/integration/streaming/test_resident_drain_manager.py
+++ b/tests/integration/streaming/test_resident_drain_manager.py
@@ -48,6 +48,39 @@ async def test_codex_terminal_success_without_live_children_finalizes_immediatel
     finally:
         await manager.stop_spawn(spawn_id)
 
+
+@pytest.mark.asyncio
+async def test_codex_failed_turn_completed_preserves_terminal_error(
+    tmp_path: Path,
+) -> None:
+    spawn_id = SpawnId("p1")
+    start_row(tmp_path, str(spawn_id), HarnessId.CODEX, None)
+    connection = FakeResidentConnection(HarnessId.CODEX)
+    manager = await start_manager(tmp_path, connection, spawn_id=spawn_id)
+
+    connection.emit(
+        resident_event(
+            HarnessId.CODEX,
+            "turn/completed",
+            {
+                "turn": {
+                    "status": "failed",
+                    "error": {"message": "The requested model is not supported."},
+                }
+            },
+        )
+    )
+
+    try:
+        outcome = await manager.wait_for_completion(spawn_id)
+        assert outcome is not None
+        assert outcome.status == "failed"
+        assert outcome.exit_code == 1
+        assert outcome.error == "The requested model is not supported."
+    finally:
+        await manager.stop_spawn(spawn_id)
+
+
 @pytest.mark.asyncio
 async def test_codex_backend_death_with_pending_success_preserves_resident_reason(
     tmp_path: Path,

--- a/tests/integration/streaming/test_spawn_drain_loop.py
+++ b/tests/integration/streaming/test_spawn_drain_loop.py
@@ -34,6 +34,7 @@ from meridian.lib.streaming.drain_coordinator import (
     DrainExitDecision,
     DrainLoopDecision,
     DrainPlan,
+    DrainTerminalDecision,
 )
 from meridian.lib.streaming.drain_wait import _cancel_task
 from meridian.lib.streaming.event_observers import EventObserverRegistry
@@ -143,6 +144,16 @@ class _Coordinator:
     def note_event_persisted(self, event: RawHarnessEvent) -> DrainLoopDecision:
         self._calls.append(("noted", event))
         return DrainLoopDecision()
+
+    async def handle_terminal_event(
+        self,
+        event: RawHarnessEvent,
+        outcome: Any,
+        action: Any,
+    ) -> DrainTerminalDecision:
+        del action
+        self._calls.append(("terminal", event))
+        return DrainTerminalDecision(recorded_outcome=outcome)
 
     async def after_event(self) -> DrainLoopDecision:
         return DrainLoopDecision()
@@ -394,6 +405,27 @@ async def test_tenth_history_write_failure_aborts_without_delivery() -> None:
     assert outcomes[0].error == (
         "Aborted drain loop after repeated output persistence failures"
     )
+
+
+@pytest.mark.asyncio
+async def test_codex_interrupted_turn_publishes_cancelled_drain_outcome() -> None:
+    interrupted = RawHarnessEvent(
+        event_type="turn/completed",
+        harness_id="codex",
+        payload={"turn": {"status": "interrupted"}},
+    )
+    outcomes: list[DrainOutcome] = []
+
+    await _run_drain(
+        [interrupted],
+        [WriteResult(success=True, seq=0)],
+        outcomes=outcomes,
+    )
+
+    assert len(outcomes) == 1
+    assert outcomes[0].status == "cancelled"
+    assert outcomes[0].exit_code == 130
+    assert outcomes[0].error == "interrupted"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/harness/test_codex_thread_termination.py
+++ b/tests/unit/harness/test_codex_thread_termination.py
@@ -64,6 +64,29 @@ def test_single_thread_turn_completed_stays_terminal_without_thread_id() -> None
     assert outcome.status == "succeeded"
 
 
+def test_failed_turn_completed_normalizes_nested_codex_error() -> None:
+    event = _codex_event(
+        "turn/completed",
+        {
+            "threadId": MAIN_THREAD,
+            "turn": {
+                "status": "failed",
+                "error": {
+                    "message": "The requested model is not supported.",
+                    "codexErrorInfo": {"type": "other"},
+                },
+            },
+        },
+    )
+
+    outcome = normalize_event(event).semantics.terminal
+
+    assert outcome is not None
+    assert outcome.status == "failed"
+    assert outcome.exit_code == 1
+    assert outcome.error == "The requested model is not supported."
+
+
 def test_opencode_child_session_terminal_events_do_not_complete_parent_scope() -> None:
     parent_scope = PrimaryEventScope(HarnessId.OPENCODE, "ses_parent")
     child_idle = _opencode_event("session.idle", "ses_child")

--- a/tests/unit/harness/test_codex_thread_termination.py
+++ b/tests/unit/harness/test_codex_thread_termination.py
@@ -87,6 +87,34 @@ def test_failed_turn_completed_normalizes_nested_codex_error() -> None:
     assert outcome.error == "The requested model is not supported."
 
 
+def test_interrupted_turn_completed_normalizes_as_cancelled() -> None:
+    event = _codex_event(
+        "turn/completed",
+        {"turn": {"status": "interrupted"}},
+    )
+
+    outcome = normalize_event(event).semantics.terminal
+
+    assert outcome is not None
+    assert outcome.status == "cancelled"
+    assert outcome.exit_code == 130
+    assert outcome.error == "interrupted"
+
+
+def test_unknown_turn_completed_status_normalizes_as_failed() -> None:
+    event = _codex_event(
+        "turn/completed",
+        {"turn": {"status": "inProgress"}},
+    )
+
+    outcome = normalize_event(event).semantics.terminal
+
+    assert outcome is not None
+    assert outcome.status == "failed"
+    assert outcome.exit_code == 1
+    assert outcome.error == "unexpected_codex_turn_status:inProgress"
+
+
 def test_opencode_child_session_terminal_events_do_not_complete_parent_scope() -> None:
     parent_scope = PrimaryEventScope(HarnessId.OPENCODE, "ses_parent")
     child_idle = _opencode_event("session.idle", "ses_child")

--- a/tests/unit/harness/test_semantics.py
+++ b/tests/unit/harness/test_semantics.py
@@ -1,0 +1,21 @@
+import pytest
+
+from meridian.lib.harness.semantics import TerminalEventOutcome
+
+
+@pytest.mark.parametrize(
+    ("exit_code", "error"),
+    [
+        (1, None),
+        (0, "reported error"),
+    ],
+)
+def test_succeeded_terminal_outcome_rejects_failure_evidence(
+    exit_code: int,
+    error: str | None,
+) -> None:
+    with pytest.raises(
+        ValueError,
+        match="succeeded terminal outcomes require exit_code=0 and no error",
+    ):
+        TerminalEventOutcome(status="succeeded", exit_code=exit_code, error=error)


### PR DESCRIPTION
## Why

Two spawn-lifecycle bugs from the #442/#448/#449 investigation (p5575):
background submission reports success for spawns whose harness is denied by
`[spawn] deny_headless_harnesses` — the denial only surfaces seconds later
as a generic worker launch failure — and Codex turns that fail upstream
(e.g. unsupported-model 400) are persisted as `succeeded` with exit 0
because `CODEX_SEMANTICS` treated every `turn/completed` as success.

## Goal

Denied spawns fail synchronously at submission with the actionable policy
error; Codex terminal classification reflects the turn's actual status.

## Summary

- **#442**: headless-deny policy moved from `bind_launch_context()` into
  `_enforce_headless_harness_policy()`, called in `prepare_launch_surface()`
  — before spawn-row reservation and worker launch. The bind-time call is
  retained as a defense-in-depth backstop (effectively unreachable in
  production since prepare gates first; the guard lives inside the single
  helper so the two call sites cannot drift).
- **#448**: Codex `turn/completed` payload resolver reads nested
  `turn.status`: `completed`/absent → succeeded/0, `failed` → failed/1 with
  the upstream error message, `interrupted` → cancelled/130 (mirrors the Pi
  abort convention), unknown → failed/1 with a diagnostic. Connection-closed
  classification unchanged. Raw connection adapter (`codex_ws.py`) untouched.
- **Invariant**: `TerminalEventOutcome` rejects succeeded outcomes with a
  nonzero exit code or an error — the invalid state #448 demonstrated is now
  unrepresentable.

## Resulting Behavior

- `meridian spawn --bg` on a denied harness returns the policy error
  immediately (with the delegate/model hint); no spawn row, log dir, or
  worker artifacts are created. `spawn wait` no longer stalls on a
  known-dead submission.
- A Codex spawn hitting an unsupported-model 400 shows `failed` / exit 1
  with the upstream message; an interrupted turn shows `cancelled` / 130.

## Changes

- `src/meridian/lib/launch/context.py` — policy extraction; prepare-time
  enforcement (guarded to `SPAWN_PREPARE` surface, primaries unaffected).
- `src/meridian/lib/harness/codex.py` — explicit turn-status ladder.
- `src/meridian/lib/harness/semantics.py` — `TerminalEventOutcome`
  `__post_init__` invariant.
- `src/meridian/lib/harness/.context/CONTEXT.md` — Codex terminal mapping
  updated to the turn-status ladder.
- Deferred: #449 (Codex death diagnostics + process identity — findings
  posted to the issue), #458 (wait fail-fast reporting, filed from this
  investigation).

## Work Item

workstream-roadmap

## Verification

- Regression tests: denied background submission leaves zero on-disk
  artifacts while a subsequent allowed spawn is unaffected; semantic-seam +
  drain-level tests for failed/interrupted/unknown Codex turns; invariant
  tests.
- Focused suites 28 passed; ruff clean; pyright 0 errors.
- Reviewed by p5609 (request-changes; all three findings addressed:
  interrupted classification, artifact assertions, invariant) and a
  second-opinion pass on a different model (ship-with-notes; applied:
  resolver restructured behind an explicit event-type guard, deliberate
  malformed-payload→failed asymmetry documented in code). Reaper test
  failures seen during review were env inheritance from the parent Meridian
  session — verified all 4 pass with a clean env; fixed on main by #459's
  conftest change.

## Knowledge Updates

- Issue #449 updated with investigation findings; #458 filed.
- kb-lead capture completed: KB repo commit `4345295` (Codex turn-status
  ladder, deny-at-prepare decision, terminal-outcome invariant, #449
  identity conflation as open question PROC-009).
- Colocated `harness/.context/CONTEXT.md` mapping updated on this branch.
- Decision log in the workstream-roadmap work dir.

## Spawn Trace

- p5575 investigator — root causes (prior session)
- p5607 coder — implemented #442/#448
- p5609 reviewer — branch review (request-changes)
- p5612 coder — review fix-ups (interrupted status, artifacts, invariant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
