### PR TITLE
v0.3.53 — spawn-cancel safety, terminal restore, and single-copy history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - Refuse to cancel live managed primary sessions unless `spawn cancel --force` is explicit.
+- Restore terminal mouse, alternate-screen, and cursor modes after a primary TUI exits.
 
 ## [0.3.52] - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Refuse to cancel live managed primary sessions unless `spawn cancel --force` is explicit.
 - Restore terminal mouse, alternate-screen, and cursor modes after a primary TUI exits.
+- Stop cancel waits as soon as the target process scope exits.
 
 ## [0.3.52] - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- Spawn history now has one authoritative copy under `spawns/<id>/history.jsonl`;
+  finalization no longer mirrors the full log into the artifact store.
+
 ## [0.3.52] - 2026-07-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Refuse to cancel live managed primary sessions unless `spawn cancel --force` is explicit.
+
 ## [0.3.52] - 2026-07-24
 
 ### Fixed

--- a/src/meridian/cli/spawn.py
+++ b/src/meridian/cli/spawn.py
@@ -993,10 +993,18 @@ def _spawn_stats(
 def _spawn_cancel(
     emit: Any,
     spawn_id: str,
+    force: Annotated[
+        bool,
+        Parameter(
+            name="--force",
+            help="Cancel even when the target is a live managed primary session.",
+        ),
+    ] = False,
 ) -> None:
     result = spawn_cancel_sync(
         SpawnCancelInput(
             spawn_id=spawn_id,
+            force=force,
         ),
         sink=_current_output_sink(),
         prepared=_prepare_spawn_runtime_write(),

--- a/src/meridian/lib/core/process_cleanup.py
+++ b/src/meridian/lib/core/process_cleanup.py
@@ -18,6 +18,7 @@ from meridian.lib.platform.process_scope.base import (
     ProcessScopeSnapshot,
     birth_time_unverified,
 )
+from meridian.lib.state.liveness import is_process_alive, is_process_alive_with_birth
 from meridian.lib.state.process_scope_projection import (
     is_scope_released,
     mark_scope_released,
@@ -26,6 +27,28 @@ from meridian.lib.state.process_scope_projection import (
 from meridian.lib.state.spawn.model import SpawnRecord
 
 logger = structlog.get_logger(__name__)
+
+
+def _wait_for_scope_exit(scope: ProcessScopeSnapshot, *, timeout: float) -> None:
+    """Wait only while a scope's recorded root process is still alive."""
+
+    import time
+
+    deadline = time.monotonic() + max(0.0, timeout)
+    while True:
+        if birth_time_unverified(scope.root_created_at_epoch):
+            alive = is_process_alive(scope.root_pid)
+        else:
+            alive = is_process_alive_with_birth(
+                scope.root_pid,
+                scope.root_created_at_epoch,
+            )
+        if not alive:
+            return
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return
+        time.sleep(min(0.05, remaining))
 
 
 def terminate_recorded_spawn_scopes(
@@ -282,8 +305,6 @@ def cancel_managed_primary(
     Idempotent — already-released scopes are skipped. Safe to call even when
     primary_metadata is not available (falls back to scope records only).
     """
-    import time
-
     scopes = read_scopes_from_disk(runtime_root, SpawnId(spawn_record.id))
     results: list[CleanupResult] = []
     spawn_id = SpawnId(spawn_record.id)
@@ -309,9 +330,11 @@ def cancel_managed_primary(
             )
             results.append(result)
 
-    # 2. Brief pause to let launcher-driven shutdown propagate.
-    if results:
-        time.sleep(1.0)
+    # 2. Let launcher-driven shutdown propagate, but stop waiting as soon as
+    # the launcher scope is actually gone.
+    launcher_scope = next((scope for scope in scopes if scope.scope_id == "launcher"), None)
+    if results and launcher_scope is not None:
+        _wait_for_scope_exit(launcher_scope, timeout=1.0)
 
     # 3. Terminate backend and TUI if still unreleased.
     for scope in scopes:

--- a/src/meridian/lib/core/spawn_service.py
+++ b/src/meridian/lib/core/spawn_service.py
@@ -71,6 +71,33 @@ if TYPE_CHECKING:
 _WAIT_POLL_INTERVAL_SECS = 0.1
 _MANAGED_CANCEL_GRACE_SECS = 5.0
 _MANAGED_CANCEL_FALLBACK_WAIT_SECS = 1.0
+
+
+def _is_live_managed_primary(runtime_root: Path, record: SpawnRecord) -> bool:
+    if record.kind != "primary" or record.chat_id is None:
+        return False
+    from meridian.lib.state.session_store import is_session_lease_owner_alive
+
+    return is_session_lease_owner_alive(runtime_root, str(record.chat_id))
+
+
+def _live_primary_cancel_refusal(record: SpawnRecord) -> str:
+    agent = (record.agent or "unknown").strip() or "unknown"
+    chat_id = str(record.chat_id) if record.chat_id is not None else "unknown"
+    uptime = "unknown"
+    if record.started_at is not None:
+        started_epoch = iso_timestamp_to_epoch(record.started_at)
+        if started_epoch is not None:
+            elapsed = max(0, int(time.time() - started_epoch))
+            hours, remainder = divmod(elapsed, 3600)
+            minutes, seconds = divmod(remainder, 60)
+            uptime = f"{hours}h {minutes}m" if hours else f"{minutes}m {seconds}s"
+    return (
+        f"Refusing to cancel live managed primary '{record.id}' "
+        f"(agent: {agent}, chat: {chat_id}, uptime: {uptime}). "
+        f"To end this interactive session anyway, pass --force: "
+        f"meridian spawn cancel {record.id} --force"
+    )
 _MAX_REAP_PASSES = 4
 logger = structlog.get_logger()
 
@@ -525,6 +552,7 @@ class SpawnApplicationService:
         spawn_id: SpawnId,
         *,
         requested_by: Literal["user", "system"] = "user",
+        force: bool = False,
     ) -> CancelOutcome:
         """Cancel a spawn through the shared surface-neutral pipeline."""
         lock = await self._locks.acquire(str(spawn_id))
@@ -533,6 +561,8 @@ class SpawnApplicationService:
             if self.is_terminal(record.status):
                 self._cleanup_orphan_managed_primary(spawn_id, record)
                 return _cancel_outcome_from_record(str(spawn_id), record, already_terminal=True)
+            if not force and _is_live_managed_primary(self._runtime_root, record):
+                raise RuntimeError(_live_primary_cancel_refusal(record))
 
             record = (
                 await asyncio.to_thread(
@@ -606,7 +636,10 @@ class SpawnApplicationService:
             if not descendants:
                 return reaped_ids
             results = await asyncio.gather(
-                *(self.cancel(SpawnId(d.id), requested_by="system") for d in descendants),
+                *(
+                    self.cancel(SpawnId(d.id), requested_by="system", force=False)
+                    for d in descendants
+                ),
                 return_exceptions=True,
             )
             for descendant, result in zip(descendants, results, strict=True):

--- a/src/meridian/lib/core/spawn_service.py
+++ b/src/meridian/lib/core/spawn_service.py
@@ -98,6 +98,8 @@ def _live_primary_cancel_refusal(record: SpawnRecord) -> str:
         f"To end this interactive session anyway, pass --force: "
         f"meridian spawn cancel {record.id} --force"
     )
+
+
 _MAX_REAP_PASSES = 4
 logger = structlog.get_logger()
 
@@ -594,6 +596,18 @@ class SpawnApplicationService:
                 manager=self._spawn_manager,
             ).cancel(spawn_id)
 
+        latest_after_delivery = self.get_spawn(spawn_id) or record
+        if not _has_live_execution_owner(latest_after_delivery, primary_metadata):
+            lock = await self._locks.acquire(str(spawn_id))
+            async with lock:
+                latest_after_delivery = self.get_spawn(spawn_id) or latest_after_delivery
+                converged = await self._force_cancel_convergence(
+                    spawn_id,
+                    latest_after_delivery,
+                )
+                if converged is not None:
+                    return _cancel_outcome_from_record(str(spawn_id), converged)
+
         terminal = await self._wait_for_terminal(spawn_id, timeout=1.0)
         if terminal is not None:
             return _cancel_outcome_from_record(str(spawn_id), terminal, already_terminal=True)
@@ -769,28 +783,30 @@ class SpawnApplicationService:
             launcher_pid, created_after_epoch=started_epoch
         )
         if launcher_alive:
+            assert launcher_pid is not None
             terminate_managed_primary_processes(
                 primary_metadata,
                 include_launcher=True,
                 include_runtime_children=False,
             )
-        else:
-            terminate_managed_primary_processes(
-                primary_metadata,
-                include_launcher=False,
-            )
-
-        latest = await self._wait_for_terminal(
-            spawn_id,
-            timeout=_MANAGED_CANCEL_GRACE_SECS,
-        )
-        if latest is None and launcher_alive:
-            terminate_managed_primary_processes(
-                primary_metadata,
-                include_launcher=False,
-            )
-            latest = await self._wait_for_terminal(
+            latest = await self._wait_for_terminal_or_process_exit(
                 spawn_id,
+                pid=launcher_pid,
+                created_after_epoch=started_epoch,
+                timeout=_MANAGED_CANCEL_GRACE_SECS,
+            )
+        else:
+            latest = None
+
+        if latest is None:
+            terminate_managed_primary_processes(
+                primary_metadata,
+                include_launcher=False,
+            )
+            latest = await self._wait_for_terminal_or_execution_exit(
+                spawn_id,
+                record=record,
+                primary_metadata=primary_metadata,
                 timeout=_MANAGED_CANCEL_FALLBACK_WAIT_SECS,
             )
 
@@ -835,6 +851,46 @@ class SpawnApplicationService:
             latest,
             finalizing=latest.status == "finalizing",
         )
+
+    async def _wait_for_terminal_or_process_exit(
+        self,
+        spawn_id: SpawnId,
+        *,
+        pid: int,
+        created_after_epoch: float | None,
+        timeout: float,
+    ) -> SpawnRecord | None:
+        deadline = time.monotonic() + max(0.0, timeout)
+        while True:
+            current = self.get_spawn(spawn_id)
+            if current is not None and self.is_terminal(current.status):
+                return current
+            if not is_process_alive(pid, created_after_epoch=created_after_epoch):
+                return None
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return None
+            await asyncio.sleep(min(_WAIT_POLL_INTERVAL_SECS, remaining))
+
+    async def _wait_for_terminal_or_execution_exit(
+        self,
+        spawn_id: SpawnId,
+        *,
+        record: SpawnRecord,
+        primary_metadata: PrimaryMetadata,
+        timeout: float,
+    ) -> SpawnRecord | None:
+        deadline = time.monotonic() + max(0.0, timeout)
+        while True:
+            current = self.get_spawn(spawn_id)
+            if current is not None and self.is_terminal(current.status):
+                return current
+            if not _has_live_execution_owner(current or record, primary_metadata):
+                return None
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return None
+            await asyncio.sleep(min(_WAIT_POLL_INTERVAL_SECS, remaining))
 
     async def complete_spawn(
         self,

--- a/src/meridian/lib/launch/AGENTS.md
+++ b/src/meridian/lib/launch/AGENTS.md
@@ -157,8 +157,8 @@ completed attempt's disk artifacts (`history.jsonl`, `stderr.log`, `report.md`,
 `runner-lifecycle.jsonl`, `last-observed-event.json`) into `attempt-N/` under the
 spawn log directory. The commit point is a single `os.replace(staging_dir,
 attempt_dir)` — crash-atomic via tmp dir staging. After the filesystem commit,
-artifact-store copies are made and active-attempt keys are deleted so the next
-attempt starts clean.
+non-history artifact-store copies are made and active-attempt keys are deleted
+so the next attempt starts clean. History remains solely in the spawn tree.
 
 Runner lifecycle and history diagnostics can execute after async boundaries. Their
 parent-creating writes use the published-spawn artifact mutation seam; never append

--- a/src/meridian/lib/launch/process/pty_launcher.py
+++ b/src/meridian/lib/launch/process/pty_launcher.py
@@ -16,6 +16,15 @@ from meridian.lib.platform import IS_WINDOWS, fcntl, pty, select, termios, tty
 
 from .ports import LaunchedProcess, ProcessLauncher
 
+_TERMINAL_RESTORE_SEQUENCE = (
+    b"\x1b[?1000l"
+    b"\x1b[?1002l"
+    b"\x1b[?1003l"
+    b"\x1b[?1006l"
+    b"\x1b[?1049l"
+    b"\x1b[?25h"
+)
+
 
 def can_use_pty() -> bool:
     return not IS_WINDOWS and sys.stdin.isatty() and sys.stdout.isatty()
@@ -127,6 +136,8 @@ def _copy_primary_pty_output(
         restore_resize()
         if saved_tty_attrs is not None:
             termios.tcsetattr(stdin_fd, termios.TCSADRAIN, saved_tty_attrs)
+        with suppress(OSError):
+            os.write(stdout_fd, _TERMINAL_RESTORE_SEQUENCE)
 
     _, status = os.waitpid(child_pid, 0)
     return os.waitstatus_to_exitcode(status)

--- a/src/meridian/lib/launch/process/runner.py
+++ b/src/meridian/lib/launch/process/runner.py
@@ -894,7 +894,7 @@ def run_harness_process(
     primary_started_local_iso: str | None = None
     launch_child_cwd = control_root
     prelaunch_state = HarnessPrelaunchState()
-    artifacts = LocalStore(root_dir=runtime_root / "artifacts")
+    artifacts = LocalStore.for_runtime_root(runtime_root)
     spawn_service = build_spawn_application_service_from_roots(config_root, runtime_root)
     lifecycle_service = spawn_service.lifecycle
 

--- a/src/meridian/lib/launch/streaming_runner.py
+++ b/src/meridian/lib/launch/streaming_runner.py
@@ -290,7 +290,6 @@ def _append_runner_lifecycle_event(
 
 
 _ATTEMPT_STORE_ARTIFACTS = (
-    HISTORY_FILENAME,
     OUTPUT_FILENAME,
     STDERR_FILENAME,
     TOKENS_FILENAME,
@@ -334,9 +333,10 @@ def _preserve_attempt_artifacts(
 
     Commit point is ``os.replace(staging_dir, attempt_dir)``. A leftover
     ``attempt-N.tmp/`` from a crashed run is folded into ``attempt-N/`` when that
-    directory is absent; otherwise the staging dir is discarded. Artifact-store
-    copies and active-key deletion happen only after the filesystem commit so
-    retries never read stale attempt-scoped store keys.
+    directory is absent; otherwise the staging dir is discarded. Non-history
+    artifact-store copies and active-key deletion happen only after the
+    filesystem commit so retries never read stale attempt-scoped store keys.
+    History is already preserved by the disk move and is never mirrored.
     """
 
     attempt_prefix = f"attempt-{completed_attempt}"
@@ -387,18 +387,21 @@ def _persist_attempt_artifacts(
     log_dir: Path,
     secrets: tuple[SecretSpec, ...],
 ) -> None:
+    # History remains authoritative in the spawn tree. Redact it in place after
+    # the attempt has stopped rather than creating a second, redacted projection.
+    for name in (HISTORY_FILENAME, STDERR_FILENAME):
+        source = log_dir / name
+        if source.exists():
+            atomic_write_bytes(source, redact_secret_bytes(source.read_bytes(), secrets))
+
     for name in (
-        HISTORY_FILENAME,
         STDERR_FILENAME,
         TOKENS_FILENAME,
     ):
         source = log_dir / name
         if not source.exists():
             continue
-        payload = source.read_bytes()
-        if name in {HISTORY_FILENAME, STDERR_FILENAME}:
-            payload = redact_secret_bytes(payload, secrets)
-        artifacts.put(make_artifact_key(spawn_id, name), payload)
+        artifacts.put(make_artifact_key(spawn_id, name), source.read_bytes())
 
 
 def _retry_blocked_after_pi_child_started(

--- a/src/meridian/lib/ops/runtime.py
+++ b/src/meridian/lib/ops/runtime.py
@@ -102,7 +102,7 @@ class OperationRuntime(BaseModel):
             authority=prepared.authority,
             config=prepared.config,
             harness_registry=harness_registry,
-            artifacts=LocalStore(root_dir=prepared.runtime_root / "artifacts"),
+            artifacts=LocalStore.for_runtime_root(prepared.runtime_root),
             sink=sink or NullSink(),
         )
 
@@ -285,7 +285,7 @@ def build_runtime_from_root_and_config(
         authority=resolved_authority,
         config=config,
         harness_registry=get_default_harness_registry(),
-        artifacts=LocalStore(root_dir=resolved_authority.runtime_root / "artifacts"),
+        artifacts=LocalStore.for_runtime_root(resolved_authority.runtime_root),
         sink=sink or NullSink(),
     )
 

--- a/src/meridian/lib/ops/session_corpus.py
+++ b/src/meridian/lib/ops/session_corpus.py
@@ -22,7 +22,6 @@ def _runtime_has_session_data(runtime_root: Path) -> bool:
     return runtime_root.is_dir() and (
         (runtime_root / "sessions.jsonl").is_file()
         or any((runtime_root / "spawns").glob("p*"))
-        or any((runtime_root / "artifacts").glob("p*"))
     )
 
 

--- a/src/meridian/lib/ops/spawn/api.py
+++ b/src/meridian/lib/ops/spawn/api.py
@@ -1242,7 +1242,7 @@ async def _spawn_cancel_impl(
         setup_telemetry(runtime_root=runtime_root, logical_owner=cancel_owner)
     register_spawn_telemetry_observer()
     try:
-        outcome = await spawn_service.cancel(SpawnId(spawn_id))
+        outcome = await spawn_service.cancel(SpawnId(spawn_id), force=payload.force)
     except RuntimeError as exc:
         return SpawnActionOutput(
             command="spawn.cancel",
@@ -1334,6 +1334,7 @@ def spawn_cancel_all_sync(
                 SpawnCancelInput(
                     spawn_id=row.id,
                     project_root=project_root.as_posix(),
+                    force=payload.include_primaries,
                 ),
                 sink=sink,
                 prepared=prepared,

--- a/src/meridian/lib/ops/spawn/models.py
+++ b/src/meridian/lib/ops/spawn/models.py
@@ -745,6 +745,7 @@ class SpawnCancelInput(BaseModel):
 
     spawn_id: str
     project_root: str | None = None
+    force: bool = False
 
 
 class SpawnCancelAllInput(BaseModel):

--- a/src/meridian/lib/ops/spawn/prepare.py
+++ b/src/meridian/lib/ops/spawn/prepare.py
@@ -246,7 +246,7 @@ def build_create_payload(
                 authority=resolved_authority,
                 config=config,
                 harness_registry=harness_registry,
-                artifacts=LocalStore(root_dir=preview_root / "artifacts"),
+                artifacts=LocalStore.for_runtime_root(preview_root),
             )
         composition_dry_run = payload.dry_run
         preview_runtime = build_spawn_mars_runtime(

--- a/src/meridian/lib/ops/spawn/query.py
+++ b/src/meridian/lib/ops/spawn/query.py
@@ -566,7 +566,7 @@ def read_written_files(
     resolved_runtime_root = runtime_root or resolve_runtime_root_for_read(project_root)
     if resolved_runtime_root is None:
         return ()
-    artifacts = LocalStore(root_dir=resolved_runtime_root / "artifacts")
+    artifacts = LocalStore.for_runtime_root(resolved_runtime_root)
     return extract_written_files(artifacts, SpawnId(spawn_id))
 
 

--- a/src/meridian/lib/state/AGENTS.md
+++ b/src/meridian/lib/state/AGENTS.md
@@ -74,8 +74,10 @@ history, launch/reaper diagnostics, failure sentinels, and harness journals use 
 seam. Heartbeats never create a missing parent directory and stop after deletion.
 The spawn repository and process-scope projection are persistence leaves with a
 one-way dependency: the projection may use repository reads and lock paths, while
-the repository never imports the projection. Cross-leaf operations belong in the aggregate `spawn_aggregate.py`; in particular, published-spawn deletion owns the lock
-order above. Reaper claims consume one immutable projection snapshot containing
+the repository never imports the projection. Cross-leaf operations belong in the
+aggregate `spawn_aggregate.py`; in particular, published-spawn deletion owns the
+lock order above and removes both `spawns/<id>/` and any legacy
+`artifacts/<id>/` directory. Reaper claims consume one immutable projection snapshot containing
 both scopes and released IDs, read under a single projection-lock acquisition.
 
 ## Write-Boundary Path Normalization

--- a/src/meridian/lib/state/artifact_store.py
+++ b/src/meridian/lib/state/artifact_store.py
@@ -47,18 +47,41 @@ class LocalStore(BaseModel):
     model_config = ConfigDict()
 
     root_dir: Path
+    spawn_root_dir: Path | None = None
+
+    @classmethod
+    def for_runtime_root(cls, runtime_root: Path) -> "LocalStore":
+        """Build a store whose history reads use the authoritative spawn tree."""
+
+        return cls(
+            root_dir=runtime_root / "artifacts",
+            spawn_root_dir=runtime_root / "spawns",
+        )
+
+    def _history_read_path(self, rel: Path) -> Path | None:
+        if self.spawn_root_dir is None or rel.name != "history.jsonl":
+            return None
+        candidate = self.spawn_root_dir / rel
+        return candidate if candidate.is_file() else None
 
     def put(self, key: ArtifactKey, data: bytes) -> None:
         rel = _normalize_key(key)
+        if self.spawn_root_dir is not None and rel.name == "history.jsonl":
+            raise ValueError("Spawn history is authoritative in the spawn tree.")
         target = self.root_dir / rel
         atomic_write_bytes(target, data)
 
     def get(self, key: ArtifactKey) -> bytes:
         rel = _normalize_key(key)
+        history_path = self._history_read_path(rel)
+        if history_path is not None:
+            return history_path.read_bytes()
         return (self.root_dir / rel).read_bytes()
 
     def exists(self, key: ArtifactKey) -> bool:
         rel = _normalize_key(key)
+        if self._history_read_path(rel) is not None:
+            return True
         return (self.root_dir / rel).exists()
 
     def delete(self, key: ArtifactKey) -> None:

--- a/src/meridian/lib/state/session_store.py
+++ b/src/meridian/lib/state/session_store.py
@@ -520,6 +520,14 @@ def has_live_session_leases(runtime_root: Path) -> bool:
     return False
 
 
+def is_session_lease_owner_alive(runtime_root: Path, chat_id: str) -> bool:
+    """Return whether one session's lease names a currently live owner process."""
+
+    paths = RuntimePaths.from_root_dir(runtime_root)
+    _exists, _generation, owner_pid = _read_session_lease_data(paths, chat_id)
+    return owner_pid is not None and is_process_alive(owner_pid)
+
+
 def list_active_session_records(runtime_root: Path) -> list[SessionRecord]:
     """Return materialized records for active sessions."""
 

--- a/src/meridian/lib/state/spawn_aggregate.py
+++ b/src/meridian/lib/state/spawn_aggregate.py
@@ -63,6 +63,19 @@ def _restore_spawn_artifact_permissions(
         raise exc_info from error
 
 
+def _remove_spawn_tree(path: Path) -> bool:
+    if not path.exists() and not path.is_symlink():
+        return True
+    try:
+        if path.is_symlink():
+            path.unlink()
+        else:
+            shutil.rmtree(path, onexc=_restore_spawn_artifact_permissions)
+    except OSError:
+        return False
+    return True
+
+
 def delete_published_spawn(
     runtime_root: Path,
     spawn_id: SpawnId | str,
@@ -83,6 +96,7 @@ def delete_published_spawn(
     if not is_safe_spawn_dir_name(resolved_spawn_id):
         raise ValueError(f"Invalid spawn ID: {resolved_spawn_id}")
     spawn_dir = paths.spawns_dir / resolved_spawn_id
+    artifact_dir = runtime_root / "artifacts" / resolved_spawn_id
 
     # Global order: spawn state, then process-scope projection.
     with (
@@ -96,8 +110,8 @@ def delete_published_spawn(
             return False
         if not spawn_dir.exists():
             return False
-        try:
-            shutil.rmtree(spawn_dir, onexc=_restore_spawn_artifact_permissions)
-        except OSError:
+        # Remove the legacy projection first so a partial failure cannot leave
+        # it behind after its authoritative spawn row is gone.
+        if not _remove_spawn_tree(artifact_dir):
             return False
-        return True
+        return _remove_spawn_tree(spawn_dir)

--- a/tests/integration/launch/test_streaming_runner_watchdog.py
+++ b/tests/integration/launch/test_streaming_runner_watchdog.py
@@ -85,6 +85,23 @@ def test_attempt_finalization_keeps_only_redacted_spawn_history(tmp_path: Path) 
     ).exists()
 
 
+def test_runtime_artifact_store_falls_back_to_legacy_history_copy(tmp_path: Path) -> None:
+    runtime_root = tmp_path / "runtime"
+    legacy_path = runtime_root / "artifacts" / "p-history" / "history.jsonl"
+    legacy_path.parent.mkdir(parents=True)
+    legacy_path.write_bytes(b"legacy history\n")
+    artifacts = LocalStore.for_runtime_root(runtime_root)
+    history_key = make_artifact_key("p-history", launch_constants.HISTORY_FILENAME)
+
+    assert artifacts.get(history_key) == b"legacy history\n"
+
+    live_path = runtime_root / "spawns" / "p-history" / "history.jsonl"
+    live_path.parent.mkdir(parents=True)
+    live_path.write_bytes(b"authoritative history\n")
+
+    assert artifacts.get(history_key) == b"authoritative history\n"
+
+
 class _NoReportExtractor:
     def extract_usage(self, artifacts: object, spawn_id: SpawnId) -> TokenUsage:
         _ = artifacts, spawn_id

--- a/tests/integration/launch/test_streaming_runner_watchdog.py
+++ b/tests/integration/launch/test_streaming_runner_watchdog.py
@@ -41,7 +41,6 @@ from tests.support.fakes import FakeClock, FakeHeartbeat
 _pi_extension_projection_fixture = _pi_extension_projection_fixture
 
 _STORE_ATTEMPT_FILES = (
-    launch_constants.HISTORY_FILENAME,
     launch_constants.OUTPUT_FILENAME,
     launch_constants.STDERR_FILENAME,
     launch_constants.TOKENS_FILENAME,
@@ -55,6 +54,35 @@ _DISK_ATTEMPT_FILES = (
     launch_constants.TOKENS_FILENAME,
     launch_constants.REPORT_FILENAME,
 )
+
+
+def test_attempt_finalization_keeps_only_redacted_spawn_history(tmp_path: Path) -> None:
+    runtime_root = tmp_path / "runtime"
+    log_dir = runtime_root / "spawns" / "p-history"
+    log_dir.mkdir(parents=True)
+    history_path = log_dir / launch_constants.HISTORY_FILENAME
+    history_path.write_text('{"content":"secret-value"}\n', encoding="utf-8")
+    artifacts = LocalStore.for_runtime_root(runtime_root)
+    secrets = (
+        streaming_runner_module.SecretSpec(key="API_TOKEN", value="secret-value"),
+    )
+
+    streaming_runner_module._persist_attempt_artifacts(
+        artifacts=artifacts,
+        spawn_id=SpawnId("p-history"),
+        log_dir=log_dir,
+        secrets=secrets,
+    )
+
+    assert history_path.read_text(encoding="utf-8") == (
+        '{"content":"[REDACTED:API_TOKEN]"}\n'
+    )
+    assert artifacts.get(
+        make_artifact_key("p-history", launch_constants.HISTORY_FILENAME)
+    ) == history_path.read_bytes()
+    assert not (
+        runtime_root / "artifacts" / "p-history" / launch_constants.HISTORY_FILENAME
+    ).exists()
 
 
 class _NoReportExtractor:
@@ -290,7 +318,10 @@ def test_retry_preserves_completed_attempt_artifacts(tmp_path: Path) -> None:
 def test_preserve_clears_active_history_before_retry_extraction(tmp_path: Path) -> None:
     log_dir = tmp_path / "spawns" / "r-stale-history"
     log_dir.mkdir(parents=True, exist_ok=True)
-    artifacts = LocalStore(root_dir=tmp_path / ".artifacts")
+    artifacts = LocalStore(
+        root_dir=tmp_path / ".artifacts",
+        spawn_root_dir=tmp_path / "spawns",
+    )
     spawn_id = SpawnId("r-stale-history")
     attempt_one_history = (
         b'{"role":"assistant","content":"attempt 1 durable completion report text"}\n'
@@ -298,7 +329,6 @@ def test_preserve_clears_active_history_before_retry_extraction(tmp_path: Path) 
     attempt_one_report = b"# Report\n\nattempt 1 durable completion\n"
     history_key = make_artifact_key(spawn_id, launch_constants.HISTORY_FILENAME)
     report_key = make_artifact_key(spawn_id, launch_constants.REPORT_FILENAME)
-    artifacts.put(history_key, attempt_one_history)
     artifacts.put(report_key, attempt_one_report)
     (log_dir / launch_constants.HISTORY_FILENAME).write_bytes(attempt_one_history)
     (log_dir / launch_constants.REPORT_FILENAME).write_bytes(attempt_one_report)
@@ -310,9 +340,9 @@ def test_preserve_clears_active_history_before_retry_extraction(tmp_path: Path) 
         completed_attempt=1,
     )
 
-    assert not artifacts.exists(history_key)
     attempt_one_history_key = make_artifact_key(spawn_id, "attempt-1/history.jsonl")
     assert artifacts.get(attempt_one_history_key) == attempt_one_history
+    assert not (tmp_path / ".artifacts" / str(spawn_id) / "attempt-1/history.jsonl").exists()
 
     reset_finalize_attempt_artifacts(
         artifacts=artifacts,
@@ -337,7 +367,10 @@ def test_preserve_clears_active_history_before_retry_extraction(tmp_path: Path) 
 def test_preserve_recovers_interrupted_rotation(tmp_path: Path) -> None:
     log_dir = tmp_path / "spawns" / "r-interrupted"
     log_dir.mkdir(parents=True, exist_ok=True)
-    artifacts = LocalStore(root_dir=tmp_path / ".artifacts")
+    artifacts = LocalStore(
+        root_dir=tmp_path / ".artifacts",
+        spawn_root_dir=tmp_path / "spawns",
+    )
     spawn_id = SpawnId("r-interrupted")
     staging_dir = log_dir / "attempt-1.tmp"
     staging_dir.mkdir(parents=True)
@@ -348,10 +381,6 @@ def test_preserve_recovers_interrupted_rotation(tmp_path: Path) -> None:
     (log_dir / launch_constants.STDERR_FILENAME).write_text(
         "late stderr\n",
         encoding="utf-8",
-    )
-    artifacts.put(
-        make_artifact_key(spawn_id, launch_constants.HISTORY_FILENAME),
-        b"active history\n",
     )
 
     streaming_runner_module._preserve_attempt_artifacts(
@@ -371,7 +400,10 @@ def test_preserve_recovers_interrupted_rotation(tmp_path: Path) -> None:
     history_key = make_artifact_key(spawn_id, launch_constants.HISTORY_FILENAME)
     attempt_one_history_key = make_artifact_key(spawn_id, "attempt-1/history.jsonl")
     assert not artifacts.exists(history_key)
-    assert artifacts.get(attempt_one_history_key) == b"active history\n"
+    assert artifacts.get(attempt_one_history_key) == b"staged history\n"
+    assert not artifacts.exists(
+        make_artifact_key(spawn_id, "attempt-1.tmp/history.jsonl")
+    )
 
 
 def test_preserve_discards_stale_staging_when_attempt_dir_exists(tmp_path: Path) -> None:

--- a/tests/integration/ops/test_diag_prune.py
+++ b/tests/integration/ops/test_diag_prune.py
@@ -91,6 +91,10 @@ def _seed_pruning_layout(
     current_root = user_home / "projects" / current_uuid
     current_spawn = current_root / "spawns" / "p1"
     _write_text(current_spawn / "history.jsonl", '{"event":"start"}\n')
+    _write_text(
+        current_root / "artifacts" / "p1" / "history.jsonl",
+        '{"event":"legacy mirror"}\n',
+    )
     _set_tree_mtime(current_spawn, 1_600_000_000.0)
     _set_path_mtime(current_root, 1_900_000_000.0)
 
@@ -154,6 +158,7 @@ def test_doctor_prune_only_prunes_current_project_artifacts(
     assert result.orphan_project_dirs == ()
     assert result.stale_spawn_artifacts and result.stale_spawn_artifacts[0].spawn_id == "p1"
     assert not current_spawn.exists()
+    assert not (current_spawn.parent.parent / "artifacts" / "p1").exists()
     assert orphan_root.exists(), "orphan dir should NOT be pruned without --global"
     assert other_spawn.exists()
 

--- a/tests/integration/state/test_reaper_cancel.py
+++ b/tests/integration/state/test_reaper_cancel.py
@@ -13,6 +13,7 @@ test_reaper_managed_primary.py.
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 from typing import Any, cast
 
@@ -414,6 +415,52 @@ def test_spawn_cancel_allows_forced_or_dead_managed_primary(
     latest = _get_spawn(runtime_root, spawn_id)
     assert latest.status == "cancelled"
     assert latest.cancel_intent is not None
+
+
+def test_spawn_cancel_returns_promptly_when_managed_primary_is_already_dead(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime_root, spawn_id = _create_spawn(
+        tmp_path,
+        kind="primary",
+        runner_pid=None,
+        started_at=_OLD_STARTED_AT,
+    )
+    _write_session_lease(runtime_root)
+    _write_primary_meta(
+        runtime_root,
+        spawn_id,
+        launcher_pid=None,
+        backend_pid=None,
+        tui_pid=None,
+        activity="idle",
+    )
+    _patch_spawn_cancel_runtime_resolution(
+        monkeypatch,
+        runtime_root=runtime_root,
+        spawn_id=spawn_id,
+    )
+    monkeypatch.setattr(
+        "meridian.lib.state.session_store.is_process_alive",
+        lambda _pid: False,
+    )
+    monkeypatch.setattr(
+        "meridian.lib.core.spawn_service.is_process_alive",
+        lambda *_args, **_kwargs: False,
+    )
+
+    started = time.monotonic()
+    output = spawn_api.spawn_cancel_sync(
+        SpawnCancelInput(
+            spawn_id=spawn_id,
+            project_root=tmp_path.as_posix(),
+        )
+    )
+    elapsed = time.monotonic() - started
+
+    assert output.status == "cancelled"
+    assert elapsed < 0.5
 
 
 def test_spawn_cancel_managed_primary_queued_converges_to_terminal(

--- a/tests/integration/state/test_reaper_cancel.py
+++ b/tests/integration/state/test_reaper_cancel.py
@@ -12,6 +12,7 @@ test_reaper_managed_primary.py.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any, cast
 
@@ -82,6 +83,21 @@ def _spawn_service(runtime_root: Path) -> SpawnApplicationService:
     return SpawnApplicationService(
         runtime_root,
         SpawnLifecycleService(runtime_root),
+    )
+
+
+def _write_session_lease(runtime_root: Path, *, chat_id: str = "c1", owner_pid: int = 8101) -> None:
+    sessions_dir = runtime_root / "sessions"
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    (sessions_dir / f"{chat_id}.lease.json").write_text(
+        json.dumps(
+            {
+                "chat_id": chat_id,
+                "owner_pid": owner_pid,
+                "session_instance_id": "session-instance-1",
+            }
+        ),
+        encoding="utf-8",
     )
 
 
@@ -301,6 +317,103 @@ def test_spawn_cancel_managed_primary_signals_launcher_first(
     assert latest.cancel_intent is not None
     assert latest.cancel_intent.exit_code == 130
     assert latest.cancel_intent.error == "cancelled"
+
+
+def test_spawn_cancel_refuses_live_managed_primary_without_force(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime_root, spawn_id = _create_spawn(
+        tmp_path,
+        kind="primary",
+        started_at=_OLD_STARTED_AT,
+    )
+    _write_session_lease(runtime_root)
+    _patch_spawn_cancel_runtime_resolution(
+        monkeypatch,
+        runtime_root=runtime_root,
+        spawn_id=spawn_id,
+    )
+    monkeypatch.setattr(
+        "meridian.lib.state.session_store.is_process_alive",
+        lambda pid: pid == 8101,
+    )
+
+    output = spawn_api.spawn_cancel_sync(
+        SpawnCancelInput(
+            spawn_id=spawn_id,
+            project_root=tmp_path.as_posix(),
+        )
+    )
+
+    assert output.status == "failed"
+    assert output.exit_code == 1
+    assert output.error is not None
+    assert "live managed primary" in output.error
+    assert "agent: tester" in output.error
+    assert "chat: c1" in output.error
+    assert "uptime:" in output.error
+    assert f"meridian spawn cancel {spawn_id} --force" in output.error
+    assert _get_spawn(runtime_root, spawn_id).cancel_intent is None
+
+
+@pytest.mark.parametrize(
+    ("force", "lease_owner_alive"),
+    [(True, True), (False, False)],
+    ids=["force-live-primary", "dead-primary-without-force"],
+)
+def test_spawn_cancel_allows_forced_or_dead_managed_primary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    force: bool,
+    lease_owner_alive: bool,
+) -> None:
+    runtime_root, spawn_id = _create_spawn(
+        tmp_path,
+        kind="primary",
+        status="queued",
+        runner_pid=None,
+        started_at=_OLD_STARTED_AT,
+    )
+    _write_session_lease(runtime_root)
+    _write_primary_meta(
+        runtime_root,
+        spawn_id,
+        launcher_pid=None,
+        backend_pid=None,
+        tui_pid=None,
+        activity="idle",
+    )
+    _patch_spawn_cancel_runtime_resolution(
+        monkeypatch,
+        runtime_root=runtime_root,
+        spawn_id=spawn_id,
+    )
+    monkeypatch.setattr(
+        "meridian.lib.state.session_store.is_process_alive",
+        lambda pid: pid == 8101 and lease_owner_alive,
+    )
+    monkeypatch.setattr(
+        "meridian.lib.core.spawn_service.is_process_alive",
+        lambda *_args, **_kwargs: False,
+    )
+    monkeypatch.setattr("meridian.lib.core.spawn_service._MANAGED_CANCEL_GRACE_SECS", 0.01)
+    monkeypatch.setattr("meridian.lib.core.spawn_service._MANAGED_CANCEL_FALLBACK_WAIT_SECS", 0.01)
+
+    output = spawn_api.spawn_cancel_sync(
+        SpawnCancelInput(
+            spawn_id=spawn_id,
+            project_root=tmp_path.as_posix(),
+            force=force,
+        )
+    )
+
+    assert output.status == "cancelled"
+    assert output.exit_code == 130
+    latest = _get_spawn(runtime_root, spawn_id)
+    assert latest.status == "cancelled"
+    assert latest.cancel_intent is not None
 
 
 def test_spawn_cancel_managed_primary_queued_converges_to_terminal(

--- a/tests/integration/state/test_spawn_artifact_lifetime.py
+++ b/tests/integration/state/test_spawn_artifact_lifetime.py
@@ -75,6 +75,26 @@ def test_late_failure_sentinel_does_not_recreate_deleted_spawn(tmp_path: Path) -
     assert not spawn_dir.exists()
 
 
+def test_spawn_deletion_removes_legacy_artifact_store_directory(tmp_path: Path) -> None:
+    runtime_root = tmp_path / "runtime"
+    spawn_id = "p1"
+    spawn_dir = runtime_root / "spawns" / spawn_id
+    artifact_dir = runtime_root / "artifacts" / spawn_id
+    _start_test_spawn(runtime_root, spawn_id, status="running")
+    finalize_spawn(runtime_root, spawn_id, "succeeded", 0, origin="runner")
+    artifact_dir.mkdir(parents=True)
+    (artifact_dir / "history.jsonl").write_text("legacy mirror\n", encoding="utf-8")
+
+    assert delete_published_spawn(
+        runtime_root,
+        spawn_id,
+        can_delete=lambda record: record is not None,
+    )
+
+    assert not spawn_dir.exists()
+    assert not artifact_dir.exists()
+
+
 def test_failure_sentinel_refuses_non_failed_spawn(tmp_path: Path) -> None:
     runtime_root = tmp_path / "runtime"
     spawn_id = "p1"

--- a/tests/platform/test_pty_launcher.py
+++ b/tests/platform/test_pty_launcher.py
@@ -1,0 +1,98 @@
+"""Real nested-PTY coverage for primary terminal teardown."""
+
+from __future__ import annotations
+
+import os
+import select
+import signal
+import sys
+import time
+from contextlib import suppress
+from pathlib import Path
+
+import pytest
+
+from meridian.lib.platform import IS_WINDOWS, pty
+
+_ENABLED_MODES = b"\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h\x1b[?1049h\x1b[?25l"
+_RESTORED_MODES = b"\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?1049l\x1b[?25h"
+
+
+@pytest.mark.skipif(IS_WINDOWS, reason="PTY relay is POSIX-only")
+def test_signalled_primary_child_restores_dec_modes_outside_capture(tmp_path: Path) -> None:
+    """A killed TUI cannot leave its caller's terminal private modes enabled."""
+
+    outer_master, outer_slave = pty.openpty()
+    status_read, status_write = os.pipe()
+    output_log = tmp_path / "primary-output.bin"
+    relay_pid = os.fork()
+
+    if relay_pid == 0:
+        try:
+            os.close(outer_master)
+            os.close(status_read)
+            os.dup2(outer_slave, 0)
+            os.dup2(outer_slave, 1)
+            if outer_slave > 1:
+                os.close(outer_slave)
+            sys.stdin = os.fdopen(os.dup(0), "r")
+            sys.stdout = os.fdopen(os.dup(1), "w")
+
+            from meridian.lib.launch.process.pty_launcher import PtyProcessLauncher
+
+            process = PtyProcessLauncher().start(
+                command=(
+                    "/bin/sh",
+                    "-c",
+                    "printf '\\033[?1000h\\033[?1002h\\033[?1003h"
+                    "\\033[?1006h\\033[?1049h\\033[?25l'; kill -TERM $$",
+                ),
+                cwd=tmp_path,
+                env=dict(os.environ),
+                output_log_path=output_log,
+            )
+            result = process.wait()
+            os.write(status_write, str(result.exit_code).encode())
+        except BaseException as exc:
+            with suppress(OSError):
+                os.write(status_write, f"error:{exc!r}".encode())
+        finally:
+            os._exit(0)
+
+    os.close(outer_slave)
+    os.close(status_write)
+    terminal_output = bytearray()
+    deadline = time.monotonic() + 5.0
+    relay_status: int | None = None
+    try:
+        while time.monotonic() < deadline:
+            ready, _, _ = select.select([outer_master], [], [], 0.05)
+            if ready:
+                try:
+                    chunk = os.read(outer_master, 4096)
+                except OSError:
+                    chunk = b""
+                if chunk:
+                    terminal_output.extend(chunk)
+            waited_pid, relay_status = os.waitpid(relay_pid, os.WNOHANG)
+            if waited_pid == relay_pid:
+                break
+        else:
+            os.kill(relay_pid, signal.SIGKILL)
+            pytest.fail("nested PTY relay did not exit")
+    finally:
+        with suppress(ChildProcessError):
+            os.waitpid(relay_pid, 0)
+        os.close(outer_master)
+
+    child_exit = os.read(status_read, 32)
+    os.close(status_read)
+
+    assert relay_status is not None
+    assert os.waitstatus_to_exitcode(relay_status) == 0
+    assert child_exit == b"-15"
+    assert _ENABLED_MODES in terminal_output
+    assert terminal_output.endswith(_RESTORED_MODES)
+    captured_child_output = output_log.read_bytes()
+    assert _ENABLED_MODES in captured_child_output
+    assert _RESTORED_MODES not in captured_child_output


### PR DESCRIPTION
## Why

Two live interactive sessions were destroyed by agents tonight, and 81.8 GB of
disk was a duplicate.

1. An agent measuring cancel latency ran `meridian spawn cancel p5709`. `p5709`
   was a **managed primary** — the user's long-running `product-lead` session
   (`chat_id: c5008`). It died mid-work, and the tmux pane was left wedged with
   mouse tracking and alternate screen still on.
2. Separately, `artifacts/<id>/history.jsonl` was a full second copy of every
   spawn's history — 81.8 GB across 13,233 spawns — and `pruning.py` only ever
   scanned `spawns/`, so nothing could ever reclaim it.

## Goal

Cancel refuses to destroy live sessions, terminals survive any hard exit, and
spawn history has exactly one authoritative copy that retention can reach.

## Summary

Patch release combining two lanes.

**Cancel safety** (`fix/spawn-cancel-safety`)

- Refuse to cancel a live managed primary without `--force`. The guard lives in
  the application service, so it fires on every path into cancel, and it reuses
  the reaper's existing lease-liveness notion rather than inventing a second
  one. Dead and orphaned primaries still cancel freely.
- The refusal names the target: agent, chat id, uptime, and the exact `--force`
  command. Tonight the agent had no way to know what `p5709` was.
- Defensive DEC-mode restore in the PTY relay's `finally` — mouse off,
  leave alternate screen, cursor visible. A signalled TUI never runs its own
  exit path, so the relay must do it.
- Replaced a hard-coded `time.sleep(1.0)` and a waited-out 10 s grace with
  liveness polling that returns the instant the scope exits, verifying process
  **birth time** so a recycled PID can't read as alive.

**Single-copy history** (`spawn-history-storage`)

- Stop writing `artifacts/<id>/history.jsonl`. `spawns/<id>/history.jsonl` is
  authoritative; legacy artifact copies still read as fallback.
- Redaction preserved by redacting the live history in place after the attempt
  stops, rather than dropping the security boundary.
- Spawn pruning now removes matching legacy artifact directories — closes the
  gap that let the mirror grow unbounded.

## Resulting Behavior

- `meridian spawn cancel <live-primary>` refuses with an actionable message.
- Cancel: **16.01 s → 0.81 s**.
- Terminals are usable after any hard exit.
- No new artifact history is written; existing copies stay readable and are
  pruned with their spawn.

## Changes

See the two merge commits. 10 + 14 files.

## Work Item

`spawn-cancel-safety`, `spawn-history-storage`.

## Verification

- `uv run pytest-llm` — **1380 passed, 2 skipped**
- `uv run ruff check .` — clean
- `uv run --extra dev python -m pyright` — **0 errors**
- Real nested-PTY test: SIGTERM child exits `-15`, reset bytes reach the outer
  PTY and stay out of captured child output.
- End-to-end spawn confirming `spawn history: present, artifact history: absent`,
  with `spawn show`, `spawn report show`, `session log`, `session search` all
  working against it.
- Cancel latency measured before/after through the real CLI against a throwaway
  record. No user-owned process was signalled during development.

## Knowledge Updates

Colocated `AGENTS.md` updated in `lib/state` and `lib/launch`.

## Release Label Guide

`release:patch`.

## Post-Merge Automation

CI computes the next stable patch from git tags. No manual tags.

## Cleanup

Worktrees `cancel-safety`, `spawn-history-storage`, `v0.3.53` removed after merge.

Supersedes #475 and #477, which remain open as the reviewable per-lane diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)