### PR TITLE
params.json refreshes to bound truth after spawn bind (#334)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- `params.json` now refreshes after bind with the spawn's actual work/task
+  dirs (`phase: "bound"`, `bound_work_dir`, `bound_task_dir`). Ambient child
+  spawns previously showed the parent's work dir forever. Pre-bind crashes
+  leave the file honestly marked `phase: "request"`. (#334)
+
 ## [0.3.47] - 2026-07-23
 
 ### Removed

--- a/src/meridian/lib/ops/spawn/execute.py
+++ b/src/meridian/lib/ops/spawn/execute.py
@@ -45,6 +45,7 @@ from .execute_bg import (
 )
 from .execute_init import (
     _announce_reserved_spawn,
+    _build_params_request_metadata,
     _emit_subrun_event,
     _materialize_spawn_work_item,
     _reserve_spawn,
@@ -312,14 +313,17 @@ def execute_spawn_background(
         runtime_root=context.runtime_root,
     )
     log_dir.mkdir(parents=True, exist_ok=True)
+    request_metadata = _build_params_request_metadata(
+        request,
+        desc=payload.desc,
+        work_id=context.work_id,
+    )
     try:
         _write_params_json(
             project_paths,
             context.runtime_root,
             context.spawn.spawn_id,
-            request,
-            desc=payload.desc,
-            work_id=context.work_id,
+            request_metadata=request_metadata,
         )
     except Exception:
         logger.warning("Failed to write params.json", spawn_id=spawn_id_text, exc_info=True)
@@ -354,6 +358,7 @@ def execute_spawn_background(
             BackgroundWorkerLaunchRequest(
                 request=persisted_request,
                 runtime=launch_runtime,
+                request_metadata=request_metadata,
             ),
         )
     except Exception as exc:
@@ -563,14 +568,17 @@ def execute_spawn_blocking(
 
     try:
         execution_cwd_str = initial_execution_cwd
+        request_metadata = _build_params_request_metadata(
+            request,
+            desc=payload.desc,
+            work_id=context.work_id,
+        )
         try:
             _write_params_json(
                 project_paths,
                 context.runtime_root,
                 spawn.spawn_id,
-                request,
-                desc=payload.desc,
-                work_id=context.work_id,
+                request_metadata=request_metadata,
             )
         except Exception:
             logger.warning(
@@ -600,6 +608,7 @@ def execute_spawn_blocking(
                 project_paths=project_paths,
                 execution_cwd=execution_cwd_str,
                 work_id=context.work_id,
+                request_metadata=request_metadata,
                 stream_stdout_to_terminal=stream_stdout_to_terminal,
                 stream_stderr_to_terminal=payload.stream,
                 event_observer=event_observer,

--- a/src/meridian/lib/ops/spawn/execute_bg.py
+++ b/src/meridian/lib/ops/spawn/execute_bg.py
@@ -35,6 +35,7 @@ from meridian.lib.telemetry.init import setup_telemetry
 from meridian.lib.telemetry.observer import register_spawn_telemetry_observer
 
 from ..runtime import OperationRuntime, build_runtime, resolve_runtime_root, runtime_context
+from .execute_init import ParamsRequestMetadata
 from .execute_runner import launch_prepared_spawn
 from .failure_policy import finalize_launch_failure, finalize_launch_failure_sync
 
@@ -57,6 +58,7 @@ class BackgroundWorkerLaunchRequest(BaseModel):
 
     request: SpawnRequest
     runtime: LaunchRuntime
+    request_metadata: ParamsRequestMetadata
 
 
 def _resolve_background_execution_cwd(
@@ -281,6 +283,7 @@ async def _execute_existing_spawn(
         runtime=runtime,
         runtime_root=runtime_root,
         project_paths=project_paths,
+        request_metadata=launch_request.request_metadata,
         spawn_record=spawn_record,
         execution_cwd=resolved_execution_cwd,
         work_id=spawn_record.work_id,

--- a/src/meridian/lib/ops/spawn/execute_init.py
+++ b/src/meridian/lib/ops/spawn/execute_init.py
@@ -18,6 +18,7 @@ from meridian.lib.core.resolved_context import ResolvedContext
 from meridian.lib.core.sink import OutputSink
 from meridian.lib.core.spawn_lifecycle import SpawnReservation
 from meridian.lib.core.types import ModelId, SpawnId
+from meridian.lib.launch.launch_types import ResolvedLaunchBinding
 from meridian.lib.launch.plan import build_spawn_mars_runtime
 from meridian.lib.launch.request import SpawnRequest, is_exact_continue_session
 from meridian.lib.launch.types import PrimarySessionMetadata
@@ -39,6 +40,31 @@ logger = structlog.get_logger(__name__)
 
 class LaunchUserInputError(ValueError):
     """Expected launch-input failure that should not emit traceback logging."""
+
+
+class ParamsRequestMetadata(BaseModel):
+    """Immutable request-time inputs retained across the bind boundary."""
+
+    model_config = ConfigDict(frozen=True)
+
+    model: str
+    harness: str
+    agent: str | None
+    agent_path: str
+    adhoc_agent_payload: str
+    appended_system_prompt: str | None
+    user_turn_content: str | None
+    desc: str
+    work_id: str | None
+    goal: str | None
+    prompt_length: int
+    reference_files: tuple[str, ...]
+    template_vars: dict[str, str]
+    skills: tuple[str, ...]
+    skill_paths: tuple[str, ...]
+    continue_session: str | None
+    continue_fork: bool
+    forked_from_chat_id: str | None
 
 
 class _SpawnContext(BaseModel):
@@ -295,14 +321,70 @@ def _announce_reserved_spawn(
     )
 
 
-def _write_params_json(
-    project_paths: ProjectConfigPaths,
-    runtime_root: Path,
-    spawn_id: SpawnId,
+def _build_params_request_metadata(
     request: SpawnRequest,
     *,
     desc: str = "",
     work_id: str | None = None,
+) -> ParamsRequestMetadata:
+    """Snapshot request metadata before any bind-time values exist."""
+
+    return ParamsRequestMetadata(
+        model=request.model or "",
+        harness=request.harness or "",
+        agent=request.agent,
+        agent_path=request.agent_metadata.get("session_agent_path") or "",
+        adhoc_agent_payload=request.prompt_payload.adhoc_agent_payload,
+        appended_system_prompt=request.prompt_payload.appended_system_prompt,
+        user_turn_content=request.prompt_payload.user_turn_content,
+        desc=desc,
+        work_id=work_id,
+        goal=request.goal,
+        prompt_length=len(request.prompt),
+        reference_files=request.reference_files,
+        template_vars=request.template_vars,
+        skills=request.skills,
+        skill_paths=request.skill_paths,
+        continue_session=request.session.requested_harness_session_id,
+        continue_fork=request.session.continue_fork,
+        forked_from_chat_id=request.session.forked_from_chat_id,
+    )
+
+
+def _params_payload(
+    request_metadata: ParamsRequestMetadata,
+    *,
+    binding: ResolvedLaunchBinding | None = None,
+) -> dict[str, Any]:
+    payload = request_metadata.model_dump(mode="json")
+    if binding is None:
+        payload["phase"] = "request"
+        return payload
+
+    run_params = binding.run_params
+    child_context_env = binding.environment.child_context_env
+    payload.update(
+        {
+            "phase": "bound",
+            "adhoc_agent_payload": run_params.adhoc_agent_payload,
+            "appended_system_prompt": run_params.appended_system_prompt,
+            "user_turn_content": run_params.user_turn_content,
+            "prompt_length": len(run_params.prompt),
+            "bound_work_id": binding.work_id,
+            "bound_work_dir": child_context_env.get("MERIDIAN_ACTIVE_WORK_DIR"),
+            "bound_task_dir": child_context_env.get("MERIDIAN_TASK_DIR"),
+        }
+    )
+    return payload
+
+
+def _write_params_json(
+    project_paths: ProjectConfigPaths,
+    runtime_root: Path,
+    spawn_id: SpawnId,
+    *,
+    request_metadata: ParamsRequestMetadata,
+    binding: ResolvedLaunchBinding | None = None,
 ) -> None:
     """Write resolved execution params to the spawn directory."""
     params_path = (
@@ -312,33 +394,16 @@ def _write_params_json(
         / "params.json"
     )
     params_path.parent.mkdir(parents=True, exist_ok=True)
-    params_payload = {
-        "model": request.model or "",
-        "harness": request.harness or "",
-        "agent": request.agent,
-        "agent_path": request.agent_metadata.get("session_agent_path") or "",
-        "adhoc_agent_payload": request.prompt_payload.adhoc_agent_payload,
-        "appended_system_prompt": request.prompt_payload.appended_system_prompt,
-        "user_turn_content": request.prompt_payload.user_turn_content,
-        "desc": desc,
-        "work_id": work_id,
-        "goal": request.goal,
-        "prompt_length": len(request.prompt),
-        "reference_files": list(request.reference_files),
-        "template_vars": request.template_vars,
-        "skills": list(request.skills),
-        "skill_paths": list(request.skill_paths),
-        "continue_session": request.session.requested_harness_session_id,
-        "continue_fork": request.session.continue_fork,
-        "forked_from_chat_id": request.session.forked_from_chat_id,
-    }
+    params_payload = _params_payload(request_metadata, binding=binding)
     atomic_write_text(params_path, json.dumps(params_payload, indent=2) + "\n")
 
 
 __all__ = [
     "LaunchUserInputError",
+    "ParamsRequestMetadata",
     "_SpawnContext",
     "_announce_reserved_spawn",
+    "_build_params_request_metadata",
     "_emit_subrun_event",
     "_materialize_spawn_work_item",
     "_reserve_spawn",

--- a/src/meridian/lib/ops/spawn/execute_runner.py
+++ b/src/meridian/lib/ops/spawn/execute_runner.py
@@ -41,7 +41,12 @@ from meridian.lib.state.session_store import update_session_claude_config_dir
 from meridian.lib.state.spawn.model import SpawnRecord
 
 from ..runtime import OperationRuntime, runtime_context
-from .execute_init import LaunchUserInputError, _spawn_child_env
+from .execute_init import (
+    LaunchUserInputError,
+    ParamsRequestMetadata,
+    _spawn_child_env,
+    _write_params_json,
+)
 from .execute_session import (
     _resolve_session_continuation,
     _session_execution_context,
@@ -138,6 +143,7 @@ async def _prepare_execution_handoff(
     spawn_record: SpawnRecord | None,
     execution_cwd: str,
     work_id: str | None,
+    request_metadata: ParamsRequestMetadata,
     ctx: RuntimeContext | None,
     prepared: PreparedLaunchSurface | None = None,
 ) -> PreparedExecutionHandoff:
@@ -289,6 +295,20 @@ async def _prepare_execution_handoff(
             harness_registry=runtime.harness_registry,
             plan_overrides=run_env_overrides,
         )
+        try:
+            _write_params_json(
+                project_paths,
+                runtime_root,
+                spawn.spawn_id,
+                request_metadata=request_metadata,
+                binding=launch_context.binding,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to refresh params.json",
+                spawn_id=str(spawn.spawn_id),
+                exc_info=True,
+            )
         write_projection_artifacts(
             log_dir=resolve_spawn_log_dir(
                 project_paths.project_root,
@@ -358,6 +378,7 @@ async def launch_prepared_spawn(
     runtime: OperationRuntime,
     runtime_root: Path,
     project_paths: ProjectConfigPaths,
+    request_metadata: ParamsRequestMetadata,
     spawn_record: SpawnRecord | None = None,
     execution_cwd: str,
     work_id: str | None = None,
@@ -384,6 +405,7 @@ async def launch_prepared_spawn(
             spawn_record=spawn_record,
             execution_cwd=execution_cwd,
             work_id=work_id,
+            request_metadata=request_metadata,
             ctx=ctx,
             prepared=prepared,
         )

--- a/tests/integration/ops/test_spawn_api_create.py
+++ b/tests/integration/ops/test_spawn_api_create.py
@@ -124,6 +124,7 @@ def test_background_headless_deny_rejects_before_reservation_without_affecting_a
         runtime_root=prepared.runtime_root,
     )
     params = json.loads((allowed_log_dir / "params.json").read_text(encoding="utf-8"))
+    assert params["phase"] == "request"
     assert params["model"] == "gemini-2.5-pro"
     assert params["harness"] == "opencode"
     assert params["prompt_length"] == len("allowed")

--- a/tests/integration/ops/test_spawn_execute_report_output.py
+++ b/tests/integration/ops/test_spawn_execute_report_output.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 import meridian.lib.ops.spawn.execute as execute_module
 import meridian.lib.ops.spawn.execute_init as execute_init_module
+import meridian.lib.ops.spawn.execute_runner as execute_runner_module
 from meridian.lib.config.settings import load_config
 from meridian.lib.core.context import RuntimeContext
 from meridian.lib.core.lifecycle import LifecycleEvent, SpawnLifecycleService
 from meridian.lib.core.sink import OutputSink
+from meridian.lib.core.types import HarnessId
 from meridian.lib.launch.request import SpawnRequest
 from meridian.lib.ops.runtime import (
     OperationRuntime,
@@ -21,6 +24,8 @@ from meridian.lib.ops.runtime import (
 from meridian.lib.ops.spawn.models import SpawnCreateInput
 from meridian.lib.state import spawn_store, work_repository, work_store
 from meridian.lib.state.paths import resolve_project_paths
+from tests.support.executables import prepend_fake_executables
+from tests.support.launch import stub_bundle_request_and_resolve
 
 if TYPE_CHECKING:
     import pytest
@@ -179,6 +184,63 @@ def test_execute_spawn_blocking_notifies_spawn_id_before_launch(
 
     assert result.status == "succeeded"
     assert notifications == [str(result.spawn_id)]
+
+
+def test_execute_spawn_blocking_refreshes_params_with_bound_ambient_work_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = _build_test_runtime(tmp_path, monkeypatch)
+    prepend_fake_executables(monkeypatch, tmp_path, "codex")
+    stub_bundle_request_and_resolve(
+        monkeypatch,
+        model="gpt-5.4",
+        harness=HarnessId.CODEX,
+    )
+
+    async def _fake_execute_with_streaming(
+        spawn: Any,
+        **kwargs: object,
+    ) -> int:
+        runtime_root = cast("Path", kwargs["runtime_root"])
+        spawn_store.finalize_spawn(
+            runtime_root,
+            str(spawn.spawn_id),
+            "succeeded",
+            0,
+            origin="runner",
+        )
+        return 0
+
+    monkeypatch.setattr(
+        execute_runner_module,
+        "execute_with_streaming",
+        _fake_execute_with_streaming,
+    )
+
+    result = execute_module.execute_spawn_blocking(
+        payload=SpawnCreateInput(prompt="run", desc="bound params"),
+        request=SpawnRequest(
+            prompt="run",
+            model="gpt-5.4",
+            harness="codex",
+        ),
+        runtime=runtime,
+        ctx=RuntimeContext(depth=1, spawn_id="p-parent"),
+    )
+
+    assert result.status == "succeeded"
+    assert result.spawn_id is not None
+    authority = resolve_runtime_authority_for_write(tmp_path / "repo")
+    assert authority.runtime_root is not None
+    params_path = authority.runtime_root / "spawns" / result.spawn_id / "params.json"
+    params = json.loads(params_path.read_text(encoding="utf-8"))
+    assert params["phase"] == "bound"
+    assert params["bound_work_id"] is None
+    assert params["bound_work_dir"] == (
+        authority.runtime_root / "spawns" / result.spawn_id / "work"
+    ).as_posix()
+    assert params["bound_task_dir"] == (tmp_path / "repo").as_posix()
 
 
 def test_execute_spawn_blocking_pre_init_failure_returns_failed_output(

--- a/tests/integration/ops/test_spawn_execute_report_output.py
+++ b/tests/integration/ops/test_spawn_execute_report_output.py
@@ -235,12 +235,14 @@ def test_execute_spawn_blocking_refreshes_params_with_bound_ambient_work_dir(
     assert authority.runtime_root is not None
     params_path = authority.runtime_root / "spawns" / result.spawn_id / "params.json"
     params = json.loads(params_path.read_text(encoding="utf-8"))
-    assert params["phase"] == "bound"
-    assert params["bound_work_id"] is None
-    assert params["bound_work_dir"] == (
+    bound_work_dir = (
         authority.runtime_root / "spawns" / result.spawn_id / "work"
     ).as_posix()
+    assert params["phase"] == "bound"
+    assert params["bound_work_id"] is None
+    assert params["bound_work_dir"] == bound_work_dir
     assert params["bound_task_dir"] == (tmp_path / "repo").as_posix()
+    assert bound_work_dir in params["appended_system_prompt"]
 
 
 def test_execute_spawn_blocking_pre_init_failure_returns_failed_output(


### PR DESCRIPTION
## Why

`params.json` is a debug artifact written pre-bind, so for ambient child
spawns its `work_id` and embedded context showed the *parent's* work dir
while the child actually ran with its own. A debug artifact that actively
misleads is worse than none — that was #334.

## Goal

`params.json` reflects the work/task dirs the spawn actually receives, while
keeping the early best-effort write that covers pre-bind failure windows.

## Summary

Two-phase living document (design: `triage-design-4issues/designs/334`):

- Early write keeps its position, fields, and best-effort guard, plus
  `"phase": "request"`.
- Immediately after `bind_spawn_launch_context()` succeeds — before
  projection artifacts — the file is atomically rewritten with content
  sourced from the bound `run_params` (not the stale request), tagged
  `"phase": "bound"` with `bound_work_id`, `bound_work_dir`,
  `bound_task_dir`.
- An immutable request-metadata snapshot (built at the early-write site) is
  threaded through foreground and persisted-background handoffs; the refresh
  merges bound values over it. No read-modify-write of params.json itself.
- Refresh failures warn and never fail the launch.

## Resulting Behavior

- `spawns/p<child>/params.json` for an ambient child ends with
  `"phase": "bound"` and `bound_work_dir` = the child's own
  `spawns/p<child>/work` — matching the env/prompt the child received.
- A crash before bind leaves the file honestly self-describing:
  `"phase": "request"`.
- `state.json` remains the lifecycle authority; params.json stays a
  consumed-by-nobody debug projection.

## Changes

- `execute_init.py`: serializer takes a metadata snapshot + optional bound
  values; `phase` field added.
- `execute.py` / `execute_bg.py` / `execute_runner.py`: snapshot plumbing
  through both launch paths; post-bind atomic refresh (best-effort).
- Tests: existing early-write assertion pins `phase: "request"`; new
  foreground-launch integration test executes real bind + refresh and
  asserts the bound-phase repro from the issue.

## Work Item

triage-designs-impl

## Verification

- `uv run ruff check .` clean; `uv run pytest-llm` 1341 passed / 2 skipped;
  pyright 0 errors.
- Adversarial review (p5676): **approved, no findings**. Reviewer manually
  probed the persisted-background worker path: early phase `request`, final
  phase `bound`, child work dir correct, refreshed prompt contains the child
  dir.
- Test-count delta vs sibling branches investigated: nothing deleted or
  weakened.

## Knowledge Updates

No colocated doc changes needed — params.json remains a debug-only artifact
with unchanged authority semantics. Work-dir DAG + decisions recorded in the
`triage-designs-impl` work item; kb-lead reconciliation runs at the end of
the four-lane batch.

## Spawn Trace

- p5671 coder — implemented two-phase params.json per design
- p5676 reviewer — adversarial review vs design contract (approved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
