### PR TITLE
Raise spawn-prompt CLI subprocess hang-guard 3s→20s (unblock release preflight)

### DIFF
--- a/tests/integration/cli/test_spawn_prompt_input.py
+++ b/tests/integration/cli/test_spawn_prompt_input.py
@@ -13,6 +13,8 @@ import pytest
 from tests.conftest import posix_only
 from tests.support.executables import prepend_fake_executables
 
+_CLI_HANG_GUARD_S = 20
+
 
 @pytest.mark.integration
 @posix_only
@@ -57,7 +59,7 @@ def test_spawn_with_reference_does_not_read_silent_open_stdin(
         stderr=subprocess.DEVNULL,
     )
     try:
-        return_code = process.wait(timeout=3)
+        return_code = process.wait(timeout=_CLI_HANG_GUARD_S)
     finally:
         if process.poll() is None:
             process.kill()
@@ -107,7 +109,7 @@ def test_spawn_prompt_file_stdin_reaches_dry_run_prompt(
         env=env,
         input=prompt,
         capture_output=True,
-        timeout=3,
+        timeout=_CLI_HANG_GUARD_S,
         check=False,
     )
 
@@ -148,7 +150,7 @@ def test_spawn_rejects_subcommand_shaped_prompts_and_suggests_transposition(
         env=env,
         text=True,
         capture_output=True,
-        timeout=3,
+        timeout=_CLI_HANG_GUARD_S,
         check=False,
     )
     typo = subprocess.run(
@@ -157,7 +159,7 @@ def test_spawn_rejects_subcommand_shaped_prompts_and_suggests_transposition(
         env=env,
         text=True,
         capture_output=True,
-        timeout=3,
+        timeout=_CLI_HANG_GUARD_S,
         check=False,
     )
     explicit_prompt = subprocess.run(
@@ -176,7 +178,7 @@ def test_spawn_rejects_subcommand_shaped_prompts_and_suggests_transposition(
         env=env,
         text=True,
         capture_output=True,
-        timeout=3,
+        timeout=_CLI_HANG_GUARD_S,
         check=False,
     )
 
@@ -228,7 +230,7 @@ def test_spawn_accepts_positional_prompt_that_does_not_match_subcommand_shape(
         env=env,
         text=True,
         capture_output=True,
-        timeout=3,
+        timeout=_CLI_HANG_GUARD_S,
         check=False,
     )
 


### PR DESCRIPTION
## What

Raise the 6 subprocess hang-guard timeouts in
`tests/integration/cli/test_spawn_prompt_input.py` from `3s` to a named
`_CLI_HANG_GUARD_S = 20`.

## Why

These tests spawn a cold `python -m meridian --harness codex …` subprocess,
which takes ~3s just to boot (CLI import + Mars harness validation) — right at
the old 3s ceiling, with no margin. On the `release-on-main` preflight
(`maxfail=1`) this reliably flaked with `subprocess.TimeoutExpired`, aborting
the **v0.3.50** release across two attempts. Different sub-invocations timed
out each run, confirming a marginal ceiling rather than a real defect.

The timeout is a **hang-guard**, not a startup-speed assertion: `subprocess`
returns the instant the process finishes, so a generous ceiling costs nothing
on passing runs and only ever applies to a genuinely stuck process. codex
cold-start only grows over time, so 20s (~6× current) removes the flake with
years of headroom while still catching a real hang quickly.

## Scope

Test-only. No product code changed. Not a regression from any specific PR —
pre-existing fragility that #469's release surfaced.

## Testing

- `ruff` clean; `pyright` 0 errors.
- `test_spawn_prompt_input.py` — 4 passed, run repeatedly, no flake.

## Release

`release:patch` — unblocks the v0.3.50 auto-release (which promotes the
already-staged `[Unreleased]` #113 entries plus this fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)