### PR TITLE
Stop mirroring spawn history into artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- Spawn history now has one authoritative copy under `spawns/<id>/history.jsonl`;
+  finalization no longer mirrors the full log into the artifact store.
+
 ## [0.3.52] - 2026-07-24
 
 ### Fixed

--- a/src/meridian/lib/launch/AGENTS.md
+++ b/src/meridian/lib/launch/AGENTS.md
@@ -157,8 +157,8 @@ completed attempt's disk artifacts (`history.jsonl`, `stderr.log`, `report.md`,
 `runner-lifecycle.jsonl`, `last-observed-event.json`) into `attempt-N/` under the
 spawn log directory. The commit point is a single `os.replace(staging_dir,
 attempt_dir)` — crash-atomic via tmp dir staging. After the filesystem commit,
-artifact-store copies are made and active-attempt keys are deleted so the next
-attempt starts clean.
+non-history artifact-store copies are made and active-attempt keys are deleted
+so the next attempt starts clean. History remains solely in the spawn tree.
 
 Runner lifecycle and history diagnostics can execute after async boundaries. Their
 parent-creating writes use the published-spawn artifact mutation seam; never append

--- a/src/meridian/lib/launch/process/runner.py
+++ b/src/meridian/lib/launch/process/runner.py
@@ -894,7 +894,7 @@ def run_harness_process(
     primary_started_local_iso: str | None = None
     launch_child_cwd = control_root
     prelaunch_state = HarnessPrelaunchState()
-    artifacts = LocalStore(root_dir=runtime_root / "artifacts")
+    artifacts = LocalStore.for_runtime_root(runtime_root)
     spawn_service = build_spawn_application_service_from_roots(config_root, runtime_root)
     lifecycle_service = spawn_service.lifecycle
 

--- a/src/meridian/lib/launch/streaming_runner.py
+++ b/src/meridian/lib/launch/streaming_runner.py
@@ -290,7 +290,6 @@ def _append_runner_lifecycle_event(
 
 
 _ATTEMPT_STORE_ARTIFACTS = (
-    HISTORY_FILENAME,
     OUTPUT_FILENAME,
     STDERR_FILENAME,
     TOKENS_FILENAME,
@@ -334,9 +333,10 @@ def _preserve_attempt_artifacts(
 
     Commit point is ``os.replace(staging_dir, attempt_dir)``. A leftover
     ``attempt-N.tmp/`` from a crashed run is folded into ``attempt-N/`` when that
-    directory is absent; otherwise the staging dir is discarded. Artifact-store
-    copies and active-key deletion happen only after the filesystem commit so
-    retries never read stale attempt-scoped store keys.
+    directory is absent; otherwise the staging dir is discarded. Non-history
+    artifact-store copies and active-key deletion happen only after the
+    filesystem commit so retries never read stale attempt-scoped store keys.
+    History is already preserved by the disk move and is never mirrored.
     """
 
     attempt_prefix = f"attempt-{completed_attempt}"
@@ -387,18 +387,21 @@ def _persist_attempt_artifacts(
     log_dir: Path,
     secrets: tuple[SecretSpec, ...],
 ) -> None:
+    # History remains authoritative in the spawn tree. Redact it in place after
+    # the attempt has stopped rather than creating a second, redacted projection.
+    for name in (HISTORY_FILENAME, STDERR_FILENAME):
+        source = log_dir / name
+        if source.exists():
+            atomic_write_bytes(source, redact_secret_bytes(source.read_bytes(), secrets))
+
     for name in (
-        HISTORY_FILENAME,
         STDERR_FILENAME,
         TOKENS_FILENAME,
     ):
         source = log_dir / name
         if not source.exists():
             continue
-        payload = source.read_bytes()
-        if name in {HISTORY_FILENAME, STDERR_FILENAME}:
-            payload = redact_secret_bytes(payload, secrets)
-        artifacts.put(make_artifact_key(spawn_id, name), payload)
+        artifacts.put(make_artifact_key(spawn_id, name), source.read_bytes())
 
 
 def _retry_blocked_after_pi_child_started(

--- a/src/meridian/lib/ops/runtime.py
+++ b/src/meridian/lib/ops/runtime.py
@@ -102,7 +102,7 @@ class OperationRuntime(BaseModel):
             authority=prepared.authority,
             config=prepared.config,
             harness_registry=harness_registry,
-            artifacts=LocalStore(root_dir=prepared.runtime_root / "artifacts"),
+            artifacts=LocalStore.for_runtime_root(prepared.runtime_root),
             sink=sink or NullSink(),
         )
 
@@ -285,7 +285,7 @@ def build_runtime_from_root_and_config(
         authority=resolved_authority,
         config=config,
         harness_registry=get_default_harness_registry(),
-        artifacts=LocalStore(root_dir=resolved_authority.runtime_root / "artifacts"),
+        artifacts=LocalStore.for_runtime_root(resolved_authority.runtime_root),
         sink=sink or NullSink(),
     )
 

--- a/src/meridian/lib/ops/session_corpus.py
+++ b/src/meridian/lib/ops/session_corpus.py
@@ -22,7 +22,6 @@ def _runtime_has_session_data(runtime_root: Path) -> bool:
     return runtime_root.is_dir() and (
         (runtime_root / "sessions.jsonl").is_file()
         or any((runtime_root / "spawns").glob("p*"))
-        or any((runtime_root / "artifacts").glob("p*"))
     )
 
 

--- a/src/meridian/lib/ops/spawn/prepare.py
+++ b/src/meridian/lib/ops/spawn/prepare.py
@@ -246,7 +246,7 @@ def build_create_payload(
                 authority=resolved_authority,
                 config=config,
                 harness_registry=harness_registry,
-                artifacts=LocalStore(root_dir=preview_root / "artifacts"),
+                artifacts=LocalStore.for_runtime_root(preview_root),
             )
         composition_dry_run = payload.dry_run
         preview_runtime = build_spawn_mars_runtime(

--- a/src/meridian/lib/ops/spawn/query.py
+++ b/src/meridian/lib/ops/spawn/query.py
@@ -566,7 +566,7 @@ def read_written_files(
     resolved_runtime_root = runtime_root or resolve_runtime_root_for_read(project_root)
     if resolved_runtime_root is None:
         return ()
-    artifacts = LocalStore(root_dir=resolved_runtime_root / "artifacts")
+    artifacts = LocalStore.for_runtime_root(resolved_runtime_root)
     return extract_written_files(artifacts, SpawnId(spawn_id))
 
 

--- a/src/meridian/lib/state/AGENTS.md
+++ b/src/meridian/lib/state/AGENTS.md
@@ -74,8 +74,10 @@ history, launch/reaper diagnostics, failure sentinels, and harness journals use 
 seam. Heartbeats never create a missing parent directory and stop after deletion.
 The spawn repository and process-scope projection are persistence leaves with a
 one-way dependency: the projection may use repository reads and lock paths, while
-the repository never imports the projection. Cross-leaf operations belong in the aggregate `spawn_aggregate.py`; in particular, published-spawn deletion owns the lock
-order above. Reaper claims consume one immutable projection snapshot containing
+the repository never imports the projection. Cross-leaf operations belong in the
+aggregate `spawn_aggregate.py`; in particular, published-spawn deletion owns the
+lock order above and removes both `spawns/<id>/` and any legacy
+`artifacts/<id>/` directory. Reaper claims consume one immutable projection snapshot containing
 both scopes and released IDs, read under a single projection-lock acquisition.
 
 ## Write-Boundary Path Normalization

--- a/src/meridian/lib/state/artifact_store.py
+++ b/src/meridian/lib/state/artifact_store.py
@@ -47,18 +47,41 @@ class LocalStore(BaseModel):
     model_config = ConfigDict()
 
     root_dir: Path
+    spawn_root_dir: Path | None = None
+
+    @classmethod
+    def for_runtime_root(cls, runtime_root: Path) -> "LocalStore":
+        """Build a store whose history reads use the authoritative spawn tree."""
+
+        return cls(
+            root_dir=runtime_root / "artifacts",
+            spawn_root_dir=runtime_root / "spawns",
+        )
+
+    def _history_read_path(self, rel: Path) -> Path | None:
+        if self.spawn_root_dir is None or rel.name != "history.jsonl":
+            return None
+        candidate = self.spawn_root_dir / rel
+        return candidate if candidate.is_file() else None
 
     def put(self, key: ArtifactKey, data: bytes) -> None:
         rel = _normalize_key(key)
+        if self.spawn_root_dir is not None and rel.name == "history.jsonl":
+            raise ValueError("Spawn history is authoritative in the spawn tree.")
         target = self.root_dir / rel
         atomic_write_bytes(target, data)
 
     def get(self, key: ArtifactKey) -> bytes:
         rel = _normalize_key(key)
+        history_path = self._history_read_path(rel)
+        if history_path is not None:
+            return history_path.read_bytes()
         return (self.root_dir / rel).read_bytes()
 
     def exists(self, key: ArtifactKey) -> bool:
         rel = _normalize_key(key)
+        if self._history_read_path(rel) is not None:
+            return True
         return (self.root_dir / rel).exists()
 
     def delete(self, key: ArtifactKey) -> None:

--- a/src/meridian/lib/state/spawn_aggregate.py
+++ b/src/meridian/lib/state/spawn_aggregate.py
@@ -63,6 +63,19 @@ def _restore_spawn_artifact_permissions(
         raise exc_info from error
 
 
+def _remove_spawn_tree(path: Path) -> bool:
+    if not path.exists() and not path.is_symlink():
+        return True
+    try:
+        if path.is_symlink():
+            path.unlink()
+        else:
+            shutil.rmtree(path, onexc=_restore_spawn_artifact_permissions)
+    except OSError:
+        return False
+    return True
+
+
 def delete_published_spawn(
     runtime_root: Path,
     spawn_id: SpawnId | str,
@@ -83,6 +96,7 @@ def delete_published_spawn(
     if not is_safe_spawn_dir_name(resolved_spawn_id):
         raise ValueError(f"Invalid spawn ID: {resolved_spawn_id}")
     spawn_dir = paths.spawns_dir / resolved_spawn_id
+    artifact_dir = runtime_root / "artifacts" / resolved_spawn_id
 
     # Global order: spawn state, then process-scope projection.
     with (
@@ -96,8 +110,8 @@ def delete_published_spawn(
             return False
         if not spawn_dir.exists():
             return False
-        try:
-            shutil.rmtree(spawn_dir, onexc=_restore_spawn_artifact_permissions)
-        except OSError:
+        # Remove the legacy projection first so a partial failure cannot leave
+        # it behind after its authoritative spawn row is gone.
+        if not _remove_spawn_tree(artifact_dir):
             return False
-        return True
+        return _remove_spawn_tree(spawn_dir)

--- a/tests/integration/launch/test_streaming_runner_watchdog.py
+++ b/tests/integration/launch/test_streaming_runner_watchdog.py
@@ -85,6 +85,23 @@ def test_attempt_finalization_keeps_only_redacted_spawn_history(tmp_path: Path) 
     ).exists()
 
 
+def test_runtime_artifact_store_falls_back_to_legacy_history_copy(tmp_path: Path) -> None:
+    runtime_root = tmp_path / "runtime"
+    legacy_path = runtime_root / "artifacts" / "p-history" / "history.jsonl"
+    legacy_path.parent.mkdir(parents=True)
+    legacy_path.write_bytes(b"legacy history\n")
+    artifacts = LocalStore.for_runtime_root(runtime_root)
+    history_key = make_artifact_key("p-history", launch_constants.HISTORY_FILENAME)
+
+    assert artifacts.get(history_key) == b"legacy history\n"
+
+    live_path = runtime_root / "spawns" / "p-history" / "history.jsonl"
+    live_path.parent.mkdir(parents=True)
+    live_path.write_bytes(b"authoritative history\n")
+
+    assert artifacts.get(history_key) == b"authoritative history\n"
+
+
 class _NoReportExtractor:
     def extract_usage(self, artifacts: object, spawn_id: SpawnId) -> TokenUsage:
         _ = artifacts, spawn_id

--- a/tests/integration/launch/test_streaming_runner_watchdog.py
+++ b/tests/integration/launch/test_streaming_runner_watchdog.py
@@ -41,7 +41,6 @@ from tests.support.fakes import FakeClock, FakeHeartbeat
 _pi_extension_projection_fixture = _pi_extension_projection_fixture
 
 _STORE_ATTEMPT_FILES = (
-    launch_constants.HISTORY_FILENAME,
     launch_constants.OUTPUT_FILENAME,
     launch_constants.STDERR_FILENAME,
     launch_constants.TOKENS_FILENAME,
@@ -55,6 +54,35 @@ _DISK_ATTEMPT_FILES = (
     launch_constants.TOKENS_FILENAME,
     launch_constants.REPORT_FILENAME,
 )
+
+
+def test_attempt_finalization_keeps_only_redacted_spawn_history(tmp_path: Path) -> None:
+    runtime_root = tmp_path / "runtime"
+    log_dir = runtime_root / "spawns" / "p-history"
+    log_dir.mkdir(parents=True)
+    history_path = log_dir / launch_constants.HISTORY_FILENAME
+    history_path.write_text('{"content":"secret-value"}\n', encoding="utf-8")
+    artifacts = LocalStore.for_runtime_root(runtime_root)
+    secrets = (
+        streaming_runner_module.SecretSpec(key="API_TOKEN", value="secret-value"),
+    )
+
+    streaming_runner_module._persist_attempt_artifacts(
+        artifacts=artifacts,
+        spawn_id=SpawnId("p-history"),
+        log_dir=log_dir,
+        secrets=secrets,
+    )
+
+    assert history_path.read_text(encoding="utf-8") == (
+        '{"content":"[REDACTED:API_TOKEN]"}\n'
+    )
+    assert artifacts.get(
+        make_artifact_key("p-history", launch_constants.HISTORY_FILENAME)
+    ) == history_path.read_bytes()
+    assert not (
+        runtime_root / "artifacts" / "p-history" / launch_constants.HISTORY_FILENAME
+    ).exists()
 
 
 class _NoReportExtractor:
@@ -290,7 +318,10 @@ def test_retry_preserves_completed_attempt_artifacts(tmp_path: Path) -> None:
 def test_preserve_clears_active_history_before_retry_extraction(tmp_path: Path) -> None:
     log_dir = tmp_path / "spawns" / "r-stale-history"
     log_dir.mkdir(parents=True, exist_ok=True)
-    artifacts = LocalStore(root_dir=tmp_path / ".artifacts")
+    artifacts = LocalStore(
+        root_dir=tmp_path / ".artifacts",
+        spawn_root_dir=tmp_path / "spawns",
+    )
     spawn_id = SpawnId("r-stale-history")
     attempt_one_history = (
         b'{"role":"assistant","content":"attempt 1 durable completion report text"}\n'
@@ -298,7 +329,6 @@ def test_preserve_clears_active_history_before_retry_extraction(tmp_path: Path) 
     attempt_one_report = b"# Report\n\nattempt 1 durable completion\n"
     history_key = make_artifact_key(spawn_id, launch_constants.HISTORY_FILENAME)
     report_key = make_artifact_key(spawn_id, launch_constants.REPORT_FILENAME)
-    artifacts.put(history_key, attempt_one_history)
     artifacts.put(report_key, attempt_one_report)
     (log_dir / launch_constants.HISTORY_FILENAME).write_bytes(attempt_one_history)
     (log_dir / launch_constants.REPORT_FILENAME).write_bytes(attempt_one_report)
@@ -310,9 +340,9 @@ def test_preserve_clears_active_history_before_retry_extraction(tmp_path: Path) 
         completed_attempt=1,
     )
 
-    assert not artifacts.exists(history_key)
     attempt_one_history_key = make_artifact_key(spawn_id, "attempt-1/history.jsonl")
     assert artifacts.get(attempt_one_history_key) == attempt_one_history
+    assert not (tmp_path / ".artifacts" / str(spawn_id) / "attempt-1/history.jsonl").exists()
 
     reset_finalize_attempt_artifacts(
         artifacts=artifacts,
@@ -337,7 +367,10 @@ def test_preserve_clears_active_history_before_retry_extraction(tmp_path: Path) 
 def test_preserve_recovers_interrupted_rotation(tmp_path: Path) -> None:
     log_dir = tmp_path / "spawns" / "r-interrupted"
     log_dir.mkdir(parents=True, exist_ok=True)
-    artifacts = LocalStore(root_dir=tmp_path / ".artifacts")
+    artifacts = LocalStore(
+        root_dir=tmp_path / ".artifacts",
+        spawn_root_dir=tmp_path / "spawns",
+    )
     spawn_id = SpawnId("r-interrupted")
     staging_dir = log_dir / "attempt-1.tmp"
     staging_dir.mkdir(parents=True)
@@ -348,10 +381,6 @@ def test_preserve_recovers_interrupted_rotation(tmp_path: Path) -> None:
     (log_dir / launch_constants.STDERR_FILENAME).write_text(
         "late stderr\n",
         encoding="utf-8",
-    )
-    artifacts.put(
-        make_artifact_key(spawn_id, launch_constants.HISTORY_FILENAME),
-        b"active history\n",
     )
 
     streaming_runner_module._preserve_attempt_artifacts(
@@ -371,7 +400,10 @@ def test_preserve_recovers_interrupted_rotation(tmp_path: Path) -> None:
     history_key = make_artifact_key(spawn_id, launch_constants.HISTORY_FILENAME)
     attempt_one_history_key = make_artifact_key(spawn_id, "attempt-1/history.jsonl")
     assert not artifacts.exists(history_key)
-    assert artifacts.get(attempt_one_history_key) == b"active history\n"
+    assert artifacts.get(attempt_one_history_key) == b"staged history\n"
+    assert not artifacts.exists(
+        make_artifact_key(spawn_id, "attempt-1.tmp/history.jsonl")
+    )
 
 
 def test_preserve_discards_stale_staging_when_attempt_dir_exists(tmp_path: Path) -> None:

--- a/tests/integration/ops/test_diag_prune.py
+++ b/tests/integration/ops/test_diag_prune.py
@@ -91,6 +91,10 @@ def _seed_pruning_layout(
     current_root = user_home / "projects" / current_uuid
     current_spawn = current_root / "spawns" / "p1"
     _write_text(current_spawn / "history.jsonl", '{"event":"start"}\n')
+    _write_text(
+        current_root / "artifacts" / "p1" / "history.jsonl",
+        '{"event":"legacy mirror"}\n',
+    )
     _set_tree_mtime(current_spawn, 1_600_000_000.0)
     _set_path_mtime(current_root, 1_900_000_000.0)
 
@@ -154,6 +158,7 @@ def test_doctor_prune_only_prunes_current_project_artifacts(
     assert result.orphan_project_dirs == ()
     assert result.stale_spawn_artifacts and result.stale_spawn_artifacts[0].spawn_id == "p1"
     assert not current_spawn.exists()
+    assert not (current_spawn.parent.parent / "artifacts" / "p1").exists()
     assert orphan_root.exists(), "orphan dir should NOT be pruned without --global"
     assert other_spawn.exists()
 

--- a/tests/integration/state/test_spawn_artifact_lifetime.py
+++ b/tests/integration/state/test_spawn_artifact_lifetime.py
@@ -75,6 +75,26 @@ def test_late_failure_sentinel_does_not_recreate_deleted_spawn(tmp_path: Path) -
     assert not spawn_dir.exists()
 
 
+def test_spawn_deletion_removes_legacy_artifact_store_directory(tmp_path: Path) -> None:
+    runtime_root = tmp_path / "runtime"
+    spawn_id = "p1"
+    spawn_dir = runtime_root / "spawns" / spawn_id
+    artifact_dir = runtime_root / "artifacts" / spawn_id
+    _start_test_spawn(runtime_root, spawn_id, status="running")
+    finalize_spawn(runtime_root, spawn_id, "succeeded", 0, origin="runner")
+    artifact_dir.mkdir(parents=True)
+    (artifact_dir / "history.jsonl").write_text("legacy mirror\n", encoding="utf-8")
+
+    assert delete_published_spawn(
+        runtime_root,
+        spawn_id,
+        can_delete=lambda record: record is not None,
+    )
+
+    assert not spawn_dir.exists()
+    assert not artifact_dir.exists()
+
+
 def test_failure_sentinel_refuses_non_failed_spawn(tmp_path: Path) -> None:
     runtime_root = tmp_path / "runtime"
     spawn_id = "p1"


### PR DESCRIPTION
## Why

Every finalized spawn copied its complete live history from `spawns/<id>/history.jsonl` to `artifacts/<id>/history.jsonl`. The duplicate reached 81.8 GB locally, and retention only scanned the spawn tree, so legacy artifact directories could outlive their spawn aggregate indefinitely.

## Goal

Keep `spawns/<id>/history.jsonl` as the single authoritative history, preserve secret redaction and retry evidence, retain reads of existing legacy copies, and delete legacy artifact directories with their spawn aggregate.

## Summary

- Stop persisting active and retry history into the artifact store.
- Route runtime artifact-store history reads to the spawn tree first, with the existing artifact tree as a legacy fallback.
- Redact the authoritative live history in place after an attempt stops, before extraction or retry preservation.
- Preserve retry history by moving the live disk file into `spawns/<id>/attempt-N/history.jsonl`.
- Delete `artifacts/<id>/` whenever aggregate retention deletes `spawns/<id>/`.
- Stop treating artifact-only directories as session-corpus evidence.

## Resulting Behavior

A finalized spawn has one history file:

```text
spawns/<id>/history.jsonl       authoritative, redacted at attempt finalization
artifacts/<id>/history.jsonl    no longer written
```

`spawn show`, `spawn report show`, `session log`, and `session search` continue to resolve the spawn history. Existing legacy artifact copies remain readable when the authoritative file is absent, but new runtime writes reject history artifact keys.

## Changes

- `LocalStore.for_runtime_root()` understands the split between the generic artifact tree and authoritative spawn-history tree. It prefers spawn history and falls back to a legacy artifact copy.
- `_persist_attempt_artifacts()` now atomically redacts live history and stderr in place, then stores only non-history artifacts. This deliberately preserves the old secret-redaction boundary rather than assuming the prior no-op samples prove secrets can never appear.
- Retry rotation no longer sources or writes artifact-store history. The existing crash-atomic disk move is the history preservation mechanism.
- Published-spawn deletion removes the legacy artifact directory first; if that removal fails, the authoritative spawn row remains eligible for a later retry rather than leaving the unbounded mirror orphaned.
- Follow-up intentionally excluded: history compaction (`raw_text` removal / superseded delta collapsing) remains a separate change.

## Work Item

`spawn-history-storage`

## Verification

Automated:

- `uv run pytest-llm` — `1375 passed, 2 skipped, 7 warnings`
- `uv run ruff check .` — clean
- `uv run --extra dev python -m pyright` — `0 errors, 12 warnings`
- Push preflight also passed pytest, Ruff, Pyright, and package build.

Real end-to-end spawn (`p5747`):

```text
$ uv run meridian spawn -a coder --prompt-file .../history-e2e.md --task-dir .../spawn-history-storage
Spawn id: p5747
p5747 succeeded (4.9s)
# Report
history storage e2e passed

$ test -f ~/.meridian/projects/mellow-hollow-brood/spawns/p5747/history.jsonl && echo 'spawn history: present'
spawn history: present
$ test ! -e ~/.meridian/projects/mellow-hollow-brood/artifacts/p5747/history.jsonl && echo 'artifact history: absent'
artifact history: absent

$ uv run meridian spawn show p5747
Spawn: p5747
Status: succeeded
...
# Report
history storage e2e passed

$ uv run meridian spawn report show p5747
# Report
history storage e2e passed

$ uv run meridian session log p5747
# Session p5747
6 entries, segment 0 (current) · showing 1-5
...
**Assistant** [5]
history storage e2e passed

$ uv run meridian session search "history storage e2e passed" p5747
Session search — 2 matches
... [user] ...
... [assistant] ...
```

Note: the report subcommand's complete CLI shape is `meridian spawn report show <id>`.

## Knowledge Updates

Updated `src/meridian/lib/launch/AGENTS.md` to record disk-only retry history and `src/meridian/lib/state/AGENTS.md` to record aggregate ownership of legacy artifact directories. Added the user-visible storage change to `CHANGELOG.md`.

## Spawn Trace

- `p5747` coder — real end-to-end verification spawn; instructed not to edit files and return a fixed report.

## Release Label Guide

Set `release:patch`: this fixes unbounded duplicate storage while preserving read behavior.

## Post-Merge Automation

Normal labeled-PR release automation applies. This PR must not be merged without explicit human approval.

## Cleanup

After merge, clean the feature worktree with `scripts/prune-worktrees.sh`.
