### PR TITLE
Bump mars-agents to 0.10.6: session.end hooks fire in Claude (enables context-autosync)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Changed
+- mars-agents bumped 0.10.5 → 0.10.6: package hooks declared on `session.end`
+  now compile to Claude Code's real `SessionEnd` event instead of the
+  nonexistent `SessionStop` (mars-agents#129). Unblocks meridian-base 0.8.9's
+  `context-autosync` hook, which pushes stranded context-repo commits (work
+  docs, KB) at session end.
 - Sparse JSON defaults for noisy CLI outputs: `spawn show`/`spawn wait` JSON
   now carries `report_path` + a bounded `report_summary` instead of the full
   `report_body` (opt back in with `--full`); `harness_session_id` is gone

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "cyclopts>=3.0",
   "fastapi>=0.115",
   "markdown-it-py>=4.0",
-  "mars-agents==0.10.5",
+  "mars-agents==0.10.6",
   "mcp>=1.0",
   "pathspec>=1.1.0",
   "psutil>=7.2.2",

--- a/uv.lock
+++ b/uv.lock
@@ -666,15 +666,15 @@ wheels = [
 
 [[package]]
 name = "mars-agents"
-version = "0.10.5"
+version = "0.10.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4a/b5/951623d8b8bf26116448ab0f78290f3b62eb89849da7a2147ab1a125936c/mars_agents-0.10.5.tar.gz", hash = "sha256:ef027e2de948cb2817667df504cfeee78e5e01a59a9ff4628798482741e46f10", size = 716091, upload-time = "2026-07-10T08:07:56.905Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/1f/1cb14eba95f65753a1dd96e197c6e61262798f0c9ca025258d2be194c346/mars_agents-0.10.6.tar.gz", hash = "sha256:ef14149bc6eb2d1b878724ef3a64b4d14f86164bdca509c9c570423e12fe8972", size = 716429, upload-time = "2026-07-24T15:00:33.271Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/e0/7fe41506a417ec73ed2d6ffe8404c4d2f70a835f9d4f222391dbd71b9eeb/mars_agents-0.10.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f597ecb02677f7f0b1597c6642c2d200f6235b4e3450ad2022e1b197304fc290", size = 3482301, upload-time = "2026-07-10T08:07:48.323Z" },
-    { url = "https://files.pythonhosted.org/packages/43/03/b7c8930d0644766767fddedd97e9a093c21862c86f0cfd3fa6c3e5f9d739/mars_agents-0.10.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1bd4badd33e8ac62b8eb029f623469394a3f98a7415895935b99835fffe61dc6", size = 3329416, upload-time = "2026-07-10T08:07:50.38Z" },
-    { url = "https://files.pythonhosted.org/packages/06/78/46f4442562cf18820247b29363284e645f0f439c492218491cb11b7766fc/mars_agents-0.10.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5761bc14d33a75983f3e404ca781762b8ca8d446af7d61af12a4c37f92244307", size = 3299337, upload-time = "2026-07-10T08:07:51.882Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/b2/22b9845702adce3396698420850a7b42d707694f2adbd6122a9ed30beed1/mars_agents-0.10.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:654dda45910aafaf72cc0f17a055728144a3891139ddcbd083d27e22ad01abad", size = 3524201, upload-time = "2026-07-10T08:07:53.289Z" },
-    { url = "https://files.pythonhosted.org/packages/85/9d/048248f6b0334ab92c2dceb2352fdd39753b18ba4236dbb6d819eea83fed/mars_agents-0.10.5-py3-none-win_amd64.whl", hash = "sha256:141723ef616a45cb43eefcfd35e3b0b4a8b1d67dae4ee12fd105977462b707cc", size = 3557743, upload-time = "2026-07-10T08:07:55.13Z" },
+    { url = "https://files.pythonhosted.org/packages/92/92/fb7a0f2e84502469237a7da22d85cf7bba123721956951cc07f60155e001/mars_agents-0.10.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c5207e835e24f30246885225ce65039115d9a4a67822a9d65608e02767b236a", size = 3388084, upload-time = "2026-07-24T15:00:23.951Z" },
+    { url = "https://files.pythonhosted.org/packages/17/66/20363f3d724bb437c5f00915448d6ebc5d8d0ab385ed9ec55913d913bb73/mars_agents-0.10.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fdd8ca2e1c77c39dbfa49b7b6c8d677073929b430ad0ac0c3ac158c2f68440a7", size = 3244698, upload-time = "2026-07-24T15:00:26.359Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ba/d43c868c37884c653c02a80842b4126ae8acf79f963f435be2f827f001e5/mars_agents-0.10.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8eae44122ae2e4e4bf0200899a8a2fab40fdb998d7125c84cf9e8ccf624cd3ea", size = 3299723, upload-time = "2026-07-24T15:00:28.124Z" },
+    { url = "https://files.pythonhosted.org/packages/43/44/0c2ec0fcedb01ea951a14c60db7aac9fbaa1be9c4909f9c2502cead2550b/mars_agents-0.10.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c6ae5fa13f3917eab5bb741df0a610ae4a3fb8e7b9f92c472a5477cf851f245", size = 3525376, upload-time = "2026-07-24T15:00:29.939Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2b/4f1b99e130e017911e33e6338b186976c75ad38de83528753d1ebd2ac24a/mars_agents-0.10.6-py3-none-win_amd64.whl", hash = "sha256:b0b832fc3a6686a9b699a65e88a8859fbff0bd3a1f1066273150bc9a5de5cbb2", size = 3534939, upload-time = "2026-07-24T15:00:31.753Z" },
 ]
 
 [[package]]
@@ -766,7 +766,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'app'", specifier = ">=0.28" },
     { name = "jinja2", marker = "extra == 'templates'", specifier = ">=3.1" },
     { name = "markdown-it-py", specifier = ">=4.0" },
-    { name = "mars-agents", specifier = "==0.10.5" },
+    { name = "mars-agents", specifier = "==0.10.6" },
     { name = "mcp", specifier = ">=1.0" },
     { name = "pathspec", specifier = ">=1.1.0" },
     { name = "psutil", specifier = ">=7.2.2" },


### PR DESCRIPTION
## Why

meridian's builtin git-autosync fires only on meridian lifecycle events
(spawn.start/finalized, work.started/done). Commits created after the last such
event — e.g. kb-lead knowledge capture as a session's final act — sat stranded
locally (observed twice in the KB repo). meridian-base 0.8.9 ships a
`context-autosync` hook that closes the gap at Claude session end, but
mars-agents ≤0.10.5 compiled `session.end` to the nonexistent Claude event
`SessionStop`, leaving the hook dead on arrival.

## Summary

- `mars-agents` 0.10.5 → 0.10.6 (pyproject pin + uv.lock), picking up
  mars-agents#129: `session.end` → `SessionEnd` (real event, exact mapping).

## Resulting Behavior

After `meridian mars sync`, the meridian-base `context-autosync` hook lands in
`.claude/settings.local.json` under `SessionEnd` and actually fires: on session
end it runs each enabled `git-autosync:*` instance (`meridian hooks list` is the
runtime authority — no-op in projects without autosync config). Verified live in
this project: hook compiled to `SessionEnd`, script exit 0, repos synced.

Note for existing checkouts: mars ≤0.10.5 wrote the hook under an orphaned
`SessionStop` key that fixed mars does not recognize as its own; it was removed
manually here. The mars hook-vocabulary redesign (audit in
work/reaper-scope-regression/design/mars-hook-authoring.md) covers residue
cleanup structurally.

## Work Item

reaper-scope-regression (follow-up chain: KB autosync gap → mars event-mapping
bug → this propagation)

## Verification

- `uv run pytest-llm` — 1357 passed, 2 skipped
- End-to-end in this project: `meridian mars sync` with 0.10.6 emits
  `SessionEnd`; staged `run.sh` exit 0; both git-autosync instances green.

## Spawn Trace

- p5694 coder — mars-agents#129 fix (upstream)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
