### PR TITLE
Sparse JSON projections for spawn/work/hooks CLI output (#113)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- Sparse JSON defaults for noisy CLI outputs: `spawn show`/`spawn wait` JSON
+  now carries `report_path` + a bounded `report_summary` instead of the full
+  `report_body` (opt back in with `--report`); `harness_session_id` is gone
+  from default spawn/work JSON; `work show` JSON is a curated summary;
+  `hooks run` JSON hides stdout/stderr behind `--output`. Multi-ID
+  `spawn show`/`status` use the same sparse shapes. Text output unchanged.
+  (#113)
+
 ## [0.3.47] - 2026-07-23
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 - Sparse JSON defaults for noisy CLI outputs: `spawn show`/`spawn wait` JSON
   now carries `report_path` + a bounded `report_summary` instead of the full
-  `report_body` (opt back in with `--report`); `harness_session_id` is gone
+  `report_body` (opt back in with `--full`); `harness_session_id` is gone
   from default spawn/work JSON; `work show` JSON is a curated summary;
-  `hooks run` JSON hides stdout/stderr behind `--output`. Multi-ID
+  `hooks run` JSON hides stdout/stderr behind `--verbose`. Multi-ID
   `spawn show`/`status` use the same sparse shapes. Text output unchanged.
   (#113)
 
@@ -1231,7 +1231,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 - Pi lifecycle machine events now transport via append-only JSONL sidecar file (`pi-lifecycle-events.jsonl`) instead of stdout/stderr; extensions write via `fs.writeSync` append-mode fd, Python reads via `PiLifecycleEventTailer` with forced catch-up before quiescence decisions; no lifecycle JSON leaks to TUI or stderr.
 - Foreground `meridian spawn` and single-spawn `spawn wait` default to report-first compact output: status, report body, transcript command. Agent-mode defaults match compact text; explicit JSON carries report/transcript fields.
-- `spawn wait` includes report body by default; use `--no-report` to suppress it.
+- `spawn wait` includes report body by default; use `--no-full` to suppress it.
 - `--fork` is now identity-preserving on both primary and spawn CLIs. It rejects identity-shaping overrides with: `--fork preserves launch identity. Use --fork-fresh to change agent, model, or skills.`
 - Bare `--fork` now defaults to `$MERIDIAN_SPAWN_ID` inside Meridian-managed sessions. Outside a managed session it fails with: `Cannot infer --fork target: not inside a Meridian-managed session. Pass --fork REF explicitly.`
 - CLI argv normalization now rewrites bare/equals forms for `--fork` and `--fork-fresh` before bootstrap and Cyclopts parsing, so forms like `--fork`, `--fork=`, and `--fork --bg` parse consistently.
@@ -1694,7 +1694,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Pi lifecycle machine events now transport via append-only JSONL sidecar file (`pi-lifecycle-events.jsonl`) instead of stdout/stderr; extensions write via `fs.writeSync` append-mode fd, Python reads via `PiLifecycleEventTailer` with forced catch-up before quiescence decisions; no lifecycle JSON leaks to TUI or stderr.
 - Git autosync: extract `autosync_store.py` — single owner of `.meridian/autosync/` file layout. Eliminates duplicated path construction and JSON parsing across `git_autosync.py`, `sync_conflicts.py`, `context.py`.
 - Agent-mode CLI output defaults to text for all commands. Prior JSON defaults on `config.get`, `spawn.cancel`, `spawn.create`, `spawn.continue`, `spawn.wait`, `context`, `work.current` flipped to text. Explicit `--json` still available.
-- `spawn.wait` omits report body by default; pass `--report` to include. Report path always shown.
+- `spawn.wait` omits report body by default; pass `--full` to include. Report path always shown.
 - Lifecycle events (`meridian.spawn.start`, `meridian.spawn.done`) suppressed in agent mode for all commands. Human mode routes `TextSink.event()` to stderr.
 - `SpawnWaitMultiOutput` and `SpawnDetailOutput` now have sparse `to_cli_wire()` projections for explicit JSON; omit internal fields like `harness_session_id`, `log_path`, `process_exit_code`.
 - Background spawn output now explicitly instructs agents to wait: "You MUST run..." with machine-actionable fields `terminal`, `wait_required`, `wait_command` in JSON output.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `hooks run` JSON hides stdout/stderr behind `--verbose`. Multi-ID
   `spawn show`/`status` use the same sparse shapes. Text output unchanged.
   (#113)
+- **Flag rename (breaking):** the previously shipped `--report`/`--no-report`
+  report opt-in on `spawn show`/`spawn status`/`spawn wait` is renamed to
+  `--full`/`--no-full`, matching `session log --full`. `--report` is no longer
+  accepted. `hooks run` gains a new `--verbose` flag to reveal captured
+  stdout/stderr in JSON. (#113)
 
 ## [0.3.47] - 2026-07-23
 
@@ -1231,7 +1236,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 - Pi lifecycle machine events now transport via append-only JSONL sidecar file (`pi-lifecycle-events.jsonl`) instead of stdout/stderr; extensions write via `fs.writeSync` append-mode fd, Python reads via `PiLifecycleEventTailer` with forced catch-up before quiescence decisions; no lifecycle JSON leaks to TUI or stderr.
 - Foreground `meridian spawn` and single-spawn `spawn wait` default to report-first compact output: status, report body, transcript command. Agent-mode defaults match compact text; explicit JSON carries report/transcript fields.
-- `spawn wait` includes report body by default; use `--no-full` to suppress it.
+- `spawn wait` includes report body by default; use `--no-report` to suppress it.
 - `--fork` is now identity-preserving on both primary and spawn CLIs. It rejects identity-shaping overrides with: `--fork preserves launch identity. Use --fork-fresh to change agent, model, or skills.`
 - Bare `--fork` now defaults to `$MERIDIAN_SPAWN_ID` inside Meridian-managed sessions. Outside a managed session it fails with: `Cannot infer --fork target: not inside a Meridian-managed session. Pass --fork REF explicitly.`
 - CLI argv normalization now rewrites bare/equals forms for `--fork` and `--fork-fresh` before bootstrap and Cyclopts parsing, so forms like `--fork`, `--fork=`, and `--fork --bg` parse consistently.
@@ -1694,7 +1699,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Pi lifecycle machine events now transport via append-only JSONL sidecar file (`pi-lifecycle-events.jsonl`) instead of stdout/stderr; extensions write via `fs.writeSync` append-mode fd, Python reads via `PiLifecycleEventTailer` with forced catch-up before quiescence decisions; no lifecycle JSON leaks to TUI or stderr.
 - Git autosync: extract `autosync_store.py` — single owner of `.meridian/autosync/` file layout. Eliminates duplicated path construction and JSON parsing across `git_autosync.py`, `sync_conflicts.py`, `context.py`.
 - Agent-mode CLI output defaults to text for all commands. Prior JSON defaults on `config.get`, `spawn.cancel`, `spawn.create`, `spawn.continue`, `spawn.wait`, `context`, `work.current` flipped to text. Explicit `--json` still available.
-- `spawn.wait` omits report body by default; pass `--full` to include. Report path always shown.
+- `spawn.wait` omits report body by default; pass `--report` to include. Report path always shown.
 - Lifecycle events (`meridian.spawn.start`, `meridian.spawn.done`) suppressed in agent mode for all commands. Human mode routes `TextSink.event()` to stderr.
 - `SpawnWaitMultiOutput` and `SpawnDetailOutput` now have sparse `to_cli_wire()` projections for explicit JSON; omit internal fields like `harness_session_id`, `log_path`, `process_exit_code`.
 - Background spawn output now explicitly instructs agents to wait: "You MUST run..." with machine-actionable fields `terminal`, `wait_required`, `wait_command` in JSON output.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -17,9 +17,9 @@ Full command surface. Use `--help` on any command for flags and options.
 | `meridian spawn list` | See running and recent spawns |
 | `meridian spawn list --profile reviewer` | Show spawns launched with the `reviewer` profile |
 | `meridian spawn list --primary` | Show only primary spawns (top-level sessions) |
-| `meridian spawn wait ID` | Block until a spawn completes; report body included by default, `--no-report` to suppress |
+| `meridian spawn wait ID` | Block until a spawn completes; report body included by default, `--no-full` to suppress |
 | `meridian spawn show ID` | Read a spawn's report and status |
-| `meridian spawn status ID` | Read spawn status summary (report body off by default; add `--report` to include) |
+| `meridian spawn status ID` | Read spawn status summary (report body off by default; add `--full` to include) |
 | `meridian spawn --continue ID -p "more"` | Resume a prior spawn with new input |
 | `meridian spawn --fork [REF] -p "next"` | Start a new spawn by forking while preserving launch identity (agent/model/skills) |
 | `meridian spawn --fork-fresh [REF] -p "next"` | Start a new spawn by forking and allowing launch identity changes (`-m`, `-a`, `--skills`) |
@@ -50,7 +50,7 @@ Common `spawn` flags:
 | `--primary` | `spawn list` only: include only `kind=primary` spawns |
 | `--approval MODE` | `default` \| `confirm` \| `auto` \| `yolo` |
 | `--metadata` | Show detailed inline accounting (model, cost, tokens, duration, report path). Still includes report body and transcript command. |
-| `--no-report` | Suppress report body from output (default is now to show it) |
+| `--no-full` | Suppress report body from output (default is now to show it) |
 | `--verbose` | Debug/runtime verbosity |
 
 `--fork` is identity-preserving by design. It rejects `-m`, `-a`, and `--skills`:
@@ -84,7 +84,7 @@ timestamps, paths, model) is hidden by default.
 | Default (no format flag) | Compact text: status + report body + `Transcript: meridian session log <id>` |
 | `--metadata` | Compact text + inline accounting (model, cost, tokens, duration, report path) |
 | `--verbose` | Debug/runtime verbosity |
-| `--no-report` | Status line only; report body suppressed |
+| `--no-full` | Status line only; report body suppressed |
 | `--format json` | Structured JSON with report body and transcript command fields |
 | `--bg` | Spawn ID + wait instructions (unchanged) |
 

--- a/src/meridian/cli/hooks_commands.py
+++ b/src/meridian/cli/hooks_commands.py
@@ -61,10 +61,10 @@ def _hooks_run(
             help="Optional event context to simulate (for example: spawn.finalized).",
         ),
     ] = None,
-    output: Annotated[
+    verbose: Annotated[
         bool,
         Parameter(
-            name="--output",
+            name="--verbose",
             help="Include captured stdout and stderr in JSON output.",
         ),
     ] = False,
@@ -75,7 +75,7 @@ def _hooks_run(
                 HookRunInput(
                     name=name,
                     event=event,
-                    include_output=output,
+                    include_output=verbose,
                     project_root=_resolved_project_root(),
                 )
             )

--- a/src/meridian/cli/hooks_commands.py
+++ b/src/meridian/cli/hooks_commands.py
@@ -61,6 +61,13 @@ def _hooks_run(
             help="Optional event context to simulate (for example: spawn.finalized).",
         ),
     ] = None,
+    output: Annotated[
+        bool,
+        Parameter(
+            name="--output",
+            help="Include captured stdout and stderr in JSON output.",
+        ),
+    ] = False,
 ) -> None:
     with manual_hook_authority_scope(suppress=should_suppress_manual_hook_authority()):
         emit(
@@ -68,6 +75,7 @@ def _hooks_run(
                 HookRunInput(
                     name=name,
                     event=event,
+                    include_output=output,
                     project_root=_resolved_project_root(),
                 )
             )

--- a/src/meridian/cli/spawn.py
+++ b/src/meridian/cli/spawn.py
@@ -810,19 +810,16 @@ def _spawn_show(
         bool,
         Parameter(name="--verbose", help="Include internal spawn diagnostics.", show=True),
     ] = False,
-    report: Annotated[
+    full: Annotated[
         bool | None,
         Parameter(
-            name="--report",
-            help=(
-                "Include full spawn report body. Enabled by default for text "
-                "output and disabled by default for JSON."
-            ),
+            name="--full",
+            help="Include the full report body (default: summary in JSON, full in text).",
         ),
     ] = None,
 ) -> None:
     output_format = _get_global_options().output.format
-    include_report_body = report if report is not None else output_format != "json"
+    include_report_body = full if full is not None else output_format != "json"
     _spawn_show_like(
         emit,
         spawn_ids=spawn_ids,
@@ -845,11 +842,11 @@ def _spawn_status(
         bool,
         Parameter(name="--verbose", help="Include internal spawn diagnostics.", show=True),
     ] = False,
-    report: Annotated[
+    full: Annotated[
         bool,
         Parameter(
-            name="--report",
-            help="Include report body in output (default: disabled).",
+            name="--full",
+            help="Include the full report body (default: disabled).",
         ),
     ] = False,
 ) -> None:
@@ -859,7 +856,7 @@ def _spawn_status(
         verbose=verbose,
         build_input=lambda spawn_id: SpawnStatusInput(
             spawn_id=spawn_id,
-            include_report_body=report,
+            include_report_body=full,
         ),
         handler=spawn_status_sync,
     )
@@ -991,19 +988,16 @@ def _spawn_wait(
         bool,
         Parameter(name="--quiet", help="Suppress wait progress output.", show=True),
     ] = False,
-    report: Annotated[
+    full: Annotated[
         bool | None,
         Parameter(
-            name="--report",
-            help=(
-                "Include full report body. Enabled by default for text output "
-                "and disabled by default for JSON."
-            ),
+            name="--full",
+            help="Include the full report body (default: summary in JSON, full in text).",
         ),
     ] = None,
 ) -> None:
     output_format = _get_global_options().output.format
-    include_report_body = report if report is not None else output_format != "json"
+    include_report_body = full if full is not None else output_format != "json"
     result = spawn_wait_sync(
         SpawnWaitInput(
             spawn_ids=spawn_ids,

--- a/src/meridian/cli/spawn.py
+++ b/src/meridian/cli/spawn.py
@@ -811,23 +811,25 @@ def _spawn_show(
         Parameter(name="--verbose", help="Include internal spawn diagnostics.", show=True),
     ] = False,
     report: Annotated[
-        bool,
+        bool | None,
         Parameter(
             name="--report",
             help=(
-                "Include full spawn report body in output (default: enabled). "
-                "Use --no-report to omit."
+                "Include full spawn report body. Enabled by default for text "
+                "output and disabled by default for JSON."
             ),
         ),
-    ] = True,
+    ] = None,
 ) -> None:
+    output_format = _get_global_options().output.format
+    include_report_body = report if report is not None else output_format != "json"
     _spawn_show_like(
         emit,
         spawn_ids=spawn_ids,
         verbose=verbose,
         build_input=lambda spawn_id: SpawnShowInput(
             spawn_id=spawn_id,
-            include_report_body=report,
+            include_report_body=include_report_body,
         ),
         handler=spawn_show_sync,
     )

--- a/src/meridian/cli/spawn.py
+++ b/src/meridian/cli/spawn.py
@@ -992,13 +992,18 @@ def _spawn_wait(
         Parameter(name="--quiet", help="Suppress wait progress output.", show=True),
     ] = False,
     report: Annotated[
-        bool,
+        bool | None,
         Parameter(
             name="--report",
-            help="Include full report body in output (default: enabled). Use --no-report to omit.",
+            help=(
+                "Include full report body. Enabled by default for text output "
+                "and disabled by default for JSON."
+            ),
         ),
-    ] = True,
+    ] = None,
 ) -> None:
+    output_format = _get_global_options().output.format
+    include_report_body = report if report is not None else output_format != "json"
     result = spawn_wait_sync(
         SpawnWaitInput(
             spawn_ids=spawn_ids,
@@ -1007,12 +1012,11 @@ def _spawn_wait(
             timeout_explicit=timeout is not None,
             verbose=verbose,
             quiet=quiet,
-            include_report_body=report,
+            include_report_body=include_report_body,
         ),
         sink=_current_output_sink(),
         prepared=_prepare_spawn_runtime_read(),
     )
-    output_format = _get_global_options().output.format
     if output_format != "json" and (metadata or verbose):
         emit(result.format_text(FormatContext(verbosity=1)))
     else:

--- a/src/meridian/cli/spawn.py
+++ b/src/meridian/cli/spawn.py
@@ -893,7 +893,7 @@ def _spawn_show_like(
         return
 
     if output_format == "json":
-        emit(list(results))
+        emit([result.to_cli_wire() for result in results])
         return
 
     fmt_ctx = FormatContext(verbosity=1) if verbose else None

--- a/src/meridian/lib/ops/commands.py
+++ b/src/meridian/lib/ops/commands.py
@@ -576,7 +576,7 @@ _OP_SPECS: tuple[ExtensionCommandSpec, ...] = (
         command_id="status",
         summary=(
             "Show spawn status, duration, model, and report path. "
-            "Use --report to include report text."
+            "Use --full to include report text."
         ),
         handler=spawn_status,
         sync_handler=spawn_status_sync,

--- a/src/meridian/lib/ops/hooks.py
+++ b/src/meridian/lib/ops/hooks.py
@@ -109,6 +109,7 @@ class HookRunInput(BaseModel):
 
     name: str
     event: HookEventName | None = None
+    include_output: bool = False
     project_root: str | None = None
 
 
@@ -132,6 +133,39 @@ class HookRunOutput(BaseModel):
     hook: str
     event: HookEventName
     result: HookRunResult
+    include_output: bool = False
+
+    def to_cli_wire(self) -> dict[str, object]:
+        """Project hook outcome, optionally including captured process output."""
+        wire: dict[str, object] = {
+            "hook": self.hook,
+            "event": self.event,
+            "outcome": self.result.outcome,
+            "success": self.result.success,
+            "skipped": self.result.skipped,
+            "skip_reason": self.result.skip_reason,
+            "error": self.result.error,
+            "exit_code": self.result.exit_code,
+            "duration_ms": self.result.duration_ms,
+        }
+        if self.include_output:
+            wire["stdout"] = self.result.stdout
+            wire["stderr"] = self.result.stderr
+        return wire
+
+    def to_cli_output(
+        self,
+        *,
+        format: str,
+        explicit_format: str | None,
+        agent_mode: bool,
+    ) -> object:
+        """CLI output protocol: project only JSON output."""
+        _ = explicit_format
+        _ = agent_mode
+        if format != "json":
+            return self
+        return self.to_cli_wire()
 
     def format_text(self, ctx: FormatContext | None = None) -> str:
         _ = ctx
@@ -365,6 +399,7 @@ def hooks_run_sync(payload: HookRunInput) -> HookRunOutput:
         hook=effective_hook.name,
         event=effective_hook.event,
         result=_result_to_output(result),
+        include_output=payload.include_output,
     )
 
 

--- a/src/meridian/lib/ops/spawn/models.py
+++ b/src/meridian/lib/ops/spawn/models.py
@@ -150,6 +150,12 @@ class SpawnCreateInput(SpawnLaunchOptions):
 
 
 class SpawnActionOutput(BaseModel):
+    """Spawn action result with distinct CLI and implicit agent projections.
+
+    ``to_cli_wire()`` is the explicit JSON contract. ``to_agent_wire()`` is
+    intentionally narrower for implicit agent-mode background spawns.
+    """
+
     model_config = ConfigDict(frozen=True)
 
     command: str
@@ -314,10 +320,14 @@ class SpawnActionOutput(BaseModel):
                 wire["cli_command"] = list(self.cli_command)
         return wire
 
+    def to_cli_wire(self) -> dict[str, object]:
+        """Project the explicit CLI JSON contract."""
+        return self.to_wire()
+
     def to_agent_wire(self) -> dict[str, object]:
         """Project sparse JSON for implicit agent-mode consumers."""
         if not (self.background and self.status == "running"):
-            return self.to_wire()
+            return self.to_cli_wire()
 
         wire: dict[str, object] = {"status": self.status}
         if self.spawn_id is not None:
@@ -351,7 +361,7 @@ class SpawnActionOutput(BaseModel):
             return self
         if explicit_format is None:
             return self.to_agent_wire()
-        return self.to_wire()
+        return self.to_cli_wire()
 
     def format_text(self, ctx: FormatContext | None = None) -> str:
         effective_ctx = ctx or FormatContext()
@@ -901,8 +911,6 @@ class SpawnDetailOutput(BaseModel):
             wire["tui_pid"] = self.tui_pid
         if self.backend_port is not None:
             wire["backend_port"] = self.backend_port
-        if self.kind == "primary" and self.harness_session_id is not None:
-            wire["harness_session_id"] = self.harness_session_id
         if self.pi_lifecycle_phase is not None:
             wire["pi_lifecycle_phase"] = self.pi_lifecycle_phase
         if self.pi_cleanup_status is not None:

--- a/src/meridian/lib/ops/spawn/query.py
+++ b/src/meridian/lib/ops/spawn/query.py
@@ -569,13 +569,14 @@ def detail_from_row(
     include_report_body: bool,
     runtime_root: Path | None = None,
 ) -> SpawnDetailOutput:
-    report_path, report_body = read_report(
+    report_path, loaded_report_body = read_report(
         project_root,
         row.id,
-        include_body=include_report_body,
+        include_body=True,
         runtime_root=runtime_root,
     )
-    report_summary = report_body[:500] if report_body else None
+    report_summary = loaded_report_body[:500] if loaded_report_body else None
+    report_body = loaded_report_body if include_report_body else None
 
     last_message: str | None = None
     log_path: str | None = None

--- a/src/meridian/lib/ops/spawn/query.py
+++ b/src/meridian/lib/ops/spawn/query.py
@@ -299,6 +299,27 @@ def read_report(
     return report_path.as_posix(), text
 
 
+def read_report_summary(
+    project_root: Path,
+    spawn_id: str,
+    *,
+    runtime_root: Path | None = None,
+) -> tuple[str | None, str | None]:
+    """Read at most the byte window needed for a 500-character report prefix."""
+    resolved_runtime_root = runtime_root or resolve_runtime_root_for_read(project_root)
+    if resolved_runtime_root is None:
+        return None, None
+    report_path = resolved_runtime_root / "spawns" / spawn_id / "report.md"
+    if not report_path.is_file():
+        return None, None
+    # A UTF-8 code point uses at most four bytes. Ignoring an incomplete trailing
+    # code point makes a byte-window read safe without reading the rest of the file.
+    with report_path.open("rb") as report_file:
+        prefix = report_file.read(500 * 4)
+    summary = prefix.decode("utf-8", errors="ignore").strip()[:500] or None
+    return report_path.as_posix(), summary
+
+
 def read_report_text(
     project_root: Path,
     spawn_id: str,
@@ -569,14 +590,21 @@ def detail_from_row(
     include_report_body: bool,
     runtime_root: Path | None = None,
 ) -> SpawnDetailOutput:
-    report_path, loaded_report_body = read_report(
-        project_root,
-        row.id,
-        include_body=True,
-        runtime_root=runtime_root,
-    )
-    report_summary = loaded_report_body[:500] if loaded_report_body else None
-    report_body = loaded_report_body if include_report_body else None
+    if include_report_body:
+        report_path, report_body = read_report(
+            project_root,
+            row.id,
+            include_body=True,
+            runtime_root=runtime_root,
+        )
+        report_summary = report_body[:500] if report_body else None
+    else:
+        report_path, report_summary = read_report_summary(
+            project_root,
+            row.id,
+            runtime_root=runtime_root,
+        )
+        report_body = None
 
     last_message: str | None = None
     log_path: str | None = None

--- a/src/meridian/lib/ops/work_dashboard.py
+++ b/src/meridian/lib/ops/work_dashboard.py
@@ -300,6 +300,52 @@ class WorkShowOutput(BaseModel):
     worktree_exists: bool | None = None  # None = no worktree; True/False = exists/missing
     worktree_pending: bool = False  # creation interrupted
 
+    def to_cli_wire(self) -> dict[str, object]:
+        """Project work identity and summary-only related records."""
+        wire: dict[str, object] = {
+            "name": self.name,
+            "status": self.status,
+            "description": self.description,
+            "created_at": self.created_at,
+            "work_dir": self.work_dir,
+            "spawns": [
+                {
+                    "id": spawn.id,
+                    "status": spawn.status,
+                    "model": spawn.model,
+                    "desc": spawn.desc,
+                }
+                for spawn in self.spawns
+            ],
+            "sessions": [
+                {
+                    "chat_id": session.chat_id,
+                    "harness": session.harness,
+                    "status": session.status,
+                    "model": session.model,
+                    "agent": session.agent,
+                }
+                for session in self.sessions
+            ],
+        }
+        if self.goal is not None:
+            wire["goal"] = self.goal
+        return wire
+
+    def to_cli_output(
+        self,
+        *,
+        format: str,
+        explicit_format: str | None,
+        agent_mode: bool,
+    ) -> object:
+        """CLI output protocol: project only JSON output."""
+        _ = explicit_format
+        _ = agent_mode
+        if format != "json":
+            return self
+        return self.to_cli_wire()
+
     def format_text(self, ctx: FormatContext | None = None) -> str:
         _ = ctx
 

--- a/src/meridian/lib/ops/work_dashboard.py
+++ b/src/meridian/lib/ops/work_dashboard.py
@@ -308,6 +308,7 @@ class WorkShowOutput(BaseModel):
             "description": self.description,
             "created_at": self.created_at,
             "work_dir": self.work_dir,
+            "task_dir": self.task_dir,
             "spawns": [
                 {
                     "id": spawn.id,

--- a/tests/integration/cli/test_sparse_json_contracts.py
+++ b/tests/integration/cli/test_sparse_json_contracts.py
@@ -184,7 +184,7 @@ def test_spawn_show_json_contract(
     )
     _assert_noisy_keys_absent(payload)
 
-    with_report = _run_json(project_root, env, "spawn", "show", "p1", "--report")
+    with_report = _run_json(project_root, env, "spawn", "show", "p1", "--full")
     assert with_report["report_body"] == "Completed the sparse JSON projection."
 
 
@@ -344,7 +344,7 @@ def test_hooks_run_json_contract(
         "hooks",
         "run",
         "projection-test",
-        "--output",
+        "--verbose",
     )
     assert with_output["stdout"] == "hook-output"
     assert with_output["stderr"] == "hook-error"

--- a/tests/integration/cli/test_sparse_json_contracts.py
+++ b/tests/integration/cli/test_sparse_json_contracts.py
@@ -228,13 +228,12 @@ def test_work_show_json_contract(
         "description",
         "created_at",
         "work_dir",
+        "task_dir",
         "spawns",
         "sessions",
     } <= payload.keys()
     assert set(payload["spawns"][0]) == {"id", "status", "model", "desc"}
-    assert {"task_dir", "worktree_path", "worktree_exists", "worktree_pending"}.isdisjoint(
-        payload
-    )
+    assert {"worktree_path", "worktree_exists", "worktree_pending"}.isdisjoint(payload)
     _assert_noisy_keys_absent(payload)
 
 

--- a/tests/integration/cli/test_sparse_json_contracts.py
+++ b/tests/integration/cli/test_sparse_json_contracts.py
@@ -1,0 +1,279 @@
+"""CLI contracts for commands whose JSON output has a curated projection."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from meridian.lib.ops.work_lifecycle import WorkStartInput, work_start_sync
+from meridian.lib.state import spawn_store
+from meridian.lib.state.paths import resolve_project_runtime_root_for_write
+from tests.conftest import posix_only
+from tests.support.executables import prepend_fake_executables
+
+_NOISY_KEYS = {"stdout", "stderr", "harness_session_id", "report_body"}
+
+
+@pytest.fixture
+def cli_project(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[tuple[Path, dict[str, str], Path]]:
+    project_root = tmp_path / "project"
+    (project_root / ".meridian").mkdir(parents=True)
+    (project_root / ".meridian" / "id").write_text("sparse-json-test\n", encoding="utf-8")
+    (project_root / "meridian.toml").write_text(
+        "[spawn]\ndeny_headless_harnesses = []\n",
+        encoding="utf-8",
+    )
+    prepend_fake_executables(monkeypatch, tmp_path, "codex")
+    monkeypatch.setenv("MERIDIAN_HOME", (tmp_path / "home").as_posix())
+    env = os.environ.copy()
+
+    runtime_root = resolve_project_runtime_root_for_write(project_root)
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    yield project_root, env, runtime_root
+
+
+def _run_json(
+    project_root: Path,
+    env: dict[str, str],
+    *args: str,
+) -> dict[str, Any]:
+    result = subprocess.run(
+        [sys.executable, "-m", "meridian", "--format", "json", *args],
+        cwd=project_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=5,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, dict)
+    return payload
+
+
+def _assert_noisy_keys_absent(payload: object) -> None:
+    if isinstance(payload, dict):
+        assert _NOISY_KEYS.isdisjoint(payload)
+        for value in payload.values():
+            _assert_noisy_keys_absent(value)
+    elif isinstance(payload, list):
+        for value in payload:
+            _assert_noisy_keys_absent(value)
+
+
+def _seed_terminal_spawn(runtime_root: Path, project_root: Path) -> None:
+    spawn_store.start_spawn(
+        runtime_root,
+        spawn_id="p1",
+        chat_id="c1",
+        model="gpt-5.4",
+        agent="implementer",
+        harness="codex",
+        kind="primary",
+        prompt="Implement sparse JSON.",
+        desc="Sparse JSON",
+        work_id="sparse-json",
+        harness_session_id="internal-session-id",
+        task_cwd=project_root.as_posix(),
+    )
+    spawn_store.finalize_spawn(
+        runtime_root,
+        "p1",
+        "succeeded",
+        0,
+        origin="runner",
+        duration_secs=1.25,
+    )
+    report_path = runtime_root / "spawns" / "p1" / "report.md"
+    report_path.write_text("Completed the sparse JSON projection.\n", encoding="utf-8")
+
+
+def _seed_work_spawn(runtime_root: Path, project_root: Path) -> None:
+    spawn_store.start_spawn(
+        runtime_root,
+        spawn_id="p2",
+        chat_id="c2",
+        model="gpt-5.4",
+        agent="implementer",
+        harness="codex",
+        prompt="Implement sparse JSON.",
+        desc="Sparse JSON",
+        work_id="sparse-json",
+        task_cwd=project_root.as_posix(),
+    )
+    spawn_store.finalize_spawn(
+        runtime_root,
+        "p2",
+        "succeeded",
+        0,
+        origin="runner",
+        duration_secs=1.25,
+    )
+
+
+@pytest.mark.integration
+@posix_only
+def test_spawn_create_json_contract(
+    cli_project: tuple[Path, dict[str, str], Path],
+) -> None:
+    project_root, env, _ = cli_project
+    payload = _run_json(
+        project_root,
+        env,
+        "--harness",
+        "codex",
+        "spawn",
+        "--agent",
+        "",
+        "--background",
+        "--dry-run",
+        "Inspect the projection.",
+    )
+
+    assert {"status", "model", "harness_id", "composed_prompt"} <= payload.keys()
+    _assert_noisy_keys_absent(payload)
+
+
+@pytest.mark.integration
+@posix_only
+def test_spawn_show_json_contract(
+    cli_project: tuple[Path, dict[str, str], Path],
+) -> None:
+    project_root, env, runtime_root = cli_project
+    _seed_terminal_spawn(runtime_root, project_root)
+
+    payload = _run_json(project_root, env, "spawn", "show", "p1")
+
+    assert {"spawn_id", "status", "model", "harness", "report_path", "report_summary"} <= (
+        payload.keys()
+    )
+    _assert_noisy_keys_absent(payload)
+
+    with_report = _run_json(project_root, env, "spawn", "show", "p1", "--report")
+    assert with_report["report_body"] == "Completed the sparse JSON projection."
+
+
+@pytest.mark.integration
+@posix_only
+def test_spawn_status_json_contract(
+    cli_project: tuple[Path, dict[str, str], Path],
+) -> None:
+    project_root, env, runtime_root = cli_project
+    _seed_terminal_spawn(runtime_root, project_root)
+
+    payload = _run_json(project_root, env, "spawn", "status", "p1")
+
+    assert {"spawn_id", "status", "model", "harness", "report_path", "report_summary"} <= (
+        payload.keys()
+    )
+    _assert_noisy_keys_absent(payload)
+
+
+@pytest.mark.integration
+@posix_only
+def test_spawn_wait_json_contract(
+    cli_project: tuple[Path, dict[str, str], Path],
+) -> None:
+    project_root, env, runtime_root = cli_project
+    _seed_terminal_spawn(runtime_root, project_root)
+
+    payload = _run_json(project_root, env, "spawn", "wait", "p1")
+
+    assert {
+        "total_runs",
+        "succeeded_runs",
+        "failed_runs",
+        "cancelled_runs",
+        "timed_out_runs",
+        "any_failed",
+        "spawns",
+    } <= payload.keys()
+    assert {"spawn_id", "status", "model", "harness"} <= payload["spawns"][0].keys()
+    _assert_noisy_keys_absent(payload)
+
+
+@pytest.mark.integration
+@posix_only
+def test_work_show_json_contract(
+    cli_project: tuple[Path, dict[str, str], Path],
+) -> None:
+    project_root, env, runtime_root = cli_project
+    work_start_sync(
+        WorkStartInput(
+            label="sparse-json",
+            description="Project noisy output.",
+            goal="Keep the useful summary.",
+            project_root=project_root.as_posix(),
+        )
+    )
+    _seed_work_spawn(runtime_root, project_root)
+
+    payload = _run_json(project_root, env, "work", "show", "sparse-json")
+
+    assert {
+        "name",
+        "status",
+        "goal",
+        "description",
+        "created_at",
+        "work_dir",
+        "spawns",
+        "sessions",
+    } <= payload.keys()
+    assert set(payload["spawns"][0]) == {"id", "status", "model", "desc"}
+    assert {"task_dir", "worktree_path", "worktree_exists", "worktree_pending"}.isdisjoint(
+        payload
+    )
+    _assert_noisy_keys_absent(payload)
+
+
+@pytest.mark.integration
+@posix_only
+def test_hooks_run_json_contract(
+    cli_project: tuple[Path, dict[str, str], Path],
+) -> None:
+    project_root, env, _ = cli_project
+    (project_root / "meridian.toml").write_text(
+        "[[hooks]]\n"
+        'name = "projection-test"\n'
+        'event = "spawn.finalized"\n'
+        'command = "printf hook-output; printf hook-error >&2"\n',
+        encoding="utf-8",
+    )
+
+    payload = _run_json(project_root, env, "hooks", "run", "projection-test")
+
+    assert {
+        "hook",
+        "event",
+        "outcome",
+        "success",
+        "skipped",
+        "skip_reason",
+        "error",
+        "exit_code",
+        "duration_ms",
+    } <= payload.keys()
+    _assert_noisy_keys_absent(payload)
+
+    with_output = _run_json(
+        project_root,
+        env,
+        "hooks",
+        "run",
+        "projection-test",
+        "--output",
+    )
+    assert with_output["stdout"] == "hook-output"
+    assert with_output["stderr"] == "hook-error"

--- a/tests/integration/cli/test_sparse_json_contracts.py
+++ b/tests/integration/cli/test_sparse_json_contracts.py
@@ -42,11 +42,11 @@ def cli_project(
     yield project_root, env, runtime_root
 
 
-def _run_json(
+def _invoke_json(
     project_root: Path,
     env: dict[str, str],
     *args: str,
-) -> dict[str, Any]:
+) -> object:
     result = subprocess.run(
         [sys.executable, "-m", "meridian", "--format", "json", *args],
         cwd=project_root,
@@ -57,8 +57,27 @@ def _run_json(
         check=False,
     )
     assert result.returncode == 0, result.stderr
-    payload = json.loads(result.stdout)
+    return json.loads(result.stdout)
+
+
+def _run_json(
+    project_root: Path,
+    env: dict[str, str],
+    *args: str,
+) -> dict[str, Any]:
+    payload = _invoke_json(project_root, env, *args)
     assert isinstance(payload, dict)
+    return payload
+
+
+def _run_json_list(
+    project_root: Path,
+    env: dict[str, str],
+    *args: str,
+) -> list[dict[str, Any]]:
+    payload = _invoke_json(project_root, env, *args)
+    assert isinstance(payload, list)
+    assert all(isinstance(item, dict) for item in payload)
     return payload
 
 
@@ -72,10 +91,15 @@ def _assert_noisy_keys_absent(payload: object) -> None:
             _assert_noisy_keys_absent(value)
 
 
-def _seed_terminal_spawn(runtime_root: Path, project_root: Path) -> None:
+def _seed_terminal_spawn(
+    runtime_root: Path,
+    project_root: Path,
+    *,
+    spawn_id: str = "p1",
+) -> None:
     spawn_store.start_spawn(
         runtime_root,
-        spawn_id="p1",
+        spawn_id=spawn_id,
         chat_id="c1",
         model="gpt-5.4",
         agent="implementer",
@@ -89,13 +113,13 @@ def _seed_terminal_spawn(runtime_root: Path, project_root: Path) -> None:
     )
     spawn_store.finalize_spawn(
         runtime_root,
-        "p1",
+        spawn_id,
         "succeeded",
         0,
         origin="runner",
         duration_secs=1.25,
     )
-    report_path = runtime_root / "spawns" / "p1" / "report.md"
+    report_path = runtime_root / "spawns" / spawn_id / "report.md"
     report_path.write_text("Completed the sparse JSON projection.\n", encoding="utf-8")
 
 
@@ -166,6 +190,30 @@ def test_spawn_show_json_contract(
 
 @pytest.mark.integration
 @posix_only
+def test_spawn_show_multi_id_json_contract(
+    cli_project: tuple[Path, dict[str, str], Path],
+) -> None:
+    project_root, env, runtime_root = cli_project
+    _seed_terminal_spawn(runtime_root, project_root, spawn_id="p1")
+    _seed_terminal_spawn(runtime_root, project_root, spawn_id="p2")
+
+    payload = _run_json_list(project_root, env, "spawn", "show", "p1", "p2")
+
+    assert [item["spawn_id"] for item in payload] == ["p1", "p2"]
+    for item in payload:
+        assert {
+            "spawn_id",
+            "status",
+            "model",
+            "harness",
+            "report_path",
+            "report_summary",
+        } <= item.keys()
+    _assert_noisy_keys_absent(payload)
+
+
+@pytest.mark.integration
+@posix_only
 def test_spawn_status_json_contract(
     cli_project: tuple[Path, dict[str, str], Path],
 ) -> None:
@@ -177,6 +225,30 @@ def test_spawn_status_json_contract(
     assert {"spawn_id", "status", "model", "harness", "report_path", "report_summary"} <= (
         payload.keys()
     )
+    _assert_noisy_keys_absent(payload)
+
+
+@pytest.mark.integration
+@posix_only
+def test_spawn_status_multi_id_json_contract(
+    cli_project: tuple[Path, dict[str, str], Path],
+) -> None:
+    project_root, env, runtime_root = cli_project
+    _seed_terminal_spawn(runtime_root, project_root, spawn_id="p1")
+    _seed_terminal_spawn(runtime_root, project_root, spawn_id="p2")
+
+    payload = _run_json_list(project_root, env, "spawn", "status", "p1", "p2")
+
+    assert [item["spawn_id"] for item in payload] == ["p1", "p2"]
+    for item in payload:
+        assert {
+            "spawn_id",
+            "status",
+            "model",
+            "harness",
+            "report_path",
+            "report_summary",
+        } <= item.keys()
     _assert_noisy_keys_absent(payload)
 
 


### PR DESCRIPTION
## Why

Agent-facing JSON output for several commands dumped full internal models —
`report_body`, `harness_session_id`, raw hook stdout/stderr, worktree
internals — burning coordinating agents' context on noise. The codebase had
already chosen curated per-command projections (`CLIOutputProtocol` /
`to_cli_wire()`); the rollout was unfinished (#113).

## Goal

Every noisy command's default JSON is a curated sparse contract; heavy
fields stay reachable via explicit flags. No `--fields`/query language — the
noisy *default* was the bug.

## Summary

Per design `triage-design-4issues/designs/113`:

- **`spawn show`**: `--full` is tri-state. Text mode keeps
  report-by-default; JSON default carries `report_path` + bounded 500-char
  `report_summary`, full `report_body` only on explicit `--full`.
  `harness_session_id` dropped from the default JSON contract
  (human-approved decision; the issue originally asked to keep it —
  deliberate divergence, `session log <chat-id>` covers the use case).
- **Flag rename (breaking)**: the report opt-in flag `--report`/`--no-report`
  — a *shipped* flag since v0.0.44 — is renamed to `--full`/`--no-full` on
  `spawn show`/`spawn status`/`spawn wait`, reusing meridian's existing
  `session log --full` vocabulary instead of inventing a name. The new
  `hooks run` output opt-in ships as `--verbose` (not `--output`, which
  already means "output file" in `misc_commands`). `--report` is no longer
  accepted. Behavior is otherwise identical to the rename — tri-state
  resolution and defaults unchanged.
- **Multi-ID `spawn show`/`spawn status`**: each result projected before
  emitting (review caught the list path bypassing projection entirely).
- **`spawn wait`**: same JSON report gating (adjacent change; agent-mode
  wait defaults to text and retains the full report — verified unaffected).
- **`work show`**: sparse `to_cli_wire()` — identity/status/timing/dirs +
  summary-only spawns/sessions. No worktree internals, no
  harness_session_id. Deliberately no verbose escape hatch.
- **`hooks run`**: outcome projection; stdout/stderr gated behind new
  `include_output` input + `--verbose` flag (mirrors `include_report_body`).
- **Bounded summary read**: summary-only paths read a capped 2000-byte,
  UTF-8-boundary-tolerant prefix instead of the whole report file.
- **Contract tests**: real-CLI JSON tests for the six projected commands
  (incl. multi-ID arrays), asserting required keys present and noisy keys
  recursively absent — also pins the four previously projected commands,
  which nothing protected before.
- **Sweep of remaining fallback commands** (`work list/sessions`,
  `hooks list/check`, config/context): measured JSON vs text size; none
  materially noisy — left unprojected, per design's "don't project for
  symmetry".

## Resulting Behavior

- `meridian --format json spawn show p123` → sparse contract with
  `report_summary`; `--full` restores the full body.
- `meridian --format json spawn show p1 p2` → JSON array of the same sparse
  shapes (previously: full model dump per spawn).
- `meridian --format json work show <slug>` → curated summary.
- `meridian --format json hooks run <name>` → outcome only; `--verbose`
  reveals stdout/stderr.
- All text output unchanged.

## Changes

- `cli/spawn.py`, `lib/ops/spawn/models.py`, `lib/ops/spawn/query.py`
- `lib/ops/work_dashboard.py`, `lib/ops/hooks.py`, `cli/hooks_commands.py`
- `tests/integration/cli/test_sparse_json_contracts.py`
- No changes to `cli/main.py` / `cli/output.py` — existing dispatch seam.

## Work Item

triage-designs-impl

## Verification

- `uv run ruff check .` clean; `uv run pytest-llm` 1348 passed / 2 skipped;
  pyright 0 errors.
- Adversarial review (p5677): verified tri-state parsing (`--full` /
  `--no-full` / omitted), text-mode invariance, agent-workflow safety of
  the wait change (probed forced agent mode — full report retained),
  multibyte-safe summaries, and real-CLI contract tests. Its blocker
  (multi-ID projection bypass) and should-fix (full report I/O on sparse
  paths) resolved in `8f2f9c25` with multi-ID contract tests.
- Flag rename (`18c85bfd`): behavior-identical — types, defaults, and
  tri-state resolution preserved verbatim, names only. Re-verified: ruff
  clean, pyright 0 errors, sparse-contract tests green (exercise `--full` /
  `--verbose`), full `pytest-llm` 1348 passed / 2 skipped on pre-push. Historical
  changelog entries restored to `--report` (`afb0c798`).

## Knowledge Updates

`SpawnActionOutput` docstring now documents the `to_cli_wire()` vs
`to_agent_wire()` two-projection situation. kb-lead reconciliation runs at
the end of the four-lane batch.

## Spawn Trace

- p5673 coder — projection rollout per design
- p5677 reviewer — adversarial review vs design contract
- p5680 coder — fix pass (multi-ID projection + bounded report read)
- p5688 coder — flag-vocabulary rename (`--report`→`--full`, `--output`→`--verbose`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
