### PR TITLE
Fix 4 triaged bugs (#321, #458, #211, #139)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- State stores persist control and working-directory paths in a consistent
+  absolute, normalized form. (#211)
+
 ## [0.3.47] - 2026-07-23
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- `meridian spawn` now rejects bare positional prompts that closely resemble
+  spawn subcommands and suggests the intended command. Explicit prompt flags
+  remain literal. (#321)
+
 ## [0.3.47] - 2026-07-23
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `meridian spawn` now rejects bare positional prompts that closely resemble
   spawn subcommands and suggests the intended command. Explicit prompt flags
   remain literal. (#321)
+- `meridian spawn wait --fail-fast` now returns on the first failed or timed-out
+  spawn and reports the spawns that remain pending. (#458)
 
 ## [0.3.47] - 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - State stores persist control and working-directory paths in a consistent
   absolute, normalized form. (#211)
+- Telemetry segment reads and tails now share one truncation-tolerant JSONL
+  parser. (#139)
 
 ## [0.3.47] - 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Fixed
-- `meridian spawn` now rejects bare positional prompts that closely resemble
-  spawn subcommands and suggests the intended command. Explicit prompt flags
-  remain literal. (#321)
+- `meridian spawn` now rejects bare, subcommand-shaped one-word prompts that
+  are not registered spawn subcommands and suggests a nearby command when
+  possible. Explicit prompt flags remain literal. (#321)
 - `meridian spawn wait --fail-fast` now returns on the first failed or timed-out
   spawn and reports the spawns that remain pending. (#458)
 - State stores persist control and working-directory paths in a consistent

--- a/src/meridian/cli/AGENTS.md
+++ b/src/meridian/cli/AGENTS.md
@@ -28,6 +28,7 @@ argv
 - **`root_source = RootSource.ARGV`** commands (e.g. `meridian init [path]`) defer bootstrap until after argument parsing. They call `prepare_for_project_write(arg_derived_root)` themselves — they don't receive a pre-prepared context.
 - **`validate_fork_mode()` is the single place for fork/from/continue conflict checks.** `spawn.py` and `primary_launch.py` both call it and consume `ForkModeResolution`. Do not re-implement conflict logic or ref resolution in handlers.
 - **`normalize_optional_value_flags()` runs before everything.** It rewrites bare `--fork`/`--fork-fresh`/`--from` to `--fork __SELF__` so Cyclopts always receives a value. Never call Cyclopts on raw argv containing these flags.
+- **Positional-prompt subcommand guard.** `_validate_positional_spawn_prompt()` in `spawn.py` rejects bare positional prompts that look like a subcommand (`^[a-z][a-z-]*$` single token) but are not in the registered subcommand set. The subcommand set is derived from the commands registered with Cyclopts, not hardcoded. `-p`/`--prompt`/`--prompt-file` bypass this guard and accept any string. The did-you-mean hint uses Damerau-Levenshtein (adjacent-transposition-aware) distance.
 
 ## Invocation Classes
 
@@ -63,6 +64,7 @@ argv
 - Don't mutate shared `App` objects for help profile selection — `HelpProfile` is selected at build time per invocation.
 - Don't re-implement fork/continue/from conflict checks in handlers — call `validate_fork_mode()` and use `ForkModeResolution`.
 - Don't push the identity lock (`--fork` + model/agent/skills conflict) into the ops layer — it's CLI ergonomic policy, not an ops invariant.
+- Don't hardcode subcommand names in the positional-prompt guard — derive the set from registered commands so new subcommands are automatically covered.
 
 ## Related
 

--- a/src/meridian/cli/spawn.py
+++ b/src/meridian/cli/spawn.py
@@ -188,6 +188,38 @@ def _resolve_spawn_prompt(
     raise ValueError("prompt required: pass -p/--prompt or --prompt-file")
 
 
+def _edit_distance(left: str, right: str) -> int:
+    """Return the Levenshtein distance between two short CLI tokens."""
+    previous = list(range(len(right) + 1))
+    for left_index, left_char in enumerate(left, start=1):
+        current = [left_index]
+        for right_index, right_char in enumerate(right, start=1):
+            current.append(
+                min(
+                    current[-1] + 1,
+                    previous[right_index] + 1,
+                    previous[right_index - 1] + (left_char != right_char),
+                )
+            )
+        previous = current
+    return previous[-1]
+
+
+def _validate_positional_spawn_prompt(
+    prompt: str | None,
+    *,
+    subcommands: frozenset[str],
+) -> None:
+    if prompt is None or not prompt or any(char.isspace() for char in prompt):
+        return
+    closest = min(subcommands, key=lambda command: (_edit_distance(prompt, command), command))
+    if _edit_distance(prompt, closest) <= 2:
+        raise ValueError(
+            f"Unknown spawn subcommand '{prompt}'; "
+            f"did you mean 'meridian spawn {closest}'?"
+        )
+
+
 def _shared_launch_input_kwargs(
     *,
     dry_run: bool,
@@ -234,7 +266,16 @@ def _shared_launch_input_kwargs(
 
 
 def _spawn_create(
+    subcommands: frozenset[str],
     emit: Any,
+    positional_prompt: Annotated[
+        str | None,
+        Parameter(
+            name="prompt",
+            help="Inline literal prompt.",
+        ),
+    ] = None,
+    *,
     prompt: Annotated[
         str | None,
         Parameter(
@@ -590,8 +631,11 @@ def _spawn_create(
         phase="prompt_resolution",
         launcher_pid=os.getpid(),
     )
+    _validate_positional_spawn_prompt(positional_prompt, subcommands=subcommands)
+    if positional_prompt is not None and prompt is not None:
+        raise ValueError("cannot specify both a positional prompt and -p/--prompt")
     resolved_prompt = _resolve_spawn_prompt(
-        prompt,
+        prompt if prompt is not None else positional_prompt,
         prompt_file,
         has_files=bool(references),
         is_continue=resolved_continue_from is not None,
@@ -1212,7 +1256,6 @@ def register_spawn_commands(app: App, emit: Emitter) -> tuple[set[str], dict[str
             "meridian.spawn.wait": _SPAWN_WAIT_HELP_EPILOGUE,
         },
         emit=emit,
-        default_handler=partial(_spawn_create, emit),
     )
     app.command(
         partial(_spawn_done, emit),
@@ -1246,4 +1289,8 @@ def register_spawn_commands(app: App, emit: Emitter) -> tuple[set[str], dict[str
         help="Removed. Use `meridian session log ID`.",
         show=False,
     )
+    registered.add("spawn.log")
+    descriptions["meridian.spawn.log"] = "Removed. Use `meridian session log ID`."
+    subcommands = frozenset(command.removeprefix("spawn.") for command in registered)
+    app.default(partial(_spawn_create, subcommands, emit))
     return registered, descriptions

--- a/src/meridian/cli/spawn.py
+++ b/src/meridian/cli/spawn.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import os
+import re
 import sys
 from collections.abc import Callable
 from functools import partial
@@ -189,20 +190,32 @@ def _resolve_spawn_prompt(
 
 
 def _edit_distance(left: str, right: str) -> int:
-    """Return the Levenshtein distance between two short CLI tokens."""
-    previous = list(range(len(right) + 1))
+    """Return the adjacent-transposition-aware edit distance for two CLI tokens."""
+    distances = [[0] * (len(right) + 1) for _ in range(len(left) + 1)]
+    for left_index in range(len(left) + 1):
+        distances[left_index][0] = left_index
+    for right_index in range(len(right) + 1):
+        distances[0][right_index] = right_index
+
     for left_index, left_char in enumerate(left, start=1):
-        current = [left_index]
         for right_index, right_char in enumerate(right, start=1):
-            current.append(
-                min(
-                    current[-1] + 1,
-                    previous[right_index] + 1,
-                    previous[right_index - 1] + (left_char != right_char),
-                )
+            distances[left_index][right_index] = min(
+                distances[left_index - 1][right_index] + 1,
+                distances[left_index][right_index - 1] + 1,
+                distances[left_index - 1][right_index - 1]
+                + (left_char != right_char),
             )
-        previous = current
-    return previous[-1]
+            if (
+                left_index > 1
+                and right_index > 1
+                and left_char == right[right_index - 2]
+                and left[left_index - 2] == right_char
+            ):
+                distances[left_index][right_index] = min(
+                    distances[left_index][right_index],
+                    distances[left_index - 2][right_index - 2] + 1,
+                )
+    return distances[-1][-1]
 
 
 def _validate_positional_spawn_prompt(
@@ -210,14 +223,22 @@ def _validate_positional_spawn_prompt(
     *,
     subcommands: frozenset[str],
 ) -> None:
-    if prompt is None or not prompt or any(char.isspace() for char in prompt):
+    if (
+        prompt is None
+        or prompt in subcommands
+        or re.fullmatch(r"[a-z][a-z-]*", prompt) is None
+    ):
         return
     closest = min(subcommands, key=lambda command: (_edit_distance(prompt, command), command))
-    if _edit_distance(prompt, closest) <= 2:
-        raise ValueError(
-            f"Unknown spawn subcommand '{prompt}'; "
-            f"did you mean 'meridian spawn {closest}'?"
-        )
+    suggestion = (
+        f"; did you mean 'meridian spawn {closest}'?"
+        if _edit_distance(prompt, closest) <= 2
+        else ""
+    )
+    raise ValueError(
+        f"unknown spawn subcommand '{prompt}'{suggestion}\n"
+        "To force a literal one-word prompt, use --prompt."
+    )
 
 
 def _shared_launch_input_kwargs(

--- a/src/meridian/cli/spawn.py
+++ b/src/meridian/cli/spawn.py
@@ -1015,6 +1015,13 @@ def _spawn_wait(
             ),
         ),
     ] = None,
+    fail_fast: Annotated[
+        bool,
+        Parameter(
+            name="--fail-fast",
+            help="Return as soon as any spawn fails, listing spawns still pending.",
+        ),
+    ] = False,
     verbose: Annotated[
         bool,
         Parameter(name="--verbose", help="Enable verbose wait status output.", show=True),
@@ -1047,6 +1054,7 @@ def _spawn_wait(
             timeout=timeout,
             yield_after_secs=yield_after_secs,
             timeout_explicit=timeout is not None,
+            fail_fast=fail_fast,
             verbose=verbose,
             quiet=quiet,
             include_report_body=report,

--- a/src/meridian/lib/ops/spawn/.context/CONTEXT.md
+++ b/src/meridian/lib/ops/spawn/.context/CONTEXT.md
@@ -9,9 +9,9 @@ Depth is read from `_MERIDIAN_DEPTH` env var in the child. The reaper also check
 and skips reaping when inside a spawn. This is an ops-layer enforcement; `launch/` does not
 independently enforce depth.
 
-## Spawn Wait — Checkpoint vs Hard Timeout
+## Spawn Wait — Checkpoint, Hard Timeout, and Fail-Fast
 
-`spawn_wait_sync()` has two timeout modes:
+`spawn_wait_sync()` has three exit paths:
 
 **Checkpoint mode** (default, `timeout_explicit=False`): waits up to `checkpoint_seconds` (harness-
 aware yield interval), then returns a `SpawnWaitMultiOutput` with `checkpoint=True` and
@@ -20,6 +20,13 @@ pattern — agents get a periodic yield to check progress rather than blocking i
 
 **Hard timeout** (`timeout_explicit=True`): waits up to `timeout` minutes, then raises `TimeoutError`
 with an actionable message listing pending spawn IDs and suggested next commands.
+
+**Fail-fast** (`fail_fast=True`): after each poll, if any completed spawn has status `failed` or
+`timed_out` AND spawns are still pending, returns early with `fail_fast=True` and `pending_ids`
+in the output. `cancelled` does not trigger fail-fast. Snapshot consistency: the pending set is
+derived from the same re-read snapshot used to build the result, so a spawn that goes terminal
+during the re-read appears correctly in one category. If everything went terminal mid-snapshot,
+the normal completed output is returned instead of a fail-fast result.
 
 The yield interval is resolved from `_MERIDIAN_HARNESS` env var (parent harness's prompt-cache TTL
 awareness) unless `yield_after_secs` is explicitly passed.

--- a/src/meridian/lib/ops/spawn/AGENTS.md
+++ b/src/meridian/lib/ops/spawn/AGENTS.md
@@ -33,6 +33,10 @@ nested processes also read it to skip reaping side effects.
 - Without args (no-arg form): scoped to the current `_MERIDIAN_DEPTH` — waits for
   spawns created at this nesting level only, not grandchild spawns.
 
+`--fail-fast` exits as soon as any spawn reaches `failed` or `timed_out`, reporting
+which spawns failed and which are still pending. `cancelled` does not trigger
+fail-fast (cancellation keeps existing aggregate-exit behavior).
+
 Checkpoint polling respects the depth-appropriate yield interval (read from
 `_MERIDIAN_HARNESS` env — the orchestrator's own harness prompt-cache TTL).
 

--- a/src/meridian/lib/ops/spawn/api.py
+++ b/src/meridian/lib/ops/spawn/api.py
@@ -1521,7 +1521,12 @@ def _emit_wait_set(
     sink.status("\n".join(lines))
 
 
-def _build_wait_multi_output(results: tuple[SpawnDetailOutput, ...]) -> SpawnWaitMultiOutput:
+def _build_wait_multi_output(
+    results: tuple[SpawnDetailOutput, ...],
+    *,
+    fail_fast: bool = False,
+    pending_ids: tuple[str, ...] = (),
+) -> SpawnWaitMultiOutput:
     total_runs = len(results)
     succeeded_runs = sum(1 for run in results if run.status == "succeeded")
     failed_runs = sum(1 for run in results if run.status == "failed")
@@ -1547,6 +1552,8 @@ def _build_wait_multi_output(results: tuple[SpawnDetailOutput, ...]) -> SpawnWai
         cancelled_runs=cancelled_runs,
         timed_out_runs=timed_out_runs,
         any_failed=any_failed,
+        fail_fast=fail_fast,
+        pending_ids=pending_ids,
         spawn_id=spawn_id,
         status=status,
         exit_code=exit_code,
@@ -1766,6 +1773,42 @@ def spawn_wait_sync(
                 if _spawn_is_terminal(row.status):
                     completed_rows[spawn_id] = row
                     pending.remove(spawn_id)
+
+            failed_rows = tuple(
+                row for row in completed_rows.values() if row.status in FAILURE_SPAWN_STATUSES
+            )
+            if payload.fail_fast and failed_rows and pending:
+                pending_ids = tuple(sorted(pending))
+                snapshot_rows = dict(completed_rows)
+                for spawn_id in pending_ids:
+                    row = read_spawn_row(project_root, spawn_id, runtime_root=runtime_root)
+                    if row is not None:
+                        snapshot_rows[spawn_id] = row
+                details = tuple(
+                    detail_from_row(
+                        project_root=project_root,
+                        row=snapshot_rows[spawn_id],
+                        include_report_body=payload.include_report_body,
+                        runtime_root=runtime_root,
+                    )
+                    for spawn_id in spawn_ids
+                    if spawn_id in snapshot_rows
+                )
+                _update_pi_wait_observation(
+                    runtime_root=runtime_root,
+                    parent_spawn_id=parent_wait_observer_id,
+                    waiting_remove=spawn_ids,
+                    observed_add=tuple(
+                        detail.spawn_id
+                        for detail in details
+                        if _spawn_is_terminal(detail.status)
+                    ),
+                )
+                return _build_wait_multi_output(
+                    details,
+                    fail_fast=True,
+                    pending_ids=pending_ids,
+                )
 
             if not pending:
                 details = tuple(

--- a/src/meridian/lib/ops/spawn/api.py
+++ b/src/meridian/lib/ops/spawn/api.py
@@ -1778,12 +1778,14 @@ def spawn_wait_sync(
                 row for row in completed_rows.values() if row.status in FAILURE_SPAWN_STATUSES
             )
             if payload.fail_fast and failed_rows and pending:
-                pending_ids = tuple(sorted(pending))
                 snapshot_rows = dict(completed_rows)
-                for spawn_id in pending_ids:
+                for spawn_id in tuple(pending):
                     row = read_spawn_row(project_root, spawn_id, runtime_root=runtime_root)
-                    if row is not None:
-                        snapshot_rows[spawn_id] = row
+                    if row is None:
+                        if has_explicit_ids:
+                            raise ValueError(f"Spawn '{spawn_id}' not found")
+                        continue
+                    snapshot_rows[spawn_id] = row
                 details = tuple(
                     detail_from_row(
                         project_root=project_root,
@@ -1793,6 +1795,13 @@ def spawn_wait_sync(
                     )
                     for spawn_id in spawn_ids
                     if spawn_id in snapshot_rows
+                )
+                pending_ids = tuple(
+                    sorted(
+                        detail.spawn_id
+                        for detail in details
+                        if not _spawn_is_terminal(detail.status)
+                    )
                 )
                 _update_pi_wait_observation(
                     runtime_root=runtime_root,
@@ -1804,6 +1813,8 @@ def spawn_wait_sync(
                         if _spawn_is_terminal(detail.status)
                     ),
                 )
+                if not pending_ids:
+                    return _build_wait_multi_output(details)
                 return _build_wait_multi_output(
                     details,
                     fail_fast=True,

--- a/src/meridian/lib/ops/spawn/models.py
+++ b/src/meridian/lib/ops/spawn/models.py
@@ -1239,6 +1239,7 @@ class SpawnWaitInput(BaseModel):
     yield_after_secs: float | None = None
     timeout_explicit: bool = False
     poll_interval_secs: float | None = None
+    fail_fast: bool = False
     verbose: bool = False
     quiet: bool = False
     include_report_body: bool = False
@@ -1255,6 +1256,8 @@ class SpawnWaitMultiOutput(BaseModel):
     cancelled_runs: int
     timed_out_runs: int = 0
     any_failed: bool
+    fail_fast: bool = False
+    pending_ids: tuple[str, ...] = ()
     checkpoint: bool = False
     checkpoint_pending_ids: tuple[str, ...] = ()
     checkpoint_chat_id: str | None = None
@@ -1269,6 +1272,18 @@ class SpawnWaitMultiOutput(BaseModel):
         effective_ctx = ctx or FormatContext()
         if self.checkpoint:
             return self._format_checkpoint_text()
+        if self.fail_fast:
+            failed_ids = ", ".join(
+                spawn.spawn_id
+                for spawn in self.spawns
+                if spawn.status in {"failed", "timed_out"}
+            )
+            pending_ids = ", ".join(self.pending_ids)
+            details = self.model_copy(
+                update={"fail_fast": False, "pending_ids": ()}
+            ).format_text(effective_ctx)
+            summary = f"Fail-fast: {failed_ids} failed. Still pending: {pending_ids}."
+            return f"{summary}\n\n{details}" if details else summary
         if not self.spawns:
             return ""
         if len(self.spawns) == 1:
@@ -1334,6 +1349,9 @@ class SpawnWaitMultiOutput(BaseModel):
             "timed_out_runs": self.timed_out_runs,
             "any_failed": self.any_failed,
         }
+        if self.fail_fast:
+            wire["fail_fast"] = True
+            wire["pending_ids"] = list(self.pending_ids)
         if self.checkpoint:
             wire["checkpoint"] = True
             wire["checkpoint_pending_ids"] = list(self.checkpoint_pending_ids)

--- a/src/meridian/lib/ops/spawn/models.py
+++ b/src/meridian/lib/ops/spawn/models.py
@@ -1282,7 +1282,10 @@ class SpawnWaitMultiOutput(BaseModel):
             details = self.model_copy(
                 update={"fail_fast": False, "pending_ids": ()}
             ).format_text(effective_ctx)
-            summary = f"Fail-fast: {failed_ids} failed. Still pending: {pending_ids}."
+            summary = (
+                f"Fail-fast: {failed_ids} failed or timed out. "
+                f"Still pending: {pending_ids}."
+            )
             return f"{summary}\n\n{details}" if details else summary
         if not self.spawns:
             return ""

--- a/src/meridian/lib/state/.context/FUTURE
+++ b/src/meridian/lib/state/.context/FUTURE
@@ -1,0 +1,7 @@
+# state/ — nice-to-have follow-ups
+
+[#211 follow-up] normalize_path_for_write (paths.py) is applied only to
+control_root/task_cwd/execution_cwd at spawn/session write sites. Other
+persisted path-like fields (claude_config_dir, agent_path, skill_paths) still
+accept raw strings — extend the same write-boundary normalization if their
+consumers ever compare or dedupe on path equality.

--- a/src/meridian/lib/state/AGENTS.md
+++ b/src/meridian/lib/state/AGENTS.md
@@ -78,6 +78,15 @@ the repository never imports the projection. Cross-leaf operations belong in the
 order above. Reaper claims consume one immutable projection snapshot containing
 both scopes and released IDs, read under a single projection-lock acquisition.
 
+## Write-Boundary Path Normalization
+
+`normalize_path_for_write()` in `paths.py` normalizes path strings to stable absolute
+form (`os.path.abspath(os.path.normpath(...))`) at the write boundary. Applied to
+`control_root`, `task_cwd`, and `execution_cwd` in both `spawn_store` and
+`session_store`. Other path-like fields (`claude_config_dir`, `agent_path`,
+`skill_paths`) are not yet normalized; see `.context/FUTURE` for the scope-out.
+New persisted path fields should use this helper at their write site.
+
 ## Atomic Write Contract
 
 State-facing writes go through `atomic.py`, which delegates file replacement to the

--- a/src/meridian/lib/state/paths.py
+++ b/src/meridian/lib/state/paths.py
@@ -1,5 +1,6 @@
 """Filesystem path helpers for file-authoritative Meridian state."""
 
+import os
 import tomllib
 from pathlib import Path
 from typing import Self, cast
@@ -11,6 +12,14 @@ from meridian.lib.config.project_paths import ProjectConfigPaths
 from meridian.lib.config.project_root import resolve_user_config_path
 from meridian.lib.core.types import SpawnId
 from meridian.lib.state.user_paths import get_or_create_project_id, get_project_id, get_user_home
+
+
+def normalize_path_for_write(path: str | None) -> str | None:
+    """Return a stable absolute form for a path persisted in state."""
+
+    if not path:
+        return path
+    return os.path.abspath(os.path.normpath(path))
 
 
 class RuntimePaths(BaseModel):

--- a/src/meridian/lib/state/session_store.py
+++ b/src/meridian/lib/state/session_store.py
@@ -26,7 +26,7 @@ from meridian.lib.platform.locking import (
 from meridian.lib.state.atomic import atomic_write_text
 from meridian.lib.state.event_store import append_event, read_events, utc_now_iso
 from meridian.lib.state.liveness import is_process_alive
-from meridian.lib.state.paths import RuntimePaths
+from meridian.lib.state.paths import RuntimePaths, normalize_path_for_write
 
 
 class _SessionLockHandles(NamedTuple):
@@ -377,9 +377,9 @@ def start_session(
             kind=kind,
             harness=harness,
             harness_session_id=HarnessSessionId(harness_session_id),
-            control_root=control_root,
-            task_cwd=task_cwd,
-            execution_cwd=execution_cwd,
+            control_root=normalize_path_for_write(control_root),
+            task_cwd=normalize_path_for_write(task_cwd),
+            execution_cwd=normalize_path_for_write(execution_cwd),
             claude_config_dir=claude_config_dir,
             model=model,
             agent=agent,

--- a/src/meridian/lib/state/spawn_store.py
+++ b/src/meridian/lib/state/spawn_store.py
@@ -32,7 +32,7 @@ from meridian.lib.core.spawn_start import SpawnStartMetadata, derive_display_lab
 from meridian.lib.core.types import ChatId, HarnessSessionId, SpawnId
 from meridian.lib.state.atomic import atomic_publish_dir, atomic_write_text
 from meridian.lib.state.event_store import lock_file
-from meridian.lib.state.paths import RuntimePaths
+from meridian.lib.state.paths import RuntimePaths, normalize_path_for_write
 from meridian.lib.state.spawn.model import (
     AUTHORITATIVE_ORIGINS,
 )
@@ -334,9 +334,9 @@ def start_spawn(
                 if harness_session_id is not None
                 else None
             ),
-            control_root=control_root,
-            task_cwd=task_cwd,
-            execution_cwd=execution_cwd,
+            control_root=normalize_path_for_write(control_root),
+            task_cwd=normalize_path_for_write(task_cwd),
+            execution_cwd=normalize_path_for_write(execution_cwd),
             claude_config_dir=claude_config_dir,
             launch_mode=launch_mode,
             worker_pid=worker_pid,
@@ -433,11 +433,11 @@ def update_spawn(
         if harness_session_id is not None:
             updates["harness_session_id"] = harness_session_id
         if control_root is not None:
-            updates["control_root"] = control_root
+            updates["control_root"] = normalize_path_for_write(control_root)
         if task_cwd is not None:
-            updates["task_cwd"] = task_cwd
+            updates["task_cwd"] = normalize_path_for_write(task_cwd)
         if execution_cwd is not None:
-            updates["execution_cwd"] = execution_cwd
+            updates["execution_cwd"] = normalize_path_for_write(execution_cwd)
         if claude_config_dir is not None:
             updates["claude_config_dir"] = claude_config_dir
         if desc is not None:

--- a/src/meridian/lib/telemetry/reader.py
+++ b/src/meridian/lib/telemetry/reader.py
@@ -20,6 +20,19 @@ def _as_string_key_dict(value: object) -> dict[str, Any] | None:
     return cast("dict[str, Any]", value)
 
 
+def _parse_jsonl_line(line: str | bytes) -> dict[str, Any] | None:
+    if isinstance(line, bytes):
+        line = line.decode("utf-8", errors="replace")
+    line = line.strip()
+    if not line:
+        return None
+    try:
+        loaded = json.loads(line)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    return _as_string_key_dict(loaded)
+
+
 def discover_segments(telemetry_dir: Path) -> list[Path]:
     """Return all JSONL segments sorted by mtime ascending."""
     if not telemetry_dir.is_dir():
@@ -67,14 +80,7 @@ def read_events(
     try:
         with path.open("r", encoding="utf-8") as file:
             for line in file:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    loaded = json.loads(line)
-                except (json.JSONDecodeError, ValueError):
-                    continue
-                envelope = _as_string_key_dict(loaded)
+                envelope = _parse_jsonl_line(line)
                 if envelope is None:
                     continue
                 if _matches_filters(
@@ -152,14 +158,7 @@ def _tail_events_from_offsets(
                     with segment.open("rb") as file:
                         file.seek(offset)
                         for raw_line in file:
-                            line = raw_line.decode("utf-8", errors="replace").strip()
-                            if not line:
-                                continue
-                            try:
-                                loaded = json.loads(line)
-                            except (json.JSONDecodeError, ValueError):
-                                continue
-                            envelope = _as_string_key_dict(loaded)
+                            envelope = _parse_jsonl_line(raw_line)
                             if envelope is None:
                                 continue
                             if _matches_filters(envelope, domain=domain, ids_filter=ids_filter):

--- a/tests/integration/cli/test_spawn_prompt_input.py
+++ b/tests/integration/cli/test_spawn_prompt_input.py
@@ -119,7 +119,7 @@ def test_spawn_prompt_file_stdin_reaches_dry_run_prompt(
 
 @pytest.mark.integration
 @posix_only
-def test_spawn_rejects_subcommand_typo_but_accepts_unrelated_bare_prompt(
+def test_spawn_rejects_subcommand_shaped_prompts_and_suggests_transposition(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -142,8 +142,8 @@ def test_spawn_rejects_subcommand_typo_but_accepts_unrelated_bare_prompt(
         "spawn",
     ]
 
-    typo = subprocess.run(
-        [*base_command, "statsu"],
+    unknown = subprocess.run(
+        [*base_command, "list-agents"],
         cwd=project_root,
         env=env,
         text=True,
@@ -151,8 +151,8 @@ def test_spawn_rejects_subcommand_typo_but_accepts_unrelated_bare_prompt(
         timeout=3,
         check=False,
     )
-    prompt = subprocess.run(
-        [*base_command, "investigate", "-a", "", "--bg", "--dry-run", "--format", "json"],
+    typo = subprocess.run(
+        [*base_command, "wiat"],
         cwd=project_root,
         env=env,
         text=True,
@@ -161,7 +161,17 @@ def test_spawn_rejects_subcommand_typo_but_accepts_unrelated_bare_prompt(
         check=False,
     )
     explicit_prompt = subprocess.run(
-        [*base_command, "-p", "statsu", "-a", "", "--bg", "--dry-run", "--format", "json"],
+        [
+            *base_command,
+            "-p",
+            "list-agents",
+            "-a",
+            "",
+            "--bg",
+            "--dry-run",
+            "--format",
+            "json",
+        ],
         cwd=project_root,
         env=env,
         text=True,
@@ -170,9 +180,57 @@ def test_spawn_rejects_subcommand_typo_but_accepts_unrelated_bare_prompt(
         check=False,
     )
 
+    assert unknown.returncode != 0
+    assert (
+        "unknown spawn subcommand 'list-agents'\n"
+        "To force a literal one-word prompt, use --prompt."
+    ) in unknown.stderr
     assert typo.returncode != 0
-    assert "did you mean 'meridian spawn stats'?" in typo.stderr.lower()
-    assert prompt.returncode == 0, prompt.stderr
-    assert json.loads(prompt.stdout)["composed_prompt"] == "investigate"
+    assert "did you mean 'meridian spawn wait'?" in typo.stderr
     assert explicit_prompt.returncode == 0, explicit_prompt.stderr
-    assert json.loads(explicit_prompt.stdout)["composed_prompt"] == "statsu"
+    assert json.loads(explicit_prompt.stdout)["composed_prompt"] == "list-agents"
+
+
+@pytest.mark.integration
+@posix_only
+def test_spawn_accepts_positional_prompt_that_does_not_match_subcommand_shape(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "project"
+    (project_root / ".meridian").mkdir(parents=True)
+    (project_root / ".meridian" / "id").write_text("prompt-shape-test", encoding="utf-8")
+    (project_root / "meridian.toml").write_text(
+        "[spawn]\ndeny_headless_harnesses = []\n",
+        encoding="utf-8",
+    )
+    prepend_fake_executables(monkeypatch, tmp_path, "codex")
+    env = os.environ.copy()
+    env["MERIDIAN_HOME"] = (tmp_path / "home").as_posix()
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "meridian",
+            "--harness",
+            "codex",
+            "spawn",
+            "wait?",
+            "-a",
+            "",
+            "--bg",
+            "--dry-run",
+            "--format",
+            "json",
+        ],
+        cwd=project_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=3,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["composed_prompt"] == "wait?"

--- a/tests/integration/cli/test_spawn_prompt_input.py
+++ b/tests/integration/cli/test_spawn_prompt_input.py
@@ -115,3 +115,64 @@ def test_spawn_prompt_file_stdin_reaches_dry_run_prompt(
     output = json.loads(result.stdout)
     assert output["status"] == "dry-run"
     assert output["composed_prompt"] == prompt.decode().strip()
+
+
+@pytest.mark.integration
+@posix_only
+def test_spawn_rejects_subcommand_typo_but_accepts_unrelated_bare_prompt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "project"
+    (project_root / ".meridian").mkdir(parents=True)
+    (project_root / ".meridian" / "id").write_text("prompt-typo-test", encoding="utf-8")
+    (project_root / "meridian.toml").write_text(
+        "[spawn]\ndeny_headless_harnesses = []\n",
+        encoding="utf-8",
+    )
+    prepend_fake_executables(monkeypatch, tmp_path, "codex")
+    env = os.environ.copy()
+    env["MERIDIAN_HOME"] = (tmp_path / "home").as_posix()
+    base_command = [
+        sys.executable,
+        "-m",
+        "meridian",
+        "--harness",
+        "codex",
+        "spawn",
+    ]
+
+    typo = subprocess.run(
+        [*base_command, "statsu"],
+        cwd=project_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=3,
+        check=False,
+    )
+    prompt = subprocess.run(
+        [*base_command, "investigate", "-a", "", "--bg", "--dry-run", "--format", "json"],
+        cwd=project_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=3,
+        check=False,
+    )
+    explicit_prompt = subprocess.run(
+        [*base_command, "-p", "statsu", "-a", "", "--bg", "--dry-run", "--format", "json"],
+        cwd=project_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=3,
+        check=False,
+    )
+
+    assert typo.returncode != 0
+    assert "did you mean 'meridian spawn stats'?" in typo.stderr.lower()
+    assert prompt.returncode == 0, prompt.stderr
+    assert json.loads(prompt.stdout)["composed_prompt"] == "investigate"
+    assert explicit_prompt.returncode == 0, explicit_prompt.stderr
+    assert json.loads(explicit_prompt.stdout)["composed_prompt"] == "statsu"

--- a/tests/integration/ops/test_spawn_api_query.py
+++ b/tests/integration/ops/test_spawn_api_query.py
@@ -345,6 +345,75 @@ def test_spawn_wait_fail_fast_returns_failed_and_pending_spawns(tmp_path: Path) 
         str(failed_id): "failed",
         str(pending_id): "running",
     }
+    assert (
+        output.format_text().splitlines()[0]
+        == "Fail-fast: p-failed failed or timed out. Still pending: p-pending."
+    )
+
+
+def test_spawn_wait_fail_fast_uses_one_snapshot_when_pending_spawn_finishes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    runtime_root = _state_root(project_root)
+    failed_id = spawn_store.start_spawn(
+        runtime_root,
+        spawn_id="p-failed",
+        chat_id="c-wait-race",
+        model="gpt-5.4",
+        agent="coder",
+        harness="codex",
+        prompt="fail",
+    )
+    spawn_store.finalize_spawn(runtime_root, failed_id, "failed", 1, origin="runner")
+    finishing_id = spawn_store.start_spawn(
+        runtime_root,
+        spawn_id="p-finishing",
+        chat_id="c-wait-race",
+        model="gpt-5.4",
+        agent="coder",
+        harness="codex",
+        prompt="finish during snapshot",
+    )
+
+    original_read_spawn_row = spawn_api.read_spawn_row
+    finishing_reads = 0
+
+    def _finish_before_snapshot_read(*args, **kwargs):
+        nonlocal finishing_reads
+        spawn_id = args[1]
+        if spawn_id == str(finishing_id):
+            finishing_reads += 1
+            if finishing_reads == 2:
+                spawn_store.finalize_spawn(
+                    runtime_root,
+                    finishing_id,
+                    "succeeded",
+                    0,
+                    origin="runner",
+                )
+        return original_read_spawn_row(*args, **kwargs)
+
+    monkeypatch.setattr(spawn_api, "read_spawn_row", _finish_before_snapshot_read)
+
+    output = spawn_api.spawn_wait_sync(
+        SpawnWaitInput(
+            project_root=project_root.as_posix(),
+            spawn_ids=(str(failed_id), str(finishing_id)),
+            fail_fast=True,
+            yield_after_secs=0,
+        )
+    )
+
+    assert finishing_reads == 2
+    assert not output.fail_fast
+    assert output.pending_ids == ()
+    assert {spawn.spawn_id: spawn.status for spawn in output.spawns} == {
+        str(failed_id): "failed",
+        str(finishing_id): "succeeded",
+    }
 
 
 def test_spawn_status_omits_report_body_until_requested(tmp_path: Path) -> None:

--- a/tests/integration/ops/test_spawn_api_query.py
+++ b/tests/integration/ops/test_spawn_api_query.py
@@ -23,6 +23,7 @@ from meridian.lib.ops.spawn.models import (
     SpawnShowInput,
     SpawnStatsInput,
     SpawnStatusInput,
+    SpawnWaitInput,
 )
 from meridian.lib.state import spawn_store
 from meridian.lib.state.paths import resolve_project_runtime_root_for_write
@@ -302,6 +303,48 @@ def test_spawn_list_and_status_surface_timed_out_status(tmp_path: Path) -> None:
     assert listed.spawns[0].status == "timed_out"
     assert status.status == "timed_out"
     assert status.exit_code == 1
+
+
+def test_spawn_wait_fail_fast_returns_failed_and_pending_spawns(tmp_path: Path) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    runtime_root = _state_root(project_root)
+    failed_id = spawn_store.start_spawn(
+        runtime_root,
+        spawn_id="p-failed",
+        chat_id="c-wait",
+        model="gpt-5.4",
+        agent="coder",
+        harness="codex",
+        prompt="fail",
+    )
+    spawn_store.finalize_spawn(runtime_root, failed_id, "failed", 1, origin="runner")
+    pending_id = spawn_store.start_spawn(
+        runtime_root,
+        spawn_id="p-pending",
+        chat_id="c-wait",
+        model="gpt-5.4",
+        agent="coder",
+        harness="codex",
+        prompt="keep running",
+    )
+
+    output = spawn_api.spawn_wait_sync(
+        SpawnWaitInput(
+            project_root=project_root.as_posix(),
+            spawn_ids=(str(failed_id), str(pending_id)),
+            fail_fast=True,
+            yield_after_secs=0,
+        )
+    )
+
+    assert output.fail_fast
+    assert output.any_failed
+    assert output.pending_ids == (str(pending_id),)
+    assert {spawn.spawn_id: spawn.status for spawn in output.spawns} == {
+        str(failed_id): "failed",
+        str(pending_id): "running",
+    }
 
 
 def test_spawn_status_omits_report_body_until_requested(tmp_path: Path) -> None:

--- a/tests/integration/state/test_session_store.py
+++ b/tests/integration/state/test_session_store.py
@@ -509,6 +509,31 @@ def test_empty_harness_session_id_normalizes_to_none_before_update(tmp_path: Pat
         session_store.stop_session(runtime_root, chat_id)
 
 
+def test_session_path_fields_are_normalized_at_write_boundary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime_root = _state_root(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    chat_id = session_store.start_session(
+        runtime_root,
+        harness="codex",
+        harness_session_id="session-1",
+        model="gpt-5.4",
+        chat_id="c43",
+        control_root="project/./root/",
+        task_cwd=None,
+        execution_cwd="",
+    )
+    try:
+        record = session_store.get_session_record(runtime_root, chat_id)
+        assert record is not None
+        assert record.control_root == (tmp_path / "project/root").as_posix()
+        assert record.task_cwd is None
+        assert record.execution_cwd == ""
+    finally:
+        session_store.stop_session(runtime_root, chat_id)
+
+
 def test_cleanup_stale_primary_session_with_live_pid_is_not_cleaned(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/integration/state/test_spawn_store_crud.py
+++ b/tests/integration/state/test_spawn_store_crud.py
@@ -92,6 +92,45 @@ def test_start_and_update_project_fields_round_trip(tmp_path: Path) -> None:
     assert row.runner_pid == 2222
 
 
+def test_spawn_path_fields_are_normalized_at_write_boundary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime_root = _state_root(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    spawn_id = str(
+        start_spawn(
+            runtime_root,
+            chat_id="c1",
+            model="gpt-5.4",
+            agent="coder",
+            harness="codex",
+            prompt="hello",
+            control_root="project/./root/",
+            task_cwd=None,
+            execution_cwd="project/root/../initial-task/",
+        )
+    )
+
+    row = get_spawn(runtime_root, spawn_id)
+    assert row is not None
+    assert row.control_root == (tmp_path / "project/root").as_posix()
+    assert row.task_cwd is None
+    assert row.execution_cwd == (tmp_path / "project/initial-task").as_posix()
+
+    update_spawn(
+        runtime_root,
+        spawn_id,
+        task_cwd="project/./updated-task/",
+        execution_cwd="project/updated-task/../execution/",
+    )
+
+    row = get_spawn(runtime_root, spawn_id)
+    assert row is not None
+    assert row.task_cwd == (tmp_path / "project/updated-task").as_posix()
+    assert row.execution_cwd == (tmp_path / "project/execution").as_posix()
+
+
 def test_invalid_persisted_status_is_reported_and_not_coerced(tmp_path: Path) -> None:
     runtime_root = _state_root(tmp_path)
     spawn_id = _start_test_spawn(runtime_root)


### PR DESCRIPTION
## Why

A 31-issue triage of the actionable backlog (session c5008) surfaced four small-scope defects worth shipping as a patch: a CLI footgun that launches real agents from typos, unnormalized paths persisted in state, no way to abort a batch wait early, and duplicated JSONL parsing in the telemetry reader.

## Goal

All four triaged bugs fixed on v0.3.47 with no behavior regressions; backlog hygiene done (16 closes, 9 relabels) so the tracker reflects reality.

## Summary

- **#321** — `meridian spawn <token>` now rejects a bare, subcommand-shaped one-word positional prompt (`^[a-z][a-z-]*$`) that isn't a registered spawn subcommand, with a Damerau-Levenshtein "did you mean" hint and an explicit `--prompt` escape-hatch pointer. Subcommand set is derived from the registered command set, so it can't drift.
- **#458** — `meridian spawn wait --fail-fast` returns on the first `failed`/`timed_out` target, reporting failed and still-pending spawns from one consistent snapshot; exit code is nonzero. Default wait behavior unchanged; cancellation intentionally does not trigger fail-fast.
- **#211** — `normalize_path_for_write()` (normpath+abspath) applied at the state-store write boundary to `control_root`/`task_cwd`/`execution_cwd` in spawn and session stores. Write-only; reads untouched. Scope-out of other path-like fields recorded in `src/meridian/lib/state/.context/FUTURE`.
- **#139** — telemetry reader's two JSONL parse loops share one `_parse_jsonl_line()`; truncation-tolerant behavior preserved exactly.

## Resulting Behavior

```
$ meridian spawn list-agents
error: unknown spawn subcommand 'list-agents'
To force a literal one-word prompt, use --prompt.

$ meridian spawn wiat
error: unknown spawn subcommand 'wiat'; did you mean 'meridian spawn wait'?

$ meridian spawn wait p7 p8 --fail-fast     # p7 fails at 1.2s, p8 runs 30s
Fail-fast: p7 failed. Still pending: p8.    # returns in ~1s, exit 1
```

State files now always carry absolute, normalized `control_root`/`task_cwd`/`execution_cwd` (no `..`, no trailing slash) regardless of how the launch was invoked.

## Changes

- First-pass #321 guard was edit-distance-only and missed the issue's `list-agents` repro; review forced the shape-based policy from the issue, and a runtime probe caught a `wiat`→`list` mis-suggestion (Levenshtein tie broken lexically), fixed with transposition-aware distance.
- Review caught a fail-fast snapshot race (`pending_ids` captured before re-read could report a spawn as failed *and* pending); pending now derives from the same snapshot, and an all-terminal-mid-snapshot result degrades to normal completed output.
- Issue hygiene (not in this diff): 15 issues closed as resolved against v0.3.47, #68 closed not-planned (POSIX-first), 9 issues relabeled.

## Work Item

reaper-scope-regression

## Verification

- `uv run ruff check .` — clean
- `uv run pytest-llm` — 1346 passed, 2 skipped (includes new integration tests: `list-agents` rejection, `wiat` suggestion, `wait?` passthrough, `--prompt` bypass, fail-fast early exit, deterministic snapshot-race transition, path-normalization write sites)
- `uv run --extra dev python -m pyright` — 0 errors
- Independent review pass (p5657): 2 blocking findings raised and fixed, re-verified
- Runtime probes (p5664): 4/4 PASS in isolated state — typo rejection leaves zero spawn records; fail-fast returns in ~1s vs 22s default; persisted paths verified normalized on disk; truncated/malformed telemetry lines skipped without exception

## Knowledge Updates

- `src/meridian/cli/AGENTS.md` — positional-prompt guard rule + no-hardcoded-subcommands anti-pattern
- `src/meridian/lib/ops/spawn/AGENTS.md` + `.context/CONTEXT.md` — fail-fast triggers and snapshot-consistency contract
- `src/meridian/lib/state/AGENTS.md` — write-boundary path normalization section
- `src/meridian/lib/state/.context/FUTURE` — #211 scope-out (other path-like fields)
- KB `concepts/spawn-wait-barrier.md` updated in the KB repo (lands independently)

## Spawn Trace

- p5654 coder — #321 + #458 implementation
- p5655 coder — #211 + #139 implementation
- p5656 coder — issue hygiene (16 closes, 9 relabels)
- p5657 reviewer — combined-diff review (2 blocking findings)
- p5664 prober — runtime verification of all 4 fixes
- p5666 coder — review/probe findings fix pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
