### PR TITLE
Export MERIDIAN_VERSION to the mars subprocess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Mars passthrough commands now report the invoking Meridian version so package
   compatibility constraints can be enforced.
 
+### Changed
+
+- Bump pinned `mars-agents` to 0.13.0, which enforces `requires-mars` and
+  `requires-meridian` engine version constraints — the feature this
+  `MERIDIAN_VERSION` export activates.
+
 ## [0.4.1] - 2026-07-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Mars passthrough commands now report the invoking Meridian version so package
+  compatibility constraints can be enforced.
+
 ## [0.4.1] - 2026-07-26
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "cyclopts>=3.0",
   "fastapi>=0.115",
   "markdown-it-py>=4.0",
-  "mars-agents==0.12.0",
+  "mars-agents==0.13.0",
   "mcp>=1.0",
   "pathspec>=1.1.0",
   "psutil>=7.2.2",

--- a/src/meridian/cli/mars_passthrough.py
+++ b/src/meridian/cli/mars_passthrough.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TextIO
 
+from meridian import __version__
 from meridian.lib.ops.mars import resolve_mars_executable
 
 
@@ -105,7 +106,11 @@ def execute_mars_passthrough(
     # With MERIDIAN_PROJECT_DIR set, parse_mars_passthrough injects --root to the
     # launcher project; Mars runs under Meridian management for all passthrough commands.
     run_kwargs: dict[str, object] = {
-        "env": {**os.environ, "MERIDIAN_MANAGED": os.environ.get("MERIDIAN_MANAGED", "1")},
+        "env": {
+            **os.environ,
+            "MERIDIAN_MANAGED": os.environ.get("MERIDIAN_MANAGED", "1"),
+            "MERIDIAN_VERSION": __version__,
+        },
     }
     try:
         if request.wants_json:

--- a/src/meridian/env_registry.py
+++ b/src/meridian/env_registry.py
@@ -176,6 +176,12 @@ ENV_VARS: tuple[EnvVar, ...] = (
         EnvSubtype.INTER_TOOL,
         "Marks invocation through Meridian for mars-agents.",
     ),
+    EnvVar(
+        "MERIDIAN_VERSION",
+        EnvTier.PUBLIC,
+        EnvSubtype.INTER_TOOL,
+        "Reports the invoking Meridian version to mars-agents.",
+    ),
     # Internal handles.
     _internal_handle("_MERIDIAN_DEPTH", "Current delegated spawn depth."),
     _internal_handle("_MERIDIAN_PARENT_SPAWN_ID", "Parent spawn identifier."),

--- a/tests/integration/cli/test_mars_passthrough.py
+++ b/tests/integration/cli/test_mars_passthrough.py
@@ -11,12 +11,13 @@ from pathlib import Path
 
 import pytest
 
+from meridian import __version__
 from tests.conftest import posix_only
 
 
 @pytest.mark.integration
 @posix_only
-def test_mars_passthrough_streams_and_propagates_exit_with_managed_env(
+def test_mars_passthrough_streams_and_propagates_exit_with_meridian_env(
     tmp_path: Path,
 ) -> None:
     runtime_root = tmp_path / "runtime"
@@ -34,7 +35,8 @@ def test_mars_passthrough_streams_and_propagates_exit_with_managed_env(
         "import json, os, sys\n"
         "with open(os.environ['MARS_RECORD'], 'w', encoding='utf-8') as record:\n"
         "    payload = {'argv': sys.argv[1:], "
-        "'managed': os.environ.get('MERIDIAN_MANAGED')}\n"
+        "'managed': os.environ.get('MERIDIAN_MANAGED'), "
+        "'version': os.environ.get('MERIDIAN_VERSION')}\n"
         "    json.dump(payload, record)\n"
         "print('mars stdout', flush=True)\n"
         "print('mars stderr', file=sys.stderr, flush=True)\n"
@@ -64,4 +66,5 @@ def test_mars_passthrough_streams_and_propagates_exit_with_managed_env(
     assert json.loads(record_path.read_text()) == {
         "argv": ["models", "list"],
         "managed": "1",
+        "version": __version__,
     }

--- a/uv.lock
+++ b/uv.lock
@@ -666,15 +666,15 @@ wheels = [
 
 [[package]]
 name = "mars-agents"
-version = "0.12.0"
+version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/b4/eb3f50ac9cfb5c24f3f0187bb012776aa847401f5a8ae23f69baef0013c1/mars_agents-0.12.0.tar.gz", hash = "sha256:6c025bb4f4a080e7ce4094b5196c52d5f5457bc57a588c00fc959dd88369974e", size = 749199, upload-time = "2026-07-25T21:49:02.64Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/38/78eec1d301a08c1750b517be14159a4ae6c8fa596a762d1e348823bd9c5e/mars_agents-0.13.0.tar.gz", hash = "sha256:98ecc3c2dfd77b5e277aadcb8af9e62c2ae95787c46d78d49dcb2f6b8b39aa12", size = 759917, upload-time = "2026-07-29T14:41:49.63Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/6a/775cb89acb8854f9de09ba669d17edf097852fb2a50b5a8922fcb7f6eced/mars_agents-0.12.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:17d9bd7b5a9b2f7661316943094506cb6628ce112e1fd441a89c9d53b10c9ddd", size = 3489593, upload-time = "2026-07-25T21:48:54.845Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/a1/73abf64e091f90b9635fd6d08664a593a7078bd4cc3d9b7f6732c5b0c6fd/mars_agents-0.12.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f33a44b72a09526cfd2d225a12211118c53c1c62d7a91e4d15e3d87c95c19e02", size = 3338861, upload-time = "2026-07-25T21:48:56.49Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/13/63242016ae80f4605862e5cb6e89e0a17230078ec86fc6c4c2de79d7aeb8/mars_agents-0.12.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:85e697ad161b5b27120ca0f2eaa6903089db1a9f185de85a75481cee1c18ae3e", size = 3394726, upload-time = "2026-07-25T21:48:58.063Z" },
-    { url = "https://files.pythonhosted.org/packages/78/35/1ea88a00d847050cd8e05fc8b1cca72c6d908a9a200ae936fd1a6581c1e3/mars_agents-0.12.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8318677d9ac95711f39dea6b8953a856bdc36598906675353fd98d7568891601", size = 3645759, upload-time = "2026-07-25T21:48:59.535Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/f1/711286a86ce19a27bbd96c240b2a161957b210afe0a1be092ba4d762447f/mars_agents-0.12.0-py3-none-win_amd64.whl", hash = "sha256:443c7106e375cf5950dbf4610b68bb1921e449f62f560603e5fd1a616d1ed7aa", size = 3613732, upload-time = "2026-07-25T21:49:00.935Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/0c/68b5c03a5da703109440ab5b87b10060a54a426a928e5ef04dc6b27936e3/mars_agents-0.13.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:cab5fd0dd96d6bd52eb935a340957496c2a987ca63d0463038ade7d557a7b83c", size = 3534087, upload-time = "2026-07-29T14:41:40.985Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/1f/8b6fe34ac4dc220727525ecaf7e01bbd92f6b9e7c45838388f3c9c8bfb59/mars_agents-0.13.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:0872e373d0a404adf4c1c040739f38c0707e856d219085124625c27d0acbc79a", size = 3381082, upload-time = "2026-07-29T14:41:42.798Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/03/abfc110189cdf10433a9977dcc8ba39be01c6510b646b85d764fa77955bb/mars_agents-0.13.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:06e29890998208d204f37061dc28867b1fab0eb1f384ad612201521942ba1822", size = 3428338, upload-time = "2026-07-29T14:41:44.557Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/58/68148080abdd1a6dd7833a0cfef077d384ded1dabd078a3c2183ef955bff/mars_agents-0.13.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca7b574969b3fbb76552c33d0acb50542e0d6978c0048fe9bc23c7c66d7e03c7", size = 3672205, upload-time = "2026-07-29T14:41:46.158Z" },
+    { url = "https://files.pythonhosted.org/packages/75/d7/725c5b7f0e93798780499c1a173132bfe00685e7884e1588829ceb2e2364/mars_agents-0.13.0-py3-none-win_amd64.whl", hash = "sha256:b6bd995380138c2456186ed50d9898c253713a549b28d63ccc183448b26a9abe", size = 3651706, upload-time = "2026-07-29T14:41:47.926Z" },
 ]
 
 [[package]]
@@ -766,7 +766,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'app'", specifier = ">=0.28" },
     { name = "jinja2", marker = "extra == 'templates'", specifier = ">=3.1" },
     { name = "markdown-it-py", specifier = ">=4.0" },
-    { name = "mars-agents", specifier = "==0.12.0" },
+    { name = "mars-agents", specifier = "==0.13.0" },
     { name = "mcp", specifier = ">=1.0" },
     { name = "pathspec", specifier = ">=1.1.0" },
     { name = "psutil", specifier = ">=7.2.2" },


### PR DESCRIPTION
## Why

mars-agents 0.13.0 (haowjy/mars-agents#158, merged and released) adds a `requires-meridian` manifest field: packages can declare the minimum meridian they need, and mars walks down to a compatible version when the requirement isn't met. Mars can only enforce it if it knows which meridian invoked it — until now the passthrough env carried `MERIDIAN_MANAGED` but not a version, and the pinned `mars-agents==0.12.0` predates the feature entirely.

## Goal

`meridian mars sync` (and every other mars passthrough) tells mars the invoking meridian version, activating `requires-meridian` enforcement. Standalone `mars` keeps skipping the check.

## Summary

`mars_passthrough.py` now exports `MERIDIAN_VERSION=<meridian.__version__>` into the mars subprocess environment. The variable is registered in the env registry as a public inter-tool contract.

## Resulting Behavior

- `meridian mars sync` against a package declaring `requires-meridian = ">=X"`: mars enforces the constraint (fallback to a compatible version, or hard error when none exists).
- `mars sync` run directly, or invoked by an older meridian: env var absent, `requires-meridian` silently skipped — unchanged behavior.
- New `--ignore-requires-mars` / `--ignore-requires-meridian` mars flags flow through the existing argv passthrough with no meridian changes.

## Changes

- `src/meridian/cli/mars_passthrough.py`: one env entry, version sourced from `meridian.__version__` (same source as `meridian --version`).
- `src/meridian/env_registry.py`: `MERIDIAN_VERSION` registered (PUBLIC / INTER_TOOL).
- `pyproject.toml` / `uv.lock`: bump pinned `mars-agents` `0.12.0` → `0.13.0`. The env export alone is inert without this — 0.12.0 has no `requires-meridian` support at all, so meridian would keep installing an engine that can't read the variable it's now exporting.

## Work Item

mars-version-constraints

## Verification

- Regression test extended: passthrough subprocess observes `MERIDIAN_VERSION` (failed before the change, passes after).
- `uv run pytest-llm tests/integration/cli/test_mars_passthrough.py tests/contract/test_env_registry.py` — 3 passed.
- `uv run ruff check .` clean; `uv run --extra dev python -m pyright` — 0 errors.
- `uv lock` resolved cleanly against the new pin (`mars-agents v0.12.0 -> v0.13.0`, 75 packages).
- End-to-end enforcement (env var → walk-down/fail-closed) probed against the real mars 0.11.0-era binary build in the mars PR's verification; the shipped 0.13.0 carries the same code reviewed there.

## Knowledge Updates

None here — behavior contract documented in the mars-agents PR and design doc (`work/mars-version-constraints/design.md`); kb-lead reconciliation runs post-ship.

## Spawn Trace

- p5871 gpt-dev — implemented env export + registry entry + regression test
- tech-lead (direct edit, user-requested) — bumped `mars-agents` pin to
  0.13.0 once haowjy/mars-agents#158 released, regenerated `uv.lock`,
  verified lint/types/tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
