### PR TITLE
Resolve tracked Claude transcripts across config-root chain (#171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- `session log`/`search`/`export`/`repair` on tracked Claude sessions now
+  find transcripts by searching the session's recorded config dir, then
+  canonical `~/.claude`, then ambient `CLAUDE_CONFIG_DIR` — instead of
+  ambient-only. Works across bare session id, chat id, and spawn id refs.
+  Untracked lookups unchanged. (#171)
+
 ## [0.3.47] - 2026-07-23
 
 ### Removed

--- a/src/meridian/lib/harness/adapter.py
+++ b/src/meridian/lib/harness/adapter.py
@@ -442,7 +442,13 @@ class SubprocessHarness(HarnessAdapter[ResolvedLaunchSpec], Protocol):
 
     def extract_report(self, artifacts: ArtifactStore, spawn_id: SpawnId) -> str | None: ...
 
-    def resolve_session_file(self, *, project_root: Path, session_id: str) -> Path | None: ...
+    def resolve_session_file(
+        self,
+        *,
+        project_root: Path,
+        session_id: str,
+        config_root_hint: Path | None = None,
+    ) -> Path | None: ...
 
     def seed_session(
         self,
@@ -721,6 +727,12 @@ class BaseHarnessAdapter(Generic[SpecT], ABC):
         _ = artifacts, spawn_id
         return None
 
-    def resolve_session_file(self, *, project_root: Path, session_id: str) -> Path | None:
-        _ = project_root, session_id
+    def resolve_session_file(
+        self,
+        *,
+        project_root: Path,
+        session_id: str,
+        config_root_hint: Path | None = None,
+    ) -> Path | None:
+        _ = project_root, session_id, config_root_hint
         return None

--- a/src/meridian/lib/harness/claude.py
+++ b/src/meridian/lib/harness/claude.py
@@ -579,11 +579,17 @@ class ClaudeAdapter(BaseHarnessAdapter[ResolvedLaunchSpec]):
         )
         return reconciled or normalized_current
 
-    def resolve_session_file(self, *, project_root: Path, session_id: str) -> Path | None:
+    def resolve_session_file(
+        self,
+        *,
+        project_root: Path,
+        session_id: str,
+        config_root_hint: Path | None = None,
+    ) -> Path | None:
         normalized_session_id = session_id.strip()
         if not normalized_session_id:
             return None
-        for project_dir in _candidate_claude_project_dirs(project_root):
+        for project_dir in _candidate_claude_project_dirs(project_root, config_root_hint):
             candidate = project_dir / f"{normalized_session_id}.jsonl"
             if candidate.is_file():
                 return candidate

--- a/src/meridian/lib/harness/claude_preflight.py
+++ b/src/meridian/lib/harness/claude_preflight.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+# pyright: reportPrivateUsage=false
 import json
 import os
 import shutil

--- a/src/meridian/lib/harness/claude_preflight.py
+++ b/src/meridian/lib/harness/claude_preflight.py
@@ -11,7 +11,7 @@ from typing import cast
 
 import structlog
 
-from meridian.lib.harness.claude_sessions import project_slug
+from meridian.lib.harness.claude_sessions import _dedupe_roots, project_slug
 from meridian.lib.launch.launch_types import PreflightResult
 from meridian.lib.launch.text_utils import dedupe_nonempty
 from meridian.lib.platform import IS_WINDOWS, get_home_path
@@ -35,20 +35,6 @@ def _claude_config_root() -> Path:
     if configured:
         return Path(configured).expanduser().resolve()
     return _default_canonical_claude_config_root()
-
-
-def _dedupe_roots(*roots: Path | None) -> tuple[Path, ...]:
-    unique_roots: list[Path] = []
-    seen: set[Path] = set()
-    for root in roots:
-        if root is None:
-            continue
-        resolved = root.resolve()
-        if resolved in seen:
-            continue
-        seen.add(resolved)
-        unique_roots.append(root)
-    return tuple(unique_roots)
 
 
 def _resolve_source_session_file(

--- a/src/meridian/lib/harness/claude_sessions.py
+++ b/src/meridian/lib/harness/claude_sessions.py
@@ -38,9 +38,34 @@ def _claude_project_dir(project_root: Path) -> Path:
     return _claude_projects_root() / project_slug(project_root)
 
 
-def candidate_claude_project_dirs(project_root: Path) -> list[Path]:
-    """Return the exact Claude project directory for this project root."""
-    return [_claude_projects_root() / project_slug(project_root)]
+def _dedupe_roots(*roots: Path | None) -> tuple[Path, ...]:
+    unique_roots: list[Path] = []
+    seen: set[Path] = set()
+    for root in roots:
+        if root is None:
+            continue
+        resolved = root.resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        unique_roots.append(root)
+    return tuple(unique_roots)
+
+
+def candidate_claude_project_dirs(
+    project_root: Path,
+    config_root_hint: Path | None = None,
+) -> list[Path]:
+    """Return Claude project directories ordered by transcript lookup trust."""
+    slug = project_slug(project_root)
+    if config_root_hint is None:
+        return [_claude_config_root() / "projects" / slug]
+    roots = _dedupe_roots(
+        config_root_hint,
+        get_home_path() / ".claude",
+        _claude_config_root(),
+    )
+    return [root / "projects" / slug for root in roots]
 
 
 def _read_claude_session_id(path: Path) -> str | None:
@@ -322,4 +347,3 @@ def detect_primary_session_id(
     except OSError:
         logger.debug("Failed to verify Claude session file", exc_info=True)
     return None
-

--- a/src/meridian/lib/harness/codex.py
+++ b/src/meridian/lib/harness/codex.py
@@ -423,8 +423,14 @@ class CodexAdapter(BaseHarnessAdapter[ResolvedLaunchSpec]):
         _ = started_at_local_iso, expected_session_id
         return _detect_primary_session_id(project_root, started_at_epoch)
 
-    def resolve_session_file(self, *, project_root: Path, session_id: str) -> Path | None:
-        _ = project_root
+    def resolve_session_file(
+        self,
+        *,
+        project_root: Path,
+        session_id: str,
+        config_root_hint: Path | None = None,
+    ) -> Path | None:
+        _ = project_root, config_root_hint
         normalized_session_id = session_id.strip()
         if not normalized_session_id:
             return None

--- a/src/meridian/lib/harness/opencode.py
+++ b/src/meridian/lib/harness/opencode.py
@@ -535,8 +535,14 @@ class OpenCodeAdapter(BaseHarnessAdapter[ResolvedLaunchSpec]):
         )
         return _detect_primary_session_id(project_root, started_at_epoch, local_iso)
 
-    def resolve_session_file(self, *, project_root: Path, session_id: str) -> Path | None:
-        _ = project_root
+    def resolve_session_file(
+        self,
+        *,
+        project_root: Path,
+        session_id: str,
+        config_root_hint: Path | None = None,
+    ) -> Path | None:
+        _ = project_root, config_root_hint
         return resolve_opencode_session_file(session_id=session_id)
 
     def extract_session_id(self, artifacts: ArtifactStore, spawn_id: SpawnId) -> str | None:

--- a/src/meridian/lib/harness/pi.py
+++ b/src/meridian/lib/harness/pi.py
@@ -343,8 +343,14 @@ class PiAdapter(BaseHarnessAdapter[ResolvedLaunchSpec]):
     def extract_report(self, artifacts: ArtifactStore, spawn_id: SpawnId) -> str | None:
         return PI_EXTRACTOR.extract_report(artifacts, spawn_id)
 
-    def resolve_session_file(self, *, project_root: Path, session_id: str) -> Path | None:
-        _ = project_root  # pi sessions are user-scoped, not project-scoped
+    def resolve_session_file(
+        self,
+        *,
+        project_root: Path,
+        session_id: str,
+        config_root_hint: Path | None = None,
+    ) -> Path | None:
+        _ = project_root, config_root_hint  # pi sessions are user-scoped
         normalized = session_id.strip()
         if not normalized:
             return None

--- a/src/meridian/lib/ops/session_repair_target.py
+++ b/src/meridian/lib/ops/session_repair_target.py
@@ -8,6 +8,7 @@ from typing import NamedTuple
 
 from meridian.lib.harness.session_detection import infer_harness_from_untracked_session_ref
 from meridian.lib.ops.session_target import (
+    _config_root_hint,
     _detect_primary_session_id,
     _is_chat_ref,
     _is_spawn_ref,
@@ -33,6 +34,7 @@ def _repair_target_from_detected_session_id(
     project_root: Path,
     harness: str | None,
     detected_session_id: str,
+    config_root_hint: Path | None,
     invalid_reason: str,
     unavailable_reason: str,
 ) -> SessionRepairTarget:
@@ -47,6 +49,7 @@ def _repair_target_from_detected_session_id(
         project_root=project_root,
         session_id=detected_session_id,
         harness=harness,
+        config_root_hint=config_root_hint,
     )
     if transcript_target is not None:
         return SessionRepairTarget(
@@ -59,9 +62,6 @@ def _repair_target_from_detected_session_id(
         source=f"{harness or 'primary'} detected session id",
         reason=unavailable_reason,
     )
-
-
-
 
 def _resolve_repair_from_chat_id(
     *,
@@ -77,6 +77,10 @@ def _resolve_repair_from_chat_id(
     harness = session_record.harness.strip() or None
     if harness is None and primary_spawn is not None:
         harness = (primary_spawn.harness or "").strip() or None
+    config_root_hint = _config_root_hint(
+        session_record.claude_config_dir
+        or (primary_spawn.claude_config_dir if primary_spawn is not None else None)
+    )
 
     transcript_target = _resolve_transcript_from_candidates(
         project_root=project_root,
@@ -89,6 +93,7 @@ def _resolve_repair_from_chat_id(
                 else None
             ),
         ],
+        config_root_hint=config_root_hint,
     )
     if transcript_target is not None:
         return SessionRepairTarget(
@@ -107,6 +112,7 @@ def _resolve_repair_from_chat_id(
             project_root=project_root,
             harness=harness,
             detected_session_id=detected_session_id,
+            config_root_hint=config_root_hint,
             invalid_reason=(
                 f"Detected session id '{detected_session_id}' for chat '{chat_id}' "
                 "looks like a spawn id; refusing repair."
@@ -135,11 +141,13 @@ def _resolve_repair_from_spawn_id(
         raise ValueError(f"Spawn '{spawn_id}' not found")
 
     harness = (row.harness or "").strip() or None
+    config_root_hint = _config_root_hint(row.claude_config_dir)
     row_session_id = (row.harness_session_id or "").strip()
     transcript_target = _resolve_transcript_from_candidates(
         project_root=project_root,
         harness=harness,
         candidate_ids=[row_session_id if not _is_spawn_ref(row_session_id) else None],
+        config_root_hint=config_root_hint,
     )
     if transcript_target is not None:
         return SessionRepairTarget(
@@ -162,10 +170,13 @@ def _resolve_repair_from_spawn_id(
         if chat_record is not None:
             if harness is None:
                 harness = chat_record.harness.strip() or None
+            if config_root_hint is None:
+                config_root_hint = _config_root_hint(chat_record.claude_config_dir)
             transcript_target = _resolve_transcript_from_candidates(
                 project_root=project_root,
                 harness=harness,
                 candidate_ids=[_latest_harness_session_id(chat_record)],
+                config_root_hint=config_root_hint,
             )
             if transcript_target is not None:
                 return SessionRepairTarget(
@@ -183,6 +194,7 @@ def _resolve_repair_from_spawn_id(
                 else None
             )
         ],
+        config_root_hint=config_root_hint,
     )
     if transcript_target is not None:
         return SessionRepairTarget(
@@ -210,6 +222,7 @@ def _resolve_repair_from_spawn_id(
         project_root=project_root,
         harness=harness,
         detected_session_id=detected_session_id,
+        config_root_hint=config_root_hint,
         invalid_reason=(
             f"Detected session id '{detected_session_id}' for spawn "
             f"'{spawn_id}' looks like a spawn id; refusing repair."
@@ -232,6 +245,7 @@ def _resolve_repair_from_session_ref(
         project_root=project_root,
         session_id=session_ref,
         harness=harness,
+        config_root_hint=None,
     )
     if transcript_target is not None:
         return SessionRepairTarget(

--- a/src/meridian/lib/ops/session_target.py
+++ b/src/meridian/lib/ops/session_target.py
@@ -175,7 +175,7 @@ def _resolve_harness_session_file(
     project_root: Path,
     session_id: str,
     harness: str | None,
-    config_root_hint: Path | None,
+    config_root_hint: Path | None = None,
 ) -> SessionLogTarget:
     normalized_session_id = session_id.strip()
     if not normalized_session_id:
@@ -250,7 +250,7 @@ def _resolve_harness_transcript_target_or_none(
     project_root: Path,
     session_id: str,
     harness: str | None,
-    config_root_hint: Path | None,
+    config_root_hint: Path | None = None,
 ) -> SessionLogTarget | None:
     try:
         return _resolve_harness_session_file(
@@ -565,7 +565,7 @@ def _resolve_transcript_from_candidates(
     project_root: Path,
     harness: str | None,
     candidate_ids: list[str | None],
-    config_root_hint: Path | None,
+    config_root_hint: Path | None = None,
 ) -> SessionLogTarget | None:
     seen: set[str] = set()
     for candidate_id in candidate_ids:

--- a/src/meridian/lib/ops/session_target.py
+++ b/src/meridian/lib/ops/session_target.py
@@ -139,10 +139,12 @@ def _resolve_adapter_file_target(
     session_id: str,
     harness_id: HarnessId,
     adapter: SubprocessHarness,
+    config_root_hint: Path | None,
 ) -> SessionLogTarget | None:
     candidate = adapter.resolve_session_file(
         project_root=project_root,
         session_id=session_id,
+        config_root_hint=config_root_hint,
     )
     if candidate is None or not candidate.is_file():
         return None
@@ -173,6 +175,7 @@ def _resolve_harness_session_file(
     project_root: Path,
     session_id: str,
     harness: str | None,
+    config_root_hint: Path | None,
 ) -> SessionLogTarget:
     normalized_session_id = session_id.strip()
     if not normalized_session_id:
@@ -195,6 +198,7 @@ def _resolve_harness_session_file(
             session_id=normalized_session_id,
             harness_id=harness_id,
             adapter=adapter,
+            config_root_hint=config_root_hint,
         )
         if (
             harness_id == HarnessId.OPENCODE
@@ -222,6 +226,7 @@ def _resolve_harness_session_file(
             session_id=normalized_session_id,
             harness_id=harness_id,
             adapter=adapter,
+            config_root_hint=config_root_hint,
         )
         if (
             harness_id == HarnessId.OPENCODE
@@ -245,12 +250,14 @@ def _resolve_harness_transcript_target_or_none(
     project_root: Path,
     session_id: str,
     harness: str | None,
+    config_root_hint: Path | None,
 ) -> SessionLogTarget | None:
     try:
         return _resolve_harness_session_file(
             project_root=project_root,
             session_id=session_id,
             harness=harness,
+            config_root_hint=config_root_hint,
         )
     except FileNotFoundError:
         return None
@@ -539,6 +546,11 @@ def _latest_harness_session_id(record: session_store.SessionRecord) -> str | Non
     return normalized or None
 
 
+def _config_root_hint(value: str | None) -> Path | None:
+    normalized = (value or "").strip()
+    return Path(normalized).expanduser() if normalized else None
+
+
 def _read_chat_session_record(
     runtime_root: Path, chat_id: str
 ) -> session_store.SessionRecord | None:
@@ -553,6 +565,7 @@ def _resolve_transcript_from_candidates(
     project_root: Path,
     harness: str | None,
     candidate_ids: list[str | None],
+    config_root_hint: Path | None,
 ) -> SessionLogTarget | None:
     seen: set[str] = set()
     for candidate_id in candidate_ids:
@@ -564,6 +577,7 @@ def _resolve_transcript_from_candidates(
             project_root=project_root,
             session_id=normalized_candidate_id,
             harness=harness,
+            config_root_hint=config_root_hint,
         )
         if transcript_target is not None:
             return transcript_target
@@ -644,6 +658,10 @@ def _resolve_from_chat_id(
     normalized_harness = session_record.harness.strip() or None
     if normalized_harness is None and primary_spawn is not None and primary_spawn.harness:
         normalized_harness = primary_spawn.harness.strip() or None
+    config_root_hint = _config_root_hint(
+        session_record.claude_config_dir
+        or (primary_spawn.claude_config_dir if primary_spawn is not None else None)
+    )
 
     output_target = _running_managed_primary_output_target(
         runtime_root,
@@ -682,6 +700,7 @@ def _resolve_from_chat_id(
         project_root=project_root,
         harness=normalized_harness,
         candidate_ids=[normalized_session_id],
+        config_root_hint=config_root_hint,
     )
     if transcript_target is not None:
         output_target = _spawn_history_fallback_for_chat_ref(
@@ -703,6 +722,7 @@ def _resolve_from_chat_id(
             project_root=project_root,
             harness=normalized_harness,
             candidate_ids=[detected_session_id],
+            config_root_hint=config_root_hint,
         )
         if transcript_target is not None:
             output_target = _spawn_history_fallback_for_chat_ref(
@@ -727,6 +747,7 @@ def _resolve_from_chat_id(
         project_root=project_root,
         session_id=normalized_session_id,
         harness=normalized_harness,
+        config_root_hint=config_root_hint,
     )
 
 
@@ -782,6 +803,7 @@ def _resolve_from_spawn_id(
 
     session_id = (row.harness_session_id or "").strip()
     harness = (row.harness or "").strip() or None
+    config_root_hint = _config_root_hint(row.claude_config_dir)
 
     if not session_id and is_primary_spawn:
         primary_meta_session_id = read_primary_harness_session_id(runtime_root, spawn_id)
@@ -826,6 +848,8 @@ def _resolve_from_spawn_id(
                 session_id = (record.harness_session_id or "").strip()
                 if record.harness.strip():
                     harness = record.harness.strip()
+                if config_root_hint is None:
+                    config_root_hint = _config_root_hint(record.claude_config_dir)
             if not session_id:
                 raise ValueError(
                     f"Spawn '{spawn_id}' has no transcript available yet "
@@ -841,11 +865,14 @@ def _resolve_from_spawn_id(
         record = session_store.resolve_session_ref(runtime_root, session_id)
         if record is not None and record.harness.strip():
             harness = record.harness.strip()
+        if record is not None and config_root_hint is None:
+            config_root_hint = _config_root_hint(record.claude_config_dir)
 
     transcript_target = _resolve_transcript_from_candidates(
         project_root=project_root,
         harness=harness,
         candidate_ids=[session_id],
+        config_root_hint=config_root_hint,
     )
     if transcript_target is not None:
         output_target = _resolved_spawn_output_fallback_target(
@@ -870,6 +897,7 @@ def _resolve_from_spawn_id(
                 project_root=project_root,
                 harness=harness,
                 candidate_ids=[detected_session_id],
+                config_root_hint=config_root_hint,
             )
             if transcript_target is not None:
                 output_target = _resolved_spawn_output_fallback_target(
@@ -896,6 +924,7 @@ def _resolve_from_spawn_id(
             project_root=project_root,
             session_id=session_id,
             harness=harness,
+            config_root_hint=config_root_hint,
         )
 
     output_target = _target_from_spawn_output(
@@ -910,6 +939,7 @@ def _resolve_from_spawn_id(
         project_root=project_root,
         session_id=session_id,
         harness=harness,
+        config_root_hint=config_root_hint,
     )
 
 
@@ -927,6 +957,7 @@ def _resolve_from_session_ref(
             project_root=project_root,
             session_id=session_id,
             harness=harness,
+            config_root_hint=_config_root_hint(record.claude_config_dir),
         )
         output_target = _spawn_history_fallback_for_session_ref(
             project_root=project_root,
@@ -953,6 +984,7 @@ def _resolve_untracked_session_ref(
         project_root=project_root,
         session_id=session_ref,
         harness=str(inferred) if inferred is not None else None,
+        config_root_hint=None,
     )
 
 

--- a/src/meridian/lib/ops/session_target.py
+++ b/src/meridian/lib/ops/session_target.py
@@ -175,7 +175,7 @@ def _resolve_harness_session_file(
     project_root: Path,
     session_id: str,
     harness: str | None,
-    config_root_hint: Path | None = None,
+    config_root_hint: Path | None,
 ) -> SessionLogTarget:
     normalized_session_id = session_id.strip()
     if not normalized_session_id:
@@ -250,7 +250,7 @@ def _resolve_harness_transcript_target_or_none(
     project_root: Path,
     session_id: str,
     harness: str | None,
-    config_root_hint: Path | None = None,
+    config_root_hint: Path | None,
 ) -> SessionLogTarget | None:
     try:
         return _resolve_harness_session_file(
@@ -565,7 +565,7 @@ def _resolve_transcript_from_candidates(
     project_root: Path,
     harness: str | None,
     candidate_ids: list[str | None],
-    config_root_hint: Path | None = None,
+    config_root_hint: Path | None,
 ) -> SessionLogTarget | None:
     seen: set[str] = set()
     for candidate_id in candidate_ids:

--- a/tests/integration/harness/test_adapter_ownership.py
+++ b/tests/integration/harness/test_adapter_ownership.py
@@ -252,6 +252,59 @@ def test_claude_adapter_uses_claude_config_dir_override(
     assert infer_harness_from_untracked_session_ref(project_root, override_session_id) == "claude"
 
 
+def test_claude_adapter_resolves_tracked_config_root_chain_in_trust_order(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    hint_root = tmp_path / "recorded"
+    canonical_root = tmp_path / "home" / ".claude"
+    ambient_root = tmp_path / "ambient"
+    monkeypatch.setenv("HOME", (tmp_path / "home").as_posix())
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", ambient_root.as_posix())
+
+    session_id = str(uuid4())
+    paths = [
+        root / "projects" / project_slug(project_root) / f"{session_id}.jsonl"
+        for root in (hint_root, canonical_root, ambient_root)
+    ]
+    for path in paths:
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            json.dumps({"type": "agent-setting", "sessionId": session_id}) + "\n",
+            encoding="utf-8",
+        )
+
+    adapter = ClaudeAdapter()
+    assert (
+        adapter.resolve_session_file(
+            project_root=project_root,
+            session_id=session_id,
+            config_root_hint=hint_root,
+        )
+        == paths[0]
+    )
+    paths[0].unlink()
+    assert (
+        adapter.resolve_session_file(
+            project_root=project_root,
+            session_id=session_id,
+            config_root_hint=hint_root,
+        )
+        == paths[1]
+    )
+    paths[1].unlink()
+    assert (
+        adapter.resolve_session_file(
+            project_root=project_root,
+            session_id=session_id,
+            config_root_hint=hint_root,
+        )
+        == paths[2]
+    )
+
+
 @pytest.mark.parametrize(
     ("configured_root", "cwd_relative", "expected_suffix"),
     [

--- a/tests/integration/ops/test_session_log_harness_retrieval.py
+++ b/tests/integration/ops/test_session_log_harness_retrieval.py
@@ -635,3 +635,60 @@ def test_session_log_resolves_claude_session_file_from_claude_config_dir_env(
     assert [(message.role, message.content) for message in output.messages] == [
         ("assistant", "claude env override transcript")
     ]
+
+
+@pytest.mark.parametrize("ref", ["claude-canonical-session", "c1", "p1"])
+def test_session_log_resolves_tracked_claude_session_from_canonical_root(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    ref: str,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    runtime_root = resolve_project_runtime_root_for_write(project_root)
+    runtime_root.mkdir(parents=True, exist_ok=True)
+
+    home = tmp_path / "home"
+    recorded_config_root = tmp_path / "recorded-overlay"
+    ambient_config_root = tmp_path / "unrelated-overlay"
+    monkeypatch.setenv("HOME", home.as_posix())
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", ambient_config_root.as_posix())
+
+    session_id = "claude-canonical-session"
+    _write_claude_session(
+        config_root=home / ".claude",
+        project_root=project_root,
+        session_id=session_id,
+        assistant_text="claude canonical transcript",
+    )
+    session_store.start_session(
+        runtime_root,
+        harness="claude",
+        harness_session_id=session_id,
+        model="claude-opus",
+        chat_id="c1",
+        claude_config_dir=recorded_config_root.as_posix(),
+        spawn_id="p1",
+    )
+    spawn_store.start_spawn(
+        runtime_root,
+        chat_id="c1",
+        model="claude-opus",
+        agent="coder",
+        harness="claude",
+        prompt="hello",
+        spawn_id="p1",
+        harness_session_id=session_id,
+        claude_config_dir=recorded_config_root.as_posix(),
+        started_at="2026-04-11T00:00:00Z",
+    )
+
+    output = session_log_sync(
+        SessionLogInput(ref=ref, project_root=project_root.as_posix(), tail=5)
+    )
+
+    assert output.session_id == session_id
+    assert output.source == "claude transcript"
+    assert [(message.role, message.content) for message in output.messages] == [
+        ("assistant", "claude canonical transcript")
+    ]

--- a/tests/integration/ops/test_session_repair_harness_retrieval.py
+++ b/tests/integration/ops/test_session_repair_harness_retrieval.py
@@ -1,0 +1,97 @@
+"""Session repair retrieval through tracked harness metadata."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pytest import MonkeyPatch
+
+from meridian.lib.harness.claude import project_slug
+from meridian.lib.ops.session_repair import (
+    SessionRepairInput,
+    repair_session_reference_sync,
+)
+from meridian.lib.state import session_store, spawn_store
+from meridian.lib.state.paths import resolve_project_runtime_root_for_write
+
+
+def _write_claude_session(
+    *,
+    config_root: Path,
+    project_root: Path,
+    session_id: str,
+) -> None:
+    project_dir = config_root / "projects" / project_slug(project_root)
+    project_dir.mkdir(parents=True)
+    (project_dir / f"{session_id}.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps({"sessionId": session_id}),
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "content": [{"type": "text", "text": "canonical transcript"}]
+                        },
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize("ref", ["c1", "p1"])
+def test_session_repair_resolves_tracked_claude_session_from_canonical_root(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    ref: str,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    runtime_root = resolve_project_runtime_root_for_write(project_root)
+    runtime_root.mkdir(parents=True, exist_ok=True)
+
+    home = tmp_path / "home"
+    recorded_config_root = tmp_path / "recorded-overlay"
+    monkeypatch.setenv("HOME", home.as_posix())
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", (tmp_path / "unrelated-overlay").as_posix())
+
+    session_id = "claude-canonical-repair-session"
+    _write_claude_session(
+        config_root=home / ".claude",
+        project_root=project_root,
+        session_id=session_id,
+    )
+    session_store.start_session(
+        runtime_root,
+        harness="claude",
+        harness_session_id=session_id,
+        model="claude-opus",
+        chat_id="c1",
+        claude_config_dir=recorded_config_root.as_posix(),
+        spawn_id="p1",
+    )
+    spawn_store.start_spawn(
+        runtime_root,
+        chat_id="c1",
+        model="claude-opus",
+        agent="coder",
+        harness="claude",
+        prompt="hello",
+        spawn_id="p1",
+        harness_session_id=session_id,
+        claude_config_dir=recorded_config_root.as_posix(),
+        started_at="2026-04-11T00:00:00Z",
+    )
+
+    output = repair_session_reference_sync(
+        SessionRepairInput(ref=ref, project_root=project_root.as_posix())
+    )
+
+    assert output.detected_harness_session_id == session_id
+    assert output.source == "claude transcript"
+    assert output.reason is None

--- a/tests/integration/ops/test_session_search_scopes.py
+++ b/tests/integration/ops/test_session_search_scopes.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from meridian.lib.harness.claude import project_slug
 from meridian.lib.ops.session_search import SessionSearchInput, session_search_sync
 from meridian.lib.state import session_store
 from meridian.lib.state.user_paths import get_project_home
@@ -147,6 +148,63 @@ def test_session_search_global_scope_includes_runtime_root(tmp_path: Path, monke
         output = session_search_sync(
             SessionSearchInput(
                 query="needle",
+                project_root=current_root.as_posix(),
+                global_scope=True,
+            )
+        )
+    finally:
+        session_store.stop_session(runtime_root, chat_id)
+
+    assert len(output.matches) == 1
+    assert output.matches[0].corpus == "runtime:orphan-one"
+
+
+def test_session_search_corpus_resolves_tracked_claude_canonical_transcript(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    user_home = tmp_path / "meridian-home"
+    home = tmp_path / "home"
+    runtime_root = user_home / "projects" / "orphan-one"
+    runtime_root.mkdir(parents=True)
+    current_root = tmp_path / "current"
+    current_root.mkdir()
+    (current_root / "meridian.toml").write_text("", encoding="utf-8")
+    monkeypatch.setenv("MERIDIAN_HOME", user_home.as_posix())
+    monkeypatch.setenv("HOME", home.as_posix())
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", (tmp_path / "unrelated-overlay").as_posix())
+
+    session_id = "claude-corpus-session"
+    project_dir = home / ".claude" / "projects" / project_slug(runtime_root)
+    project_dir.mkdir(parents=True)
+    (project_dir / f"{session_id}.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps({"sessionId": session_id}),
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "content": [{"type": "text", "text": "corpus canonical needle"}]
+                        },
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    chat_id = session_store.start_session(
+        runtime_root,
+        harness="claude",
+        harness_session_id=session_id,
+        model="claude-opus",
+        claude_config_dir=(tmp_path / "recorded-overlay").as_posix(),
+    )
+    try:
+        output = session_search_sync(
+            SessionSearchInput(
+                query="canonical needle",
                 project_root=current_root.as_posix(),
                 global_scope=True,
             )


### PR DESCRIPTION
## Why

`meridian session log <ref>` (and search/export/repair) failed for tracked
Claude sessions whenever the ambient `CLAUDE_CONFIG_DIR` pointed at an
unrelated overlay — resolution searched exactly one root. The session record
already persisted the effective config dir; lookup just threw it away (#171).

## Goal

Tracked Claude transcript resolution succeeds regardless of the ambient
`CLAUDE_CONFIG_DIR`, using metadata that already exists. No schema changes,
no behavior change for untracked sessions or other harnesses.

## Summary

Per design `triage-design-4issues/designs/171` (option a):

- Adapter seam widened: `resolve_session_file(..., config_root_hint)` on the
  protocol/default and all concrete overrides — codex/opencode/pi
  accept-and-ignore (their roots aren't env-relocatable this way).
- The persisted `SessionRecord.claude_config_dir` /
  `SpawnRecord.claude_config_dir` is threaded through every tracked ref
  form: bare harness session id, chat id, spawn id, corpus search, and (per
  review) all tracked `session repair` paths including
  `_repair_target_from_detected_session_id()`.
- Claude adapter searches a deduped trust-ordered chain: recorded config
  dir → canonical `get_home_path()/.claude` → ambient. First existing
  `<session_id>.jsonl` wins. `_dedupe_roots` lifted from preflight into
  `claude_sessions.py` and shared.
- Helper hint params are required (no `= None` defaults) — every caller
  explicitly chooses tracked metadata or untracked `None` (review caught the
  defaults masking missed repair callers).

## Resulting Behavior

With a tracked session whose transcript sits under canonical `~/.claude`
and ambient `CLAUDE_CONFIG_DIR` pointing at an unrelated overlay:

- `session log <session-id|chat-id|spawn-id>`, `session search`,
  `session export`, and `session repair` all resolve the transcript.
  Previously: "no transcript available".
- Untracked refs behave exactly as before (ambient-only).

## Changes

- `lib/harness/adapter.py`, `claude.py`, `codex.py`, `opencode.py`, `pi.py`
  — seam widening
- `lib/harness/claude_sessions.py` — candidate chain + shared dedup
- `lib/ops/session_target.py`, `session_repair_target.py` — hint threading
  across all tracked ref forms and repair paths
- Tests: parameterized regression (canonical transcript + unrelated ambient
  overlay) via bare/chat/spawn refs, corpus search, trust-order coverage,
  and repair via chat + spawn ids. All confirmed red before the fix.

## Work Item

triage-designs-impl

## Verification

- `uv run ruff check .` clean; `uv run pytest-llm` 1347 passed / 2 skipped;
  pyright 0 errors.
- Adversarial review (p5675): verified seam totality with a registry-wide
  runtime probe (no TypeError), corpus-search claim confirmed in source,
  chain order/dedup, untracked invariance, and preflight imports. Its
  finding (tracked `session repair` still ambient-only, reproduced at
  runtime) resolved in `d3a0190b` with red-first regression tests.

## Knowledge Updates

No colocated doc changes — resolution policy stays in `ops/session_target`,
mechanics in `lib/harness/`, per existing seam docs. kb-lead reconciliation
runs at the end of the four-lane batch.

## Spawn Trace

- p5670 coder — implemented hint chain per design
- p5675 reviewer — adversarial review vs design contract
- p5679 coder — fix pass (repair-path hint threading)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
