### PR TITLE
Triage batch (final 3): params.json bind refresh (#334), Claude transcript resolution (#171), codex backend-death diagnostics (#449)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- `session log`/`search`/`export`/`repair` on tracked Claude sessions now
+  find transcripts by searching the session's recorded config dir, then
+  canonical `~/.claude`, then ambient `CLAUDE_CONFIG_DIR` — instead of
+  ambient-only. Works across bare session id, chat id, and spawn id refs.
+  Untracked lookups unchanged. (#171)
+
 ## [0.3.47] - 2026-07-23
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Codex backend death mid-turn now records the exit code and a stderr
+  excerpt in the terminal error instead of generic transport text
+  ("no close frame received or sent"). Exactly one close event is emitted
+  even when the exit watcher and socket reader race, and expected shutdown
+  never reports backend death. Teardown failures can no longer leave event
+  consumers hanging without a stream sentinel. (#449)
+- Reaper diagnostics for managed backends now report PGID reachability
+  alongside root-PID aliveness. A launcher-shim root exiting no longer reads
+  as "backend dead" while a reparented child serves on. Diagnostic signal
+  only — no kill/finalize decision changes. (#449)
+
 ## [0.3.47] - 2026-07-23
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- `params.json` now refreshes after bind with the spawn's actual work/task
+  dirs (`phase: "bound"`, `bound_work_dir`, `bound_task_dir`). Ambient child
+  spawns previously showed the parent's work dir forever. Pre-bind crashes
+  leave the file honestly marked `phase: "request"`. (#334)
+
 ## [0.3.47] - 2026-07-23
 
 ### Removed

--- a/src/meridian/lib/harness/adapter.py
+++ b/src/meridian/lib/harness/adapter.py
@@ -442,7 +442,13 @@ class SubprocessHarness(HarnessAdapter[ResolvedLaunchSpec], Protocol):
 
     def extract_report(self, artifacts: ArtifactStore, spawn_id: SpawnId) -> str | None: ...
 
-    def resolve_session_file(self, *, project_root: Path, session_id: str) -> Path | None: ...
+    def resolve_session_file(
+        self,
+        *,
+        project_root: Path,
+        session_id: str,
+        config_root_hint: Path | None = None,
+    ) -> Path | None: ...
 
     def seed_session(
         self,
@@ -721,6 +727,12 @@ class BaseHarnessAdapter(Generic[SpecT], ABC):
         _ = artifacts, spawn_id
         return None
 
-    def resolve_session_file(self, *, project_root: Path, session_id: str) -> Path | None:
-        _ = project_root, session_id
+    def resolve_session_file(
+        self,
+        *,
+        project_root: Path,
+        session_id: str,
+        config_root_hint: Path | None = None,
+    ) -> Path | None:
+        _ = project_root, session_id, config_root_hint
         return None

--- a/src/meridian/lib/harness/claude.py
+++ b/src/meridian/lib/harness/claude.py
@@ -579,11 +579,17 @@ class ClaudeAdapter(BaseHarnessAdapter[ResolvedLaunchSpec]):
         )
         return reconciled or normalized_current
 
-    def resolve_session_file(self, *, project_root: Path, session_id: str) -> Path | None:
+    def resolve_session_file(
+        self,
+        *,
+        project_root: Path,
+        session_id: str,
+        config_root_hint: Path | None = None,
+    ) -> Path | None:
         normalized_session_id = session_id.strip()
         if not normalized_session_id:
             return None
-        for project_dir in _candidate_claude_project_dirs(project_root):
+        for project_dir in _candidate_claude_project_dirs(project_root, config_root_hint):
             candidate = project_dir / f"{normalized_session_id}.jsonl"
             if candidate.is_file():
                 return candidate

--- a/src/meridian/lib/harness/claude_preflight.py
+++ b/src/meridian/lib/harness/claude_preflight.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+# pyright: reportPrivateUsage=false
 import json
 import os
 import shutil

--- a/src/meridian/lib/harness/claude_preflight.py
+++ b/src/meridian/lib/harness/claude_preflight.py
@@ -11,7 +11,7 @@ from typing import cast
 
 import structlog
 
-from meridian.lib.harness.claude_sessions import project_slug
+from meridian.lib.harness.claude_sessions import _dedupe_roots, project_slug
 from meridian.lib.launch.launch_types import PreflightResult
 from meridian.lib.launch.text_utils import dedupe_nonempty
 from meridian.lib.platform import IS_WINDOWS, get_home_path
@@ -35,20 +35,6 @@ def _claude_config_root() -> Path:
     if configured:
         return Path(configured).expanduser().resolve()
     return _default_canonical_claude_config_root()
-
-
-def _dedupe_roots(*roots: Path | None) -> tuple[Path, ...]:
-    unique_roots: list[Path] = []
-    seen: set[Path] = set()
-    for root in roots:
-        if root is None:
-            continue
-        resolved = root.resolve()
-        if resolved in seen:
-            continue
-        seen.add(resolved)
-        unique_roots.append(root)
-    return tuple(unique_roots)
 
 
 def _resolve_source_session_file(

--- a/src/meridian/lib/harness/claude_sessions.py
+++ b/src/meridian/lib/harness/claude_sessions.py
@@ -38,9 +38,34 @@ def _claude_project_dir(project_root: Path) -> Path:
     return _claude_projects_root() / project_slug(project_root)
 
 
-def candidate_claude_project_dirs(project_root: Path) -> list[Path]:
-    """Return the exact Claude project directory for this project root."""
-    return [_claude_projects_root() / project_slug(project_root)]
+def _dedupe_roots(*roots: Path | None) -> tuple[Path, ...]:
+    unique_roots: list[Path] = []
+    seen: set[Path] = set()
+    for root in roots:
+        if root is None:
+            continue
+        resolved = root.resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        unique_roots.append(root)
+    return tuple(unique_roots)
+
+
+def candidate_claude_project_dirs(
+    project_root: Path,
+    config_root_hint: Path | None = None,
+) -> list[Path]:
+    """Return Claude project directories ordered by transcript lookup trust."""
+    slug = project_slug(project_root)
+    if config_root_hint is None:
+        return [_claude_config_root() / "projects" / slug]
+    roots = _dedupe_roots(
+        config_root_hint,
+        get_home_path() / ".claude",
+        _claude_config_root(),
+    )
+    return [root / "projects" / slug for root in roots]
 
 
 def _read_claude_session_id(path: Path) -> str | None:
@@ -322,4 +347,3 @@ def detect_primary_session_id(
     except OSError:
         logger.debug("Failed to verify Claude session file", exc_info=True)
     return None
-

--- a/src/meridian/lib/harness/codex.py
+++ b/src/meridian/lib/harness/codex.py
@@ -423,8 +423,14 @@ class CodexAdapter(BaseHarnessAdapter[ResolvedLaunchSpec]):
         _ = started_at_local_iso, expected_session_id
         return _detect_primary_session_id(project_root, started_at_epoch)
 
-    def resolve_session_file(self, *, project_root: Path, session_id: str) -> Path | None:
-        _ = project_root
+    def resolve_session_file(
+        self,
+        *,
+        project_root: Path,
+        session_id: str,
+        config_root_hint: Path | None = None,
+    ) -> Path | None:
+        _ = project_root, config_root_hint
         normalized_session_id = session_id.strip()
         if not normalized_session_id:
             return None

--- a/src/meridian/lib/harness/connections/codex_ws.py
+++ b/src/meridian/lib/harness/connections/codex_ws.py
@@ -902,57 +902,101 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
             self._event_stream_ended = True
 
     async def _cleanup_resources(self, *, mark_stopped: bool) -> None:
-        if self._backend_exit_task is not None:
-            self._backend_exit_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError, Exception):
-                await self._backend_exit_task
-            self._backend_exit_task = None
+        try:
+            if self._backend_exit_task is not None:
+                self._backend_exit_task.cancel()
+                try:
+                    await self._backend_exit_task
+                except asyncio.CancelledError:
+                    pass
+                except Exception:
+                    logger.warning("Codex backend-exit watcher cleanup failed", exc_info=True)
+                self._backend_exit_task = None
 
-        await self._close_ws()
+            await self._close_ws()
 
-        if self._reader_task is not None:
-            self._reader_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError, Exception):
-                await self._reader_task
-            self._reader_task = None
+            if self._reader_task is not None:
+                self._reader_task.cancel()
+                try:
+                    await self._reader_task
+                except asyncio.CancelledError:
+                    pass
+                except Exception:
+                    logger.warning("Codex websocket reader cleanup failed", exc_info=True)
+                self._reader_task = None
 
-        scope_handle = self._scope_handle
-        self._scope_handle = None
-        process = self._process
-        self._process = None
+            scope_handle = self._scope_handle
+            self._scope_handle = None
+            process = self._process
+            self._process = None
 
-        if scope_handle is not None and process is not None and process.returncode is None:
-            await scope_handle.terminate(
-                grace_seconds=_STOP_WAIT_TIMEOUT_SECONDS,
-                reason="stop_called",
-            )
-        elif process is not None and process.returncode is None:
-            # Legacy fallback when scope handle was never created (e.g. start()
-            # failed before subprocess was launched).
-            process.terminate()
+            if scope_handle is not None and process is not None and process.returncode is None:
+                try:
+                    await scope_handle.terminate(
+                        grace_seconds=_STOP_WAIT_TIMEOUT_SECONDS,
+                        reason="stop_called",
+                    )
+                except Exception:
+                    logger.warning("Codex process-scope cleanup failed", exc_info=True)
+            elif process is not None and process.returncode is None:
+                # Legacy fallback when scope registration did not complete.
+                try:
+                    process.terminate()
+                    try:
+                        await asyncio.wait_for(
+                            process.wait(),
+                            timeout=_STOP_WAIT_TIMEOUT_SECONDS,
+                        )
+                    except TimeoutError:
+                        process.kill()
+                        await process.wait()
+                except Exception:
+                    logger.warning("Codex subprocess cleanup failed", exc_info=True)
+
+            parent_death_link = self._parent_death_link
+            self._parent_death_link = None
             try:
-                await asyncio.wait_for(process.wait(), timeout=_STOP_WAIT_TIMEOUT_SECONDS)
-            except TimeoutError:
-                process.kill()
-                await process.wait()
+                await asyncio.to_thread(
+                    release_parent_death_link,
+                    parent_death_link,
+                )
+            except Exception:
+                logger.warning("Codex parent-death link cleanup failed", exc_info=True)
 
-        await asyncio.to_thread(release_parent_death_link, self._parent_death_link)
-        self._parent_death_link = None
-        self._fail_pending_requests(RuntimeError("Codex connection stopped"))
-        await self._clear_stale_hitl_requests(reason="connection_stopped")
-        self._clear_turn_liveness_signals()
-        self._thread_id = None
-        self._cancel_requested = False
-        self._signal_in_flight = False
-        self._liveness.signal_request_resolved("cancel")
-        self._launch_spec = None
-        self._codex_home = None
-        self._startup_emitter = None
-        self._close_log_handles()
+            try:
+                self._fail_pending_requests(RuntimeError("Codex connection stopped"))
+            except Exception:
+                logger.warning("Codex pending-request cleanup failed", exc_info=True)
+            try:
+                await self._clear_stale_hitl_requests(reason="connection_stopped")
+            except Exception:
+                logger.warning("Codex HITL request cleanup failed", exc_info=True)
+            try:
+                self._clear_turn_liveness_signals()
+                self._liveness.signal_request_resolved("cancel")
+            except Exception:
+                logger.warning("Codex liveness cleanup failed", exc_info=True)
 
-        if mark_stopped:
-            self._transition("stopped")
-            await self._emit_connection_closed_once(None)
+            self._thread_id = None
+            self._cancel_requested = False
+            self._signal_in_flight = False
+            self._launch_spec = None
+            self._codex_home = None
+            self._startup_emitter = None
+            self._close_log_handles()
+        except Exception:
+            # Last-resort containment for cleanup state added in the future.
+            # Known teardown operations above are isolated individually so one
+            # failure does not skip the remaining cleanup steps.
+            logger.warning("Codex resource cleanup failed", exc_info=True)
+        finally:
+            if mark_stopped:
+                try:
+                    self._transition("stopped")
+                except Exception:
+                    logger.warning("Codex final state normalization failed", exc_info=True)
+                    self._state = "stopped"
+                await self._emit_connection_closed_once(None)
 
     async def _close_ws(self) -> None:
         ws = self._ws
@@ -960,8 +1004,10 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
             return
 
         self._ws = None
-        with contextlib.suppress(Exception):
+        try:
             await ws.close()
+        except Exception:
+            logger.warning("Codex websocket close failed", exc_info=True)
 
     async def _send_json(self, payload: dict[str, object]) -> None:
         ws = self._ws
@@ -1194,11 +1240,15 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
                 future.set_exception(error)
 
     def _close_log_handles(self) -> None:
-        if self._stderr_handle is not None:
-            self._stderr_handle.close()
-            self._stderr_handle = None
+        stderr_handle = self._stderr_handle
+        self._stderr_handle = None
         self._stderr_log_path = None
         self._stderr_read_offset = 0
+        if stderr_handle is not None:
+            try:
+                stderr_handle.close()
+            except Exception:
+                logger.warning("Codex stderr log cleanup failed", exc_info=True)
 
     def _startup_exit_exception(self) -> Exception:
         process = self._process

--- a/src/meridian/lib/harness/connections/codex_ws.py
+++ b/src/meridian/lib/harness/connections/codex_ws.py
@@ -85,7 +85,8 @@ from meridian.lib.state.paths import resolve_project_runtime_root_for_write, res
 _DEFAULT_CONNECT_TIMEOUT_SECONDS = 30.0
 _DEFAULT_REQUEST_TIMEOUT_SECONDS = 30.0
 _STOP_WAIT_TIMEOUT_SECONDS = 5.0
-_STARTUP_STDERR_MAX_BYTES = 16 * 1024
+_PROCESS_EXIT_DIAGNOSTIC_WAIT_SECONDS = 0.1
+_STDERR_EXCERPT_MAX_BYTES = 16 * 1024
 _ADDRESS_IN_USE_MARKERS: Final[tuple[str, ...]] = (
     "address already in use",
     "address in use",
@@ -217,8 +218,10 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
         self._process: Process | None = None
         self._ws: Any | None = None
         self._reader_task: asyncio.Task[None] | None = None
+        self._backend_exit_task: asyncio.Task[None] | None = None
         self._send_lock = asyncio.Lock()
         self._stop_lock = asyncio.Lock()
+        self._terminal_lock = asyncio.Lock()
         self._stderr_handle: BufferedWriter | None = None
         self._stderr_log_path: Path | None = None
         self._stderr_read_offset = 0
@@ -244,6 +247,7 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
         self._signal_in_flight = False
         self._primary_observer_mode = False
         self._startup_emitter: StartupPhaseEmitter | None = None
+        self._event_stream_ended = False
 
     @property
     def state(self) -> ConnectionState:
@@ -360,6 +364,7 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
         self._pending_requests = {}
         self._hitl_requests = {}
         self._event_queue = asyncio.Queue()
+        self._event_stream_ended = False
         self._current_turn_id = None
         self._thread_id = None
         self._liveness.reset()
@@ -413,6 +418,7 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
                 ws_url,
                 timeout_seconds=self._connect_timeout(),
             )
+            self._backend_exit_task = asyncio.create_task(self._watch_backend_exit())
             self._reader_task = asyncio.create_task(self._read_messages_loop())
 
             await self._request(
@@ -739,17 +745,7 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
                         f"{self._LIVENESS_TIMEOUT_SECONDS:.1f}s without events"
                     )
                     logger.warning(message)
-                    if self._state in {"starting", "connected"}:
-                        self._emit_startup_phase(StartupPhase.HARNESS_FAILED)
-                        self._transition("failed")
-                        await self._event_queue.put(
-                            RawHarnessEvent(
-                                event_type="meridian/error/connectionClosed",
-                                payload={"message": message},
-                                harness_id=self.harness_id.value,
-                                raw_text=None,
-                            )
-                        )
+                    await self._emit_connection_closed_once({"message": message})
                     return
                 except Exception as exc:
                     if _is_clean_websocket_close(exc):
@@ -812,22 +808,106 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
                 )
         except Exception as exc:
             if self._state in {"starting", "connected"}:
-                self._emit_startup_phase(StartupPhase.HARNESS_FAILED)
-                self._transition("failed")
-                await self._event_queue.put(
-                    RawHarnessEvent(
-                        event_type="meridian/error/connectionClosed",
-                        payload={"message": str(exc)},
-                        harness_id=self.harness_id.value,
-                        raw_text=None,
+                await self._emit_connection_closed_once(
+                    await self._connection_closed_payload(
+                        str(exc),
+                        wait_for_process=True,
                     )
                 )
         finally:
             self._fail_pending_requests(RuntimeError("Codex websocket closed"))
             await self._clear_stale_hitl_requests(reason="websocket_closed")
+            if not self._event_stream_ended:
+                payload = await self._connection_closed_payload(
+                    "Codex websocket closed",
+                    wait_for_process=True,
+                )
+                await self._emit_connection_closed_once(
+                    payload if "backend_exit_code" in payload else None
+                )
+
+    async def _watch_backend_exit(self) -> None:
+        process = self._process
+        if process is None:
+            return
+        try:
+            return_code = await process.wait()
+            if self._state not in {"starting", "connected"}:
+                return
+            await self._emit_connection_closed_once(
+                self._backend_exit_payload(return_code)
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning("Codex backend-exit watcher failed", exc_info=True)
+
+    async def _connection_closed_payload(
+        self,
+        message: str,
+        *,
+        wait_for_process: bool,
+    ) -> dict[str, object]:
+        process = self._process
+        if wait_for_process and process is not None and process.returncode is None:
+            with contextlib.suppress(TimeoutError, Exception):
+                await asyncio.wait_for(
+                    asyncio.shield(process.wait()),
+                    timeout=_PROCESS_EXIT_DIAGNOSTIC_WAIT_SECONDS,
+                )
+        return_code = process.returncode if process is not None else None
+        if return_code is None:
+            return {"message": message}
+        return self._backend_exit_payload(return_code)
+
+    def _backend_exit_payload(self, return_code: int) -> dict[str, object]:
+        stderr_excerpt = self._read_stderr_excerpt()
+        detail = f"Codex app-server exited with code {return_code}."
+        if stderr_excerpt:
+            detail = f"{detail}\n\nCodex app-server stderr:\n{stderr_excerpt}"
+        return {
+            "message": detail,
+            "backend_exit_code": return_code,
+            "backend_stderr_excerpt": stderr_excerpt,
+        }
+
+    async def _emit_connection_closed_once(
+        self,
+        payload: dict[str, object] | None,
+    ) -> None:
+        """Emit at most one close event and terminate the event stream once.
+
+        ``None`` is the clean/expected-shutdown path. Shutdown changes state
+        before cleanup, so a racing watcher cannot report intentional process
+        termination as backend death.
+        """
+
+        async with self._terminal_lock:
+            if self._event_stream_ended:
+                return
+            if payload is not None and self._state in {"starting", "connected"}:
+                self._emit_startup_phase(StartupPhase.HARNESS_FAILED)
+                self._transition("failed")
+                message = str(payload.get("message") or "Codex connection closed")
+                self._fail_pending_requests(RuntimeError(message))
+                await self._event_queue.put(
+                    RawHarnessEvent(
+                        event_type="meridian/error/connectionClosed",
+                        payload=payload,
+                        harness_id=self.harness_id.value,
+                        raw_text=None,
+                    )
+                )
             await self._event_queue.put(None)
+            self._event_stream_ended = True
 
     async def _cleanup_resources(self, *, mark_stopped: bool) -> None:
+        if self._backend_exit_task is not None:
+            self._backend_exit_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await self._backend_exit_task
+            self._backend_exit_task = None
+
         await self._close_ws()
 
         if self._reader_task is not None:
@@ -872,7 +952,7 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
 
         if mark_stopped:
             self._transition("stopped")
-            await self._event_queue.put(None)
+            await self._emit_connection_closed_once(None)
 
     async def _close_ws(self) -> None:
         ws = self._ws
@@ -1123,7 +1203,7 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
     def _startup_exit_exception(self) -> Exception:
         process = self._process
         exit_code = process.returncode if process is not None else None
-        stderr_excerpt = self._read_startup_stderr_excerpt()
+        stderr_excerpt = self._read_stderr_excerpt()
         if _looks_like_address_in_use(stderr_excerpt):
             return PortBindError(
                 "Codex app-server failed to bind websocket port "
@@ -1136,22 +1216,26 @@ class CodexConnection(HarnessConnection[ResolvedLaunchSpec]):
             )
         return RuntimeError(f"Codex app-server exited before websocket connect (exit={exit_code})")
 
-    def _read_startup_stderr_excerpt(self) -> str:
+    def _read_stderr_excerpt(self) -> str:
         stderr_handle = self._stderr_handle
         if stderr_handle is not None:
-            stderr_handle.flush()
+            with contextlib.suppress(OSError, ValueError):
+                stderr_handle.flush()
 
         path = self._stderr_log_path
-        if path is None or not path.exists():
+        if path is None:
             return ""
 
-        with path.open("rb") as handle:
-            handle.seek(0, os.SEEK_END)
-            end_offset = handle.tell()
-            start_offset = min(self._stderr_read_offset, end_offset)
-            read_offset = max(start_offset, end_offset - _STARTUP_STDERR_MAX_BYTES)
-            handle.seek(read_offset, os.SEEK_SET)
-            data = handle.read(max(0, end_offset - read_offset))
+        try:
+            with path.open("rb") as handle:
+                handle.seek(0, os.SEEK_END)
+                end_offset = handle.tell()
+                start_offset = min(self._stderr_read_offset, end_offset)
+                read_offset = max(start_offset, end_offset - _STDERR_EXCERPT_MAX_BYTES)
+                handle.seek(read_offset, os.SEEK_SET)
+                data = handle.read(max(0, end_offset - read_offset))
+        except OSError:
+            return ""
         return data.decode("utf-8", errors="replace").strip()
 
     def _resident_backend_dead(self) -> bool:

--- a/src/meridian/lib/harness/opencode.py
+++ b/src/meridian/lib/harness/opencode.py
@@ -535,8 +535,14 @@ class OpenCodeAdapter(BaseHarnessAdapter[ResolvedLaunchSpec]):
         )
         return _detect_primary_session_id(project_root, started_at_epoch, local_iso)
 
-    def resolve_session_file(self, *, project_root: Path, session_id: str) -> Path | None:
-        _ = project_root
+    def resolve_session_file(
+        self,
+        *,
+        project_root: Path,
+        session_id: str,
+        config_root_hint: Path | None = None,
+    ) -> Path | None:
+        _ = project_root, config_root_hint
         return resolve_opencode_session_file(session_id=session_id)
 
     def extract_session_id(self, artifacts: ArtifactStore, spawn_id: SpawnId) -> str | None:

--- a/src/meridian/lib/harness/pi.py
+++ b/src/meridian/lib/harness/pi.py
@@ -343,8 +343,14 @@ class PiAdapter(BaseHarnessAdapter[ResolvedLaunchSpec]):
     def extract_report(self, artifacts: ArtifactStore, spawn_id: SpawnId) -> str | None:
         return PI_EXTRACTOR.extract_report(artifacts, spawn_id)
 
-    def resolve_session_file(self, *, project_root: Path, session_id: str) -> Path | None:
-        _ = project_root  # pi sessions are user-scoped, not project-scoped
+    def resolve_session_file(
+        self,
+        *,
+        project_root: Path,
+        session_id: str,
+        config_root_hint: Path | None = None,
+    ) -> Path | None:
+        _ = project_root, config_root_hint  # pi sessions are user-scoped
         normalized = session_id.strip()
         if not normalized:
             return None

--- a/src/meridian/lib/harness/semantics.py
+++ b/src/meridian/lib/harness/semantics.py
@@ -94,17 +94,6 @@ def connection_closed_outcome(
     """Build the shared outcome for a Meridian synthetic connection close."""
 
     error = stringify_terminal_error(event.payload.get("message")) or "connection_closed"
-    backend_exit_code = event.payload.get("backend_exit_code")
-    stderr_excerpt = stringify_terminal_error(
-        event.payload.get("backend_stderr_excerpt")
-    )
-    diagnostics: list[str] = []
-    if isinstance(backend_exit_code, int):
-        diagnostics.append(f"backend exit code: {backend_exit_code}")
-    if stderr_excerpt and stderr_excerpt not in error:
-        diagnostics.append(f"backend stderr:\n{stderr_excerpt}")
-    if diagnostics:
-        error = f"{error}\n\n" + "\n\n".join(diagnostics)
     return TerminalEventOutcome(status=SpawnStatus.FAILED, exit_code=1, error=error, cause=cause)
 
 

--- a/src/meridian/lib/harness/semantics.py
+++ b/src/meridian/lib/harness/semantics.py
@@ -94,6 +94,17 @@ def connection_closed_outcome(
     """Build the shared outcome for a Meridian synthetic connection close."""
 
     error = stringify_terminal_error(event.payload.get("message")) or "connection_closed"
+    backend_exit_code = event.payload.get("backend_exit_code")
+    stderr_excerpt = stringify_terminal_error(
+        event.payload.get("backend_stderr_excerpt")
+    )
+    diagnostics: list[str] = []
+    if isinstance(backend_exit_code, int):
+        diagnostics.append(f"backend exit code: {backend_exit_code}")
+    if stderr_excerpt and stderr_excerpt not in error:
+        diagnostics.append(f"backend stderr:\n{stderr_excerpt}")
+    if diagnostics:
+        error = f"{error}\n\n" + "\n\n".join(diagnostics)
     return TerminalEventOutcome(status=SpawnStatus.FAILED, exit_code=1, error=error, cause=cause)
 
 

--- a/src/meridian/lib/ops/session_repair_target.py
+++ b/src/meridian/lib/ops/session_repair_target.py
@@ -8,6 +8,7 @@ from typing import NamedTuple
 
 from meridian.lib.harness.session_detection import infer_harness_from_untracked_session_ref
 from meridian.lib.ops.session_target import (
+    _config_root_hint,
     _detect_primary_session_id,
     _is_chat_ref,
     _is_spawn_ref,
@@ -33,6 +34,7 @@ def _repair_target_from_detected_session_id(
     project_root: Path,
     harness: str | None,
     detected_session_id: str,
+    config_root_hint: Path | None,
     invalid_reason: str,
     unavailable_reason: str,
 ) -> SessionRepairTarget:
@@ -47,6 +49,7 @@ def _repair_target_from_detected_session_id(
         project_root=project_root,
         session_id=detected_session_id,
         harness=harness,
+        config_root_hint=config_root_hint,
     )
     if transcript_target is not None:
         return SessionRepairTarget(
@@ -59,9 +62,6 @@ def _repair_target_from_detected_session_id(
         source=f"{harness or 'primary'} detected session id",
         reason=unavailable_reason,
     )
-
-
-
 
 def _resolve_repair_from_chat_id(
     *,
@@ -77,6 +77,10 @@ def _resolve_repair_from_chat_id(
     harness = session_record.harness.strip() or None
     if harness is None and primary_spawn is not None:
         harness = (primary_spawn.harness or "").strip() or None
+    config_root_hint = _config_root_hint(
+        session_record.claude_config_dir
+        or (primary_spawn.claude_config_dir if primary_spawn is not None else None)
+    )
 
     transcript_target = _resolve_transcript_from_candidates(
         project_root=project_root,
@@ -89,6 +93,7 @@ def _resolve_repair_from_chat_id(
                 else None
             ),
         ],
+        config_root_hint=config_root_hint,
     )
     if transcript_target is not None:
         return SessionRepairTarget(
@@ -107,6 +112,7 @@ def _resolve_repair_from_chat_id(
             project_root=project_root,
             harness=harness,
             detected_session_id=detected_session_id,
+            config_root_hint=config_root_hint,
             invalid_reason=(
                 f"Detected session id '{detected_session_id}' for chat '{chat_id}' "
                 "looks like a spawn id; refusing repair."
@@ -135,11 +141,13 @@ def _resolve_repair_from_spawn_id(
         raise ValueError(f"Spawn '{spawn_id}' not found")
 
     harness = (row.harness or "").strip() or None
+    config_root_hint = _config_root_hint(row.claude_config_dir)
     row_session_id = (row.harness_session_id or "").strip()
     transcript_target = _resolve_transcript_from_candidates(
         project_root=project_root,
         harness=harness,
         candidate_ids=[row_session_id if not _is_spawn_ref(row_session_id) else None],
+        config_root_hint=config_root_hint,
     )
     if transcript_target is not None:
         return SessionRepairTarget(
@@ -162,10 +170,13 @@ def _resolve_repair_from_spawn_id(
         if chat_record is not None:
             if harness is None:
                 harness = chat_record.harness.strip() or None
+            if config_root_hint is None:
+                config_root_hint = _config_root_hint(chat_record.claude_config_dir)
             transcript_target = _resolve_transcript_from_candidates(
                 project_root=project_root,
                 harness=harness,
                 candidate_ids=[_latest_harness_session_id(chat_record)],
+                config_root_hint=config_root_hint,
             )
             if transcript_target is not None:
                 return SessionRepairTarget(
@@ -183,6 +194,7 @@ def _resolve_repair_from_spawn_id(
                 else None
             )
         ],
+        config_root_hint=config_root_hint,
     )
     if transcript_target is not None:
         return SessionRepairTarget(
@@ -210,6 +222,7 @@ def _resolve_repair_from_spawn_id(
         project_root=project_root,
         harness=harness,
         detected_session_id=detected_session_id,
+        config_root_hint=config_root_hint,
         invalid_reason=(
             f"Detected session id '{detected_session_id}' for spawn "
             f"'{spawn_id}' looks like a spawn id; refusing repair."
@@ -232,6 +245,7 @@ def _resolve_repair_from_session_ref(
         project_root=project_root,
         session_id=session_ref,
         harness=harness,
+        config_root_hint=None,
     )
     if transcript_target is not None:
         return SessionRepairTarget(

--- a/src/meridian/lib/ops/session_target.py
+++ b/src/meridian/lib/ops/session_target.py
@@ -175,7 +175,7 @@ def _resolve_harness_session_file(
     project_root: Path,
     session_id: str,
     harness: str | None,
-    config_root_hint: Path | None,
+    config_root_hint: Path | None = None,
 ) -> SessionLogTarget:
     normalized_session_id = session_id.strip()
     if not normalized_session_id:
@@ -250,7 +250,7 @@ def _resolve_harness_transcript_target_or_none(
     project_root: Path,
     session_id: str,
     harness: str | None,
-    config_root_hint: Path | None,
+    config_root_hint: Path | None = None,
 ) -> SessionLogTarget | None:
     try:
         return _resolve_harness_session_file(
@@ -565,7 +565,7 @@ def _resolve_transcript_from_candidates(
     project_root: Path,
     harness: str | None,
     candidate_ids: list[str | None],
-    config_root_hint: Path | None,
+    config_root_hint: Path | None = None,
 ) -> SessionLogTarget | None:
     seen: set[str] = set()
     for candidate_id in candidate_ids:

--- a/src/meridian/lib/ops/session_target.py
+++ b/src/meridian/lib/ops/session_target.py
@@ -139,10 +139,12 @@ def _resolve_adapter_file_target(
     session_id: str,
     harness_id: HarnessId,
     adapter: SubprocessHarness,
+    config_root_hint: Path | None,
 ) -> SessionLogTarget | None:
     candidate = adapter.resolve_session_file(
         project_root=project_root,
         session_id=session_id,
+        config_root_hint=config_root_hint,
     )
     if candidate is None or not candidate.is_file():
         return None
@@ -173,6 +175,7 @@ def _resolve_harness_session_file(
     project_root: Path,
     session_id: str,
     harness: str | None,
+    config_root_hint: Path | None,
 ) -> SessionLogTarget:
     normalized_session_id = session_id.strip()
     if not normalized_session_id:
@@ -195,6 +198,7 @@ def _resolve_harness_session_file(
             session_id=normalized_session_id,
             harness_id=harness_id,
             adapter=adapter,
+            config_root_hint=config_root_hint,
         )
         if (
             harness_id == HarnessId.OPENCODE
@@ -222,6 +226,7 @@ def _resolve_harness_session_file(
             session_id=normalized_session_id,
             harness_id=harness_id,
             adapter=adapter,
+            config_root_hint=config_root_hint,
         )
         if (
             harness_id == HarnessId.OPENCODE
@@ -245,12 +250,14 @@ def _resolve_harness_transcript_target_or_none(
     project_root: Path,
     session_id: str,
     harness: str | None,
+    config_root_hint: Path | None,
 ) -> SessionLogTarget | None:
     try:
         return _resolve_harness_session_file(
             project_root=project_root,
             session_id=session_id,
             harness=harness,
+            config_root_hint=config_root_hint,
         )
     except FileNotFoundError:
         return None
@@ -539,6 +546,11 @@ def _latest_harness_session_id(record: session_store.SessionRecord) -> str | Non
     return normalized or None
 
 
+def _config_root_hint(value: str | None) -> Path | None:
+    normalized = (value or "").strip()
+    return Path(normalized).expanduser() if normalized else None
+
+
 def _read_chat_session_record(
     runtime_root: Path, chat_id: str
 ) -> session_store.SessionRecord | None:
@@ -553,6 +565,7 @@ def _resolve_transcript_from_candidates(
     project_root: Path,
     harness: str | None,
     candidate_ids: list[str | None],
+    config_root_hint: Path | None,
 ) -> SessionLogTarget | None:
     seen: set[str] = set()
     for candidate_id in candidate_ids:
@@ -564,6 +577,7 @@ def _resolve_transcript_from_candidates(
             project_root=project_root,
             session_id=normalized_candidate_id,
             harness=harness,
+            config_root_hint=config_root_hint,
         )
         if transcript_target is not None:
             return transcript_target
@@ -644,6 +658,10 @@ def _resolve_from_chat_id(
     normalized_harness = session_record.harness.strip() or None
     if normalized_harness is None and primary_spawn is not None and primary_spawn.harness:
         normalized_harness = primary_spawn.harness.strip() or None
+    config_root_hint = _config_root_hint(
+        session_record.claude_config_dir
+        or (primary_spawn.claude_config_dir if primary_spawn is not None else None)
+    )
 
     output_target = _running_managed_primary_output_target(
         runtime_root,
@@ -682,6 +700,7 @@ def _resolve_from_chat_id(
         project_root=project_root,
         harness=normalized_harness,
         candidate_ids=[normalized_session_id],
+        config_root_hint=config_root_hint,
     )
     if transcript_target is not None:
         output_target = _spawn_history_fallback_for_chat_ref(
@@ -703,6 +722,7 @@ def _resolve_from_chat_id(
             project_root=project_root,
             harness=normalized_harness,
             candidate_ids=[detected_session_id],
+            config_root_hint=config_root_hint,
         )
         if transcript_target is not None:
             output_target = _spawn_history_fallback_for_chat_ref(
@@ -727,6 +747,7 @@ def _resolve_from_chat_id(
         project_root=project_root,
         session_id=normalized_session_id,
         harness=normalized_harness,
+        config_root_hint=config_root_hint,
     )
 
 
@@ -782,6 +803,7 @@ def _resolve_from_spawn_id(
 
     session_id = (row.harness_session_id or "").strip()
     harness = (row.harness or "").strip() or None
+    config_root_hint = _config_root_hint(row.claude_config_dir)
 
     if not session_id and is_primary_spawn:
         primary_meta_session_id = read_primary_harness_session_id(runtime_root, spawn_id)
@@ -826,6 +848,8 @@ def _resolve_from_spawn_id(
                 session_id = (record.harness_session_id or "").strip()
                 if record.harness.strip():
                     harness = record.harness.strip()
+                if config_root_hint is None:
+                    config_root_hint = _config_root_hint(record.claude_config_dir)
             if not session_id:
                 raise ValueError(
                     f"Spawn '{spawn_id}' has no transcript available yet "
@@ -841,11 +865,14 @@ def _resolve_from_spawn_id(
         record = session_store.resolve_session_ref(runtime_root, session_id)
         if record is not None and record.harness.strip():
             harness = record.harness.strip()
+        if record is not None and config_root_hint is None:
+            config_root_hint = _config_root_hint(record.claude_config_dir)
 
     transcript_target = _resolve_transcript_from_candidates(
         project_root=project_root,
         harness=harness,
         candidate_ids=[session_id],
+        config_root_hint=config_root_hint,
     )
     if transcript_target is not None:
         output_target = _resolved_spawn_output_fallback_target(
@@ -870,6 +897,7 @@ def _resolve_from_spawn_id(
                 project_root=project_root,
                 harness=harness,
                 candidate_ids=[detected_session_id],
+                config_root_hint=config_root_hint,
             )
             if transcript_target is not None:
                 output_target = _resolved_spawn_output_fallback_target(
@@ -896,6 +924,7 @@ def _resolve_from_spawn_id(
             project_root=project_root,
             session_id=session_id,
             harness=harness,
+            config_root_hint=config_root_hint,
         )
 
     output_target = _target_from_spawn_output(
@@ -910,6 +939,7 @@ def _resolve_from_spawn_id(
         project_root=project_root,
         session_id=session_id,
         harness=harness,
+        config_root_hint=config_root_hint,
     )
 
 
@@ -927,6 +957,7 @@ def _resolve_from_session_ref(
             project_root=project_root,
             session_id=session_id,
             harness=harness,
+            config_root_hint=_config_root_hint(record.claude_config_dir),
         )
         output_target = _spawn_history_fallback_for_session_ref(
             project_root=project_root,
@@ -953,6 +984,7 @@ def _resolve_untracked_session_ref(
         project_root=project_root,
         session_id=session_ref,
         harness=str(inferred) if inferred is not None else None,
+        config_root_hint=None,
     )
 
 

--- a/src/meridian/lib/ops/session_target.py
+++ b/src/meridian/lib/ops/session_target.py
@@ -175,7 +175,7 @@ def _resolve_harness_session_file(
     project_root: Path,
     session_id: str,
     harness: str | None,
-    config_root_hint: Path | None = None,
+    config_root_hint: Path | None,
 ) -> SessionLogTarget:
     normalized_session_id = session_id.strip()
     if not normalized_session_id:
@@ -250,7 +250,7 @@ def _resolve_harness_transcript_target_or_none(
     project_root: Path,
     session_id: str,
     harness: str | None,
-    config_root_hint: Path | None = None,
+    config_root_hint: Path | None,
 ) -> SessionLogTarget | None:
     try:
         return _resolve_harness_session_file(
@@ -565,7 +565,7 @@ def _resolve_transcript_from_candidates(
     project_root: Path,
     harness: str | None,
     candidate_ids: list[str | None],
-    config_root_hint: Path | None = None,
+    config_root_hint: Path | None,
 ) -> SessionLogTarget | None:
     seen: set[str] = set()
     for candidate_id in candidate_ids:

--- a/src/meridian/lib/ops/spawn/execute.py
+++ b/src/meridian/lib/ops/spawn/execute.py
@@ -45,6 +45,7 @@ from .execute_bg import (
 )
 from .execute_init import (
     _announce_reserved_spawn,
+    _build_params_request_metadata,
     _emit_subrun_event,
     _materialize_spawn_work_item,
     _reserve_spawn,
@@ -312,14 +313,17 @@ def execute_spawn_background(
         runtime_root=context.runtime_root,
     )
     log_dir.mkdir(parents=True, exist_ok=True)
+    request_metadata = _build_params_request_metadata(
+        request,
+        desc=payload.desc,
+        work_id=context.work_id,
+    )
     try:
         _write_params_json(
             project_paths,
             context.runtime_root,
             context.spawn.spawn_id,
-            request,
-            desc=payload.desc,
-            work_id=context.work_id,
+            request_metadata=request_metadata,
         )
     except Exception:
         logger.warning("Failed to write params.json", spawn_id=spawn_id_text, exc_info=True)
@@ -354,6 +358,7 @@ def execute_spawn_background(
             BackgroundWorkerLaunchRequest(
                 request=persisted_request,
                 runtime=launch_runtime,
+                request_metadata=request_metadata,
             ),
         )
     except Exception as exc:
@@ -563,14 +568,17 @@ def execute_spawn_blocking(
 
     try:
         execution_cwd_str = initial_execution_cwd
+        request_metadata = _build_params_request_metadata(
+            request,
+            desc=payload.desc,
+            work_id=context.work_id,
+        )
         try:
             _write_params_json(
                 project_paths,
                 context.runtime_root,
                 spawn.spawn_id,
-                request,
-                desc=payload.desc,
-                work_id=context.work_id,
+                request_metadata=request_metadata,
             )
         except Exception:
             logger.warning(
@@ -600,6 +608,7 @@ def execute_spawn_blocking(
                 project_paths=project_paths,
                 execution_cwd=execution_cwd_str,
                 work_id=context.work_id,
+                request_metadata=request_metadata,
                 stream_stdout_to_terminal=stream_stdout_to_terminal,
                 stream_stderr_to_terminal=payload.stream,
                 event_observer=event_observer,

--- a/src/meridian/lib/ops/spawn/execute_bg.py
+++ b/src/meridian/lib/ops/spawn/execute_bg.py
@@ -35,6 +35,7 @@ from meridian.lib.telemetry.init import setup_telemetry
 from meridian.lib.telemetry.observer import register_spawn_telemetry_observer
 
 from ..runtime import OperationRuntime, build_runtime, resolve_runtime_root, runtime_context
+from .execute_init import ParamsRequestMetadata
 from .execute_runner import launch_prepared_spawn
 from .failure_policy import finalize_launch_failure, finalize_launch_failure_sync
 
@@ -57,6 +58,7 @@ class BackgroundWorkerLaunchRequest(BaseModel):
 
     request: SpawnRequest
     runtime: LaunchRuntime
+    request_metadata: ParamsRequestMetadata
 
 
 def _resolve_background_execution_cwd(
@@ -281,6 +283,7 @@ async def _execute_existing_spawn(
         runtime=runtime,
         runtime_root=runtime_root,
         project_paths=project_paths,
+        request_metadata=launch_request.request_metadata,
         spawn_record=spawn_record,
         execution_cwd=resolved_execution_cwd,
         work_id=spawn_record.work_id,

--- a/src/meridian/lib/ops/spawn/execute_init.py
+++ b/src/meridian/lib/ops/spawn/execute_init.py
@@ -18,6 +18,7 @@ from meridian.lib.core.resolved_context import ResolvedContext
 from meridian.lib.core.sink import OutputSink
 from meridian.lib.core.spawn_lifecycle import SpawnReservation
 from meridian.lib.core.types import ModelId, SpawnId
+from meridian.lib.launch.launch_types import ResolvedLaunchBinding
 from meridian.lib.launch.plan import build_spawn_mars_runtime
 from meridian.lib.launch.request import SpawnRequest, is_exact_continue_session
 from meridian.lib.launch.types import PrimarySessionMetadata
@@ -39,6 +40,31 @@ logger = structlog.get_logger(__name__)
 
 class LaunchUserInputError(ValueError):
     """Expected launch-input failure that should not emit traceback logging."""
+
+
+class ParamsRequestMetadata(BaseModel):
+    """Immutable request-time inputs retained across the bind boundary."""
+
+    model_config = ConfigDict(frozen=True)
+
+    model: str
+    harness: str
+    agent: str | None
+    agent_path: str
+    adhoc_agent_payload: str
+    appended_system_prompt: str | None
+    user_turn_content: str | None
+    desc: str
+    work_id: str | None
+    goal: str | None
+    prompt_length: int
+    reference_files: tuple[str, ...]
+    template_vars: dict[str, str]
+    skills: tuple[str, ...]
+    skill_paths: tuple[str, ...]
+    continue_session: str | None
+    continue_fork: bool
+    forked_from_chat_id: str | None
 
 
 class _SpawnContext(BaseModel):
@@ -295,14 +321,70 @@ def _announce_reserved_spawn(
     )
 
 
-def _write_params_json(
-    project_paths: ProjectConfigPaths,
-    runtime_root: Path,
-    spawn_id: SpawnId,
+def _build_params_request_metadata(
     request: SpawnRequest,
     *,
     desc: str = "",
     work_id: str | None = None,
+) -> ParamsRequestMetadata:
+    """Snapshot request metadata before any bind-time values exist."""
+
+    return ParamsRequestMetadata(
+        model=request.model or "",
+        harness=request.harness or "",
+        agent=request.agent,
+        agent_path=request.agent_metadata.get("session_agent_path") or "",
+        adhoc_agent_payload=request.prompt_payload.adhoc_agent_payload,
+        appended_system_prompt=request.prompt_payload.appended_system_prompt,
+        user_turn_content=request.prompt_payload.user_turn_content,
+        desc=desc,
+        work_id=work_id,
+        goal=request.goal,
+        prompt_length=len(request.prompt),
+        reference_files=request.reference_files,
+        template_vars=request.template_vars,
+        skills=request.skills,
+        skill_paths=request.skill_paths,
+        continue_session=request.session.requested_harness_session_id,
+        continue_fork=request.session.continue_fork,
+        forked_from_chat_id=request.session.forked_from_chat_id,
+    )
+
+
+def _params_payload(
+    request_metadata: ParamsRequestMetadata,
+    *,
+    binding: ResolvedLaunchBinding | None = None,
+) -> dict[str, Any]:
+    payload = request_metadata.model_dump(mode="json")
+    if binding is None:
+        payload["phase"] = "request"
+        return payload
+
+    run_params = binding.run_params
+    child_context_env = binding.environment.child_context_env
+    payload.update(
+        {
+            "phase": "bound",
+            "adhoc_agent_payload": run_params.adhoc_agent_payload,
+            "appended_system_prompt": run_params.appended_system_prompt,
+            "user_turn_content": run_params.user_turn_content,
+            "prompt_length": len(run_params.prompt),
+            "bound_work_id": binding.work_id,
+            "bound_work_dir": child_context_env.get("MERIDIAN_ACTIVE_WORK_DIR"),
+            "bound_task_dir": child_context_env.get("MERIDIAN_TASK_DIR"),
+        }
+    )
+    return payload
+
+
+def _write_params_json(
+    project_paths: ProjectConfigPaths,
+    runtime_root: Path,
+    spawn_id: SpawnId,
+    *,
+    request_metadata: ParamsRequestMetadata,
+    binding: ResolvedLaunchBinding | None = None,
 ) -> None:
     """Write resolved execution params to the spawn directory."""
     params_path = (
@@ -312,33 +394,16 @@ def _write_params_json(
         / "params.json"
     )
     params_path.parent.mkdir(parents=True, exist_ok=True)
-    params_payload = {
-        "model": request.model or "",
-        "harness": request.harness or "",
-        "agent": request.agent,
-        "agent_path": request.agent_metadata.get("session_agent_path") or "",
-        "adhoc_agent_payload": request.prompt_payload.adhoc_agent_payload,
-        "appended_system_prompt": request.prompt_payload.appended_system_prompt,
-        "user_turn_content": request.prompt_payload.user_turn_content,
-        "desc": desc,
-        "work_id": work_id,
-        "goal": request.goal,
-        "prompt_length": len(request.prompt),
-        "reference_files": list(request.reference_files),
-        "template_vars": request.template_vars,
-        "skills": list(request.skills),
-        "skill_paths": list(request.skill_paths),
-        "continue_session": request.session.requested_harness_session_id,
-        "continue_fork": request.session.continue_fork,
-        "forked_from_chat_id": request.session.forked_from_chat_id,
-    }
+    params_payload = _params_payload(request_metadata, binding=binding)
     atomic_write_text(params_path, json.dumps(params_payload, indent=2) + "\n")
 
 
 __all__ = [
     "LaunchUserInputError",
+    "ParamsRequestMetadata",
     "_SpawnContext",
     "_announce_reserved_spawn",
+    "_build_params_request_metadata",
     "_emit_subrun_event",
     "_materialize_spawn_work_item",
     "_reserve_spawn",

--- a/src/meridian/lib/ops/spawn/execute_runner.py
+++ b/src/meridian/lib/ops/spawn/execute_runner.py
@@ -41,7 +41,12 @@ from meridian.lib.state.session_store import update_session_claude_config_dir
 from meridian.lib.state.spawn.model import SpawnRecord
 
 from ..runtime import OperationRuntime, runtime_context
-from .execute_init import LaunchUserInputError, _spawn_child_env
+from .execute_init import (
+    LaunchUserInputError,
+    ParamsRequestMetadata,
+    _spawn_child_env,
+    _write_params_json,
+)
 from .execute_session import (
     _resolve_session_continuation,
     _session_execution_context,
@@ -138,6 +143,7 @@ async def _prepare_execution_handoff(
     spawn_record: SpawnRecord | None,
     execution_cwd: str,
     work_id: str | None,
+    request_metadata: ParamsRequestMetadata,
     ctx: RuntimeContext | None,
     prepared: PreparedLaunchSurface | None = None,
 ) -> PreparedExecutionHandoff:
@@ -289,6 +295,20 @@ async def _prepare_execution_handoff(
             harness_registry=runtime.harness_registry,
             plan_overrides=run_env_overrides,
         )
+        try:
+            _write_params_json(
+                project_paths,
+                runtime_root,
+                spawn.spawn_id,
+                request_metadata=request_metadata,
+                binding=launch_context.binding,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to refresh params.json",
+                spawn_id=str(spawn.spawn_id),
+                exc_info=True,
+            )
         write_projection_artifacts(
             log_dir=resolve_spawn_log_dir(
                 project_paths.project_root,
@@ -358,6 +378,7 @@ async def launch_prepared_spawn(
     runtime: OperationRuntime,
     runtime_root: Path,
     project_paths: ProjectConfigPaths,
+    request_metadata: ParamsRequestMetadata,
     spawn_record: SpawnRecord | None = None,
     execution_cwd: str,
     work_id: str | None = None,
@@ -384,6 +405,7 @@ async def launch_prepared_spawn(
             spawn_record=spawn_record,
             execution_cwd=execution_cwd,
             work_id=work_id,
+            request_metadata=request_metadata,
             ctx=ctx,
             prepared=prepared,
         )

--- a/src/meridian/lib/platform/process_scope/AGENTS.md
+++ b/src/meridian/lib/platform/process_scope/AGENTS.md
@@ -42,6 +42,13 @@ that have reparented to PID 1. `SIGTERM` to the root PID only reaches the root â
 it's already dead, reparented children escape entirely. Use POSIX containment when
 available; psutil fallback is accepted as degraded.
 
+Scope roots are launch shims and therefore identify what Meridian launched; they are
+not guaranteed to remain the serving backend process. The PGID is the cleanup handle
+that contains shim descendants, including reparented children. Reaper diagnostics
+report `pgid_reachable` as best-effort evidence only: signal 0 counts zombies, has no
+process-group birth-time reuse guard, and cannot see a child that changes its own
+process group.
+
 ## Legacy Windows Job Object Handle Lifetime
 
 `assign_to_new_job(pid)` returns `(job_name, job_handle)`. The handle must stay alive â€”

--- a/src/meridian/lib/platform/process_scope/__init__.py
+++ b/src/meridian/lib/platform/process_scope/__init__.py
@@ -19,6 +19,7 @@ from meridian.lib.platform.process_scope.fallback import (
     terminate_tree,
     terminate_tree_sync,
 )
+from meridian.lib.platform.process_scope.posix import is_pgid_reachable
 
 logger = structlog.get_logger(__name__)
 
@@ -79,6 +80,7 @@ __all__ = [
     "CleanupResult",
     "ProcessScopeSnapshot",
     "ScopedProcessHandle",
+    "is_pgid_reachable",
     "terminate_scope_sync",
     "terminate_tree",
     "terminate_tree_sync",

--- a/src/meridian/lib/platform/process_scope/posix.py
+++ b/src/meridian/lib/platform/process_scope/posix.py
@@ -1,16 +1,38 @@
 """POSIX process-group scope adapter.
 
-Importable on Windows, but all functions raise RuntimeError if called there.
+Importable on Windows, but process-group operations are POSIX-only.
 """
 
 from __future__ import annotations
 
+import os
 from contextlib import suppress
 
 import psutil
 
 from meridian.lib.platform import IS_WINDOWS
 from meridian.lib.platform.process_scope.base import CleanupResult, birth_time_unverified
+
+
+def is_pgid_reachable(pgid: int) -> bool:
+    """Return whether signal 0 can reach a POSIX process group.
+
+    This is deliberately weaker than an "alive" check: process-group IDs have
+    no birth-time reuse guard, and signal 0 also succeeds for groups containing
+    only zombies. Use this as best-effort diagnostics, never process identity.
+    """
+
+    if pgid <= 0:
+        return False
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
 
 
 def _scan_by_pgid(pgid: int) -> list[psutil.Process]:
@@ -20,8 +42,6 @@ def _scan_by_pgid(pgid: int) -> list[psutil.Process]:
     root process is already dead and the normal PGID-kill path produced a
     ProcessLookupError (group dissolved before SIGTERM landed).
     """
-    import os
-
     result: list[psutil.Process] = []
     for proc in psutil.process_iter(["pid"]):
         with suppress(psutil.NoSuchProcess, psutil.AccessDenied, OSError):
@@ -66,7 +86,6 @@ def terminate_pgid(
             degraded_fallback=True,
         )
 
-    import os
     import signal
 
     # --- PID reuse guard (PROC-006) --- fail-closed for confirmed reuse only.
@@ -161,4 +180,4 @@ def terminate_pgid(
     )
 
 
-__all__ = ["terminate_pgid"]
+__all__ = ["is_pgid_reachable", "terminate_pgid"]

--- a/src/meridian/lib/state/liveness.py
+++ b/src/meridian/lib/state/liveness.py
@@ -1,6 +1,5 @@
-"""Process liveness and POSIX process-group diagnostic probes."""
+"""Process liveness probes."""
 
-import os
 import time
 from pathlib import Path
 
@@ -9,27 +8,6 @@ import psutil
 from meridian.lib.platform.process_scope.base import birth_time_unverified
 
 _PID_REUSE_GUARD_SECS = 30.0
-
-
-def is_pgid_reachable(pgid: int) -> bool:
-    """Return whether signal 0 can reach a POSIX process group.
-
-    This is deliberately weaker than an "alive" check: process-group IDs have
-    no birth-time reuse guard, and signal 0 also succeeds for groups containing
-    only zombies. Use this as best-effort diagnostics, never process identity.
-    """
-
-    if pgid <= 0:
-        return False
-    try:
-        os.killpg(pgid, 0)
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True
-    except OSError:
-        return False
-    return True
 
 
 def is_process_alive(pid: int, created_after_epoch: float | None = None) -> bool:

--- a/src/meridian/lib/state/liveness.py
+++ b/src/meridian/lib/state/liveness.py
@@ -1,5 +1,6 @@
-"""Cross-platform process liveness via psutil."""
+"""Process liveness and POSIX process-group diagnostic probes."""
 
+import os
 import time
 from pathlib import Path
 
@@ -8,6 +9,27 @@ import psutil
 from meridian.lib.platform.process_scope.base import birth_time_unverified
 
 _PID_REUSE_GUARD_SECS = 30.0
+
+
+def is_pgid_reachable(pgid: int) -> bool:
+    """Return whether signal 0 can reach a POSIX process group.
+
+    This is deliberately weaker than an "alive" check: process-group IDs have
+    no birth-time reuse guard, and signal 0 also succeeds for groups containing
+    only zombies. Use this as best-effort diagnostics, never process identity.
+    """
+
+    if pgid <= 0:
+        return False
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
 
 
 def is_process_alive(pid: int, created_after_epoch: float | None = None) -> bool:

--- a/src/meridian/lib/state/reaper.py
+++ b/src/meridian/lib/state/reaper.py
@@ -8,7 +8,7 @@ import time
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, TypedDict, cast
 
 import structlog
 
@@ -31,7 +31,7 @@ from meridian.lib.platform.locking import lock_file
 from meridian.lib.platform.process_scope.base import ProcessScopeSnapshot
 from meridian.lib.state.atomic import atomic_write_text
 from meridian.lib.state.launch_boundary import LaunchBoundarySummary, read_launch_boundary_summary
-from meridian.lib.state.liveness import is_process_alive
+from meridian.lib.state.liveness import is_pgid_reachable, is_process_alive
 from meridian.lib.state.managed_primary import (
     ManagedPrimaryReconciliationStrategy,
     ManagedPrimarySnapshot,
@@ -88,6 +88,31 @@ class ArtifactSnapshot:
     durable_report_completion: bool
     runner_pid_alive: bool
     launch_boundary: LaunchBoundarySummary
+
+
+class ScopeLiveness(TypedDict):
+    """Best-effort liveness projection for a process containment scope."""
+
+    root_alive: bool
+    pgid_reachable: bool | None
+    likely_serving: bool
+
+
+def scope_liveness(scope: ProcessScopeSnapshot) -> ScopeLiveness:
+    """Project root identity and group reachability into one diagnostic view."""
+
+    root_alive = is_process_alive(
+        scope.root_pid,
+        created_after_epoch=(scope.root_created_at_epoch or None),
+    )
+    pgid_reachable = (
+        is_pgid_reachable(scope.pgid) if scope.pgid is not None else None
+    )
+    return {
+        "root_alive": root_alive,
+        "pgid_reachable": pgid_reachable,
+        "likely_serving": root_alive or pgid_reachable is True,
+    }
 
 
 def _runner_exit_at_epoch(runner_exit_at: str | None) -> float | None:
@@ -326,21 +351,34 @@ def decide_reconciliation(
 
 
 def _log_orphan_primary_diagnostics(
+    runtime_root: Path,
     record: SpawnRecord,
     snapshot: ArtifactSnapshot,
     managed_snapshot: ManagedPrimarySnapshot | None,
 ) -> None:
     if managed_snapshot is not None:
         metadata = managed_snapshot.metadata
+        scopes = read_scopes_from_disk(runtime_root, SpawnId(record.id))
         launcher_pid = metadata.launcher_pid
         launcher_alive = managed_snapshot.launcher_pid_alive if launcher_pid is not None else None
+        backend_scope = next(
+            (scope for scope in scopes if scope.root_pid == metadata.backend_pid),
+            None,
+        )
+        backend_liveness = (
+            scope_liveness(backend_scope) if backend_scope is not None else None
+        )
         backend_alive = (
-            is_process_alive(
-                metadata.backend_pid,
-                created_after_epoch=managed_snapshot.started_epoch,
+            backend_liveness["likely_serving"]
+            if backend_liveness is not None
+            else (
+                is_process_alive(
+                    metadata.backend_pid,
+                    created_after_epoch=managed_snapshot.started_epoch,
+                )
+                if metadata.backend_pid is not None
+                else None
             )
-            if metadata.backend_pid is not None
-            else None
         )
         tui_alive = (
             is_process_alive(
@@ -358,6 +396,16 @@ def _log_orphan_primary_diagnostics(
             launcher_alive=launcher_alive,
             backend_pid=metadata.backend_pid,
             backend_alive=backend_alive,
+            backend_root_alive=(
+                backend_liveness["root_alive"]
+                if backend_liveness is not None
+                else backend_alive
+            ),
+            backend_pgid_reachable=(
+                backend_liveness["pgid_reachable"]
+                if backend_liveness is not None
+                else None
+            ),
             tui_pid=metadata.tui_pid,
             tui_alive=tui_alive,
             activity=metadata.activity,
@@ -411,15 +459,14 @@ def _record_orphan_finalize_evidence(
     ]
     child_processes: list[dict[str, object]] = []
     for scope in scopes:
+        liveness = scope_liveness(scope)
         child_processes.append(
             {
                 "scope_id": scope.scope_id,
                 "role": scope.role,
                 "pid": scope.root_pid,
-                "alive": is_process_alive(
-                    scope.root_pid,
-                    created_after_epoch=(scope.root_created_at_epoch or None),
-                ),
+                **liveness,
+                "alive": liveness["likely_serving"],
             }
         )
 
@@ -430,7 +477,7 @@ def _record_orphan_finalize_evidence(
             None,
         )
         worker_alive = (
-            bool(matching_scope["alive"])
+            bool(matching_scope["likely_serving"])
             if matching_scope is not None
             else is_process_alive(record.worker_pid, created_after_epoch=snapshot.started_epoch)
         )
@@ -451,7 +498,7 @@ def _record_orphan_finalize_evidence(
         },
         "child_processes": child_processes,
         "worker_or_backend_alive": worker_alive is True
-        or any(bool(item["alive"]) for item in child_processes),
+        or any(bool(item["likely_serving"]) for item in child_processes),
         "heartbeat_age_secs": (
             max(0.0, now - heartbeat_epoch) if heartbeat_epoch is not None else None
         ),
@@ -838,7 +885,12 @@ def reconcile_active_spawn(
     if decision.error == "orphan_primary" and (
         managed_snapshot is not None or _is_potential_managed_primary(record)
     ):
-        _log_orphan_primary_diagnostics(record, generic_snapshot, managed_snapshot)
+        _log_orphan_primary_diagnostics(
+            runtime_root,
+            record,
+            generic_snapshot,
+            managed_snapshot,
+        )
     return _cleanup_after_finalize(
         runtime_root,
         _finalize_failed(

--- a/src/meridian/lib/state/reaper.py
+++ b/src/meridian/lib/state/reaper.py
@@ -28,10 +28,11 @@ from meridian.lib.launch.constants import (
     OUTPUT_FILENAME,
 )
 from meridian.lib.platform.locking import lock_file
+from meridian.lib.platform.process_scope import is_pgid_reachable
 from meridian.lib.platform.process_scope.base import ProcessScopeSnapshot
 from meridian.lib.state.atomic import atomic_write_text
 from meridian.lib.state.launch_boundary import LaunchBoundarySummary, read_launch_boundary_summary
-from meridian.lib.state.liveness import is_pgid_reachable, is_process_alive
+from meridian.lib.state.liveness import is_process_alive
 from meridian.lib.state.managed_primary import (
     ManagedPrimaryReconciliationStrategy,
     ManagedPrimarySnapshot,

--- a/tests/integration/harness/test_adapter_ownership.py
+++ b/tests/integration/harness/test_adapter_ownership.py
@@ -252,6 +252,59 @@ def test_claude_adapter_uses_claude_config_dir_override(
     assert infer_harness_from_untracked_session_ref(project_root, override_session_id) == "claude"
 
 
+def test_claude_adapter_resolves_tracked_config_root_chain_in_trust_order(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    hint_root = tmp_path / "recorded"
+    canonical_root = tmp_path / "home" / ".claude"
+    ambient_root = tmp_path / "ambient"
+    monkeypatch.setenv("HOME", (tmp_path / "home").as_posix())
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", ambient_root.as_posix())
+
+    session_id = str(uuid4())
+    paths = [
+        root / "projects" / project_slug(project_root) / f"{session_id}.jsonl"
+        for root in (hint_root, canonical_root, ambient_root)
+    ]
+    for path in paths:
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            json.dumps({"type": "agent-setting", "sessionId": session_id}) + "\n",
+            encoding="utf-8",
+        )
+
+    adapter = ClaudeAdapter()
+    assert (
+        adapter.resolve_session_file(
+            project_root=project_root,
+            session_id=session_id,
+            config_root_hint=hint_root,
+        )
+        == paths[0]
+    )
+    paths[0].unlink()
+    assert (
+        adapter.resolve_session_file(
+            project_root=project_root,
+            session_id=session_id,
+            config_root_hint=hint_root,
+        )
+        == paths[1]
+    )
+    paths[1].unlink()
+    assert (
+        adapter.resolve_session_file(
+            project_root=project_root,
+            session_id=session_id,
+            config_root_hint=hint_root,
+        )
+        == paths[2]
+    )
+
+
 @pytest.mark.parametrize(
     ("configured_root", "cwd_relative", "expected_suffix"),
     [

--- a/tests/integration/harness/test_codex_connection_liveness.py
+++ b/tests/integration/harness/test_codex_connection_liveness.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+from pathlib import Path
 
 import pytest
 
@@ -19,14 +20,39 @@ class _FakeProcess:
     returncode: int | None = None
 
 
-class _RecordingScopeHandle:
+class _ControllableProcess:
+    pid = 4243
+
     def __init__(self) -> None:
+        self.returncode: int | None = None
+        self._exited = asyncio.Event()
+        self.wait_cancelled = False
+
+    async def wait(self) -> int:
+        try:
+            await self._exited.wait()
+        except asyncio.CancelledError:
+            self.wait_cancelled = True
+            raise
+        assert self.returncode is not None
+        return self.returncode
+
+    def exit(self, returncode: int) -> None:
+        self.returncode = returncode
+        self._exited.set()
+
+
+class _RecordingScopeHandle:
+    def __init__(self, process: _ControllableProcess | None = None) -> None:
         self.terminate_calls = 0
+        self._process = process
 
     async def terminate(self, *, grace_seconds: float, reason: str) -> None:
         _ = reason
         assert grace_seconds > 0
         self.terminate_calls += 1
+        if self._process is not None:
+            self._process.exit(-15)
 
 
 class _FreezesAfterMessagesWebSocket:
@@ -45,6 +71,23 @@ class _FreezesAfterMessagesWebSocket:
 
     async def close(self) -> None:
         self.closed = True
+
+
+class _FailingWebSocket:
+    def __init__(self) -> None:
+        self.closed = False
+        self.fail = asyncio.Event()
+
+    def __aiter__(self) -> _FailingWebSocket:
+        return self
+
+    async def __anext__(self) -> str:
+        await self.fail.wait()
+        raise RuntimeError("socket disappeared")
+
+    async def close(self) -> None:
+        self.closed = True
+        self.fail.set()
 
 
 async def _collect_events(connection: CodexConnection) -> list[RawHarnessEvent]:
@@ -146,5 +189,59 @@ async def test_codex_stop_terminates_scope_when_reader_task_already_failed() -> 
 
     await connection.stop(reason="test")
 
+    assert scope_handle.terminate_calls == 1
+    assert connection.state == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_codex_backend_exit_and_reader_race_emit_one_enriched_close(
+    tmp_path: Path,
+) -> None:
+    connection = CodexConnection()
+    connection._state = "connected"
+    process = _ControllableProcess()
+    connection._process = process  # type: ignore[assignment]
+    websocket = _FailingWebSocket()
+    connection._ws = websocket
+    stderr_path = tmp_path / "stderr.log"
+    stderr_path.write_text("fatal vendor detail\n", encoding="utf-8")
+    connection._stderr_log_path = stderr_path
+
+    reader = asyncio.create_task(connection._read_messages_loop())
+    watcher = asyncio.create_task(connection._watch_backend_exit())
+    websocket.fail.set()
+    process.exit(23)
+
+    events = await _collect_events(connection)
+    await asyncio.gather(reader, watcher)
+
+    assert len(events) == 1
+    assert events[0].event_type == "meridian/error/connectionClosed"
+    assert events[0].payload["backend_exit_code"] == 23
+    assert events[0].payload["backend_stderr_excerpt"] == "fatal vendor detail"
+    assert connection.state == "failed"
+
+
+@pytest.mark.asyncio
+async def test_codex_expected_stop_cancels_watcher_before_backend_termination() -> None:
+    connection = CodexConnection()
+    connection._state = "connected"
+    process = _ControllableProcess()
+    connection._process = process  # type: ignore[assignment]
+    websocket = _FailingWebSocket()
+    connection._ws = websocket
+    scope_handle = _RecordingScopeHandle(process)
+    connection._scope_handle = scope_handle  # type: ignore[assignment]
+    connection._backend_exit_task = asyncio.create_task(
+        connection._watch_backend_exit()
+    )
+    connection._reader_task = asyncio.create_task(connection._read_messages_loop())
+    await asyncio.sleep(0)
+
+    await connection.stop(reason="test")
+    events = await _collect_events(connection)
+
+    assert events == []
+    assert process.wait_cancelled is True
     assert scope_handle.terminate_calls == 1
     assert connection.state == "stopped"

--- a/tests/integration/harness/test_codex_connection_liveness.py
+++ b/tests/integration/harness/test_codex_connection_liveness.py
@@ -230,6 +230,10 @@ async def test_codex_backend_exit_and_reader_race_emit_one_enriched_close(
     close_event = terminal_sequence[0]
     assert close_event is not None
     assert close_event.event_type == "meridian/error/connectionClosed"
+    assert close_event.payload["message"] == (
+        "Codex app-server exited with code 23.\n\n"
+        "Codex app-server stderr:\nfatal vendor detail"
+    )
     assert close_event.payload["backend_exit_code"] == 23
     assert close_event.payload["backend_stderr_excerpt"] == "fatal vendor detail"
     assert terminal_sequence[1] is None

--- a/tests/integration/harness/test_codex_connection_liveness.py
+++ b/tests/integration/harness/test_codex_connection_liveness.py
@@ -94,6 +94,17 @@ async def _collect_events(connection: CodexConnection) -> list[RawHarnessEvent]:
     return [event async for event in connection.events()]
 
 
+def _drain_raw_event_queue(
+    connection: CodexConnection,
+) -> list[RawHarnessEvent | None]:
+    queued: list[RawHarnessEvent | None] = []
+    while True:
+        try:
+            queued.append(connection._event_queue.get_nowait())
+        except asyncio.QueueEmpty:
+            return queued
+
+
 async def _collect_codex_events_under_fake_clock(
     determinism: AsyncDeterminism,
     connection: CodexConnection,
@@ -212,14 +223,51 @@ async def test_codex_backend_exit_and_reader_race_emit_one_enriched_close(
     websocket.fail.set()
     process.exit(23)
 
-    events = await _collect_events(connection)
     await asyncio.gather(reader, watcher)
+    terminal_sequence = _drain_raw_event_queue(connection)
 
-    assert len(events) == 1
-    assert events[0].event_type == "meridian/error/connectionClosed"
-    assert events[0].payload["backend_exit_code"] == 23
-    assert events[0].payload["backend_stderr_excerpt"] == "fatal vendor detail"
+    assert len(terminal_sequence) == 2
+    close_event = terminal_sequence[0]
+    assert close_event is not None
+    assert close_event.event_type == "meridian/error/connectionClosed"
+    assert close_event.payload["backend_exit_code"] == 23
+    assert close_event.payload["backend_stderr_excerpt"] == "fatal vendor detail"
+    assert terminal_sequence[1] is None
+    assert connection._event_queue.empty()
     assert connection.state == "failed"
+
+
+@pytest.mark.asyncio
+async def test_codex_backend_exit_watcher_closes_lingering_websocket(
+    tmp_path: Path,
+) -> None:
+    connection = CodexConnection()
+    connection._state = "connected"
+    process = _ControllableProcess()
+    connection._process = process  # type: ignore[assignment]
+    websocket = _FreezesAfterMessagesWebSocket([])
+    connection._ws = websocket
+    stderr_path = tmp_path / "stderr.log"
+    stderr_path.write_text("watcher-only failure\n", encoding="utf-8")
+    connection._stderr_log_path = stderr_path
+    reader = asyncio.create_task(connection._read_messages_loop())
+    watcher = asyncio.create_task(connection._watch_backend_exit())
+    await asyncio.sleep(0)
+
+    process.exit(31)
+    await watcher
+    terminal_sequence = _drain_raw_event_queue(connection)
+    reader.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await reader
+
+    assert len(terminal_sequence) == 2
+    close_event = terminal_sequence[0]
+    assert close_event is not None
+    assert close_event.payload["backend_exit_code"] == 31
+    assert close_event.payload["backend_stderr_excerpt"] == "watcher-only failure"
+    assert terminal_sequence[1] is None
+    assert connection._event_queue.empty()
 
 
 @pytest.mark.asyncio
@@ -245,3 +293,26 @@ async def test_codex_expected_stop_cancels_watcher_before_backend_termination() 
     assert process.wait_cancelled is True
     assert scope_handle.terminate_calls == 1
     assert connection.state == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_codex_cleanup_failure_still_ends_expected_stop_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _fail_parent_death_cleanup(_link: object) -> None:
+        raise OSError("watchdog reap failed")
+
+    monkeypatch.setattr(
+        codex_ws,
+        "release_parent_death_link",
+        _fail_parent_death_cleanup,
+    )
+    connection = CodexConnection()
+    connection._state = "connected"
+
+    await connection.stop(reason="test")
+
+    assert connection.state == "stopped"
+    assert connection._event_stream_ended is True
+    assert _drain_raw_event_queue(connection) == [None]
+    assert connection._event_queue.empty()

--- a/tests/integration/ops/test_session_log_harness_retrieval.py
+++ b/tests/integration/ops/test_session_log_harness_retrieval.py
@@ -635,3 +635,60 @@ def test_session_log_resolves_claude_session_file_from_claude_config_dir_env(
     assert [(message.role, message.content) for message in output.messages] == [
         ("assistant", "claude env override transcript")
     ]
+
+
+@pytest.mark.parametrize("ref", ["claude-canonical-session", "c1", "p1"])
+def test_session_log_resolves_tracked_claude_session_from_canonical_root(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    ref: str,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    runtime_root = resolve_project_runtime_root_for_write(project_root)
+    runtime_root.mkdir(parents=True, exist_ok=True)
+
+    home = tmp_path / "home"
+    recorded_config_root = tmp_path / "recorded-overlay"
+    ambient_config_root = tmp_path / "unrelated-overlay"
+    monkeypatch.setenv("HOME", home.as_posix())
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", ambient_config_root.as_posix())
+
+    session_id = "claude-canonical-session"
+    _write_claude_session(
+        config_root=home / ".claude",
+        project_root=project_root,
+        session_id=session_id,
+        assistant_text="claude canonical transcript",
+    )
+    session_store.start_session(
+        runtime_root,
+        harness="claude",
+        harness_session_id=session_id,
+        model="claude-opus",
+        chat_id="c1",
+        claude_config_dir=recorded_config_root.as_posix(),
+        spawn_id="p1",
+    )
+    spawn_store.start_spawn(
+        runtime_root,
+        chat_id="c1",
+        model="claude-opus",
+        agent="coder",
+        harness="claude",
+        prompt="hello",
+        spawn_id="p1",
+        harness_session_id=session_id,
+        claude_config_dir=recorded_config_root.as_posix(),
+        started_at="2026-04-11T00:00:00Z",
+    )
+
+    output = session_log_sync(
+        SessionLogInput(ref=ref, project_root=project_root.as_posix(), tail=5)
+    )
+
+    assert output.session_id == session_id
+    assert output.source == "claude transcript"
+    assert [(message.role, message.content) for message in output.messages] == [
+        ("assistant", "claude canonical transcript")
+    ]

--- a/tests/integration/ops/test_session_repair_harness_retrieval.py
+++ b/tests/integration/ops/test_session_repair_harness_retrieval.py
@@ -1,0 +1,97 @@
+"""Session repair retrieval through tracked harness metadata."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pytest import MonkeyPatch
+
+from meridian.lib.harness.claude import project_slug
+from meridian.lib.ops.session_repair import (
+    SessionRepairInput,
+    repair_session_reference_sync,
+)
+from meridian.lib.state import session_store, spawn_store
+from meridian.lib.state.paths import resolve_project_runtime_root_for_write
+
+
+def _write_claude_session(
+    *,
+    config_root: Path,
+    project_root: Path,
+    session_id: str,
+) -> None:
+    project_dir = config_root / "projects" / project_slug(project_root)
+    project_dir.mkdir(parents=True)
+    (project_dir / f"{session_id}.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps({"sessionId": session_id}),
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "content": [{"type": "text", "text": "canonical transcript"}]
+                        },
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize("ref", ["c1", "p1"])
+def test_session_repair_resolves_tracked_claude_session_from_canonical_root(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    ref: str,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    runtime_root = resolve_project_runtime_root_for_write(project_root)
+    runtime_root.mkdir(parents=True, exist_ok=True)
+
+    home = tmp_path / "home"
+    recorded_config_root = tmp_path / "recorded-overlay"
+    monkeypatch.setenv("HOME", home.as_posix())
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", (tmp_path / "unrelated-overlay").as_posix())
+
+    session_id = "claude-canonical-repair-session"
+    _write_claude_session(
+        config_root=home / ".claude",
+        project_root=project_root,
+        session_id=session_id,
+    )
+    session_store.start_session(
+        runtime_root,
+        harness="claude",
+        harness_session_id=session_id,
+        model="claude-opus",
+        chat_id="c1",
+        claude_config_dir=recorded_config_root.as_posix(),
+        spawn_id="p1",
+    )
+    spawn_store.start_spawn(
+        runtime_root,
+        chat_id="c1",
+        model="claude-opus",
+        agent="coder",
+        harness="claude",
+        prompt="hello",
+        spawn_id="p1",
+        harness_session_id=session_id,
+        claude_config_dir=recorded_config_root.as_posix(),
+        started_at="2026-04-11T00:00:00Z",
+    )
+
+    output = repair_session_reference_sync(
+        SessionRepairInput(ref=ref, project_root=project_root.as_posix())
+    )
+
+    assert output.detected_harness_session_id == session_id
+    assert output.source == "claude transcript"
+    assert output.reason is None

--- a/tests/integration/ops/test_session_search_scopes.py
+++ b/tests/integration/ops/test_session_search_scopes.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from meridian.lib.harness.claude import project_slug
 from meridian.lib.ops.session_search import SessionSearchInput, session_search_sync
 from meridian.lib.state import session_store
 from meridian.lib.state.user_paths import get_project_home
@@ -147,6 +148,63 @@ def test_session_search_global_scope_includes_runtime_root(tmp_path: Path, monke
         output = session_search_sync(
             SessionSearchInput(
                 query="needle",
+                project_root=current_root.as_posix(),
+                global_scope=True,
+            )
+        )
+    finally:
+        session_store.stop_session(runtime_root, chat_id)
+
+    assert len(output.matches) == 1
+    assert output.matches[0].corpus == "runtime:orphan-one"
+
+
+def test_session_search_corpus_resolves_tracked_claude_canonical_transcript(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    user_home = tmp_path / "meridian-home"
+    home = tmp_path / "home"
+    runtime_root = user_home / "projects" / "orphan-one"
+    runtime_root.mkdir(parents=True)
+    current_root = tmp_path / "current"
+    current_root.mkdir()
+    (current_root / "meridian.toml").write_text("", encoding="utf-8")
+    monkeypatch.setenv("MERIDIAN_HOME", user_home.as_posix())
+    monkeypatch.setenv("HOME", home.as_posix())
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", (tmp_path / "unrelated-overlay").as_posix())
+
+    session_id = "claude-corpus-session"
+    project_dir = home / ".claude" / "projects" / project_slug(runtime_root)
+    project_dir.mkdir(parents=True)
+    (project_dir / f"{session_id}.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps({"sessionId": session_id}),
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "content": [{"type": "text", "text": "corpus canonical needle"}]
+                        },
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    chat_id = session_store.start_session(
+        runtime_root,
+        harness="claude",
+        harness_session_id=session_id,
+        model="claude-opus",
+        claude_config_dir=(tmp_path / "recorded-overlay").as_posix(),
+    )
+    try:
+        output = session_search_sync(
+            SessionSearchInput(
+                query="canonical needle",
                 project_root=current_root.as_posix(),
                 global_scope=True,
             )

--- a/tests/integration/ops/test_spawn_api_create.py
+++ b/tests/integration/ops/test_spawn_api_create.py
@@ -124,6 +124,7 @@ def test_background_headless_deny_rejects_before_reservation_without_affecting_a
         runtime_root=prepared.runtime_root,
     )
     params = json.loads((allowed_log_dir / "params.json").read_text(encoding="utf-8"))
+    assert params["phase"] == "request"
     assert params["model"] == "gemini-2.5-pro"
     assert params["harness"] == "opencode"
     assert params["prompt_length"] == len("allowed")

--- a/tests/integration/ops/test_spawn_execute_report_output.py
+++ b/tests/integration/ops/test_spawn_execute_report_output.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 import meridian.lib.ops.spawn.execute as execute_module
 import meridian.lib.ops.spawn.execute_init as execute_init_module
+import meridian.lib.ops.spawn.execute_runner as execute_runner_module
 from meridian.lib.config.settings import load_config
 from meridian.lib.core.context import RuntimeContext
 from meridian.lib.core.lifecycle import LifecycleEvent, SpawnLifecycleService
 from meridian.lib.core.sink import OutputSink
+from meridian.lib.core.types import HarnessId
 from meridian.lib.launch.request import SpawnRequest
 from meridian.lib.ops.runtime import (
     OperationRuntime,
@@ -21,6 +24,8 @@ from meridian.lib.ops.runtime import (
 from meridian.lib.ops.spawn.models import SpawnCreateInput
 from meridian.lib.state import spawn_store, work_repository, work_store
 from meridian.lib.state.paths import resolve_project_paths
+from tests.support.executables import prepend_fake_executables
+from tests.support.launch import stub_bundle_request_and_resolve
 
 if TYPE_CHECKING:
     import pytest
@@ -179,6 +184,63 @@ def test_execute_spawn_blocking_notifies_spawn_id_before_launch(
 
     assert result.status == "succeeded"
     assert notifications == [str(result.spawn_id)]
+
+
+def test_execute_spawn_blocking_refreshes_params_with_bound_ambient_work_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = _build_test_runtime(tmp_path, monkeypatch)
+    prepend_fake_executables(monkeypatch, tmp_path, "codex")
+    stub_bundle_request_and_resolve(
+        monkeypatch,
+        model="gpt-5.4",
+        harness=HarnessId.CODEX,
+    )
+
+    async def _fake_execute_with_streaming(
+        spawn: Any,
+        **kwargs: object,
+    ) -> int:
+        runtime_root = cast("Path", kwargs["runtime_root"])
+        spawn_store.finalize_spawn(
+            runtime_root,
+            str(spawn.spawn_id),
+            "succeeded",
+            0,
+            origin="runner",
+        )
+        return 0
+
+    monkeypatch.setattr(
+        execute_runner_module,
+        "execute_with_streaming",
+        _fake_execute_with_streaming,
+    )
+
+    result = execute_module.execute_spawn_blocking(
+        payload=SpawnCreateInput(prompt="run", desc="bound params"),
+        request=SpawnRequest(
+            prompt="run",
+            model="gpt-5.4",
+            harness="codex",
+        ),
+        runtime=runtime,
+        ctx=RuntimeContext(depth=1, spawn_id="p-parent"),
+    )
+
+    assert result.status == "succeeded"
+    assert result.spawn_id is not None
+    authority = resolve_runtime_authority_for_write(tmp_path / "repo")
+    assert authority.runtime_root is not None
+    params_path = authority.runtime_root / "spawns" / result.spawn_id / "params.json"
+    params = json.loads(params_path.read_text(encoding="utf-8"))
+    assert params["phase"] == "bound"
+    assert params["bound_work_id"] is None
+    assert params["bound_work_dir"] == (
+        authority.runtime_root / "spawns" / result.spawn_id / "work"
+    ).as_posix()
+    assert params["bound_task_dir"] == (tmp_path / "repo").as_posix()
 
 
 def test_execute_spawn_blocking_pre_init_failure_returns_failed_output(

--- a/tests/integration/ops/test_spawn_execute_report_output.py
+++ b/tests/integration/ops/test_spawn_execute_report_output.py
@@ -235,12 +235,14 @@ def test_execute_spawn_blocking_refreshes_params_with_bound_ambient_work_dir(
     assert authority.runtime_root is not None
     params_path = authority.runtime_root / "spawns" / result.spawn_id / "params.json"
     params = json.loads(params_path.read_text(encoding="utf-8"))
-    assert params["phase"] == "bound"
-    assert params["bound_work_id"] is None
-    assert params["bound_work_dir"] == (
+    bound_work_dir = (
         authority.runtime_root / "spawns" / result.spawn_id / "work"
     ).as_posix()
+    assert params["phase"] == "bound"
+    assert params["bound_work_id"] is None
+    assert params["bound_work_dir"] == bound_work_dir
     assert params["bound_task_dir"] == (tmp_path / "repo").as_posix()
+    assert bound_work_dir in params["appended_system_prompt"]
 
 
 def test_execute_spawn_blocking_pre_init_failure_returns_failed_output(

--- a/tests/integration/state/test_spawn_artifact_lifetime.py
+++ b/tests/integration/state/test_spawn_artifact_lifetime.py
@@ -1,6 +1,7 @@
 """Spawn-owned artifacts cannot outlive their published row."""
 
 import asyncio
+import json
 import os
 import shutil
 import threading
@@ -27,6 +28,7 @@ from meridian.lib.state.history import HarnessHistoryWriter
 from meridian.lib.state.paths import resolve_project_runtime_root_for_write
 from meridian.lib.state.reaper import (
     _collect_artifact_snapshot,
+    _log_orphan_primary_diagnostics,
     _record_orphan_finalize_evidence,
 )
 from meridian.lib.state.spawn_aggregate import delete_published_spawn
@@ -459,6 +461,126 @@ def test_reaper_evidence_refuses_terminal_spawn(tmp_path: Path) -> None:
     _record_orphan_finalize_evidence(runtime_root, record, snapshot, now)
 
     assert not evidence_path.exists()
+
+
+def test_reaper_evidence_uses_scope_liveness_for_shim_backend(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from meridian.lib.platform.process_scope.base import ProcessScopeSnapshot
+    from meridian.lib.state.process_scope_projection import record_scope
+
+    runtime_root = tmp_path / "runtime"
+    spawn_id = SpawnId("p1")
+    evidence_path = runtime_root / "spawns" / str(spawn_id) / "finalize-evidence.json"
+    _start_test_spawn(runtime_root, str(spawn_id), status="running")
+    scope = ProcessScopeSnapshot(
+        scope_id="backend",
+        owner_policy="spawn_owned",
+        owner_id=str(spawn_id),
+        role="harness_backend",
+        containment="posix_pgid",
+        root_pid=41001,
+        root_created_at_epoch=100.0,
+        pgid=41001,
+        job_name=None,
+        degraded_reason=None,
+    )
+    record_scope(runtime_root, spawn_id, scope)
+    monkeypatch.setattr(
+        "meridian.lib.state.reaper.is_process_alive",
+        lambda _pid, created_after_epoch=None: False,
+    )
+    monkeypatch.setattr(
+        "meridian.lib.state.reaper.is_pgid_reachable",
+        lambda _pgid: True,
+    )
+    record = get_spawn(runtime_root, str(spawn_id))
+    assert record is not None
+    now = time.time()
+    snapshot = _collect_artifact_snapshot(runtime_root, record, now)
+
+    _record_orphan_finalize_evidence(runtime_root, record, snapshot, now)
+
+    evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+    backend = evidence["child_processes"][0]
+    assert backend == {
+        "scope_id": "backend",
+        "role": "harness_backend",
+        "pid": 41001,
+        "root_alive": False,
+        "pgid_reachable": True,
+        "likely_serving": True,
+        "alive": True,
+    }
+    assert evidence["worker_or_backend_alive"] is True
+
+
+def test_orphan_primary_diagnostics_use_scope_liveness(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from meridian.lib.platform.process_scope.base import ProcessScopeSnapshot
+    from meridian.lib.state.managed_primary import ManagedPrimarySnapshot
+    from meridian.lib.state.primary_meta import PrimaryMetadata
+    from meridian.lib.state.process_scope_projection import record_scope
+
+    runtime_root = tmp_path / "runtime"
+    spawn_id = SpawnId("p1")
+    _start_test_spawn(runtime_root, str(spawn_id), status="running")
+    record_scope(
+        runtime_root,
+        spawn_id,
+        ProcessScopeSnapshot(
+            scope_id="backend",
+            owner_policy="spawn_owned",
+            owner_id=str(spawn_id),
+            role="harness_backend",
+            containment="posix_pgid",
+            root_pid=41001,
+            root_created_at_epoch=100.0,
+            pgid=41001,
+            job_name=None,
+            degraded_reason=None,
+        ),
+    )
+    monkeypatch.setattr(
+        "meridian.lib.state.reaper.is_process_alive",
+        lambda _pid, created_after_epoch=None: False,
+    )
+    monkeypatch.setattr(
+        "meridian.lib.state.reaper.is_pgid_reachable",
+        lambda _pgid: True,
+    )
+    warnings: list[dict[str, object]] = []
+
+    class _Logger:
+        def warning(self, _message: str, **fields: object) -> None:
+            warnings.append(fields)
+
+    monkeypatch.setattr("meridian.lib.state.reaper.logger", _Logger())
+    record = get_spawn(runtime_root, str(spawn_id))
+    assert record is not None
+    now = time.time()
+
+    _log_orphan_primary_diagnostics(
+        runtime_root,
+        record,
+        _collect_artifact_snapshot(runtime_root, record, now),
+        ManagedPrimarySnapshot(
+            metadata=PrimaryMetadata(
+                launcher_pid=42001,
+                backend_pid=41001,
+                activity="idle",
+            ),
+            launcher_pid_alive=False,
+            started_epoch=100.0,
+        ),
+    )
+
+    assert warnings[0]["backend_alive"] is True
+    assert warnings[0]["backend_root_alive"] is False
+    assert warnings[0]["backend_pgid_reachable"] is True
 
 
 def test_late_native_primary_metadata_does_not_recreate_deleted_spawn(

--- a/tests/unit/harness/test_semantics.py
+++ b/tests/unit/harness/test_semantics.py
@@ -26,12 +26,15 @@ def test_succeeded_terminal_outcome_rejects_failure_evidence(
         TerminalEventOutcome(status="succeeded", exit_code=exit_code, error=error)
 
 
-def test_connection_closed_outcome_includes_backend_diagnostics() -> None:
+def test_connection_closed_outcome_uses_preformatted_message() -> None:
     outcome = connection_closed_outcome(
         RawHarnessEvent(
             event_type="meridian/error/connectionClosed",
             payload={
-                "message": "transport closed",
+                "message": (
+                    "Codex app-server exited with code 23.\n\n"
+                    "Codex app-server stderr:\nfatal vendor detail"
+                ),
                 "backend_exit_code": 23,
                 "backend_stderr_excerpt": "fatal vendor detail",
             },
@@ -41,8 +44,7 @@ def test_connection_closed_outcome_includes_backend_diagnostics() -> None:
     )
 
     assert outcome.error == (
-        "transport closed\n\n"
-        "backend exit code: 23\n\n"
-        "backend stderr:\nfatal vendor detail"
+        "Codex app-server exited with code 23.\n\n"
+        "Codex app-server stderr:\nfatal vendor detail"
     )
     assert outcome.cause is TerminalOutcomeCause.REPLACEABLE_TRANSPORT_CLOSE

--- a/tests/unit/harness/test_semantics.py
+++ b/tests/unit/harness/test_semantics.py
@@ -1,6 +1,11 @@
 import pytest
 
-from meridian.lib.harness.semantics import TerminalEventOutcome
+from meridian.lib.harness.connections.base import RawHarnessEvent
+from meridian.lib.harness.semantics import (
+    TerminalEventOutcome,
+    TerminalOutcomeCause,
+    connection_closed_outcome,
+)
 
 
 @pytest.mark.parametrize(
@@ -19,3 +24,25 @@ def test_succeeded_terminal_outcome_rejects_failure_evidence(
         match="succeeded terminal outcomes require exit_code=0 and no error",
     ):
         TerminalEventOutcome(status="succeeded", exit_code=exit_code, error=error)
+
+
+def test_connection_closed_outcome_includes_backend_diagnostics() -> None:
+    outcome = connection_closed_outcome(
+        RawHarnessEvent(
+            event_type="meridian/error/connectionClosed",
+            payload={
+                "message": "transport closed",
+                "backend_exit_code": 23,
+                "backend_stderr_excerpt": "fatal vendor detail",
+            },
+            harness_id="codex",
+        ),
+        cause=TerminalOutcomeCause.REPLACEABLE_TRANSPORT_CLOSE,
+    )
+
+    assert outcome.error == (
+        "transport closed\n\n"
+        "backend exit code: 23\n\n"
+        "backend stderr:\nfatal vendor detail"
+    )
+    assert outcome.cause is TerminalOutcomeCause.REPLACEABLE_TRANSPORT_CLOSE


### PR DESCRIPTION
## Why

Three independent triage fixes, each a real gap in coordination fidelity:

- **#334** — after a spawn binds its real work/task dirs, `params.json` was never
  refreshed; ambient child spawns showed the *parent's* work dir forever, and
  crashed spawns couldn't be distinguished from bound ones.
- **#171** — `session log`/`search`/`export`/`repair` on tracked Claude sessions
  only looked in the ambient `CLAUDE_CONFIG_DIR`, so transcripts recorded under a
  different config root (common for spawns) were effectively unreachable.
- **#449** — Codex backend death mid-turn surfaced as a generic transport error
  ("no close frame received or sent") with no exit code or stderr; watcher/reader
  races could emit duplicate close events; expected shutdown could be misreported
  as backend death.

Combined into one PR (one release) rather than three rolling-rebased PRs, since
the lanes are disjoint and were each reviewed and merge-prepped independently.

## Goal

- `params.json` reflects a spawn's *actual* bound directories, with an honest
  `phase` for pre-bind crashes.
- Tracked Claude transcripts resolve across the config-root chain regardless of
  which config dir recorded them.
- Codex backend death yields actionable diagnostics (exit code + stderr), exactly
  one close event under races, and no false "backend death" on clean shutdown.
- All three land consistent with `#465`'s process-scope/reaper refactor already on
  main (no architectural drift).

## Summary

Supersedes #466 (#334), #468 (#171), #467 (#449) — integrated on one branch with
a single `CHANGELOG.md` reconciliation.

- **#334** — `params.json` refreshes post-bind to `phase: "bound"` with
  `bound_work_dir`/`bound_task_dir`; pre-bind crashes stay `phase: "request"`.
- **#171** — tracked-session transcript resolution searches recorded config dir →
  canonical `~/.claude` → ambient `CLAUDE_CONFIG_DIR`, across session/chat/spawn
  id refs. Untracked lookups unchanged.
- **#449** — Codex death records exit code + stderr excerpt in the terminal
  error; single close event under exit-watcher/reader races; expected shutdown
  never reports backend death; teardown failure can't strand consumers without a
  stream sentinel. Reaper diagnostics add PGID reachability alongside root-PID
  aliveness (diagnostic only — no kill/finalize change).
- **Merge-prep alignment (vs #465):** `is_pgid_reachable` relocated
  `state/liveness.py` → `platform/process_scope/posix.py` (canonical PGID home,
  next to `terminate_pgid`), re-exported; `connection_closed_outcome` no longer
  re-appends `backend_exit_code`/stderr (codex's transport already formats them —
  single harness-owned formatter). #334/#171 confirmed orthogonal to #465.

## Resulting Behavior

- `meridian --format json spawn show <ambient-child>` → `params.json` shows the
  child's own bound work/task dir with `phase: "bound"`, not the parent's.
- `meridian session log <ref>` for a tracked Claude session recorded under a
  non-default config dir now finds and prints the transcript (previously: not
  found). Works for bare session id, chat id, and spawn id.
- When a Codex backend dies mid-turn, the spawn's terminal error reads e.g.
  `Codex app-server exited with code 1.\n\nCodex app-server stderr: <detail>`
  instead of `no close frame received or sent`.
- All text output and untracked/legacy paths unchanged.

## Changes

- **#334:** `lib/ops/spawn/execute.py`, `execute_init.py`, `execute_bg.py`,
  `execute_runner.py` (two-phase params: request metadata → bound refresh).
- **#171:** `lib/harness/adapter.py`, `claude.py`, `claude_preflight.py`,
  `claude_sessions.py`, `codex.py`, `opencode.py`, `pi.py`,
  `lib/ops/session_target.py`, `session_repair_target.py` (config-root hint chain
  threaded through tracked resolution).
- **#449:** `lib/harness/connections/codex_ws.py` (canonical `_backend_exit_payload`
  formatter, single-close-owner, exit watcher), `lib/state/liveness.py`,
  `lib/state/reaper.py`, `lib/platform/process_scope/{posix,__init__}.py` (PGID
  probe relocation + re-export).
- **Risk/notes:** `harness/semantics.py` shows net-zero vs main — #449 originally
  added a shared-formatter append; the merge-prep fix removed it, reverting to
  main's clean state (formatting owned by the codex transport). Reaper mechanisms
  confirmed complementary to #465's (not unified, by design).
- **Follow-ups (filed):** #472 (cap unbounded `stderr.log`/`history.jsonl`), #473
  (automatic archiving + retention).

## Work Item

triage-designs-impl

## Verification

- Integrated tree: `ruff` clean, `pyright` 0 errors, `pytest-llm` **1372 passed /
  2 skipped**.
- CI on #474: `full-gate` / `fast-gate` / `compat` / `lint` / `pr-changelog-note`
  all pass. `windows-gate` fails (non-blocking `continue-on-error`) on the
  pre-existing POSIX-vs-Windows path-separator suite only — zero failures in
  `liveness`/`reaper`/`process_scope`/`semantics`/`codex_ws`, i.e. nothing these
  changes touch.
- Merge-prep: reviewer p5700 checked #467/#468 for conceptual drift vs #465; the
  two #449 drifts were fixed (p5701) and the diff verified by tech-lead (tests
  retightened to assert a single-formatted codex error).
- Each lane's focused suites passed pre-integration (#334, #171, #449 designs +
  adversarial reviews).

## Knowledge Updates

Batch KB capture committed (kb `6378040`, later reconciled by `bc66a89`):
decision entries + terminal-owner, scope-liveness, trust-chain, and
two-phase-params concept docs covering #449/#171/#334; 3 stale pages fixed. KB
commits staged locally, unpushed (pushed at batch close).

## Spawn Trace

- p5671 coder — #334 two-phase `params.json` per design
- p5676 reviewer — #334 adversarial review (approved)
- p5670 coder — #171 config-root hint chain per design
- p5675 reviewer — #171 adversarial review
- p5679 coder — #171 fix pass (repair-path hint threading)
- p5669 coder — #449 diagnostics + liveness per design
- p5674 reviewer — #449 adversarial review
- p5678 coder — #449 fix pass (crash-only teardown + race-test hardening)
- p5700 reviewer — merge-prep consistency review vs #465
- p5701 coder — #449 drift fix (PGID probe relocation + single failure formatter)

## Release Label Guide

Set one `release:*` label on this PR:

- `release:patch` / `release:stable` — next stable **patch** release after merge
- `release:minor` — next stable **minor** release after merge
- `release:major` — next stable **major** release after merge
- `release:rc` — next **prerelease (RC)** after merge
- `release:skip` — no release for this merge

No `release:*` label defaults to a prerelease (RC). Unknown `release:*` labels also default to RC.

**This PR: `release:patch`** → v0.3.52 covering all three issues.

## Post-Merge Automation

After merge to `main`, CI (`.github/workflows/release-on-merge.yml`) will:

1. Read the PR release label
2. Skip only when `release:skip` is present (no label defaults to RC)
3. Compute the next stable or RC version from existing `v*` tags
4. Update `src/meridian/__init__.py` + promote `CHANGELOG.md` `[Unreleased]`
5. Commit `Release X.Y.Z`, create/push `vX.Y.Z`
6. Run `.github/workflows/publish-pypi.yml`

## Cleanup

After merge, clean merged worktrees with:

```bash
scripts/prune-worktrees.sh
```

Closes #334, closes #171, closes #449.
