### PR TITLE
docs: remove stale colocated architecture claims

### DIFF
--- a/src/meridian/lib/catalog/.context/CONTEXT.md
+++ b/src/meridian/lib/catalog/.context/CONTEXT.md
@@ -49,25 +49,6 @@ separate CLI invocations and prevent alias updates from being picked up.
 4. If found in all-models list → return `AliasEntry` with empty alias (direct model ID passthrough)
 5. If not found → return `AliasEntry` with the input as model ID and unresolved harness
 
-### Agent Profile Model-Policy Parsing Rules (`agent.py`)
-
-**`models:`** — raises `ValueError` at parse time. Removed; use `model-policies:` for
-per-model overrides.
-
-**`fanout:`** — raises `ValueError` at parse time. Not supported; profiles express
-fallback candidates via ordered `model-policies` list rules instead.
-
-**`fallback-order:`** in a `model-policies` rule — raises `ValueError`. Fallback
-order is implicit from rule list position; remove this key.
-
-**`no-fallback: true`** — opt-out on individual `model-policies` rules. Rules with
-this set are excluded from harness-availability fallback. `model-glob` rules are
-always `no_fallback = True`, hardcoded in `_parse_model_policies()` regardless of
-what the profile declares.
-
-**First-match wins.** Duplicate rules with the same selector are silently unreachable —
-no parse error. The first matching rule in list order wins.
-
 ### AliasEntry
 
 `AliasEntry.harness` property: returns `resolved_harness` if mars provided it;

--- a/src/meridian/lib/catalog/AGENTS.md
+++ b/src/meridian/lib/catalog/AGENTS.md
@@ -39,19 +39,6 @@ guess.
 discard at operation end. Do not share across operations — cache is intentionally
 scoped.
 
-## Anti-Patterns
-
-**Don't use `fanout:` in profile frontmatter.** It raises `ValueError` at parse time.
-Express fallback candidates as ordered `model-policies` list rules instead — list
-position is fallback order.
-
-**Don't use `fallback-order:` in `model-policies` rules.** It raises `ValueError`.
-Remove the key; fallback order is implicit from rule list position.
-
-**Don't assume `model-glob` rules participate in harness-availability fallback.**
-They are always `no_fallback = True` and are skipped by the fallback walk regardless
-of what the profile declares.
-
 ## Fallback: `.mars/models-merged.json`
 
 When the mars binary is unavailable, `load_mars_aliases()` reads
@@ -78,8 +65,7 @@ agent = load_agent_profile(project_root, "coder")
 ## Depth
 
 → [.context/CONTEXT.md](.context/CONTEXT.md) — mars subprocess integration, resolve vs
-list asymmetry, `MarsResultCache` scoping contract, fallback to merged JSON,
-model-policy parsing rules
+list asymmetry, `MarsResultCache` scoping contract, and fallback to merged JSON
 
 ## Related
 

--- a/src/meridian/lib/config/AGENTS.md
+++ b/src/meridian/lib/config/AGENTS.md
@@ -61,7 +61,7 @@ module and run inside that transaction.
 
 - `settings.py` — `MeridianConfig`, `load_config()`: start here
 - `schema.py` — `config_field()`, `ConfigOptionMeta`: field metadata and parse helpers
-- `project_root.py` — `resolve_project_root()`, `resolve_user_config_path()`
+- `project_root.py` — `resolve_project_root_resolution()`, `resolve_user_config_path()`
 - `context_config.py` — `ContextConfig`, `ContextSourceType`: context path schema
 - `catalog.py` — `build_option_catalog()`: introspects `MeridianConfig` for CLI/docs
 

--- a/src/meridian/lib/core/.context/CONTEXT.md
+++ b/src/meridian/lib/core/.context/CONTEXT.md
@@ -40,7 +40,7 @@ resolve(cli_overrides, env_overrides, profile_overrides, config_overrides)
 
 Returns first-non-None per field across N layers. Constructors:
 `from_env()`, `from_agent_profile()`, `from_config()`, `from_spawn_config()`,
-`from_spawn_input()`, `from_launch_request()` — one per precedence level.
+`from_spawn_input()`, and `from_alias_entry()` — one per precedence source.
 
 **Do not default to `""` or `0` to signal "not set" — use `None`.** A
 non-None value at any layer wins, even if it's the empty string.
@@ -211,9 +211,9 @@ policy:
 - Else if cancellation was requested → `ExecutionTerminalOutcome(status="cancelled", ...)`.
 - Else → `None` (no opinion — caller must fall back to its own outcome).
 
-This helper is consumed by `SpawnApplicationService._force_cancel_convergence()`,
-`SpawnApplicationService.complete_execution()`, and `reaper._completion_or_cancel_decision()`.
-All three converge on the same precedence rule.
+This helper is consumed by spawn application services and by
+`state/reconciliation.py:completion_or_cancel_decision()`. They converge on the
+same precedence rule.
 
 ### Execution Terminal State Resolution
 

--- a/src/meridian/lib/harness/connections/.context/CONTEXT.md
+++ b/src/meridian/lib/harness/connections/.context/CONTEXT.md
@@ -182,7 +182,7 @@ Both are 10 MiB uniform across adapters:
 
 Claude CLI supports `--input-format stream-json --output-format stream-json` for
 bidirectional NDJSON over process pipes. This avoids a local HTTP server or WebSocket
-listener. The `_ws.py` filename predates this transport and was kept to avoid churn.
+listener.
 
 ### Codex: Port Pre-Reservation
 

--- a/src/meridian/lib/harness/passthrough/AGENTS.md
+++ b/src/meridian/lib/harness/passthrough/AGENTS.md
@@ -9,13 +9,13 @@ user-facing TUI process. Nothing else.
 In a managed-primary session, Meridian connects to the harness first (as turn owner),
 then launches a TUI process for the user to observe/interact. This package builds
 both sides of that setup:
-1. `build_connection_config()` — produces `ConnectionConfig` for Meridian's connection.
+1. `build_config()` — produces `ConnectionConfig` for Meridian's connection.
 2. `build_tui_command()` — produces the command the user's TUI will run to attach.
 
 **Claude does not support managed-primary.** `ClaudePassthrough` always raises
 `PassthroughError`. Claude primary sessions use the PTY path instead.
 
-**Codex pre-reserves a port.** Port reservation happens inside `build_connection_config()`
+**Codex pre-reserves a port.** Port reservation happens inside `build_config()`
 before the harness process starts. This creates a race window: if the harness binds
 a different port, the pre-reserved one is wrong. The connection layer handles retries.
 
@@ -24,7 +24,7 @@ a different port, the pre-reserved one is wrong. The connection layer handles re
 **Access via `get_passthrough(harness_id)`** — not by instantiating classes directly.
 Raises `PassthroughError` for unsupported harnesses (Claude).
 
-**The two build steps are ordered.** Call `build_connection_config()` first (creates
+**The two build steps are ordered.** Call `build_config()` first (creates
 the server endpoint), then `build_tui_command()` (uses the endpoint URL from the config).
 Reversing the order will produce a TUI command pointing at nothing.
 

--- a/src/meridian/lib/launch/.context/CONTEXT.md
+++ b/src/meridian/lib/launch/.context/CONTEXT.md
@@ -157,31 +157,11 @@ inside `prepare_launch_surface()`:
 only for `ops/spawn/prepare.py` dry-run display (needs a real argv for `cli_command`).
 Do not set `REQUIRED` on execution paths.
 
-### Model-Policy Overlay Composition (`policies.py`)
+### Mars Launch-Bundle Policy Resolution (`policies.py`)
 
-**Overlay prepends; does not replace.** `effective_model_policies()` in
-`compiler.py` builds the
-combined policy list as:
-
-```python
-(*overlay_rules, *profile_rules)
-```
-
-Overlay rules (from `AgentOverlayConfig.model_policies`) get first-match priority.
-Profile rules apply for tokens the overlay doesn't match. When the overlay is absent
-or has no `model_policies`, profile rules stand alone.
-
-**Harness-availability fallback** walks the combined list in order, skipping rules
-where `no_fallback=True` or `match_type == "model-glob"`. The first candidate whose
-harness is available wins. Source: `_fallback_candidates_from_policies()`.
-
-**Fallback chain** (`compiler_result.fallback_chain`) contains only rules with
-`match_type` in `{alias, model}` and `no_fallback=False`, preserving list order.
-Source: `_effective_fallback_chain()`.
-
-**Demoted base candidate.** When a policy rule transformed the primary result (e.g.,
-matched an alias rule and rerouted the harness), the pre-transformation base is tried
-first as a fallback before walking the policy list. Source: `_demoted_base_candidate()`.
+`PRIMARY` and `SPAWN_PREPARE` share `_resolve_policy_from_bundle()`. Mars resolves
+the model, harness, and fallback chain; Meridian applies the returned launch bundle
+rather than reconstructing profile policy composition or fallback ordering.
 
 ### _MERIDIAN_HARNESS Child Env
 

--- a/src/meridian/lib/launch/AGENTS.md
+++ b/src/meridian/lib/launch/AGENTS.md
@@ -122,21 +122,6 @@ Use `LaunchArgvIntent.SPEC_ONLY` on execution paths. `LaunchArgvIntent.REQUIRED`
 `ops/spawn/prepare.py` dry-run display (needs real argv for `cli_command`). **Do not set
 `REQUIRED` on execution paths.**
 
-## Model-Policy Overlay Semantics
-
-Overlay rules (from `AgentOverlayConfig.model_policies`) **prepend** to profile rules —
-they do not replace them. Effective list = overlay rules first, profile rules second.
-First rule whose selector matches wins; later rules with the same selector are silently
-unreachable.
-
-Harness-availability fallback walks the combined list in order, skipping rules with
-`no_fallback=True` and rules with `match_type == "model-glob"` (always excluded).
-The demoted base candidate (pre-policy-transform) is tried before the policy list
-when a policy rule caused the primary harness selection.
-
-Source: `compiler.py:effective_model_policies()`, `policies.py:_fallback_candidates_from_policies()`.
-Detail: [.context/CONTEXT.md](.context/CONTEXT.md#model-policy-overlay-composition-policiespy).
-
 ## Startup Watchdog
 
 `_start_spawn_with_timeout()` in `streaming_runner.py` wraps the entire pre-connect
@@ -208,8 +193,8 @@ See [.context/CONTEXT.md](.context/CONTEXT.md#why-user-turn-not-system-prompt) f
    injection, reference loading and anchor semantics (`kb:` prefix, `@` unsupported),
    worktree path assignment vs managed ownership separation, workspace projection
    detail, env injection, background worker trust model, _MERIDIAN_HARNESS child env
-   behavior, exact continue replay contract, full invariant table, model-policy
-   overlay composition and fallback chain rules, user-turn context threading
+   behavior, exact continue replay contract, full invariant table, Mars launch-bundle
+   policy resolution, user-turn context threading
    (`resolve_task_context_inputs()`) and why prior-context goes in the user turn.
 
 ## Related

--- a/src/meridian/lib/launch/streaming/.context/CONTEXT.md
+++ b/src/meridian/lib/launch/streaming/.context/CONTEXT.md
@@ -10,17 +10,13 @@ Priority order (highest to lowest):
 2. **Budget exceeded** — token or cost budget exhausted → `status: failed`, `error: budget_exceeded`
 3. **Timeout** — wall-clock timeout → `status: failed`, `exit_code: 3`, `error: timeout`
 4. **Watchdog** — watchdog reports spawn stopped → `stop_required: False`, no synthetic status
-5. **Completion** — drain loop completed; opens a grace window for a late terminal frame
-6. **Signal** — SIGINT/SIGTERM; lowest precedence — if completion already resolved, completion wins
+5. **Inactivity** — inactivity watchdog reports spawn stopped → `stop_required: False`, no synthetic status
+6. **Completion** — drain loop completed
+7. **Signal** — SIGINT/SIGTERM; lowest precedence — if completion already resolved, completion wins
 
-### Completion Grace Window
-
-When `completion_task` wins the race and no terminal frame has arrived, `_completion_grace()`
-waits up to `grace_seconds` (default 0.5s) for a late `terminal_event_future`. This handles
-the common case where the harness emits a terminal event just after the drain loop signals
-completion. If the grace window expires without a terminal frame, `ArbitrationDecision` has
-`stop_required=False` and no synthetic status — the caller determines final state from the
-drain outcome.
+When completion wins, `_completion_decision()` in `terminal_arbitrator.py` immediately
+uses an already-finished terminal frame or returns a completion decision. It does not
+wait for a later frame.
 
 ### Watchdog Noop
 
@@ -29,8 +25,9 @@ The caller must not treat this as a termination — the watchdog observed nothin
 
 ### Optional Triggers
 
-`timeout_task`, `budget_task`, and `watchdog_task` are optional (pass `None` to exclude from race).
-Their absence does not affect the priority ordering of the remaining triggers.
+`timeout_task`, `budget_task`, `watchdog_task`, and `inactivity_task` are optional
+(pass `None` to exclude from the race). Their absence does not affect the priority
+ordering of the remaining triggers.
 
 ## FileHeartbeat
 

--- a/src/meridian/lib/launch/streaming/AGENTS.md
+++ b/src/meridian/lib/launch/streaming/AGENTS.md
@@ -14,9 +14,9 @@ resulting outcome. The streaming runner acts on this decision to finalize the sp
 Terminal triggers have a priority order — if multiple fire simultaneously, the
 highest-priority trigger wins. Trigger priority is documented in `.context/CONTEXT.md`.
 
-**`heartbeat.py`** — `FileHeartbeat` touches a file on a fixed interval while a
-spawn is alive. The reaper in `lib/state/reaper.py` reads heartbeat age to determine
-if a spawn is orphaned (heartbeat age > 120s means the runner may be dead).
+**`heartbeat.py`** — `FileHeartbeat.touch()` performs one file timestamp update.
+The streaming runner owns periodic scheduling. The reaper in `lib/state/reaper.py`
+reads heartbeat age to determine if a spawn is orphaned.
 
 ## Key Rules
 
@@ -24,18 +24,13 @@ if a spawn is orphaned (heartbeat age > 120s means the runner may be dead).
 trigger fires, then cancels the others. Do not call it multiple times for the same
 spawn.
 
-**`FileHeartbeat` must be started and stopped as a context manager** (or via
-`start()`/`stop()`). A heartbeat that is never stopped continues touching the file
-after the spawn finishes, delaying orphan detection.
-
-**The grace window matters.** After the harness sends a terminal event, there is a
-brief window to receive any late terminal frames before the arbitrator cuts off.
-Do not remove the grace window — late frames contain finalization data.
+**`FileHeartbeat` does not schedule itself.** Call `touch()` from the streaming
+runner's heartbeat loop; the class has no lifecycle or context-manager API.
 
 ## Depth
 
 → [.context/CONTEXT.md](.context/CONTEXT.md) — trigger priority order, arbitration
-   semantics, grace window timing, heartbeat file location.
+   semantics, and heartbeat file behavior.
 
 ## Related
 

--- a/src/meridian/lib/spawn/.context/CONTEXT.md
+++ b/src/meridian/lib/spawn/.context/CONTEXT.md
@@ -23,10 +23,10 @@ project-level — because archived visibility is per-user, not per-project.
 
 ## Contracts
 
-**Locking.** `read_archived_spawns()` and `write_archived_spawns()` both acquire
-`archived_spawns.flock` before reading or writing. Do not read or write
-`archived_spawns.json` without holding this lock. The write path uses
-`atomic_write_text()` (tmp+rename) inside the flock.
+**Locking.** `read_archived_spawns()` takes a shared lock at
+`<runtime_root>/locks/archived-spawns.lock`. All writes go through
+`mutate_archived_spawns()`, which holds a non-reentrant exclusive lock across the
+read-modify-write and publishes with `atomic_write_text()`.
 
 **Idempotent writes.** `archive_spawn()` reads, adds, writes — it is idempotent.
 Calling it twice for the same spawn ID leaves the file unchanged on the second call.

--- a/src/meridian/lib/state/.context/CONTEXT.md
+++ b/src/meridian/lib/state/.context/CONTEXT.md
@@ -145,11 +145,12 @@ for non-empty report content that is not a terminal control frame (`cancelled`/`
 JSON) and is not a `# Spawn failed` generated markdown wrapper. Used by both reaper
 and cancel convergence paths.
 
-`_completion_or_cancel_decision()` centralizes durable-completion-vs-cancel precedence
-for the reaper: if a durable report exists, the spawn resolves `succeeded` regardless
-of cancel intent; otherwise pending cancel intent resolves `cancelled` with the intent's
-exit code and error. Call this helper rather than branching on completion and cancel
-independently; a late cancel must not downgrade a completed spawn.
+`reconciliation.py:completion_or_cancel_decision()` centralizes
+durable-completion-vs-cancel precedence for reconciliation callers: if a durable
+report exists, the spawn resolves `succeeded` regardless of cancel intent; otherwise
+pending cancel intent resolves `cancelled` with the intent's exit code and error.
+Call this helper rather than branching on completion and cancel independently; a
+late cancel must not downgrade a completed spawn.
 
 **Managed-primary orphan cleanup:**
 

--- a/src/meridian/lib/state/spawn/.context/CONTEXT.md
+++ b/src/meridian/lib/state/spawn/.context/CONTEXT.md
@@ -72,10 +72,13 @@ may contain active work, so those paths skip it rather than deleting live data.
 ## Locked Mutation Model
 
 Every published-spawn mutation calls `write_state_locked()`. It acquires the stable
-per-spawn lock at `locks/spawns/<id>.lock` (outside the spawn artifact directory,
-never unlinked), re-reads `state.json`, applies a pure mutator, and writes
-atomically. There is no public unlocked write path — the prior two-tier model
-(owner writes without lock / external writes with lock) was collapsed in PR #422.
+per-spawn lock at `locks/spawns/<id>.lock`, outside the spawn artifact directory,
+re-reads `state.json`, applies a pure mutator, and writes atomically. Lock lifetime
+and orphan cleanup follow the parent
+[`state/.context/CONTEXT.md`](../../.context/CONTEXT.md#platform-locking); this page does
+not restate that contract. There is no public unlocked write path — the prior
+two-tier model (owner writes without lock / external writes with lock) was collapsed
+in PR #422.
 
 The conformance guard `tests/contract/test_state_write_conformance.py` rejects new
 raw writes to authoritative state files at CI.
@@ -187,6 +190,6 @@ quarantine signal that migration and retention depend on to fail closed.
 ## Related
 
 - [`../AGENTS.md`](../AGENTS.md) — entry points
-- [`../.context/CONTEXT.md`](../.context/CONTEXT.md) — parent state module contracts
+- [`../../.context/CONTEXT.md`](../../.context/CONTEXT.md) — parent state module contracts
 - `$MERIDIAN_CONTEXT_KB_DIR/architecture/spawn-finalization.md` — finalization authority lattice, `runner_exit_*` invariant, and reaper contract
 - `$MERIDIAN_CONTEXT_KB_DIR/architecture/state-system.md` — per-spawn state layout, locking, and reconciliation model


### PR DESCRIPTION
## Why

Colocated maintainer docs still described deleted or renamed launch, catalog, passthrough, archive-locking, and state-lock machinery. Those claims gave contributors incorrect APIs and ownership boundaries.

## Goal

Make the CLI-001 through CLI-011 colocated documentation match the current code while keeping qi-layer guidance minimal and load-bearing.

## Summary

- Corrected streaming terminal priority, completion behavior, and heartbeat ownership.
- Replaced retired Python policy-composition guidance with the shared Mars launch-bundle seam.
- Updated renamed config, passthrough, reconciliation, and archive-lock APIs.
- Removed deleted catalog model-policy parsing and obsolete `_ws.py` rationale.
- Made spawn lock documentation defer to the canonical parent lifetime contract.

## Resulting Behavior

Maintainers following `AGENTS.md` and `.context/CONTEXT.md` now reach current modules and APIs instead of deleted helpers or behavior.

## Changes

Documentation-only change. No runtime behavior, source code, schema, or dependencies changed.

## Work Item

mars-native-hook-events

## Verification

Docs-only change; no new behavioral test was added.

- Inspected each CLI-001 through CLI-011 claim against its current implementation module.
- `meridian kg check src/meridian/lib` — clean, 99 files and 124 links.
- `meridian mermaid check src/meridian/lib` — clean; no Mermaid blocks found.
- Pre-push hook: `uv run --extra dev ruff check .` — passed.
- Pre-push hook: `uv run --extra dev python -m pyright` — 0 errors (12 existing warnings).
- Pre-push hook: `uv run --extra dev pytest -x -q` — 1357 passed, 2 skipped.
- Pre-push hook: `uv build --no-sources` — passed.

## Knowledge Updates

Updated the affected colocated `AGENTS.md` and `.context/CONTEXT.md` files. No KB update was needed because this lane is scoped to meridian-cli CLI findings.

## Spawn Trace

None — completed directly in the assigned docs-only lane.
