### PR TITLE
Pi first-event fixes + managed-stdio seam: de-flake, watchdog bypass, exit-code classification, timing policy, bounded stderr, cursor pgid isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,12 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Pi failure extraction and output normalization now live with the Pi harness
   instead of the harness-agnostic launch layer.
 - Claude subprocess transport now uses the shared managed-stdio process lifecycle.
+- Cursor subprocess transport now uses the shared managed-stdio process lifecycle
+  and launches in its own POSIX process group.
 
 ### Fixed
+- Cursor process-scope termination can no longer target Meridian's own process
+  group when cancelling or reaping a subprocess.
 - Claude failure excerpts are bounded to stderr from the current process launch,
   excluding stale output left in reused spawn logs.
 - Pi failure details now read a bounded stderr tail from only the current

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   instead of the harness-agnostic launch layer.
 
 ### Fixed
+- Pi first-response timing tests now use per-connection policies with realistic
+  deadlines, avoiding process races while keeping the slow no-response case fast.
 - Second Pi stderr test no longer flakes under CI load: dropped the 50ms
   `_FIRST_STDOUT_AFTER_INITIAL_PROMPT_TIMEOUT_SECONDS` override from
   `test_pi_rpc_connection_surfaces_stderr_on_early_exit_before_first_event`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- Pi failure-output normalization now lives with the Pi harness instead of the
+  harness-agnostic launch layer.
+
 ### Fixed
 - Second Pi stderr test no longer flakes under CI load: dropped the 50ms
   `_FIRST_STDOUT_AFTER_INITIAL_PROMPT_TIMEOUT_SECONDS` override from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   and launches in its own POSIX process group.
 
 ### Fixed
+- Managed stdio launches now reap their provisional process tree when durable
+  scope registration fails or is cancelled.
 - Cursor process-scope termination can no longer target Meridian's own process
   group when cancelling or reaping a subprocess.
 - Claude failure excerpts are bounded to stderr from the current process launch,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   via process-death detection instead of racing an artificial timeout. Also
   removed that test's dead abort/kill grace overrides — the shim exits before
   teardown, so those timers never engaged.
+- Malformed Pi stdout no longer bypasses the first-response watchdog; parse
+  diagnostics still surface without making the harness appear ready.
+- Pi processes that exit before their first event now report the real exit code
+  and stderr instead of being mislabeled as a first-response timeout.
 
 ## [0.3.48] - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Changed
-- Pi failure-output normalization now lives with the Pi harness instead of the
-  harness-agnostic launch layer.
+- Pi failure extraction and output normalization now live with the Pi harness
+  instead of the harness-agnostic launch layer.
 
 ### Fixed
 - Second Pi stderr test no longer flakes under CI load: dropped the 50ms

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   instead of the harness-agnostic launch layer.
 
 ### Fixed
+- Pi failure details now read a bounded stderr tail from only the current
+  process launch, excluding stale output left in reused spawn logs.
 - Pi first-response timing tests now use per-connection policies with realistic
   deadlines, avoiding process races while keeping the slow no-response case fast.
 - Second Pi stderr test no longer flakes under CI load: dropped the 50ms

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Second Pi stderr test no longer flakes under CI load: dropped the 50ms
+  `_FIRST_STDOUT_AFTER_INITIAL_PROMPT_TIMEOUT_SECONDS` override from
+  `test_pi_rpc_connection_surfaces_stderr_on_early_exit_before_first_event`,
+  the sibling missed by the v0.3.44 de-flake. Early-exit stderr now surfaces
+  via process-death detection instead of racing an artificial timeout. Also
+  removed that test's dead abort/kill grace overrides — the shim exits before
+  teardown, so those timers never engaged.
+
 ## [0.3.48] - 2026-07-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 - Pi failure extraction and output normalization now live with the Pi harness
   instead of the harness-agnostic launch layer.
+- Claude subprocess transport now uses the shared managed-stdio process lifecycle.
 
 ### Fixed
+- Claude failure excerpts are bounded to stderr from the current process launch,
+  excluding stale output left in reused spawn logs.
 - Pi failure details now read a bounded stderr tail from only the current
   process launch, excluding stale output left in reused spawn logs.
 - Pi first-response timing tests now use per-connection policies with realistic

--- a/src/meridian/lib/harness/AGENTS.md
+++ b/src/meridian/lib/harness/AGENTS.md
@@ -104,6 +104,10 @@ parent signals, or supply the parent report.
   optional payload resolvers. `normalize_event()` dispatches by `HarnessId` before
   event name and returns raw evidence with its one normalized descriptor; shared
   `semantics.py` contains no harness event names.
+- `pi_failure.py` — Pi failure output formatting (`compact_pi_failure_output`) and
+  history-based failure extraction (`extract_pi_failure_from_history`). Harness-owned;
+  consumed by `connections/pi_rpc.py` (stderr compaction), `extractors/pi.py` (report
+  extraction), and `launch/report.py` (spawn report Pi failure path).
 - `common.py` — shared extraction helpers used by adapters.
 - `transcript.py` — cross-harness session read path. `TranscriptMessage` (with
   `tool_call: ToolCall | None` and `is_tool_result: bool`), `ToolCall` (canonical

--- a/src/meridian/lib/harness/connections/.context/CONTEXT.md
+++ b/src/meridian/lib/harness/connections/.context/CONTEXT.md
@@ -28,8 +28,11 @@ stdout is not the quiescence authority.
 **Pi startup requires an initial prompt.** Unlike other harnesses that can start in a
 listening state, spawned Pi RPC sessions must receive an initial user message. The
 connection validates this (`_validate_initial_prompt_requirement()`) and enforces a
-30-second timeout for the first stdout event after the prompt
-(`_FIRST_STDOUT_AFTER_INITIAL_PROMPT_TIMEOUT_SECONDS`).
+first-event timeout (default 30 s) after the prompt. The timeout value, abort grace,
+and kill grace are carried by a frozen `PiRpcTimingPolicy` injected at the
+`PiRpcConnection` constructor. The deadline is stamped at prompt-write success, not at
+the consumer's first `events()` iteration. Tests inject policies with short timeouts
+through the constructor; there are no module-level timing Finals to monkeypatch.
 
 **Pi injected prompts are acknowledged commands.** Every prompt carries an RPC `id`
 and `streamingBehavior: "followUp"`; the field is valid whether Pi is busy or idle.

--- a/src/meridian/lib/harness/connections/.context/FUTURE
+++ b/src/meridian/lib/harness/connections/.context/FUTURE
@@ -1,0 +1,28 @@
+# connections/ — nice-to-have follow-ups
+
+[pi_rpc timing seam] Pi connection tests steer timing by monkeypatching
+module-private Final constants (_FIRST_STDOUT_AFTER_INITIAL_PROMPT_TIMEOUT_SECONDS,
+_PROCESS_ABORT_GRACE_SECONDS, _PROCESS_KILL_GRACE_SECONDS) in pi_rpc.py. This has
+produced two CI flakes: v0.3.44 (#459) removed a 50ms first-stdout override from
+test_pi_spawn_manager_startup_diagnostics_report_outcome_and_marker; the sibling
+test_pi_rpc_connection_surfaces_stderr_on_early_exit_before_first_event carried the
+same override and flaked again on the v0.3.48 release commit. Both fixes were
+per-instance.
+
+Remedy (NOT "inject the three constants into ConnectionConfig" — that just moves the
+race and bloats the shared launch boundary): make the first-event deadline explicit
+in the handshake model and stamp it when the initial prompt write succeeds (not when
+the consumer starts iterating events); inject an immutable per-connection timing
+policy / clock for focused unit tests; and keep abort/kill grace as process-management
+policy inside the managed-stdio helper (see the managed-stdio extraction note below),
+not as public config. Real-subprocess integration tests should use realistic deadlines
+rather than racing 10-50ms overrides. Track as a scoped issue.
+
+[managed-stdio seam] pi_rpc.py, claude_ws.py, and cursor_subprocess.py duplicate
+stderr-log ownership, subprocess creation, spawn-scope registration, PID/scope
+properties, termination escalation, and handle cleanup. Extract a focused
+managed_stdio helper (or a stdio variant of managed_backend.py) that owns the child
+process, durable scope, bounded stderr tail, and termination — keeping each adapter's
+wire protocol and graceful-abort semantics in place. Do NOT grow base.py into a
+stateful base class; it is a clean contracts module and the transports have materially
+different lifecycle rules.

--- a/src/meridian/lib/harness/connections/.context/FUTURE
+++ b/src/meridian/lib/harness/connections/.context/FUTURE
@@ -1,36 +1,8 @@
 # connections/ — nice-to-have follow-ups
 
-[pi_rpc timing seam] Pi connection tests steer timing by monkeypatching
-module-private Final constants (_FIRST_STDOUT_AFTER_INITIAL_PROMPT_TIMEOUT_SECONDS,
-_PROCESS_ABORT_GRACE_SECONDS, _PROCESS_KILL_GRACE_SECONDS) in pi_rpc.py. This has
-produced two CI flakes: v0.3.44 (#459) removed a 50ms first-stdout override from
-test_pi_spawn_manager_startup_diagnostics_report_outcome_and_marker; the sibling
-test_pi_rpc_connection_surfaces_stderr_on_early_exit_before_first_event carried the
-same override and flaked again on the v0.3.48 release commit. Both fixes were
-per-instance.
-
-Remedy (NOT "inject the three constants into ConnectionConfig" — that just moves the
-race and bloats the shared launch boundary): make the first-event deadline explicit
-in the handshake model and stamp it when the initial prompt write succeeds (not when
-the consumer starts iterating events); inject an immutable per-connection timing
-policy / clock for focused unit tests; and keep abort/kill grace as process-management
-policy inside the managed-stdio helper (see the managed-stdio extraction note below),
-not as public config. Real-subprocess integration tests should use realistic deadlines
-rather than racing 10-50ms overrides. Track as a scoped issue.
-
-[managed-stdio seam] pi_rpc.py, claude_ws.py, and cursor_subprocess.py duplicate
-stderr-log ownership, subprocess creation, spawn-scope registration, PID/scope
-properties, termination escalation, and handle cleanup. Extract a focused
-managed_stdio helper (or a stdio variant of managed_backend.py) that owns the child
-process, durable scope, bounded stderr tail, and termination — keeping each adapter's
-wire protocol and graceful-abort semantics in place. Do NOT grow base.py into a
-stateful base class; it is a clean contracts module and the transports have materially
-different lifecycle rules.
-
-[pi_rpc bounded stderr read] _read_stderr_snippet (pi_rpc.py ~787-803) Path.read_text()s
-the entire stderr.log and runs stack compaction over all of it before truncating to
-4096 chars — a runaway Pi process can block the event loop / spend memory exactly on the
-failure path. Claude/Codex/OpenCode use bounded binary tail reads and record the
-current-launch offset. Record the stderr offset when the file is opened and read only a
-bounded tail from the current launch, decoding with replacement, then compact that.
-(Natural to fold into the managed-stdio seam above.)
+[managed-stdio seam] Migrate claude_ws.py and cursor_subprocess.py onto the
+managed_stdio helper now used by pi_rpc.py. The helper owns stderr-log and subprocess
+lifetime, durable scope registration, termination escalation, and bounded stderr
+tails; each adapter keeps its wire protocol and graceful-abort semantics. Do NOT grow
+base.py into a stateful base class; it is a clean contracts module and the transports
+have materially different lifecycle rules.

--- a/src/meridian/lib/harness/connections/.context/FUTURE
+++ b/src/meridian/lib/harness/connections/.context/FUTURE
@@ -1,8 +1,1 @@
 # connections/ — nice-to-have follow-ups
-
-[managed-stdio seam] Migrate claude_ws.py and cursor_subprocess.py onto the
-managed_stdio helper now used by pi_rpc.py. The helper owns stderr-log and subprocess
-lifetime, durable scope registration, termination escalation, and bounded stderr
-tails; each adapter keeps its wire protocol and graceful-abort semantics. Do NOT grow
-base.py into a stateful base class; it is a clean contracts module and the transports
-have materially different lifecycle rules.

--- a/src/meridian/lib/harness/connections/.context/FUTURE
+++ b/src/meridian/lib/harness/connections/.context/FUTURE
@@ -26,3 +26,17 @@ process, durable scope, bounded stderr tail, and termination — keeping each ad
 wire protocol and graceful-abort semantics in place. Do NOT grow base.py into a
 stateful base class; it is a clean contracts module and the transports have materially
 different lifecycle rules.
+
+[pi_rpc bounded stderr read] _read_stderr_snippet (pi_rpc.py ~787-803) Path.read_text()s
+the entire stderr.log and runs stack compaction over all of it before truncating to
+4096 chars — a runaway Pi process can block the event loop / spend memory exactly on the
+failure path. Claude/Codex/OpenCode use bounded binary tail reads and record the
+current-launch offset. Record the stderr offset when the file is opened and read only a
+bounded tail from the current launch, decoding with replacement, then compact that.
+(Natural to fold into the managed-stdio seam above.)
+
+[pi_rpc failure-formatting boundary leak] pi_rpc.py imports compact_pi_failure_output
+from lib.launch.report (pi_rpc.py:46, 800) — Pi-specific presentation living in the
+upward, harness-agnostic launch layer. Move Pi failure normalization into a harness-owned
+module (e.g. harness/pi_failure.py or the Pi extractor surface); the launch report path
+should consume it through the existing harness bundle/extractor boundary.

--- a/src/meridian/lib/harness/connections/.context/FUTURE
+++ b/src/meridian/lib/harness/connections/.context/FUTURE
@@ -34,9 +34,3 @@ failure path. Claude/Codex/OpenCode use bounded binary tail reads and record the
 current-launch offset. Record the stderr offset when the file is opened and read only a
 bounded tail from the current launch, decoding with replacement, then compact that.
 (Natural to fold into the managed-stdio seam above.)
-
-[pi_rpc failure-formatting boundary leak] pi_rpc.py imports compact_pi_failure_output
-from lib.launch.report (pi_rpc.py:46, 800) — Pi-specific presentation living in the
-upward, harness-agnostic launch layer. Move Pi failure normalization into a harness-owned
-module (e.g. harness/pi_failure.py or the Pi extractor surface); the launch report path
-should consume it through the existing harness bundle/extractor boundary.

--- a/src/meridian/lib/harness/connections/AGENTS.md
+++ b/src/meridian/lib/harness/connections/AGENTS.md
@@ -70,6 +70,8 @@ an awaited startup boundary, artifact opens and guarded scope registration fail 
   `register_spawn_owned_process` helper also serves stdio children (Claude, Pi,
   Cursor) — its placement here is accepted naming debt ahead of #424's layering
   split.
+- `managed_stdio.py` — spawn-lifetime stdio child ownership, durable scope
+  registration, termination escalation, and bounded current-launch stderr tails.
 - `__init__.py` — `get_connection_class(harness_id, transport_id)`.
 
 ## Depth

--- a/src/meridian/lib/harness/connections/claude_ws.py
+++ b/src/meridian/lib/harness/connections/claude_ws.py
@@ -5,12 +5,9 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import os
 import signal
-from asyncio.subprocess import PIPE, Process
+from asyncio.subprocess import PIPE
 from collections.abc import AsyncIterator
-from io import BufferedWriter
-from pathlib import Path
 from typing import TYPE_CHECKING, Final, cast
 
 if TYPE_CHECKING:
@@ -31,8 +28,10 @@ from meridian.lib.harness.connections.base import (
     reap_on_ownership_transfer_failure,
     validate_prompt_size,
 )
-from meridian.lib.harness.connections.managed_backend import register_spawn_owned_process
-from meridian.lib.harness.errors import HarnessBinaryNotFound
+from meridian.lib.harness.connections.managed_stdio import (
+    ManagedStdioProcess,
+    launch_managed_stdio,
+)
 from meridian.lib.harness.semantics import EventSemantics
 from meridian.lib.launch.constants import BASE_COMMAND_CLAUDE_STREAMING
 from meridian.lib.launch.launch_types import ResolvedLaunchSpec
@@ -43,15 +42,13 @@ from meridian.lib.observability.trace_helpers import (
     trace_wire_send,
 )
 from meridian.lib.platform import IS_WINDOWS
-from meridian.lib.platform.process_scope import ProcessScopeSnapshot, ScopedProcessHandle
-from meridian.lib.state.paths import resolve_project_runtime_root_for_write, resolve_spawn_log_dir
+from meridian.lib.platform.process_scope import ProcessScopeSnapshot
 
 logger = logging.getLogger(__name__)
 
 _PROCESS_KILL_GRACE_SECONDS: Final[float] = 10.0
 _STDOUT_READLINE_LIMIT: Final[int] = 128 * 1024 * 1024  # 128 MiB
 _VERSION_CHECK_TIMEOUT_SECONDS: Final[float] = 5.0
-_STDERR_MAX_BYTES: Final[int] = 16 * 1024
 _TESTED_VERSION_PREFIXES: Final[tuple[str, ...]] = ("1.", "2.")
 _HARNESS_NAME: Final[str] = HarnessId.CLAUDE.value
 
@@ -97,12 +94,9 @@ class ClaudeConnection(HarnessConnection[ResolvedLaunchSpec]):
         self._state: ConnectionState = "created"
         self._spawn_id: SpawnId = SpawnId("")
         self._config: ConnectionConfig | None = None
-        self._process: Process | None = None
-        self._scope_handle: ScopedProcessHandle | None = None
+        self._child: ManagedStdioProcess | None = None
         self._send_lock = asyncio.Lock()
         self._stop_lock = asyncio.Lock()
-        self._stderr_handle: BufferedWriter | None = None
-        self._stderr_log_path: Path | None = None
         self._protocol_validated = False
         self._event_stream_started = False
         self._tracer: DebugTracer | None = None
@@ -132,15 +126,13 @@ class ClaudeConnection(HarnessConnection[ResolvedLaunchSpec]):
 
     @property
     def subprocess_pid(self) -> int | None:
-        process = self._process
-        if process is None:
-            return None
-        return process.pid
+        child = self._child
+        return None if child is None else child.pid
 
     @property
     def scope_snapshot(self) -> ProcessScopeSnapshot | None:
-        handle = self._scope_handle
-        return None if handle is None else handle.snapshot
+        child = self._child
+        return None if child is None else child.scope_snapshot
 
     async def start(self, config: ConnectionConfig, spec: ResolvedLaunchSpec) -> None:
         """Launch Claude subprocess and send the initial user prompt via stdin."""
@@ -227,7 +219,8 @@ class ClaudeConnection(HarnessConnection[ResolvedLaunchSpec]):
     async def events(self) -> AsyncIterator[RawHarnessEvent]:
         """Yield RawHarnessEvent objects read line-by-line from Claude stdout."""
 
-        process = self._process
+        child = self._child
+        process = None if child is None else child.process
         if process is None:
             return
         stdout = process.stdout
@@ -363,49 +356,19 @@ class ClaudeConnection(HarnessConnection[ResolvedLaunchSpec]):
         return None
 
     async def _start_subprocess(self, config: ConnectionConfig, spec: ResolvedLaunchSpec) -> None:
-        spawn_dir = resolve_spawn_log_dir(
-            config.control_root,
-            config.spawn_id,
-            runtime_root=(
-                config.runtime_root
-                or resolve_project_runtime_root_for_write(config.control_root)
-            ),
-        )
-
-        stderr_path = spawn_dir / "stderr.log"
-        self._stderr_log_path = stderr_path
-        self._stderr_handle = stderr_path.open("ab")
-
         command = self._build_command(config, spec)
-
         env = dict(config.child_env)
-
-        try:
-            self._process = await asyncio.create_subprocess_exec(
-                *command,
-                cwd=str(config.control_root),
-                env=env,
-                stdin=PIPE,
-                stdout=PIPE,
-                stderr=self._stderr_handle,
-                limit=_STDOUT_READLINE_LIMIT,
-                start_new_session=not IS_WINDOWS,
-            )
-            self._scope_handle = await register_spawn_owned_process(
-                spawn_id=config.spawn_id,
-                control_root=config.control_root,
-                process=self._process,
-                scope_id="stdio",
-                role="harness_stdio",
-                runtime_root=config.runtime_root,
-                persist=config.runtime_root is not None,
-            )
-        except (FileNotFoundError, NotADirectoryError) as exc:
-            raise HarnessBinaryNotFound.from_os_error(
-                harness_id=self.harness_id,
-                error=exc,
-                binary_name=command[0],
-            ) from exc
+        self._child = await launch_managed_stdio(
+            config=config,
+            harness_id=self.harness_id,
+            command=command,
+            env=env,
+            cwd=str(config.control_root),
+            stdin=PIPE,
+            stdout_limit=_STDOUT_READLINE_LIMIT,
+            kill_grace_seconds=_PROCESS_KILL_GRACE_SECONDS,
+            terminate_reason="claude_connection_stop",
+        )
 
     def _build_command(self, config: ConnectionConfig, spec: ResolvedLaunchSpec) -> list[str]:
         _ = config
@@ -425,7 +388,8 @@ class ClaudeConnection(HarnessConnection[ResolvedLaunchSpec]):
         await self._send_json({"type": "user", "message": {"role": "user", "content": text}})
 
     async def _send_json(self, payload: dict[str, object]) -> None:
-        process = self._process
+        child = self._child
+        process = None if child is None else child.process
         if process is None or process.stdin is None:
             raise ConnectionNotReady("Claude subprocess stdin is not available.")
 
@@ -436,7 +400,8 @@ class ClaudeConnection(HarnessConnection[ResolvedLaunchSpec]):
             await process.stdin.drain()
 
     async def _signal_process(self, sig: signal.Signals) -> None:
-        process = self._process
+        child = self._child
+        process = None if child is None else child.process
         if process is None or process.returncode is not None:
             return
         trace_wire_send(self._tracer, "signal_sent", "", signal=sig.name)
@@ -448,56 +413,16 @@ class ClaudeConnection(HarnessConnection[ResolvedLaunchSpec]):
             process.send_signal(sig)
 
     async def _cleanup_resources(self, *, terminate_process: bool) -> None:
+        child = self._child
+        if child is None:
+            return
         if terminate_process:
-            await self._terminate_process()
-        self._close_log_handles()
-
-    async def _terminate_process(self) -> None:
-        process = self._process
-        if process is None:
-            return
-        scope_handle = self._scope_handle
-        self._scope_handle = None
-        if scope_handle is not None and process.returncode is None:
-            await scope_handle.terminate(
-                grace_seconds=_PROCESS_KILL_GRACE_SECONDS,
-                reason="claude_connection_stop",
-            )
-            self._process = None
-            return
-        if process.returncode is None:
-            # Close stdin to signal no more input; then terminate if needed.
-            if process.stdin is not None:
-                try:
-                    process.stdin.close()
-                except Exception:
-                    logger.debug("Failed to close Claude subprocess stdin", exc_info=True)
-            process.terminate()
-            try:
-                await asyncio.wait_for(process.wait(), timeout=_PROCESS_KILL_GRACE_SECONDS)
-            except TimeoutError:
-                process.kill()
-                await process.wait()
-        self._process = None
-
-    def _close_log_handles(self) -> None:
-        if self._stderr_handle is not None:
-            self._stderr_handle.close()
-            self._stderr_handle = None
-        self._stderr_log_path = None
+            await child.terminate()
+        child.close_stderr_handle()
 
     def _read_stderr_excerpt(self) -> str:
-        if self._stderr_handle is not None:
-            self._stderr_handle.flush()
-        path = self._stderr_log_path
-        if path is None or not path.exists():
-            return ""
-        with path.open("rb") as handle:
-            handle.seek(0, os.SEEK_END)
-            end_offset = handle.tell()
-            handle.seek(max(0, end_offset - _STDERR_MAX_BYTES), os.SEEK_SET)
-            data = handle.read()
-        return data.decode("utf-8", errors="replace").strip()
+        child = self._child
+        return "" if child is None else child.read_stderr_tail() or ""
 
     def _parse_stdout_line(self, line: str) -> list[RawHarnessEvent]:
         """Parse one line of NDJSON from Claude stdout into RawHarnessEvent objects."""

--- a/src/meridian/lib/harness/connections/cursor_subprocess.py
+++ b/src/meridian/lib/harness/connections/cursor_subprocess.py
@@ -9,7 +9,6 @@ import uuid
 from asyncio.subprocess import DEVNULL, PIPE, Process
 from collections.abc import AsyncIterator, Callable
 from contextlib import suppress
-from io import BufferedWriter
 from typing import Final, cast
 
 from meridian.lib.core.types import HarnessId, SpawnId
@@ -25,12 +24,14 @@ from meridian.lib.harness.connections.base import (
     reap_on_ownership_transfer_failure,
     validate_prompt_size,
 )
-from meridian.lib.harness.connections.managed_backend import register_spawn_owned_process
+from meridian.lib.harness.connections.managed_stdio import (
+    ManagedStdioProcess,
+    launch_managed_stdio,
+)
 from meridian.lib.harness.extractors.cursor import CURSOR_EXTRACTOR
 from meridian.lib.launch.constants import BASE_COMMAND_CURSOR_SUBPROCESS
 from meridian.lib.launch.launch_types import ResolvedLaunchSpec
-from meridian.lib.platform.process_scope import ProcessScopeSnapshot, ScopedProcessHandle
-from meridian.lib.state.paths import resolve_project_runtime_root_for_write, resolve_spawn_log_dir
+from meridian.lib.platform.process_scope import ProcessScopeSnapshot
 
 logger = logging.getLogger(__name__)
 
@@ -60,9 +61,7 @@ class CursorSubprocessConnection(HarnessConnection[ResolvedLaunchSpec]):
         self._spawn_id: SpawnId = SpawnId("")
         self._session_id: str | None = None
         self._session_id_observer: Callable[[str], None] | None = None
-        self._process: Process | None = None
-        self._scope_handle: ScopedProcessHandle | None = None
-        self._stderr_handle: BufferedWriter | None = None
+        self._child: ManagedStdioProcess | None = None
         self._event_stream_started = False
         self._protocol_validated = False
         self._stop_lock = asyncio.Lock()
@@ -89,15 +88,13 @@ class CursorSubprocessConnection(HarnessConnection[ResolvedLaunchSpec]):
 
     @property
     def subprocess_pid(self) -> int | None:
-        process = self._process
-        if process is None:
-            return None
-        return process.pid
+        child = self._child
+        return None if child is None else child.pid
 
     @property
     def scope_snapshot(self) -> ProcessScopeSnapshot | None:
-        handle = self._scope_handle
-        return None if handle is None else handle.snapshot
+        child = self._child
+        return None if child is None else child.scope_snapshot
 
     async def start(self, config: ConnectionConfig, spec: ResolvedLaunchSpec) -> None:
         if self._state != "created":
@@ -106,16 +103,6 @@ class CursorSubprocessConnection(HarnessConnection[ResolvedLaunchSpec]):
         validate_prompt_size(config)
         self._spawn_id = config.spawn_id
         self._set_state("starting")
-
-        spawn_dir = resolve_spawn_log_dir(
-            config.control_root,
-            config.spawn_id,
-            runtime_root=(
-                config.runtime_root
-                or resolve_project_runtime_root_for_write(config.control_root)
-            ),
-        )
-        self._stderr_handle = (spawn_dir / "stderr.log").open("ab")
 
         env = dict(config.child_env)
         self._session_id_observer = config.session_id_observer
@@ -139,23 +126,16 @@ class CursorSubprocessConnection(HarnessConnection[ResolvedLaunchSpec]):
         )
 
         try:
-            self._process = await asyncio.create_subprocess_exec(
-                *command,
-                cwd=str(config.control_root),
+            self._child = await launch_managed_stdio(
+                config=config,
+                harness_id=self.harness_id,
+                command=command,
                 env=env,
+                cwd=str(config.control_root),
                 stdin=DEVNULL,
-                stdout=PIPE,
-                stderr=self._stderr_handle,
-                limit=_STDOUT_READLINE_LIMIT,
-            )
-            self._scope_handle = await register_spawn_owned_process(
-                spawn_id=config.spawn_id,
-                control_root=config.control_root,
-                process=self._process,
-                scope_id="stdio",
-                role="harness_stdio",
-                runtime_root=config.runtime_root,
-                persist=config.runtime_root is not None,
+                stdout_limit=_STDOUT_READLINE_LIMIT,
+                kill_grace_seconds=_PROCESS_STOP_TIMEOUT_SECONDS,
+                terminate_reason="cursor_connection_stop",
             )
             self._set_state("connected")
         except BaseException:
@@ -197,10 +177,13 @@ class CursorSubprocessConnection(HarnessConnection[ResolvedLaunchSpec]):
             return
         if self._state != "failed":
             self._set_state("stopping")
-        await self._terminate_process()
+        child = self._child
+        if child is not None:
+            await child.terminate()
 
     async def events(self) -> AsyncIterator[RawHarnessEvent]:
-        process = self._process
+        child = self._child
+        process = None if child is None else child.process
         if process is None:
             return
         stdout = process.stdout
@@ -284,35 +267,12 @@ class CursorSubprocessConnection(HarnessConnection[ResolvedLaunchSpec]):
         self._state = next_state
 
     async def _cleanup_resources(self, *, terminate_process: bool) -> None:
+        child = self._child
+        if child is None:
+            return
         if terminate_process:
-            await self._terminate_process()
-        if self._stderr_handle is not None:
-            self._stderr_handle.close()
-            self._stderr_handle = None
-
-    async def _terminate_process(self) -> None:
-        process = self._process
-        if process is None:
-            return
-        scope_handle = self._scope_handle
-        self._scope_handle = None
-        if scope_handle is not None and process.returncode is None:
-            await scope_handle.terminate(
-                grace_seconds=_PROCESS_STOP_TIMEOUT_SECONDS,
-                reason="cursor_connection_stop",
-            )
-            self._process = None
-            return
-        if process.returncode is None:
-            with suppress(ProcessLookupError):
-                process.terminate()
-            try:
-                await asyncio.wait_for(process.wait(), timeout=_PROCESS_STOP_TIMEOUT_SECONDS)
-            except TimeoutError:
-                with suppress(ProcessLookupError):
-                    process.kill()
-                await process.wait()
-        self._process = None
+            await child.terminate()
+        child.close_stderr_handle()
 
     def _observe_session_id_from_event(self, event: RawHarnessEvent) -> None:
         detected = CURSOR_EXTRACTOR.detect_session_id_from_event(event)

--- a/src/meridian/lib/harness/connections/managed_backend.py
+++ b/src/meridian/lib/harness/connections/managed_backend.py
@@ -30,6 +30,50 @@ from meridian.lib.state.paths import (
 from meridian.lib.state.process_scope_projection import record_scope
 
 
+def spawn_owned_process_handle(
+    *,
+    spawn_id: SpawnId,
+    process: asyncio.subprocess.Process,
+    scope_id: str,
+    role: str,
+    parent_death_linked: bool = False,
+    job_name: str | None = None,
+) -> ScopedProcessHandle:
+    """Capture process-tree termination facts for an already launched child."""
+
+    pid = process.pid
+    pgid: int | None = None
+    containment: str
+    if not IS_WINDOWS:
+        try:
+            pgid = os.getpgid(pid)
+            containment = "posix_pgid"
+        except OSError:
+            containment = "pid_tree_fallback"
+    else:
+        containment = "windows_job"
+
+    try:
+        birth_time = psutil.Process(pid).create_time()
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        birth_time = PROCESS_BIRTH_UNKNOWN_EPOCH
+
+    snapshot = ProcessScopeSnapshot(
+        scope_id=scope_id,
+        owner_policy="spawn_owned",
+        owner_id=str(spawn_id),
+        role=role,
+        containment=containment,
+        root_pid=pid,
+        root_created_at_epoch=birth_time,
+        pgid=pgid,
+        job_name=job_name,
+        degraded_reason=None,
+        parent_death_linked=parent_death_linked,
+    )
+    return ScopedProcessHandle(process=process, snapshot=snapshot)
+
+
 @dataclass(frozen=True)
 class ManagedBackendConfig:
     """Inputs for launching a managed backend process."""
@@ -68,40 +112,17 @@ async def register_spawn_owned_process(
     resolved_runtime_root = runtime_root or resolve_project_runtime_root_for_write(
         control_root
     )
-    pid = process.pid
-    pgid: int | None = None
-    containment: str
-    if not IS_WINDOWS:
-        try:
-            pgid = os.getpgid(pid)
-            containment = "posix_pgid"
-        except OSError:
-            containment = "pid_tree_fallback"
-    else:
-        containment = "windows_job"
-
-    try:
-        birth_time = psutil.Process(pid).create_time()
-    except (psutil.NoSuchProcess, psutil.AccessDenied):
-        birth_time = PROCESS_BIRTH_UNKNOWN_EPOCH
-
-    snapshot = ProcessScopeSnapshot(
+    scope_handle = spawn_owned_process_handle(
+        spawn_id=spawn_id,
+        process=process,
         scope_id=scope_id,
-        owner_policy="spawn_owned",
-        owner_id=str(spawn_id),
         role=role,
-        containment=containment,
-        root_pid=pid,
-        root_created_at_epoch=birth_time,
-        pgid=pgid,
-        job_name=job_name,
-        degraded_reason=None,
         parent_death_linked=parent_death_linked,
+        job_name=job_name,
     )
-    scope_handle = ScopedProcessHandle(process=process, snapshot=snapshot)
     try:
         if persist:
-            record_scope(resolved_runtime_root, spawn_id, snapshot)
+            record_scope(resolved_runtime_root, spawn_id, scope_handle.snapshot)
     except BaseException:
         await scope_handle.terminate(reason="scope_registration_failed")
         raise

--- a/src/meridian/lib/harness/connections/managed_stdio.py
+++ b/src/meridian/lib/harness/connections/managed_stdio.py
@@ -1,0 +1,236 @@
+"""Managed stdio child process launch and cleanup."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+from collections.abc import Mapping, Sequence
+from contextlib import suppress
+from io import BufferedWriter
+from pathlib import Path
+from typing import Final
+
+from meridian.lib.core.types import HarnessId
+from meridian.lib.harness.connections.base import ConnectionConfig
+from meridian.lib.harness.connections.managed_backend import register_spawn_owned_process
+from meridian.lib.harness.errors import HarnessBinaryNotFound
+from meridian.lib.platform import IS_WINDOWS
+from meridian.lib.platform.process_scope import ProcessScopeSnapshot, ScopedProcessHandle
+from meridian.lib.state.paths import (
+    resolve_project_runtime_root_for_write,
+    resolve_spawn_log_dir,
+)
+
+STDIO_STDERR_TAIL_MAX_BYTES: Final[int] = 16 * 1024
+
+
+class ManagedStdioProcess:
+    """Own a spawn-lifetime stdio child and its durable process scope."""
+
+    def __init__(
+        self,
+        *,
+        process: asyncio.subprocess.Process,
+        scope_handle: ScopedProcessHandle,
+        stderr_handle: BufferedWriter,
+        stderr_log_path: Path,
+        stderr_read_offset: int,
+        kill_grace_seconds: float,
+        terminate_reason: str,
+    ) -> None:
+        self._process: asyncio.subprocess.Process | None = process
+        self._scope_handle: ScopedProcessHandle | None = scope_handle
+        self._stderr_handle: BufferedWriter | None = stderr_handle
+        self._stderr_log_path: Path | None = stderr_log_path
+        self._stderr_read_offset = stderr_read_offset
+        self._kill_grace_seconds = kill_grace_seconds
+        self._terminate_reason = terminate_reason
+
+    @property
+    def process(self) -> asyncio.subprocess.Process | None:
+        return self._process
+
+    @property
+    def pid(self) -> int | None:
+        process = self._process
+        return None if process is None else process.pid
+
+    @property
+    def returncode(self) -> int | None:
+        process = self._process
+        return None if process is None else process.returncode
+
+    @property
+    def stdout(self) -> asyncio.StreamReader | None:
+        process = self._process
+        return None if process is None else process.stdout
+
+    @property
+    def stdin(self) -> asyncio.StreamWriter | None:
+        process = self._process
+        return None if process is None else process.stdin
+
+    @property
+    def scope_snapshot(self) -> ProcessScopeSnapshot | None:
+        handle = self._scope_handle
+        return None if handle is None else handle.snapshot
+
+    @property
+    def stderr_log_path(self) -> Path | None:
+        return self._stderr_log_path
+
+    async def wait_for_exit(self, *, timeout: float) -> bool:
+        process = self._process
+        if process is None or process.returncode is not None:
+            return True
+        try:
+            await asyncio.wait_for(process.wait(), timeout=timeout)
+            return True
+        except TimeoutError:
+            return False
+
+    async def terminate(self) -> bool:
+        process = self._process
+        if process is None:
+            return False
+
+        scope_handle = self._scope_handle
+        self._scope_handle = None
+        if process.returncode is not None:
+            self._process = None
+            return False
+        if scope_handle is not None:
+            result = await scope_handle.terminate(
+                grace_seconds=self._kill_grace_seconds,
+                reason=self._terminate_reason,
+            )
+            self._process = None
+            return result.kill_escalated
+
+        if process.stdin is not None:
+            with suppress(Exception):
+                process.stdin.close()
+        if IS_WINDOWS:
+            with suppress(ProcessLookupError):
+                process.terminate()
+        else:
+            with suppress(ProcessLookupError):
+                process.send_signal(signal.SIGTERM)
+        try:
+            await asyncio.wait_for(process.wait(), timeout=self._kill_grace_seconds)
+        except TimeoutError:
+            with suppress(ProcessLookupError):
+                process.kill()
+            await process.wait()
+        self._process = None
+        return True
+
+    def read_stderr_tail(
+        self,
+        *,
+        max_bytes: int = STDIO_STDERR_TAIL_MAX_BYTES,
+    ) -> str | None:
+        handle = self._stderr_handle
+        if handle is not None:
+            with suppress(OSError):
+                handle.flush()
+        path = self._stderr_log_path
+        if path is None or not path.is_file():
+            return None
+        try:
+            with path.open("rb") as reader:
+                end = reader.seek(0, os.SEEK_END)
+                start = min(self._stderr_read_offset, end)
+                read_from = max(start, end - max_bytes)
+                reader.seek(read_from)
+                raw = reader.read(end - read_from)
+        except OSError:
+            return None
+        decoded = raw.decode("utf-8", errors="replace").strip()
+        return decoded or None
+
+    def close_stderr_handle(self) -> None:
+        handle = self._stderr_handle
+        if handle is None:
+            return
+        with suppress(OSError):
+            handle.flush()
+        handle.close()
+        self._stderr_handle = None
+
+
+async def launch_managed_stdio(
+    *,
+    config: ConnectionConfig,
+    harness_id: HarnessId,
+    command: Sequence[str],
+    env: Mapping[str, str],
+    cwd: str,
+    stdin: int,
+    stdout_limit: int,
+    kill_grace_seconds: float,
+    terminate_reason: str,
+) -> ManagedStdioProcess:
+    """Launch and register a spawn-lifetime stdio child process."""
+
+    spawn_dir = resolve_spawn_log_dir(
+        config.control_root,
+        config.spawn_id,
+        runtime_root=(
+            config.runtime_root
+            or resolve_project_runtime_root_for_write(config.control_root)
+        ),
+    )
+    stderr_log_path = spawn_dir / "stderr.log"
+    stderr_handle = stderr_log_path.open("ab")
+    stderr_read_offset = stderr_handle.tell()
+    try:
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *command,
+                cwd=cwd,
+                env=env,
+                stdin=stdin,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=stderr_handle,
+                limit=stdout_limit,
+                start_new_session=not IS_WINDOWS,
+            )
+        except (FileNotFoundError, NotADirectoryError) as exc:
+            raise HarnessBinaryNotFound.from_os_error(
+                harness_id=harness_id,
+                error=exc,
+                binary_name=command[0],
+            ) from exc
+        scope_handle = await register_spawn_owned_process(
+            spawn_id=config.spawn_id,
+            control_root=config.control_root,
+            process=process,
+            scope_id="stdio",
+            role="harness_stdio",
+            runtime_root=config.runtime_root,
+            persist=config.runtime_root is not None,
+        )
+    except BaseException:
+        with suppress(OSError):
+            stderr_handle.flush()
+        stderr_handle.close()
+        raise
+
+    return ManagedStdioProcess(
+        process=process,
+        scope_handle=scope_handle,
+        stderr_handle=stderr_handle,
+        stderr_log_path=stderr_log_path,
+        stderr_read_offset=stderr_read_offset,
+        kill_grace_seconds=kill_grace_seconds,
+        terminate_reason=terminate_reason,
+    )
+
+
+__all__ = [
+    "STDIO_STDERR_TAIL_MAX_BYTES",
+    "ManagedStdioProcess",
+    "launch_managed_stdio",
+]

--- a/src/meridian/lib/harness/connections/managed_stdio.py
+++ b/src/meridian/lib/harness/connections/managed_stdio.py
@@ -12,8 +12,14 @@ from pathlib import Path
 from typing import Final
 
 from meridian.lib.core.types import HarnessId
-from meridian.lib.harness.connections.base import ConnectionConfig
-from meridian.lib.harness.connections.managed_backend import register_spawn_owned_process
+from meridian.lib.harness.connections.base import (
+    ConnectionConfig,
+    reap_on_ownership_transfer_failure,
+)
+from meridian.lib.harness.connections.managed_backend import (
+    register_spawn_owned_process,
+    spawn_owned_process_handle,
+)
 from meridian.lib.harness.errors import HarnessBinaryNotFound
 from meridian.lib.platform import IS_WINDOWS
 from meridian.lib.platform.process_scope import ProcessScopeSnapshot, ScopedProcessHandle
@@ -185,6 +191,7 @@ async def launch_managed_stdio(
     stderr_log_path = spawn_dir / "stderr.log"
     stderr_handle = stderr_log_path.open("ab")
     stderr_read_offset = stderr_handle.tell()
+    provisional_scope_handle: ScopedProcessHandle | None = None
     try:
         try:
             process = await asyncio.create_subprocess_exec(
@@ -203,6 +210,12 @@ async def launch_managed_stdio(
                 error=exc,
                 binary_name=command[0],
             ) from exc
+        provisional_scope_handle = spawn_owned_process_handle(
+            spawn_id=config.spawn_id,
+            process=process,
+            scope_id="stdio",
+            role="harness_stdio",
+        )
         scope_handle = await register_spawn_owned_process(
             spawn_id=config.spawn_id,
             control_root=config.control_root,
@@ -213,6 +226,13 @@ async def launch_managed_stdio(
             persist=config.runtime_root is not None,
         )
     except BaseException:
+        if provisional_scope_handle is not None:
+            await reap_on_ownership_transfer_failure(
+                lambda: provisional_scope_handle.terminate(
+                    grace_seconds=kill_grace_seconds,
+                    reason=terminate_reason,
+                )
+            )
         with suppress(OSError):
             stderr_handle.flush()
         stderr_handle.close()

--- a/src/meridian/lib/harness/connections/pi_rpc.py
+++ b/src/meridian/lib/harness/connections/pi_rpc.py
@@ -31,6 +31,7 @@ from meridian.lib.harness.connections.base import (
 )
 from meridian.lib.harness.connections.managed_backend import register_spawn_owned_process
 from meridian.lib.harness.errors import HarnessBinaryNotFound
+from meridian.lib.harness.pi_failure import compact_pi_failure_output
 from meridian.lib.harness.pi_lifecycle_events import (
     PI_CANONICAL_LIFECYCLE_TYPE_PREFIXES,
     PI_SUPPORTED_LIFECYCLE_SCHEMA_VERSION,
@@ -43,7 +44,6 @@ from meridian.lib.harness.pi_runtime_resolver import (
 )
 from meridian.lib.launch.constants import BASE_COMMAND_PI_SUBPROCESS
 from meridian.lib.launch.launch_types import ResolvedLaunchSpec
-from meridian.lib.launch.report import compact_pi_failure_output
 from meridian.lib.observability.trace_helpers import (
     trace_parse_error,
     trace_state_change,

--- a/src/meridian/lib/harness/connections/pi_rpc.py
+++ b/src/meridian/lib/harness/connections/pi_rpc.py
@@ -884,4 +884,4 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
 PiConnection = PiRpcConnection
 
 
-__all__ = ["PiConnection", "PiRpcConnection"]
+__all__ = ["PiConnection", "PiRpcConnection", "PiRpcTimingPolicy"]

--- a/src/meridian/lib/harness/connections/pi_rpc.py
+++ b/src/meridian/lib/harness/connections/pi_rpc.py
@@ -5,14 +5,10 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import signal
 import time
-from asyncio.subprocess import PIPE, Process
+from asyncio.subprocess import PIPE
 from collections.abc import AsyncIterator, Callable, Sequence
-from contextlib import suppress
 from dataclasses import dataclass
-from io import BufferedWriter
-from pathlib import Path
 from typing import Final, Literal, NamedTuple, cast
 
 from meridian.lib.core.telemetry import StartupPhase, StartupPhaseEmitter
@@ -30,8 +26,10 @@ from meridian.lib.harness.connections.base import (
     reap_on_ownership_transfer_failure,
     validate_prompt_size,
 )
-from meridian.lib.harness.connections.managed_backend import register_spawn_owned_process
-from meridian.lib.harness.errors import HarnessBinaryNotFound
+from meridian.lib.harness.connections.managed_stdio import (
+    ManagedStdioProcess,
+    launch_managed_stdio,
+)
 from meridian.lib.harness.pi_failure import compact_pi_failure_output
 from meridian.lib.harness.pi_lifecycle_events import (
     PI_CANONICAL_LIFECYCLE_TYPE_PREFIXES,
@@ -51,9 +49,7 @@ from meridian.lib.observability.trace_helpers import (
     trace_wire_recv,
     trace_wire_send,
 )
-from meridian.lib.platform import IS_WINDOWS
-from meridian.lib.platform.process_scope import ProcessScopeSnapshot, ScopedProcessHandle
-from meridian.lib.state.paths import resolve_project_runtime_root_for_write, resolve_spawn_log_dir
+from meridian.lib.platform.process_scope import ProcessScopeSnapshot
 
 logger = logging.getLogger(__name__)
 _HARNESS_NAME: Final = HarnessId.PI.value
@@ -136,10 +132,7 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
         self._clock = clock
         self._state: ConnectionState = "created"
         self._spawn_id: SpawnId = SpawnId("")
-        self._process: Process | None = None
-        self._scope_handle: ScopedProcessHandle | None = None
-        self._stderr_handle: BufferedWriter | None = None
-        self._stderr_log_path: Path | None = None
+        self._child: ManagedStdioProcess | None = None
         self._event_stream_started = False
         self._session_id: str | None = None
         self._tracer = None
@@ -183,15 +176,11 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
 
     @property
     def subprocess_pid(self) -> int | None:
-        process = self._process
-        if process is None:
-            return None
-        return process.pid
+        return None if self._child is None else self._child.pid
 
     @property
     def scope_snapshot(self) -> ProcessScopeSnapshot | None:
-        handle = self._scope_handle
-        return None if handle is None else handle.snapshot
+        return None if self._child is None else self._child.scope_snapshot
 
     async def start(self, config: ConnectionConfig, spec: ResolvedLaunchSpec) -> None:
         if self._state != "created":
@@ -285,7 +274,8 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
             self._set_state("stopping")
 
         await self._send_abort_message()
-        exited_during_abort_grace = await self._wait_for_process_exit(
+        child = self._child
+        exited_during_abort_grace = child is None or await child.wait_for_exit(
             timeout=self._timing.abort_grace_seconds
         )
         stop_escalated = False
@@ -344,7 +334,10 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
         await self._send_abort_message()
 
     async def events(self) -> AsyncIterator[RawHarnessEvent]:
-        process = self._process
+        child = self._child
+        if child is None:
+            return
+        process = child.process
         if process is None or process.stdout is None:
             return
         if self._event_stream_started:
@@ -412,7 +405,7 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
                         timeout_secs=self._timing.first_event_timeout_seconds,
                     )
                     yield self._error_event(detail)
-                    await self._terminate_process()
+                    await child.terminate()
                     break
                 except Exception as exc:
                     if self._state not in {"stopping", "stopped"}:
@@ -452,7 +445,7 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
                             return_code=return_code,
                         )
                         yield self._error_event(detail)
-                        await self._terminate_process()
+                        await child.terminate()
                         break
                     if return_code != 0 and self._state not in {"stopping", "stopped"}:
                         detail = self._failure_detail_with_stderr(
@@ -508,19 +501,6 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
             await self._cleanup_resources(terminate_process=False)
 
     async def _start_subprocess(self, config: ConnectionConfig, spec: ResolvedLaunchSpec) -> None:
-        spawn_dir = resolve_spawn_log_dir(
-            config.control_root,
-            config.spawn_id,
-            runtime_root=(
-                config.runtime_root
-                or resolve_project_runtime_root_for_write(config.control_root)
-            ),
-        )
-
-        stderr_path = spawn_dir / "stderr.log"
-        self._stderr_log_path = stderr_path
-        self._stderr_handle = stderr_path.open("ab")
-
         command = project_subprocess_spec(
             self.harness_id,
             spec,
@@ -540,33 +520,17 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
         command[0] = resolved_runtime.binary_path
         self._launch_command = tuple(command)
         self._launch_cwd = str(config.control_root)
-
-        try:
-            self._process = await asyncio.create_subprocess_exec(
-                *command,
-                cwd=self._launch_cwd,
-                env=env,
-                stdin=PIPE,
-                stdout=PIPE,
-                stderr=self._stderr_handle,
-                limit=_STDOUT_READLINE_LIMIT,
-                start_new_session=not IS_WINDOWS,
-            )
-            self._scope_handle = await register_spawn_owned_process(
-                spawn_id=config.spawn_id,
-                control_root=config.control_root,
-                process=self._process,
-                scope_id="stdio",
-                role="harness_stdio",
-                runtime_root=config.runtime_root,
-                persist=config.runtime_root is not None,
-            )
-        except (FileNotFoundError, NotADirectoryError) as exc:
-            raise HarnessBinaryNotFound.from_os_error(
-                harness_id=self.harness_id,
-                error=exc,
-                binary_name=command[0],
-            ) from exc
+        self._child = await launch_managed_stdio(
+            config=config,
+            harness_id=self.harness_id,
+            command=command,
+            env=env,
+            cwd=self._launch_cwd,
+            stdin=PIPE,
+            stdout_limit=_STDOUT_READLINE_LIMIT,
+            kill_grace_seconds=self._timing.kill_grace_seconds,
+            terminate_reason="pi_connection_stop",
+        )
 
     async def _read_stdio_stream(
         self,
@@ -760,7 +724,8 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
         if self._state != "connected":
             raise ConnectionNotReady("Pi RPC connection is not ready for send operations.")
 
-        process = self._process
+        child = self._child
+        process = None if child is None else child.process
         if process is None or process.stdin is None or process.returncode is not None:
             raise ConnectionNotReady("Pi RPC subprocess is not available for writes.")
 
@@ -776,7 +741,8 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
         if self._abort_sent:
             return
 
-        process = self._process
+        child = self._child
+        process = None if child is None else child.process
         if process is None or process.returncode is not None:
             return
         if process.stdin is None:
@@ -809,16 +775,6 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
             return
         raise ValueError(_PI_SPAWNED_PROMPT_REQUIRED_REASON)
 
-    async def _wait_for_process_exit(self, *, timeout: float) -> bool:
-        process = self._process
-        if process is None or process.returncode is not None:
-            return True
-        try:
-            await asyncio.wait_for(process.wait(), timeout=timeout)
-            return True
-        except TimeoutError:
-            return False
-
     def _set_state(self, next_state: ConnectionState) -> None:
         if next_state == self._state:
             return
@@ -831,22 +787,16 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
         self._state = next_state
 
     def _read_stderr_snippet(self) -> str | None:
-        if self._stderr_handle is not None:
-            with suppress(OSError):
-                self._stderr_handle.flush()
-        stderr_path = self._stderr_log_path
-        if stderr_path is None or not stderr_path.is_file():
+        child = self._child
+        if child is None:
             return None
-        try:
-            raw = stderr_path.read_text(encoding="utf-8", errors="replace").strip()
-        except OSError:
+        tail = child.read_stderr_tail()
+        if not tail:
             return None
-        if not raw:
-            return None
-        raw = compact_pi_failure_output(raw)
-        if len(raw) <= _STDERR_SNIPPET_LIMIT:
-            return raw
-        return f"{raw[:_STDERR_SNIPPET_LIMIT]}…<truncated>"
+        compacted = compact_pi_failure_output(tail)
+        if len(compacted) <= _STDERR_SNIPPET_LIMIT:
+            return compacted
+        return f"{compacted[:_STDERR_SNIPPET_LIMIT]}…<truncated>"
 
     def _failure_detail_with_stderr(self, detail: str) -> str:
         stderr_snippet = self._read_stderr_snippet()
@@ -873,9 +823,11 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
         self._fail_pending_prompt_acks()
         stop_escalated = False
         if terminate_process:
-            stop_escalated = await self._terminate_process()
-        if not self._events_stream_active:
-            self._close_log_handles()
+            child = self._child
+            if child is not None:
+                stop_escalated = await child.terminate()
+        if not self._events_stream_active and self._child is not None:
+            self._child.close_stderr_handle()
         return stop_escalated
 
     def _fail_pending_prompt_acks(self) -> None:
@@ -887,48 +839,6 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
                     )
                 )
 
-    async def _terminate_process(self) -> bool:
-        process = self._process
-        if process is None:
-            return False
-        stop_escalated = False
-        scope_handle = self._scope_handle
-        self._scope_handle = None
-        if scope_handle is not None and process.returncode is None:
-            result = await scope_handle.terminate(
-                grace_seconds=self._timing.kill_grace_seconds,
-                reason="pi_connection_stop",
-            )
-            self._process = None
-            return result.kill_escalated
-        if process.returncode is None:
-            stop_escalated = True
-            if process.stdin is not None:
-                try:
-                    process.stdin.close()
-                except Exception:
-                    logger.debug("Failed to close Pi RPC subprocess stdin", exc_info=True)
-            if IS_WINDOWS:
-                process.terminate()
-            else:
-                process.send_signal(signal.SIGTERM)
-            try:
-                await asyncio.wait_for(
-                    process.wait(),
-                    timeout=self._timing.kill_grace_seconds,
-                )
-            except TimeoutError:
-                process.kill()
-                await process.wait()
-        self._process = None
-        return stop_escalated
-
-    def _close_log_handles(self) -> None:
-        if self._stderr_handle is not None:
-            with suppress(OSError):
-                self._stderr_handle.flush()
-            self._stderr_handle.close()
-            self._stderr_handle = None
     def _emit_startup_phase(self, phase: StartupPhase) -> None:
         emitter = self._startup_emitter
         if emitter is not None:

--- a/src/meridian/lib/harness/connections/pi_rpc.py
+++ b/src/meridian/lib/harness/connections/pi_rpc.py
@@ -12,7 +12,7 @@ from collections.abc import AsyncIterator, Sequence
 from contextlib import suppress
 from io import BufferedWriter
 from pathlib import Path
-from typing import Final, Literal, cast
+from typing import Final, Literal, NamedTuple, cast
 
 from meridian.lib.core.telemetry import StartupPhase, StartupPhaseEmitter
 from meridian.lib.core.types import HarnessId, SpawnId
@@ -63,6 +63,9 @@ _PARSE_ERROR_RAW_LINE_LIMIT: Final[int] = 2048
 _STDERR_SNIPPET_LIMIT: Final[int] = 4096
 _PI_PHASE_EVENT_TYPE: Final[str] = "meridian.pi.lifecycle.phase"
 _PI_FIRST_EVENT_TIMEOUT_REASON: Final[str] = "pi_rpc_no_response_after_initial_prompt"
+_PI_STREAM_CLOSED_BEFORE_FIRST_EVENT_REASON: Final[str] = (
+    "pi_rpc_stream_closed_before_initial_response"
+)
 _PI_SPAWNED_PROMPT_REQUIRED_REASON: Final[str] = "pi_rpc_spawned_prompt_required"
 _FIRST_STDOUT_AFTER_INITIAL_PROMPT_TIMEOUT_SECONDS: Final[float] = 30.0
 _PI_SESSION_DIR_FLAG: Final[str] = "--session-dir"
@@ -80,6 +83,13 @@ def pi_subprocess_exit_error(return_code: int) -> str:
 def is_pi_subprocess_exit_error(error: str | None) -> bool:
     """Whether an error originated from the canonical Pi process-exit failure."""
     return error is not None and error.startswith(PI_SUBPROCESS_EXIT_ERROR_PREFIX)
+
+
+class ParsedStdoutLine(NamedTuple):
+    """A parsed stdout event and whether it belongs to the Pi protocol."""
+
+    event: RawHarnessEvent | None
+    is_protocol_event: bool
 
 
 class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
@@ -417,7 +427,12 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
                         and self._state not in {"stopping", "stopped"}
                     ):
                         self._waiting_for_first_pi_event_after_prompt = False
-                        detail = self._failure_detail_with_stderr(_PI_FIRST_EVENT_TIMEOUT_REASON)
+                        reason = (
+                            pi_subprocess_exit_error(return_code)
+                            if return_code not in (0, None)
+                            else _PI_STREAM_CLOSED_BEFORE_FIRST_EVENT_REASON
+                        )
+                        detail = self._failure_detail_with_stderr(reason)
                         self._mark_failed(detail)
                         yield self._lifecycle_phase_event(
                             "first_pi_event_eof_before_response",
@@ -442,30 +457,32 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
                     continue
 
                 trace_wire_recv(self._tracer, "stdout_line", raw_text, bytes=len(line_bytes))
-                event = self._parse_stdout_line(raw_text)
+                parsed = self._parse_stdout_line(raw_text)
+                event = parsed.event
                 if event is None:
                     continue
-                self._emit_harness_ready_once()
-                if (
-                    self._waiting_for_first_pi_event_after_prompt
-                    and not self._first_pi_event_received
-                ):
-                    self._first_pi_event_received = True
-                    self._waiting_for_first_pi_event_after_prompt = False
-                    yield self._lifecycle_phase_event(
-                        "first_pi_event_received",
-                        first_event_type=event.event_type,
-                    )
-                if event.event_type == "session":
-                    session_id = event.payload.get("id")
-                    if isinstance(session_id, str) and session_id.strip():
-                        self._session_id = session_id.strip()
-                    if not self._session_event_seen:
-                        self._session_event_seen = True
+                if parsed.is_protocol_event:
+                    self._emit_harness_ready_once()
+                    if (
+                        self._waiting_for_first_pi_event_after_prompt
+                        and not self._first_pi_event_received
+                    ):
+                        self._first_pi_event_received = True
+                        self._waiting_for_first_pi_event_after_prompt = False
                         yield self._lifecycle_phase_event(
-                            "session_event_seen",
-                            session_id=self._session_id,
+                            "first_pi_event_received",
+                            first_event_type=event.event_type,
                         )
+                    if event.event_type == "session":
+                        session_id = event.payload.get("id")
+                        if isinstance(session_id, str) and session_id.strip():
+                            self._session_id = session_id.strip()
+                        if not self._session_event_seen:
+                            self._session_event_seen = True
+                            yield self._lifecycle_phase_event(
+                                "session_event_seen",
+                                session_id=self._session_id,
+                            )
                 yield event
             if not self._session_event_seen:
                 yield self._lifecycle_phase_event("session_event_absent")
@@ -581,25 +598,31 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
             rewritten.extend((_PI_SESSION_DIR_FLAG, session_dir))
         return rewritten
 
-    def _parse_stdout_line(self, line: str) -> RawHarnessEvent | None:
+    def _parse_stdout_line(self, line: str) -> ParsedStdoutLine:
         payload_text = line.strip()
         if not payload_text:
-            return None
+            return ParsedStdoutLine(None, False)
         try:
             payload_obj = json.loads(payload_text)
         except json.JSONDecodeError:
             logger.warning("Skipping malformed Pi stdout line: %s", payload_text)
             trace_parse_error(self._tracer, "pi", payload_text, error="malformed_json")
-            return self._lifecycle_parse_error_event(
-                reason="malformed_json",
-                raw_line=payload_text,
+            return ParsedStdoutLine(
+                self._lifecycle_parse_error_event(
+                    reason="malformed_json",
+                    raw_line=payload_text,
+                ),
+                False,
             )
         if not isinstance(payload_obj, dict):
             logger.warning("Skipping non-object Pi stdout line: %s", payload_text)
             trace_parse_error(self._tracer, "pi", payload_text, error="non_object")
-            return self._lifecycle_parse_error_event(
-                reason="non_object",
-                raw_line=payload_text,
+            return ParsedStdoutLine(
+                self._lifecycle_parse_error_event(
+                    reason="non_object",
+                    raw_line=payload_text,
+                ),
+                False,
             )
 
         payload = cast("dict[str, object]", payload_obj)
@@ -607,9 +630,12 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
         if not isinstance(event_type, str) or not event_type.strip():
             logger.warning("Skipping Pi stdout line without string 'type': %s", payload_text)
             trace_parse_error(self._tracer, "pi", payload_text, error="missing_type")
-            return self._lifecycle_parse_error_event(
-                reason="missing_type",
-                raw_line=payload_text,
+            return ParsedStdoutLine(
+                self._lifecycle_parse_error_event(
+                    reason="missing_type",
+                    raw_line=payload_text,
+                ),
+                False,
             )
         normalized_type = event_type.strip()
         if normalized_type.startswith(PI_CANONICAL_LIFECYCLE_TYPE_PREFIXES):
@@ -618,7 +644,7 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
                 "disk-backed task state is authoritative: %s",
                 normalized_type,
             )
-            return None
+            return ParsedStdoutLine(None, False)
         if self._has_unsupported_lifecycle_schema_version(
             event_type=normalized_type,
             payload=payload,
@@ -629,22 +655,28 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
                 payload_text,
                 error="unsupported_schema_version",
             )
-            return self._lifecycle_parse_error_event(
-                reason="unsupported_schema_version",
-                error="unsupported_schema_version",
-                raw_type=normalized_type,
-                raw_line=payload_text,
+            return ParsedStdoutLine(
+                self._lifecycle_parse_error_event(
+                    reason="unsupported_schema_version",
+                    error="unsupported_schema_version",
+                    raw_type=normalized_type,
+                    raw_line=payload_text,
+                ),
+                False,
             )
 
         if normalized_type == "response" and self._resolve_prompt_ack(payload):
             payload = dict(payload)
             payload["meridian_control_action"] = "inject"
 
-        return RawHarnessEvent(
-            event_type=normalized_type,
-            payload=payload,
-            harness_id=_HARNESS_NAME,
-            raw_text=line,
+        return ParsedStdoutLine(
+            RawHarnessEvent(
+                event_type=normalized_type,
+                payload=payload,
+                harness_id=_HARNESS_NAME,
+                raw_text=line,
+            ),
+            True,
         )
 
     def _resolve_prompt_ack(self, payload: dict[str, object]) -> bool:

--- a/src/meridian/lib/harness/connections/pi_rpc.py
+++ b/src/meridian/lib/harness/connections/pi_rpc.py
@@ -8,8 +8,9 @@ import logging
 import signal
 import time
 from asyncio.subprocess import PIPE, Process
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncIterator, Callable, Sequence
 from contextlib import suppress
+from dataclasses import dataclass
 from io import BufferedWriter
 from pathlib import Path
 from typing import Final, Literal, NamedTuple, cast
@@ -57,8 +58,6 @@ from meridian.lib.state.paths import resolve_project_runtime_root_for_write, res
 logger = logging.getLogger(__name__)
 _HARNESS_NAME: Final = HarnessId.PI.value
 _STDOUT_READLINE_LIMIT: Final[int] = 10 * 1024 * 1024
-_PROCESS_ABORT_GRACE_SECONDS: Final[float] = 5.0
-_PROCESS_KILL_GRACE_SECONDS: Final[float] = 5.0
 _PARSE_ERROR_RAW_LINE_LIMIT: Final[int] = 2048
 _STDERR_SNIPPET_LIMIT: Final[int] = 4096
 _PI_PHASE_EVENT_TYPE: Final[str] = "meridian.pi.lifecycle.phase"
@@ -67,7 +66,6 @@ _PI_STREAM_CLOSED_BEFORE_FIRST_EVENT_REASON: Final[str] = (
     "pi_rpc_stream_closed_before_initial_response"
 )
 _PI_SPAWNED_PROMPT_REQUIRED_REASON: Final[str] = "pi_rpc_spawned_prompt_required"
-_FIRST_STDOUT_AFTER_INITIAL_PROMPT_TIMEOUT_SECONDS: Final[float] = 30.0
 _PI_SESSION_DIR_FLAG: Final[str] = "--session-dir"
 PI_SUBPROCESS_EXIT_ERROR_PREFIX: Final[str] = "Pi subprocess exited with code "
 _STREAM_LINE_KIND: Final[Literal["line"]] = "line"
@@ -90,6 +88,13 @@ class ParsedStdoutLine(NamedTuple):
 
     event: RawHarnessEvent | None
     is_protocol_event: bool
+
+
+@dataclass(frozen=True)
+class PiRpcTimingPolicy:
+    first_event_timeout_seconds: float = 30.0
+    abort_grace_seconds: float = 5.0
+    kill_grace_seconds: float = 5.0
 
 
 class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
@@ -121,7 +126,14 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
         "stopped": set(),
     }
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        timing: PiRpcTimingPolicy | None = None,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._timing = timing or PiRpcTimingPolicy()
+        self._clock = clock
         self._state: ConnectionState = "created"
         self._spawn_id: SpawnId = SpawnId("")
         self._process: Process | None = None
@@ -136,6 +148,7 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
         self._initial_prompt: str = ""
         self._initial_prompt_sent = False
         self._waiting_for_first_pi_event_after_prompt = False
+        self._first_event_deadline_monotonic: float | None = None
         self._first_pi_event_received = False
         self._session_event_seen = False
         self._harness_ready_emitted = False
@@ -196,6 +209,7 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
         self._initial_prompt = config.prompt
         self._initial_prompt_sent = not bool(config.prompt.strip())
         self._waiting_for_first_pi_event_after_prompt = False
+        self._first_event_deadline_monotonic = None
         self._first_pi_event_received = False
         self._session_event_seen = False
         self._harness_ready_emitted = False
@@ -227,9 +241,12 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
                     prompt_bytes=prompt_bytes,
                 )
                 self._waiting_for_first_pi_event_after_prompt = True
+                self._first_event_deadline_monotonic = (
+                    self._clock() + self._timing.first_event_timeout_seconds
+                )
                 self._queue_lifecycle_phase_event(
                     "waiting_for_first_pi_event_after_prompt",
-                    timeout_secs=_FIRST_STDOUT_AFTER_INITIAL_PROMPT_TIMEOUT_SECONDS,
+                    timeout_secs=self._timing.first_event_timeout_seconds,
                 )
             else:
                 self._queue_lifecycle_phase_event(
@@ -269,7 +286,7 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
 
         await self._send_abort_message()
         exited_during_abort_grace = await self._wait_for_process_exit(
-            timeout=_PROCESS_ABORT_GRACE_SECONDS
+            timeout=self._timing.abort_grace_seconds
         )
         stop_escalated = False
         if exited_during_abort_grace:
@@ -348,29 +365,23 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
                 )
             )
         ]
-        first_stdout_deadline_monotonic: float | None = None
-
         try:
             while self._pending_lifecycle_phase_events:
                 yield self._pending_lifecycle_phase_events.pop(0)
             while True:
-                now_monotonic = time.monotonic()
+                now_monotonic = self._clock()
                 try:
                     timeout_secs: float | None = None
                     if (
                         self._waiting_for_first_pi_event_after_prompt
                         and not self._first_pi_event_received
                     ):
-                        if first_stdout_deadline_monotonic is None:
-                            first_stdout_deadline_monotonic = (
-                                time.monotonic()
-                                + _FIRST_STDOUT_AFTER_INITIAL_PROMPT_TIMEOUT_SECONDS
-                            )
-                        timeout_secs = first_stdout_deadline_monotonic - now_monotonic
+                        deadline = self._first_event_deadline_monotonic
+                        if deadline is None:
+                            raise RuntimeError("Missing Pi first-event deadline")
+                        timeout_secs = deadline - now_monotonic
                         if timeout_secs <= 0:
                             raise TimeoutError
-                    else:
-                        first_stdout_deadline_monotonic = None
                     if timeout_secs is None:
                         stream_kind, payload = await stream_queue.get()
                     elif timeout_secs <= 0:
@@ -381,23 +392,24 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
                             timeout=timeout_secs,
                         )
                 except TimeoutError:
-                    now_monotonic = time.monotonic()
+                    now_monotonic = self._clock()
                     if (
                         not self._waiting_for_first_pi_event_after_prompt
                         or self._first_pi_event_received
                     ):
                         continue
                     if (
-                        first_stdout_deadline_monotonic is None
-                        or now_monotonic < first_stdout_deadline_monotonic
+                        self._first_event_deadline_monotonic is None
+                        or now_monotonic < self._first_event_deadline_monotonic
                     ):
                         continue
                     detail = self._failure_detail_with_stderr(_PI_FIRST_EVENT_TIMEOUT_REASON)
                     self._mark_failed(detail)
                     self._waiting_for_first_pi_event_after_prompt = False
+                    self._first_event_deadline_monotonic = None
                     yield self._lifecycle_phase_event(
                         "first_pi_event_timeout",
-                        timeout_secs=_FIRST_STDOUT_AFTER_INITIAL_PROMPT_TIMEOUT_SECONDS,
+                        timeout_secs=self._timing.first_event_timeout_seconds,
                     )
                     yield self._error_event(detail)
                     await self._terminate_process()
@@ -427,6 +439,7 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
                         and self._state not in {"stopping", "stopped"}
                     ):
                         self._waiting_for_first_pi_event_after_prompt = False
+                        self._first_event_deadline_monotonic = None
                         reason = (
                             pi_subprocess_exit_error(return_code)
                             if return_code not in (0, None)
@@ -469,6 +482,7 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
                     ):
                         self._first_pi_event_received = True
                         self._waiting_for_first_pi_event_after_prompt = False
+                        self._first_event_deadline_monotonic = None
                         yield self._lifecycle_phase_event(
                             "first_pi_event_received",
                             first_event_type=event.event_type,
@@ -882,7 +896,7 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
         self._scope_handle = None
         if scope_handle is not None and process.returncode is None:
             result = await scope_handle.terminate(
-                grace_seconds=_PROCESS_KILL_GRACE_SECONDS,
+                grace_seconds=self._timing.kill_grace_seconds,
                 reason="pi_connection_stop",
             )
             self._process = None
@@ -899,7 +913,10 @@ class PiRpcConnection(HarnessConnection[ResolvedLaunchSpec]):
             else:
                 process.send_signal(signal.SIGTERM)
             try:
-                await asyncio.wait_for(process.wait(), timeout=_PROCESS_KILL_GRACE_SECONDS)
+                await asyncio.wait_for(
+                    process.wait(),
+                    timeout=self._timing.kill_grace_seconds,
+                )
             except TimeoutError:
                 process.kill()
                 await process.wait()

--- a/src/meridian/lib/harness/extractors/pi.py
+++ b/src/meridian/lib/harness/extractors/pi.py
@@ -17,10 +17,11 @@ from meridian.lib.harness.common import (
     _iter_json_lines_artifact,  # pyright: ignore[reportPrivateUsage]
 )
 from meridian.lib.harness.connections.base import RawHarnessEvent
+from meridian.lib.harness.pi_failure import compact_pi_failure_output
 from meridian.lib.harness.pi_paths import resolve_pi_spawn_session_root
 from meridian.lib.launch.constants import HISTORY_FILENAME
 from meridian.lib.launch.launch_types import ResolvedLaunchSpec
-from meridian.lib.launch.report import compact_pi_failure_output, extract_pi_failure_from_history
+from meridian.lib.launch.report import extract_pi_failure_from_history
 from meridian.lib.platform import IS_WINDOWS
 
 from .base import HarnessExtractor

--- a/src/meridian/lib/harness/extractors/pi.py
+++ b/src/meridian/lib/harness/extractors/pi.py
@@ -17,11 +17,13 @@ from meridian.lib.harness.common import (
     _iter_json_lines_artifact,  # pyright: ignore[reportPrivateUsage]
 )
 from meridian.lib.harness.connections.base import RawHarnessEvent
-from meridian.lib.harness.pi_failure import compact_pi_failure_output
+from meridian.lib.harness.pi_failure import (
+    compact_pi_failure_output,
+    extract_pi_failure_from_history,
+)
 from meridian.lib.harness.pi_paths import resolve_pi_spawn_session_root
 from meridian.lib.launch.constants import HISTORY_FILENAME
 from meridian.lib.launch.launch_types import ResolvedLaunchSpec
-from meridian.lib.launch.report import extract_pi_failure_from_history
 from meridian.lib.platform import IS_WINDOWS
 
 from .base import HarnessExtractor

--- a/src/meridian/lib/harness/pi_failure.py
+++ b/src/meridian/lib/harness/pi_failure.py
@@ -1,0 +1,47 @@
+"""Pi failure-output normalization."""
+
+import logging
+
+
+def _pi_failure_output_verbose() -> bool:
+    """Whether Pi failure text should include JS stack traces (e.g. extension errors)."""
+    return logging.getLogger().isEnabledFor(logging.INFO)
+
+
+def _is_js_stack_trace_line(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped:
+        return False
+    if stripped.startswith("at "):
+        return True
+    if stripped.startswith("(") and "file:///" in stripped:
+        return True
+    return "file:///" in stripped and ("/index.js:" in stripped or ".ts:" in stripped)
+
+
+def compact_pi_failure_output(message: str, *, verbose: bool | None = None) -> str:
+    """Collapse Pi extension/JS stack noise for user-facing spawn failure output."""
+    text = message.strip()
+    if not text:
+        return text
+    show_verbose = _pi_failure_output_verbose() if verbose is None else verbose
+    if show_verbose:
+        return text
+
+    lines = text.splitlines()
+    has_stack = any(_is_js_stack_trace_line(line) for line in lines)
+    first_line = lines[0].strip() if lines else ""
+    is_extension_error = first_line.startswith("Extension ") and " error:" in first_line
+    if not has_stack and not is_extension_error:
+        return text
+
+    compact: list[str] = []
+    for line in lines:
+        if _is_js_stack_trace_line(line):
+            break
+        stripped = line.strip()
+        if stripped:
+            compact.append(stripped)
+    if not compact:
+        return first_line or text
+    return compact[0] if is_extension_error else "\n".join(compact)

--- a/src/meridian/lib/harness/pi_failure.py
+++ b/src/meridian/lib/harness/pi_failure.py
@@ -1,6 +1,29 @@
-"""Pi failure-output normalization."""
+"""Pi failure extraction and output normalization."""
 
+import json
 import logging
+from typing import cast
+
+_PI_LIFECYCLE_PHASE_EVENT = "meridian.pi.lifecycle.phase"
+_PI_LIFECYCLE_NOISE_PHASES = frozenset(
+    {
+        "cleanup_running",
+        "cleanup_completed",
+        "cleanup_escalated",
+        "cleanup_failed",
+        "process_spawned",
+        "initial_prompt_sent",
+        "waiting_for_first_pi_event_after_prompt",
+        "first_pi_event_received",
+        "first_pi_event_timeout",
+        "first_pi_event_eof_before_response",
+        "no_initial_prompt",
+        "session_event_seen",
+        "session_event_absent",
+        "quiescence_micro_drain_started",
+        "waiting_for_tracked_children",
+    }
+)
 
 
 def _pi_failure_output_verbose() -> bool:
@@ -45,3 +68,114 @@ def compact_pi_failure_output(message: str, *, verbose: bool | None = None) -> s
     if not compact:
         return first_line or text
     return compact[0] if is_extension_error else "\n".join(compact)
+
+
+def _event_name(payload: dict[str, object]) -> str:
+    return (
+        str(payload.get("event_type", payload.get("event", payload.get("type", ""))))
+        .strip()
+        .lower()
+    )
+
+
+def _failure_text_from_value(value: object) -> str:
+    if isinstance(value, str):
+        return value.strip()
+
+    if isinstance(value, list):
+        parts = [_failure_text_from_value(item) for item in cast("list[object]", value)]
+        return "\n".join(part for part in parts if part).strip()
+
+    if isinstance(value, dict):
+        payload = cast("dict[str, object]", value)
+        parts: list[str] = []
+        for key in ("text", "message", "output"):
+            if key in payload:
+                text = _failure_text_from_value(payload[key])
+                if text:
+                    parts.append(text)
+        if "content" in payload:
+            text = _failure_text_from_value(payload["content"])
+            if text:
+                parts.append(text)
+        return "\n".join(parts).strip()
+
+    return ""
+
+
+def _history_record_payload(payload_obj: object) -> dict[str, object] | None:
+    if not isinstance(payload_obj, dict):
+        return None
+    record = cast("dict[str, object]", payload_obj)
+    if "event_type" in record or "payload" in record:
+        return record
+    return {"payload": record}
+
+
+def _unwrap_history_payload(record: dict[str, object]) -> dict[str, object]:
+    nested = record.get("payload")
+    if isinstance(nested, dict):
+        return cast("dict[str, object]", nested)
+    return record
+
+
+def is_pi_lifecycle_noise_payload(payload: dict[str, object]) -> bool:
+    event_type = _event_name(payload)
+    if event_type != _PI_LIFECYCLE_PHASE_EVENT:
+        inner_type = str(payload.get("type", "")).strip().lower()
+        if inner_type != _PI_LIFECYCLE_PHASE_EVENT:
+            return False
+    phase = str(payload.get("phase", "")).strip().lower()
+    return phase in _PI_LIFECYCLE_NOISE_PHASES or (
+        phase == "finalized" and not payload.get("error")
+    )
+
+
+def _pi_failure_from_payload(payload: dict[str, object]) -> str | None:
+    event_type = _event_name(payload)
+    if event_type == "response":
+        command = str(payload.get("command", "")).strip().lower()
+        is_inject_response = payload.get("meridian_control_action") == "inject"
+        if command == "prompt" and payload.get("success") is False and not is_inject_response:
+            error = _failure_text_from_value(payload.get("error"))
+            return error or "pi_prompt_rejected"
+    if event_type == _PI_LIFECYCLE_PHASE_EVENT:
+        phase = str(payload.get("phase", "")).strip().lower()
+        if phase == "finalized":
+            error = _failure_text_from_value(payload.get("error"))
+            if error:
+                return error
+    if event_type == "error":
+        message = _failure_text_from_value(payload.get("message"))
+        if message:
+            return message
+    nested = payload.get("payload")
+    if isinstance(nested, dict):
+        return _pi_failure_from_payload(cast("dict[str, object]", nested))
+    return None
+
+
+def extract_pi_failure_from_history(output_lines: str) -> str | None:
+    """Extract the last Pi failure recorded in newline-delimited history."""
+    last_failure: str | None = None
+    for line in output_lines.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            payload_obj: object = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        record = _history_record_payload(payload_obj)
+        if record is None:
+            continue
+        event_type = str(record.get("event_type", "")).strip().lower()
+        payload = _unwrap_history_payload(record)
+        if event_type and _event_name(payload) != event_type:
+            merged = dict(payload)
+            merged.setdefault("type", event_type)
+            payload = merged
+        failure = _pi_failure_from_payload(payload)
+        if failure:
+            last_failure = compact_pi_failure_output(failure)
+    return last_failure

--- a/src/meridian/lib/launch/report.py
+++ b/src/meridian/lib/launch/report.py
@@ -13,6 +13,7 @@ from meridian.lib.core.spawn_lifecycle import (
 )
 from meridian.lib.core.types import SpawnId
 from meridian.lib.harness.adapter import SpawnExtractor
+from meridian.lib.harness.pi_failure import compact_pi_failure_output
 from meridian.lib.launch.constants import HISTORY_FILENAME, OUTPUT_FILENAME
 from meridian.lib.state.artifact_store import ArtifactStore
 
@@ -152,50 +153,6 @@ def _is_pi_lifecycle_noise_payload(payload: dict[str, object]) -> bool:
     return phase in _PI_LIFECYCLE_NOISE_PHASES or (
         phase == "finalized" and not payload.get("error")
     )
-
-
-def _pi_failure_output_verbose() -> bool:
-    """Whether Pi failure text should include JS stack traces (e.g. extension errors)."""
-    return logging.getLogger().isEnabledFor(logging.INFO)
-
-
-def _is_js_stack_trace_line(line: str) -> bool:
-    stripped = line.strip()
-    if not stripped:
-        return False
-    if stripped.startswith("at "):
-        return True
-    if stripped.startswith("(") and "file:///" in stripped:
-        return True
-    return "file:///" in stripped and ("/index.js:" in stripped or ".ts:" in stripped)
-
-
-def compact_pi_failure_output(message: str, *, verbose: bool | None = None) -> str:
-    """Collapse Pi extension/JS stack noise for user-facing spawn failure output."""
-    text = message.strip()
-    if not text:
-        return text
-    show_verbose = _pi_failure_output_verbose() if verbose is None else verbose
-    if show_verbose:
-        return text
-
-    lines = text.splitlines()
-    has_stack = any(_is_js_stack_trace_line(line) for line in lines)
-    first_line = lines[0].strip() if lines else ""
-    is_extension_error = first_line.startswith("Extension ") and " error:" in first_line
-    if not has_stack and not is_extension_error:
-        return text
-
-    compact: list[str] = []
-    for line in lines:
-        if _is_js_stack_trace_line(line):
-            break
-        stripped = line.strip()
-        if stripped:
-            compact.append(stripped)
-    if not compact:
-        return first_line or text
-    return compact[0] if is_extension_error else "\n".join(compact)
 
 
 def _pi_failure_from_payload(payload: dict[str, object]) -> str | None:

--- a/src/meridian/lib/launch/report.py
+++ b/src/meridian/lib/launch/report.py
@@ -13,7 +13,10 @@ from meridian.lib.core.spawn_lifecycle import (
 )
 from meridian.lib.core.types import SpawnId
 from meridian.lib.harness.adapter import SpawnExtractor
-from meridian.lib.harness.pi_failure import compact_pi_failure_output
+from meridian.lib.harness.pi_failure import (
+    extract_pi_failure_from_history,
+    is_pi_lifecycle_noise_payload,
+)
 from meridian.lib.launch.constants import HISTORY_FILENAME, OUTPUT_FILENAME
 from meridian.lib.state.artifact_store import ArtifactStore
 
@@ -21,26 +24,6 @@ from .artifact_io import read_artifact_text
 
 ReportSource = Literal["report_md", "assistant_message", "failure_reason", "pi_failure"]
 _LOGGER = logging.getLogger(__name__)
-_PI_LIFECYCLE_PHASE_EVENT = "meridian.pi.lifecycle.phase"
-_PI_LIFECYCLE_NOISE_PHASES = frozenset(
-    {
-        "cleanup_running",
-        "cleanup_completed",
-        "cleanup_escalated",
-        "cleanup_failed",
-        "process_spawned",
-        "initial_prompt_sent",
-        "waiting_for_first_pi_event_after_prompt",
-        "first_pi_event_received",
-        "first_pi_event_timeout",
-        "first_pi_event_eof_before_response",
-        "no_initial_prompt",
-        "session_event_seen",
-        "session_event_absent",
-        "quiescence_micro_drain_started",
-        "waiting_for_tracked_children",
-    }
-)
 
 
 class ExtractedReport(BaseModel):
@@ -48,14 +31,6 @@ class ExtractedReport(BaseModel):
 
     content: str | None
     source: ReportSource | None
-
-
-def _event_name(payload: dict[str, object]) -> str:
-    return (
-        str(payload.get("event_type", payload.get("event", payload.get("type", ""))))
-        .strip()
-        .lower()
-    )
 
 
 def _is_terminal_control_frame(text: str) -> bool:
@@ -143,67 +118,6 @@ def _unwrap_history_payload(record: dict[str, object]) -> dict[str, object]:
     return record
 
 
-def _is_pi_lifecycle_noise_payload(payload: dict[str, object]) -> bool:
-    event_type = _event_name(payload)
-    if event_type != _PI_LIFECYCLE_PHASE_EVENT:
-        inner_type = str(payload.get("type", "")).strip().lower()
-        if inner_type != _PI_LIFECYCLE_PHASE_EVENT:
-            return False
-    phase = str(payload.get("phase", "")).strip().lower()
-    return phase in _PI_LIFECYCLE_NOISE_PHASES or (
-        phase == "finalized" and not payload.get("error")
-    )
-
-
-def _pi_failure_from_payload(payload: dict[str, object]) -> str | None:
-    event_type = _event_name(payload)
-    if event_type == "response":
-        command = str(payload.get("command", "")).strip().lower()
-        is_inject_response = payload.get("meridian_control_action") == "inject"
-        if command == "prompt" and payload.get("success") is False and not is_inject_response:
-            error = _text_from_value(payload.get("error"))
-            return error or "pi_prompt_rejected"
-    if event_type == _PI_LIFECYCLE_PHASE_EVENT:
-        phase = str(payload.get("phase", "")).strip().lower()
-        if phase == "finalized":
-            error = _text_from_value(payload.get("error"))
-            if error:
-                return error
-    if event_type == "error":
-        message = _text_from_value(payload.get("message"))
-        if message:
-            return message
-    nested = payload.get("payload")
-    if isinstance(nested, dict):
-        return _pi_failure_from_payload(cast("dict[str, object]", nested))
-    return None
-
-
-def extract_pi_failure_from_history(output_lines: str) -> str | None:
-    last_failure: str | None = None
-    for line in output_lines.splitlines():
-        stripped = line.strip()
-        if not stripped:
-            continue
-        try:
-            payload_obj: object = json.loads(stripped)
-        except json.JSONDecodeError:
-            continue
-        record = _history_record_payload(payload_obj)
-        if record is None:
-            continue
-        event_type = str(record.get("event_type", "")).strip().lower()
-        payload = _unwrap_history_payload(record)
-        if event_type and _event_name(payload) != event_type:
-            merged = dict(payload)
-            merged.setdefault("type", event_type)
-            payload = merged
-        failure = _pi_failure_from_payload(payload)
-        if failure:
-            last_failure = compact_pi_failure_output(failure)
-    return last_failure
-
-
 def _extract_last_assistant_message(output_lines: str) -> str | None:
     last_assistant: str | None = None
     last_text_line: str | None = None
@@ -219,7 +133,7 @@ def _extract_last_assistant_message(output_lines: str) -> str | None:
         record = _history_record_payload(payload_obj)
         if record is not None:
             payload = _unwrap_history_payload(record)
-            if _is_pi_lifecycle_noise_payload(payload):
+            if is_pi_lifecycle_noise_payload(payload):
                 continue
             if is_control_report_payload(payload):
                 continue

--- a/tests/integration/harness/test_cursor_subprocess_connection.py
+++ b/tests/integration/harness/test_cursor_subprocess_connection.py
@@ -158,6 +158,8 @@ async def test_cursor_create_chat_and_resume_reuse_session_with_store_attributio
 
     fresh_id = SpawnId("p-cursor-fresh")
     fresh = await _start(tmp_path, fresh_id)
+    assert fresh.subprocess_pid is not None
+    assert os.getpgid(fresh.subprocess_pid) != os.getpgrp()
     assert fresh.session_id == _MINTED_ID
     assert str(spawn_store.get_spawn(tmp_path, fresh_id).harness_session_id) == _MINTED_ID
     await _wait_for_commands(

--- a/tests/integration/harness/test_managed_stdio.py
+++ b/tests/integration/harness/test_managed_stdio.py
@@ -1,0 +1,82 @@
+"""Managed stdio process ownership tests."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+import sys
+from pathlib import Path
+
+import psutil
+import pytest
+
+from meridian.lib.core.types import HarnessId, SpawnId
+from meridian.lib.harness.connections import managed_stdio
+from meridian.lib.harness.connections.base import ConnectionConfig
+from meridian.lib.state.paths import resolve_project_runtime_root_for_write
+from meridian.lib.state.spawn_store import start_spawn
+
+
+@pytest.mark.asyncio
+async def test_launch_managed_stdio_reaps_child_when_registration_raises(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spawn_id = SpawnId("stdio-registration-failure")
+    runtime_root = resolve_project_runtime_root_for_write(tmp_path)
+    start_spawn(
+        runtime_root,
+        spawn_id=spawn_id,
+        chat_id="chat-1",
+        model="test-model",
+        agent="tester",
+        harness="pi",
+        prompt="test",
+        status="running",
+    )
+    launched: list[asyncio.subprocess.Process] = []
+
+    async def fail_registration(**kwargs: object) -> object:
+        launched.append(kwargs["process"])  # type: ignore[arg-type]
+        raise RuntimeError("injected registration failure")
+
+    monkeypatch.setattr(
+        managed_stdio,
+        "register_spawn_owned_process",
+        fail_registration,
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match="injected registration failure"):
+            await managed_stdio.launch_managed_stdio(
+                config=ConnectionConfig(
+                    spawn_id=spawn_id,
+                    harness_id=HarnessId.PI,
+                    prompt="test",
+                    control_root=tmp_path,
+                    child_env={},
+                    runtime_root=runtime_root,
+                ),
+                harness_id=HarnessId.PI,
+                command=(sys.executable, "-c", "import time; time.sleep(60)"),
+                env=os.environ.copy(),
+                cwd=str(tmp_path),
+                stdin=asyncio.subprocess.PIPE,
+                stdout_limit=64 * 1024,
+                kill_grace_seconds=0.1,
+                terminate_reason="test_cleanup",
+            )
+
+        assert len(launched) == 1
+        await asyncio.wait_for(launched[0].wait(), timeout=1.0)
+        stderr_log = runtime_root / "spawns" / str(spawn_id) / "stderr.log"
+        assert stderr_log.resolve() not in {
+            Path(open_file.path).resolve()
+            for open_file in psutil.Process().open_files()
+        }
+    finally:
+        for process in launched:
+            if process.returncode is None:
+                os.killpg(process.pid, signal.SIGKILL)
+                await process.wait()

--- a/tests/integration/harness/test_pi_integration.py
+++ b/tests/integration/harness/test_pi_integration.py
@@ -756,9 +756,6 @@ async def test_pi_rpc_connection_surfaces_stderr_on_early_exit_before_first_even
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _configure_extension_projection(monkeypatch, tmp_path)
-    monkeypatch.setattr(pi_rpc_module, "_FIRST_STDOUT_AFTER_INITIAL_PROMPT_TIMEOUT_SECONDS", 0.05)
-    monkeypatch.setattr(pi_rpc_module, "_PROCESS_ABORT_GRACE_SECONDS", 0.01)
-    monkeypatch.setattr(pi_rpc_module, "_PROCESS_KILL_GRACE_SECONDS", 0.01)
 
     spawn_id = SpawnId("p-pi-stderr-early-exit")
     crash_stderr = "TypeError: markAsUncloneable is not a function"

--- a/tests/integration/harness/test_pi_integration.py
+++ b/tests/integration/harness/test_pi_integration.py
@@ -125,12 +125,13 @@ def test_pi_rpc_connection_surfaces_stdout_parse_diagnostics(
     line: str,
     expected_reason: str,
 ) -> None:
-    event = PiRpcConnection()._parse_stdout_line(line)
+    parsed = PiRpcConnection()._parse_stdout_line(line)
 
-    assert event is not None
-    assert event.event_type == "meridian.lifecycle.parse_error"
-    assert event.payload["reason"] == expected_reason
-    assert event.harness_id == HarnessId.PI.value
+    assert parsed.event is not None
+    assert parsed.event.event_type == "meridian.lifecycle.parse_error"
+    assert parsed.event.payload["reason"] == expected_reason
+    assert parsed.event.harness_id == HarnessId.PI.value
+    assert parsed.is_protocol_event is False
 
 
 
@@ -814,6 +815,123 @@ async def test_pi_rpc_connection_surfaces_stderr_on_early_exit_before_first_even
         / "stderr.log"
     )
     assert crash_stderr in stderr_log.read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(sys.platform == "win32", reason="uses POSIX executable shim")
+async def test_pi_rpc_malformed_line_does_not_satisfy_first_event_watchdog(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_extension_projection(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        pi_rpc_module,
+        "_FIRST_STDOUT_AFTER_INITIAL_PROMPT_TIMEOUT_SECONDS",
+        0.2,
+    )
+    monkeypatch.setattr(pi_rpc_module, "_PROCESS_ABORT_GRACE_SECONDS", 0.5)
+    monkeypatch.setattr(pi_rpc_module, "_PROCESS_KILL_GRACE_SECONDS", 0.5)
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    shim = bin_dir / "pi"
+    shim.write_text(
+        "#!/bin/sh\n"
+        "if [ \"$1\" = \"--version\" ]; then echo 'pi 1.2.3'; exit 0; fi\n"
+        f"if [ \"$1\" = \"--help\" ]; then echo '{_PI_HELP_SURFACE}'; exit 0; fi\n"
+        "read -r _prompt_line || true\n"
+        "printf '%s\\n' '{bad json'\n"
+        "sleep 5\n",
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+
+    connection = PiRpcConnection()
+    await _start_existing_pi_connection(
+        connection,
+        ConnectionConfig(
+            spawn_id=SpawnId("p-pi-malformed-first-event"),
+            harness_id=HarnessId.PI,
+            prompt="hello",
+            control_root=tmp_path,
+            child_env={},
+            pi_session_role="spawned",
+        ),
+        ResolvedLaunchSpec(
+            harness=HarnessId.PI,
+            prompt="hello",
+            permission_resolver=UnsafeNoOpPermissionResolver(_suppress_warning=True),
+        ),
+    )
+
+    events = [event async for event in connection.events()]
+
+    assert any(
+        event.event_type == "meridian.lifecycle.parse_error" for event in events
+    )
+    error_messages = [
+        str(event.payload.get("message", ""))
+        for event in events
+        if event.event_type == "meridian/error/connectionClosed"
+    ]
+    assert error_messages
+    assert pi_rpc_module._PI_FIRST_EVENT_TIMEOUT_REASON in error_messages[0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(sys.platform == "win32", reason="uses POSIX executable shim")
+async def test_pi_rpc_nonzero_exit_before_first_event_reports_exit_code(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_extension_projection(monkeypatch, tmp_path)
+
+    crash_stderr = "Pi crashed before its first response"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    shim = bin_dir / "pi"
+    shim.write_text(
+        "#!/bin/sh\n"
+        "if [ \"$1\" = \"--version\" ]; then echo 'pi 1.2.3'; exit 0; fi\n"
+        f"if [ \"$1\" = \"--help\" ]; then echo '{_PI_HELP_SURFACE}'; exit 0; fi\n"
+        "read -r _prompt_line || true\n"
+        f"printf '%s\\n' '{crash_stderr}' >&2\n"
+        "exit 7\n",
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+
+    connection = PiRpcConnection()
+    await _start_existing_pi_connection(
+        connection,
+        ConnectionConfig(
+            spawn_id=SpawnId("p-pi-exit-before-first-event"),
+            harness_id=HarnessId.PI,
+            prompt="hello",
+            control_root=tmp_path,
+            child_env={},
+            pi_session_role="spawned",
+        ),
+        ResolvedLaunchSpec(
+            harness=HarnessId.PI,
+            prompt="hello",
+            permission_resolver=UnsafeNoOpPermissionResolver(_suppress_warning=True),
+        ),
+    )
+
+    events = [event async for event in connection.events()]
+    error_messages = [
+        str(event.payload.get("message", ""))
+        for event in events
+        if event.event_type == "meridian/error/connectionClosed"
+    ]
+
+    assert error_messages
+    assert pi_rpc_module.pi_subprocess_exit_error(7) in error_messages[0]
+    assert pi_rpc_module._PI_FIRST_EVENT_TIMEOUT_REASON not in error_messages[0]
+    assert crash_stderr in error_messages[0]
 
 
 @pytest.mark.asyncio

--- a/tests/integration/harness/test_pi_integration.py
+++ b/tests/integration/harness/test_pi_integration.py
@@ -17,7 +17,7 @@ from meridian.lib.harness.connections.base import (
     ConnectionNotReady,
     RawHarnessEvent,
 )
-from meridian.lib.harness.connections.pi_rpc import PiRpcConnection
+from meridian.lib.harness.connections.pi_rpc import PiRpcConnection, PiRpcTimingPolicy
 from meridian.lib.harness.semantics import normalize_event
 from meridian.lib.launch.launch_types import ResolvedLaunchSpec
 from meridian.lib.safety.permissions import UnsafeNoOpPermissionResolver
@@ -545,8 +545,16 @@ async def test_pi_spawn_manager_startup_diagnostics_report_outcome_and_marker(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _configure_extension_projection(monkeypatch, tmp_path)
-    monkeypatch.setattr(pi_rpc_module, "_PROCESS_ABORT_GRACE_SECONDS", 0.01)
-    monkeypatch.setattr(pi_rpc_module, "_PROCESS_KILL_GRACE_SECONDS", 0.01)
+
+    async def start_connection(
+        config: ConnectionConfig,
+        spec: ResolvedLaunchSpec,
+    ) -> PiRpcConnection:
+        connection = PiRpcConnection(
+            timing=PiRpcTimingPolicy(first_event_timeout_seconds=2.0)
+        )
+        await _start_existing_pi_connection(connection, config, spec)
+        return connection
 
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
@@ -581,7 +589,7 @@ async def test_pi_spawn_manager_startup_diagnostics_report_outcome_and_marker(
     manager = SpawnManager(
         runtime_root=tmp_path,
         project_root=tmp_path,
-        start_connection=_start_pi_connection,
+        start_connection=start_connection,
         control_server_factory=lambda _spawn_id, _socket_path, _manager: _NoopControlServer(),
     )
 
@@ -824,13 +832,6 @@ async def test_pi_rpc_malformed_line_does_not_satisfy_first_event_watchdog(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _configure_extension_projection(monkeypatch, tmp_path)
-    monkeypatch.setattr(
-        pi_rpc_module,
-        "_FIRST_STDOUT_AFTER_INITIAL_PROMPT_TIMEOUT_SECONDS",
-        0.2,
-    )
-    monkeypatch.setattr(pi_rpc_module, "_PROCESS_ABORT_GRACE_SECONDS", 0.5)
-    monkeypatch.setattr(pi_rpc_module, "_PROCESS_KILL_GRACE_SECONDS", 0.5)
 
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
@@ -847,7 +848,9 @@ async def test_pi_rpc_malformed_line_does_not_satisfy_first_event_watchdog(
     shim.chmod(0o755)
     monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
 
-    connection = PiRpcConnection()
+    connection = PiRpcConnection(
+        timing=PiRpcTimingPolicy(first_event_timeout_seconds=1.0)
+    )
     await _start_existing_pi_connection(
         connection,
         ConnectionConfig(

--- a/tests/integration/harness/test_pi_integration.py
+++ b/tests/integration/harness/test_pi_integration.py
@@ -768,6 +768,7 @@ async def test_pi_rpc_connection_surfaces_stderr_on_early_exit_before_first_even
 
     spawn_id = SpawnId("p-pi-stderr-early-exit")
     crash_stderr = "TypeError: markAsUncloneable is not a function"
+    prior_launch_stderr = "sentinel from a prior Pi launch"
 
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
@@ -784,6 +785,17 @@ async def test_pi_rpc_connection_surfaces_stderr_on_early_exit_before_first_even
     )
     shim.chmod(0o755)
     monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+
+    stderr_log = (
+        resolve_spawn_log_dir(
+            tmp_path,
+            spawn_id,
+            runtime_root=resolve_project_runtime_root_for_write(tmp_path),
+        )
+        / "stderr.log"
+    )
+    stderr_log.parent.mkdir(parents=True)
+    stderr_log.write_text(f"{prior_launch_stderr}\n", encoding="utf-8")
 
     connection = PiRpcConnection()
     await _start_existing_pi_connection(
@@ -812,16 +824,9 @@ async def test_pi_rpc_connection_surfaces_stderr_on_early_exit_before_first_even
     assert error_events
     message = str(error_events[0].payload.get("message", ""))
     assert crash_stderr in message
+    assert prior_launch_stderr not in message
     assert "Pi subprocess stderr:" in message
 
-    stderr_log = (
-        resolve_spawn_log_dir(
-            tmp_path,
-            spawn_id,
-            runtime_root=resolve_project_runtime_root_for_write(tmp_path),
-        )
-        / "stderr.log"
-    )
     assert crash_stderr in stderr_log.read_text(encoding="utf-8")
 
 

--- a/tests/unit/harness/test_pi_failure.py
+++ b/tests/unit/harness/test_pi_failure.py
@@ -6,12 +6,11 @@ import json
 
 import pytest
 
-from meridian.lib.harness.extractors.pi import PI_EXTRACTOR as _PI_EXTRACTOR
-from meridian.lib.harness.pi_failure import compact_pi_failure_output
+from meridian.lib.harness.pi_failure import (
+    compact_pi_failure_output,
+    extract_pi_failure_from_history,
+)
 from meridian.lib.launch.errors import should_retry
-from meridian.lib.launch.report import extract_pi_failure_from_history
-
-_ = _PI_EXTRACTOR  # Initialize harness modules before importing launch.report in isolation.
 
 
 def test_extract_pi_failure_from_prompt_rejection() -> None:

--- a/tests/unit/launch/test_pi_report_extraction.py
+++ b/tests/unit/launch/test_pi_report_extraction.py
@@ -7,11 +7,9 @@ import json
 import pytest
 
 from meridian.lib.harness.extractors.pi import PI_EXTRACTOR as _PI_EXTRACTOR
+from meridian.lib.harness.pi_failure import compact_pi_failure_output
 from meridian.lib.launch.errors import should_retry
-from meridian.lib.launch.report import (
-    compact_pi_failure_output,
-    extract_pi_failure_from_history,
-)
+from meridian.lib.launch.report import extract_pi_failure_from_history
 
 _ = _PI_EXTRACTOR  # Initialize harness modules before importing launch.report in isolation.
 


### PR DESCRIPTION
## Why

Started as a one-line CI flake fix. A thermo-nuclear review of `pi_rpc.py` then
surfaced two runtime-verified **correctness** bugs (folded in), plus four
structural findings — all of which are absorbed here rather than deferred, per
work-item decision. A design pass for the structural work additionally uncovered
one latent **containment hazard** in the Cursor adapter, also fixed here.

## Summary

In dependency order:

1. **Flake fix (test-only)** — `5668ca7c`. Dropped the 50ms
   first-stdout override (and dead grace overrides) that raced CI load; the test
   now relies on process-death detection, the path its name describes. Sibling of
   the v0.3.44 (#459) de-flake.

2. **Correctness: malformed stdout no longer bypasses the 30s watchdog** —
   `c9520aed`. `_parse_stdout_line` returns a typed
   `ParsedStdoutLine(event, is_protocol_event)`; only valid protocol events emit
   readiness / complete the first-event handshake. Diagnostics still surface.

3. **Correctness: early Pi exit reports the real exit code, not a timeout** —
   `c9520aed`. EOF-before-first-event now selects
   `pi_subprocess_exit_error(return_code)` for nonzero exits (+ stderr), a
   distinct `pi_rpc_stream_closed_before_initial_response` for clean EOF, and
   keeps the timeout reason only for the genuine process-alive timeout.

4. **Boundary-leak fix** — `8210e777`, `fa35ea7b`. Pi failure formatting
   (`compact_pi_failure_output`) and history extraction
   (`extract_pi_failure_from_history` + helpers) moved from the harness-agnostic
   `lib/launch/report.py` into harness-owned `lib/harness/pi_failure.py`; launch
   now depends downward. Pure relocation.

5. **Pi timing seam** — `080cd7ae`. The three monkeypatchable module Finals are
   **deleted** (stragglers fail loudly) and replaced by a frozen
   `PiRpcTimingPolicy` + injectable clock on the connection constructor; the
   first-event deadline is stamped when the initial prompt write succeeds, not
   when the consumer starts iterating. The two tests that raced 10–200ms
   monkeypatched timeouts now inject race-free 1–2s policies. Root-causes the
   flake *class* behind #459 and this PR's origin.

6. **`managed_stdio.py` seam + Pi migration + bounded stderr tail** — `a0720c5d`.
   New helper owns the stdio child process, stderr.log (+ current-launch offset),
   durable scope registration, and SIGTERM→grace→SIGKILL escalation for
   spawn-lifetime stdio children. Pi migrates onto it. `_read_stderr_snippet` now
   reads a bounded 16 KiB current-launch tail (matching codex/opencode) instead of
   `read_text()` on the whole file — a runaway Pi can no longer make the failure
   path read unbounded bytes, and a reused stderr.log no longer leaks a previous
   launch's noise. New integration test proves prior-launch exclusion.

7. **Claude migration** — `74f7ac4a`. Mechanical; Claude's stderr excerpt gains
   the current-launch offset bound it lacked.

8. **Cursor migration + `start_new_session` fix** — `51239043`. Mechanical move
   **plus the one deliberate behavior change in this PR**: Cursor's child now runs
   in its own session (`start_new_session=not IS_WINDOWS`, matching Pi/Claude).
   Previously the child inherited Meridian's process group, so its durable scope
   recorded `posix_pgid` containment pointing at *Meridian's own group* — and
   `process_scope/posix.py`'s `killpg` has no own-pgid guard, meaning a cursor
   cancel or reaper pass could SIGTERM Meridian itself. New integration assertion:
   child pgid ≠ parent pgid.

9. **Ownership-transfer hardening (review finding)** — `634c0bdc`. The
   full-branch review found that `launch_managed_stdio()` could strand an
   unscoped child if scope registration raised (or its cleanup was cancelled)
   post-exec — a regression vs main, where adapters held the process reference
   before registration. The helper now captures a provisional scope handle
   immediately after exec and performs cancellation-shielded, process-tree-aware
   reaping on any failure in the transfer window. Fault-injection regression test
   included (confirmed failing pre-fix).

## Resulting Behavior

- Malformed Pi stdout is surfaced as a diagnostic but cannot satisfy readiness;
  the first-response watchdog still fires.
- A Pi process that exits before its first event reports its exit code and stderr.
- Pi failure details contain only the current launch's stderr, bounded.
- Pi connection tests cannot monkeypatch timing Finals (deleted); timing is
  injected policy.
- Cursor children are session-isolated; scope termination can no longer signal
  Meridian's own process group.
- No changes to `base.py`, `ConnectionConfig`, or the managed-*backend* helper.

## Design

`work/reaper-scope-regression/design/managed-stdio-seam.md` (meridian docs repo) —
ownership boundaries, per-adapter migration contracts, decided-against options.
All `connections/.context/FUTURE` entries from the review are resolved and removed.

## Verification

- `uv run pytest-llm` — **1349 passed, 2 skipped** (full suite)
- `uv run pytest-llm tests/integration/harness/` — **88 passed** (Pi, Claude,
  Cursor, child-env boundary, managed_stdio fault injection)
- `uv run ruff check .` — clean
- `uv run --extra dev python -m pyright` — **0 errors**
- Full-branch review (p5687): verified the c9520aed semantics, deadline
  stamp/clear sites, stderr-handle guard, scope metadata, and cursor pgid blast
  radius as preserved; runtime-probed Pi clean-EOF, Claude SIGINT, and the
  ownership leak. Its one High finding (ownership-transfer gap) and one Low
  (`__all__`) are fixed in `634c0bdc`. Taken on faith: native Windows (untested
  legacy per AGENTS.md), real SIGKILL-after-grace per adapter.

## Work Item

reaper-scope-regression (follow-up; surfaced during that work's release CI + review)

## Spawn Trace

- p5667 reviewer (thermo-nuclear) — module audit that surfaced the correctness bugs + structural findings
- p5672 coder (+testing) — discriminated parse result + failure-classification fix
- design-lead — managed-stdio seam + timing policy design (found the cursor pgid hazard)
- p5682 / p5684 coder — boundary-leak relocation (both halves)
- p5685 coder (+testing) — timing policy + managed_stdio + Pi migration
- p5686 coder (+testing) — Claude/Cursor migrations + pgid fix
- p5687 reviewer — full-branch review (found the ownership-transfer gap)
- p5693 coder (+testing) — ownership-transfer fix + regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
