### PR TITLE
Fall back when a work item's task_dir worktree is removed (#482)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fall back with a destination-naming warning when a work item's task directory
+  has disappeared, honor explicit `--task-dir` overrides, and report a structured
+  `work_task_dir_missing` error instead of crashing `task-dir` when no fallback exists.
+
 ## [0.4.1] - 2026-07-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Caveman style. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fall back with a destination-naming warning when a work item's task directory
   has disappeared, honor explicit `--task-dir` overrides, and report a structured
   `work_task_dir_missing` error instead of crashing `task-dir` when no fallback exists.
+- Emit CLI warnings consistently as `warning:` on stderr, and give structured JSON
+  errors a stable machine-readable error name.
 
 ## [0.4.2] - 2026-07-29
 

--- a/src/meridian/cli/.context/FUTURE
+++ b/src/meridian/cli/.context/FUTURE
@@ -1,0 +1,7 @@
+# FUTURE — src/meridian/cli
+
+- Warning output inconsistency: `meridian task-dir` emits lowercase
+  `warning: ...` on stderr (output.py sinks), while human-format spawn
+  dry-run prints `Warning: ...` on stdout. Unify casing and stream for
+  warnings across CLI surfaces. Surfaced during #482 probe (work item
+  release-patch-482-481).

--- a/src/meridian/cli/.context/FUTURE
+++ b/src/meridian/cli/.context/FUTURE
@@ -1,7 +1,0 @@
-# FUTURE — src/meridian/cli
-
-- Warning output inconsistency: `meridian task-dir` emits lowercase
-  `warning: ...` on stderr (output.py sinks), while human-format spawn
-  dry-run prints `Warning: ...` on stdout. Unify casing and stream for
-  warnings across CLI surfaces. Surfaced during #482 probe (work item
-  release-patch-482-481).

--- a/src/meridian/cli/artifact_cmd.py
+++ b/src/meridian/cli/artifact_cmd.py
@@ -112,7 +112,7 @@ def cmd_artifact_list(
     ] = "text",
 ) -> None:
     """List recorded artifact serves without changing state."""
-    from meridian.cli.main import get_global_options
+    from meridian.cli.main import current_output_sink, get_global_options
 
     serves = load_serves()
     effective_fmt = "json" if get_global_options().output.format == "json" else fmt
@@ -129,7 +129,7 @@ def cmd_artifact_list(
         dns_name = service.tailscale_dns_name()
     except (service.ArtifactError, OSError) as exc:
         dns_name = None
-        print(f"Warning: artifact URLs unavailable: {exc}", file=sys.stderr)
+        current_output_sink().warning(f"artifact URLs unavailable: {exc}")
     print(f"{'SLUG':<22} {'LOCAL':<7} {'ALIVE':<6} {'AGE':<8} {'TTL':<11} {'DIRECTORY':<30} URL")
     for serve in serves:
         created = _created_at(serve)

--- a/src/meridian/cli/main.py
+++ b/src/meridian/cli/main.py
@@ -73,6 +73,7 @@ from meridian.cli.startup.policy import TelemetryMode as StartupTelemetryMode
 from meridian.cli.utils import parse_csv_list
 from meridian.lib.core.sink import OutputSink
 from meridian.lib.core.util import FormatContext
+from meridian.lib.launch.cwd import WorkTaskDirMissing
 from meridian.lib.telemetry import emit_telemetry
 
 if TYPE_CHECKING:
@@ -828,11 +829,17 @@ def _operation_error_message(exc: Exception) -> str:
     return exc.__class__.__name__
 
 
-def _emit_error(message: str, *, exit_code: int = 1) -> None:
+def _emit_error(
+    message: str, *, exit_code: int = 1, name: str | None = None
+) -> None:
     """Emit an error via the active sink and exit."""
 
     sink, flush_after = _resolve_sink(_GLOBAL_OPTIONS.get())
-    sink.error(message, exit_code=exit_code)
+    named_error = getattr(sink, "named_error", None)
+    if name is not None and callable(named_error):
+        named_error(name, message, exit_code=exit_code)
+    else:
+        sink.error(message, exit_code=exit_code)
     if flush_after:
         flush_sink(sink)
     raise SystemExit(exit_code)
@@ -1172,6 +1179,11 @@ def _main_impl(argv: Sequence[str] | None = None) -> None:
                     raise
                 except TimeoutError as exc:
                     _emit_error(_operation_error_message(exc), exit_code=124)
+                except WorkTaskDirMissing as exc:
+                    _emit_error(
+                        _operation_error_message(exc),
+                        name="work_task_dir_missing",
+                    )
                 except (KeyError, ValueError, FileNotFoundError, OSError, RuntimeError) as exc:
                     _emit_error(_operation_error_message(exc))
         finally:

--- a/src/meridian/cli/main.py
+++ b/src/meridian/cli/main.py
@@ -835,11 +835,7 @@ def _emit_error(
     """Emit an error via the active sink and exit."""
 
     sink, flush_after = _resolve_sink(_GLOBAL_OPTIONS.get())
-    named_error = getattr(sink, "named_error", None)
-    if name is not None and callable(named_error):
-        named_error(name, message, exit_code=exit_code)
-    else:
-        sink.error(message, exit_code=exit_code)
+    sink.error(message, exit_code=exit_code, name=name)
     if flush_after:
         flush_sink(sink)
     raise SystemExit(exit_code)

--- a/src/meridian/cli/output.py
+++ b/src/meridian/cli/output.py
@@ -129,13 +129,16 @@ class TextSink:
     def warning(self, message: str) -> None:
         print(f"warning: {message}", file=self._stderr)
 
-    def error(self, message: str, exit_code: int = 1) -> None:
-        _ = exit_code
+    def error(
+        self,
+        message: str,
+        *,
+        exit_code: int = 1,
+        name: str | None = None,
+    ) -> None:
+        """Emit a human error; ``name`` is intentionally JSON-only metadata."""
+        _ = (exit_code, name)
         print(f"error: {message}", file=self._stderr)
-
-    def named_error(self, name: str, message: str, exit_code: int = 1) -> None:
-        _ = name
-        self.error(message, exit_code=exit_code)
 
     def heartbeat(self, message: str) -> None:
         print(message, file=self._stderr, flush=True)
@@ -176,17 +179,23 @@ class JsonSink:
         print(message, file=self._stderr)
 
     def warning(self, message: str) -> None:
-        print(f"warning: {message}", file=self._stderr)
-
-    def error(self, message: str, exit_code: int = 1) -> None:
-        payload = {"error": message, "exit_code": exit_code}
         print(
-            json.dumps(_to_json_value(payload), separators=(",", ":")),
+            json.dumps({"warning": message}, separators=(",", ":")),
             file=self._stderr,
         )
 
-    def named_error(self, name: str, message: str, exit_code: int = 1) -> None:
-        payload = {"error": name, "message": message, "exit_code": exit_code}
+    def error(
+        self,
+        message: str,
+        *,
+        exit_code: int = 1,
+        name: str | None = None,
+    ) -> None:
+        payload = (
+            {"error": message, "exit_code": exit_code}
+            if name is None
+            else {"error": name, "message": message, "exit_code": exit_code}
+        )
         print(
             json.dumps(_to_json_value(payload), separators=(",", ":")),
             file=self._stderr,

--- a/src/meridian/cli/output.py
+++ b/src/meridian/cli/output.py
@@ -176,7 +176,10 @@ class JsonSink:
         self._has_result = True
 
     def status(self, message: str) -> None:
-        print(message, file=self._stderr)
+        print(
+            json.dumps({"status": message}, separators=(",", ":")),
+            file=self._stderr,
+        )
 
     def warning(self, message: str) -> None:
         print(
@@ -202,7 +205,11 @@ class JsonSink:
         )
 
     def heartbeat(self, message: str) -> None:
-        print(message, file=self._stderr, flush=True)
+        print(
+            json.dumps({"heartbeat": message}, separators=(",", ":")),
+            file=self._stderr,
+            flush=True,
+        )
 
     def event(self, payload: dict[str, Any]) -> None:
         if not self._emit_events:

--- a/src/meridian/cli/output.py
+++ b/src/meridian/cli/output.py
@@ -133,6 +133,10 @@ class TextSink:
         _ = exit_code
         print(f"error: {message}", file=self._stderr)
 
+    def named_error(self, name: str, message: str, exit_code: int = 1) -> None:
+        _ = name
+        self.error(message, exit_code=exit_code)
+
     def heartbeat(self, message: str) -> None:
         print(message, file=self._stderr, flush=True)
 
@@ -176,6 +180,13 @@ class JsonSink:
 
     def error(self, message: str, exit_code: int = 1) -> None:
         payload = {"error": message, "exit_code": exit_code}
+        print(
+            json.dumps(_to_json_value(payload), separators=(",", ":")),
+            file=self._stderr,
+        )
+
+    def named_error(self, name: str, message: str, exit_code: int = 1) -> None:
+        payload = {"error": name, "message": message, "exit_code": exit_code}
         print(
             json.dumps(_to_json_value(payload), separators=(",", ":")),
             file=self._stderr,

--- a/src/meridian/cli/spawn.py
+++ b/src/meridian/cli/spawn.py
@@ -142,6 +142,21 @@ def _spawn_create_exit_code(result: SpawnActionOutput) -> int:
     return 1
 
 
+def _emit_spawn_warnings(*results: SpawnActionOutput) -> None:
+    """Emit human-mode action warnings through the CLI sink.
+
+    JSON results retain their structured ``warning`` fields without also writing
+    unstructured warning text to stderr.
+    """
+
+    if _get_global_options().output.format == "json":
+        return
+    sink = _current_output_sink()
+    for result in results:
+        if result.warning:
+            sink.warning(result.warning)
+
+
 def _read_prompt_from_stdin() -> str:
     if sys.stdin.isatty():
         raise ValueError("--prompt-file - requires stdin to be piped or redirected")
@@ -738,6 +753,7 @@ def _spawn_create(
             on_spawn_id=_foreground_spawn_id_notifier(quiet=quiet),
         )
     output_format = _get_global_options().output.format
+    _emit_spawn_warnings(result)
     if output_format != "json" and metadata:
         detailed_output = _spawn_create_metadata_output(result)
         if detailed_output is not None:
@@ -1009,6 +1025,7 @@ def _spawn_cancel(
         sink=_current_output_sink(),
         prepared=_prepare_spawn_runtime_write(),
     )
+    _emit_spawn_warnings(result)
     emit(result)
     if result.status == "failed":
         raise SystemExit(1)
@@ -1185,6 +1202,7 @@ def _spawn_cancel_all(
         sink=_current_output_sink(),
         prepared=_prepare_spawn_runtime_write(),
     )
+    _emit_spawn_warnings(*result.results)
     emit(result)
     if result.failed_count:
         raise SystemExit(1)
@@ -1203,6 +1221,7 @@ def _spawn_done(
         sink=_current_output_sink(),
         prepared=_prepare_spawn_runtime_write(),
     )
+    _emit_spawn_warnings(result)
     emit(result)
     if result.status == "failed":
         raise SystemExit(1)
@@ -1221,6 +1240,7 @@ def _spawn_rearm(
         sink=_current_output_sink(),
         prepared=_prepare_spawn_runtime_write(),
     )
+    _emit_spawn_warnings(result)
     emit(result)
     if result.status == "failed":
         raise SystemExit(1)

--- a/src/meridian/cli/task_dir_cmd.py
+++ b/src/meridian/cli/task_dir_cmd.py
@@ -23,7 +23,12 @@ Emitter = Callable[[Any], None]
 
 
 def _task_dir_query(emit: Emitter) -> None:
-    emit(task_dir_sync(TaskDirInput()))
+    from meridian.cli.main import current_output_sink
+
+    output = task_dir_sync(TaskDirInput())
+    if output.warning:
+        current_output_sink().warning(output.warning)
+    emit(output)
 
 
 def _task_dir_set(

--- a/src/meridian/lib/core/sink.py
+++ b/src/meridian/lib/core/sink.py
@@ -11,7 +11,13 @@ class OutputSink(Protocol):
 
     def warning(self, message: str) -> None: ...
 
-    def error(self, message: str, exit_code: int = 1) -> None: ...
+    def error(
+        self,
+        message: str,
+        *,
+        exit_code: int = 1,
+        name: str | None = None,
+    ) -> None: ...
 
     def heartbeat(self, message: str) -> None: ...
 
@@ -28,8 +34,14 @@ class NullSink:
     def warning(self, message: str) -> None:
         _ = message
 
-    def error(self, message: str, exit_code: int = 1) -> None:
-        _ = (message, exit_code)
+    def error(
+        self,
+        message: str,
+        *,
+        exit_code: int = 1,
+        name: str | None = None,
+    ) -> None:
+        _ = (message, exit_code, name)
 
     def heartbeat(self, message: str) -> None:
         _ = message

--- a/src/meridian/lib/launch/.context/CONTEXT.md
+++ b/src/meridian/lib/launch/.context/CONTEXT.md
@@ -234,6 +234,22 @@ Resolution priority in `resolve_task_cwd()`:
 5. caller cwd when outside the project tree (`source="ambient-cwd"`)
 6. authority root default
 
+**Stale task_dir fallback.** When a work item's configured `task_dir` no longer
+exists on disk (the common case after a worktree is removed post-merge),
+resolution skips the stale tier with a warning and falls through to the next
+valid tier. The fallback is read-time only — work state is never mutated on a
+read path. `WorkTaskDirMissing` is raised only when even the fallback
+`authority_root` does not exist; it is mapped to error name
+`work_task_dir_missing` at the pre-init boundary in `ops/spawn/pre_init.py`.
+Both `resolve_task_cwd()` and `resolve_effective_task_dir()` implement this.
+
+**Warning threading.** `TaskCwdResolution.warning` carries the stale-path
+warning from `resolve_task_cwd()`. Callers must explicitly merge it into
+`SpawnRequest.warning` because `launch_resolution.request_updates` does not
+include it. Both `launch_primary()` in `__init__.py` and `build_create_payload()`
+in `ops/spawn/prepare.py` perform this merge. Omitting the merge silently drops
+the warning — a trap for any new caller of `resolve_launch_inputs()`.
+
 ### Reference Loading and Anchor Semantics
 
 `reference.py` owns `-f` reference file loading and template substitution.
@@ -259,6 +275,16 @@ files produce a warning instead.
 Launch uses a work item's `task_dir` as its logical task cwd. Persisted
 `WorktreeMetadata` is state/display metadata only; launch does not provision or
 manage git worktrees.
+
+**Premature-derivation trap in `ops/spawn/prepare.py`.** `build_create_payload()`
+derives the parent's inheritable task dir via `derive_inheritable_task_dir()`
+before calling `resolve_launch_inputs()`. That derivation calls
+`resolve_effective_task_dir()`, which can raise on a stale work-item path.
+When an explicit `--task-dir` flag is present, `build_create_payload()` skips
+the derivation entirely (sets `inherited_for_child = None`) so the stale value
+never blocks an explicit override. Without this skip, the stale-path exception
+fires before the explicit flag reaches `resolve_task_cwd()`, breaking the
+documented config-precedence rule that CLI flags always win.
 
 ### Workspace Projection
 

--- a/src/meridian/lib/launch/__init__.py
+++ b/src/meridian/lib/launch/__init__.py
@@ -178,9 +178,16 @@ def launch_primary(
     )
     request_updates = dict(launch_resolution.request_updates)
     request_updates["work_id_hint"] = effective_work_id
-    spawn_request = build_primary_spawn_request(request=request).model_copy(
-        update=request_updates
-    )
+    spawn_request = build_primary_spawn_request(request=request)
+    request_updates["warning"] = "\n".join(
+        warning
+        for warning in (
+            spawn_request.warning,
+            launch_resolution.task_cwd_resolution.warning,
+        )
+        if warning
+    ) or None
+    spawn_request = spawn_request.model_copy(update=request_updates)
     prepared_policy = compile_prepared_policy_surface(
         request=spawn_request,
         runtime=runtime,

--- a/src/meridian/lib/launch/cwd.py
+++ b/src/meridian/lib/launch/cwd.py
@@ -93,22 +93,28 @@ def _active_task_dir_for_item(
     return Path(item.task_dir).expanduser().resolve()
 
 
-def _stale_work_task_dir_warning(
+def _stale_work_task_dir_message(
     *,
     task_dir: Path,
     work_id: str,
 ) -> str:
     return (
         f"Work item '{work_id}' has a configured task_dir that does not exist: "
-        f"{task_dir}. Falling back without changing work state."
+        f"{task_dir}."
     )
 
 
-def _require_fallback_root(project_root: Path, warning: str) -> Path:
+def _fallback_warning(message: str | None, destination: Path) -> str | None:
+    if message is None:
+        return None
+    return f"{message} Falling back to {destination} (work state unchanged)."
+
+
+def _require_fallback_root(project_root: Path, message: str) -> Path:
     if project_root.is_dir():
         return project_root
     raise WorkTaskDirMissing(
-        f"{warning}\nNo fallback project directory exists: {project_root}"
+        f"{message}\nNo fallback project directory exists: {project_root}"
     )
 
 
@@ -171,17 +177,17 @@ def resolve_effective_task_dir(
         if work_path is not None:
             if work_path.is_dir():
                 return EffectiveTaskDir(task_dir=work_path, source="work-item")
-            warning = _stale_work_task_dir_warning(
+            stale_message = _stale_work_task_dir_message(
                 task_dir=work_path,
                 work_id=normalized_work_id,
             )
         else:
-            warning = None
+            stale_message = None
     else:
-        warning = None
+        stale_message = None
 
     if not skip_inherited and inherited_task_dir is not None:
-        if warning is None:
+        if stale_message is None:
             resolved_inherited = _validated_inherited_task_dir(inherited_task_dir)
             return EffectiveTaskDir(task_dir=resolved_inherited, source="inherited")
         resolved_inherited = inherited_task_dir.expanduser().resolve()
@@ -189,17 +195,17 @@ def resolve_effective_task_dir(
             return EffectiveTaskDir(
                 task_dir=resolved_inherited,
                 source="inherited",
-                warning=warning,
+                warning=_fallback_warning(stale_message, resolved_inherited),
             )
 
     return EffectiveTaskDir(
         task_dir=(
-            _require_fallback_root(resolved_project_root, warning)
-            if warning is not None
+            _require_fallback_root(resolved_project_root, stale_message)
+            if stale_message is not None
             else resolved_project_root
         ),
         source="project-root",
-        warning=warning,
+        warning=_fallback_warning(stale_message, resolved_project_root),
     )
 
 
@@ -284,19 +290,19 @@ def resolve_task_cwd(
                 source="explicit-work-task-dir",
                 work_item=selected_work_id,
             )
-        stale_warning = _stale_work_task_dir_warning(
+        stale_message = _stale_work_task_dir_message(
             task_dir=explicit_path,
             work_id=selected_work_id,
         )
     else:
-        stale_warning = None
+        stale_message = None
 
     inherited_override = (
         str(inherited_task_dir).strip() if inherited_task_dir is not None else ""
     )
     if inherited_override:
         inherited_candidate = Path(inherited_override).expanduser().resolve()
-        if stale_warning is None:
+        if stale_message is None:
             inherited_path = _validated_inherited_task_dir(inherited_candidate)
         elif inherited_candidate.is_dir():
             inherited_path = inherited_candidate
@@ -307,7 +313,7 @@ def resolve_task_cwd(
                 task_cwd=inherited_path,
                 source="inherited-task-dir",
                 work_item=selected_work_id or ambient_selected_work_id,
-                warning=stale_warning,
+                warning=_fallback_warning(stale_message, inherited_path),
             )
 
     if selected_work_id is None and ambient_selected_work_id is not None:
@@ -327,7 +333,7 @@ def resolve_task_cwd(
                 source="ambient-work-task-dir",
                 work_item=ambient_selected_work_id,
             )
-        stale_warning = _stale_work_task_dir_warning(
+        stale_message = _stale_work_task_dir_message(
             task_dir=ambient_path,
             work_id=ambient_selected_work_id,
         )
@@ -341,13 +347,13 @@ def resolve_task_cwd(
             task_cwd=inferred_caller_cwd,
             source="ambient-cwd",
             work_item=selected_work_id or ambient_selected_work_id,
-            warning=stale_warning,
+            warning=_fallback_warning(stale_message, inferred_caller_cwd),
         )
 
     return TaskCwdResolution(
         task_cwd=(
-            _require_fallback_root(resolved_authority_root, stale_warning)
-            if stale_warning is not None
+            _require_fallback_root(resolved_authority_root, stale_message)
+            if stale_message is not None
             else resolved_authority_root
         ),
         source=(
@@ -360,5 +366,5 @@ def resolve_task_cwd(
             )
         ),
         work_item=selected_work_id or ambient_selected_work_id,
-        warning=stale_warning,
+        warning=_fallback_warning(stale_message, resolved_authority_root),
     )

--- a/src/meridian/lib/launch/cwd.py
+++ b/src/meridian/lib/launch/cwd.py
@@ -17,6 +17,7 @@ class EffectiveTaskDir:
 
     task_dir: Path
     source: Literal["scope", "work-item", "inherited", "project-root"]
+    warning: str | None = None
 
 
 @dataclass(frozen=True)
@@ -26,6 +27,11 @@ class TaskCwdResolution:
     task_cwd: Path
     source: str
     work_item: str | None
+    warning: str | None = None
+
+
+class WorkTaskDirMissing(Exception):
+    """No usable fallback exists for a stale work-item task directory."""
 
 
 @dataclass(frozen=True)
@@ -87,17 +93,22 @@ def _active_task_dir_for_item(
     return Path(item.task_dir).expanduser().resolve()
 
 
-def _validated_task_dir(
+def _stale_work_task_dir_warning(
     *,
     task_dir: Path,
     work_id: str,
-) -> Path:
-    if task_dir.is_dir():
-        return task_dir
-    raise ValueError(
-        f"Work item '{work_id}' has a configured task_dir that does not exist.\n"
-        f"  task_dir: {task_dir}\n"
-        "Use --task-dir to set a valid directory for this work item."
+) -> str:
+    return (
+        f"Work item '{work_id}' has a configured task_dir that does not exist: "
+        f"{task_dir}. Falling back without changing work state."
+    )
+
+
+def _require_fallback_root(project_root: Path, warning: str) -> Path:
+    if project_root.is_dir():
+        return project_root
+    raise WorkTaskDirMissing(
+        f"{warning}\nNo fallback project directory exists: {project_root}"
     )
 
 
@@ -158,21 +169,37 @@ def resolve_effective_task_dir(
             work_id=normalized_work_id,
         )
         if work_path is not None:
-            return EffectiveTaskDir(
-                task_dir=_validated_task_dir(
-                    task_dir=work_path,
-                    work_id=normalized_work_id,
-                ),
-                source="work-item",
+            if work_path.is_dir():
+                return EffectiveTaskDir(task_dir=work_path, source="work-item")
+            warning = _stale_work_task_dir_warning(
+                task_dir=work_path,
+                work_id=normalized_work_id,
             )
+        else:
+            warning = None
+    else:
+        warning = None
 
     if not skip_inherited and inherited_task_dir is not None:
-        resolved_inherited = _validated_inherited_task_dir(inherited_task_dir)
-        return EffectiveTaskDir(task_dir=resolved_inherited, source="inherited")
+        if warning is None:
+            resolved_inherited = _validated_inherited_task_dir(inherited_task_dir)
+            return EffectiveTaskDir(task_dir=resolved_inherited, source="inherited")
+        resolved_inherited = inherited_task_dir.expanduser().resolve()
+        if resolved_inherited.is_dir():
+            return EffectiveTaskDir(
+                task_dir=resolved_inherited,
+                source="inherited",
+                warning=warning,
+            )
 
     return EffectiveTaskDir(
-        task_dir=resolved_project_root,
+        task_dir=(
+            _require_fallback_root(resolved_project_root, warning)
+            if warning is not None
+            else resolved_project_root
+        ),
         source="project-root",
+        warning=warning,
     )
 
 
@@ -251,29 +278,39 @@ def resolve_task_cwd(
                 source="explicit-work-authority-root",
                 work_item=selected_work_id,
             )
-        return TaskCwdResolution(
-            task_cwd=_validated_task_dir(
-                task_dir=explicit_path,
-                work_id=selected_work_id,
-            ),
-            source="explicit-work-task-dir",
-            work_item=selected_work_id,
+        if explicit_path.is_dir():
+            return TaskCwdResolution(
+                task_cwd=explicit_path,
+                source="explicit-work-task-dir",
+                work_item=selected_work_id,
+            )
+        stale_warning = _stale_work_task_dir_warning(
+            task_dir=explicit_path,
+            work_id=selected_work_id,
         )
+    else:
+        stale_warning = None
 
     inherited_override = (
         str(inherited_task_dir).strip() if inherited_task_dir is not None else ""
     )
     if inherited_override:
-        inherited_path = _validated_inherited_task_dir(
-            Path(inherited_override).expanduser().resolve()
-        )
-        return TaskCwdResolution(
-            task_cwd=inherited_path,
-            source="inherited-task-dir",
-            work_item=ambient_selected_work_id,
-        )
+        inherited_candidate = Path(inherited_override).expanduser().resolve()
+        if stale_warning is None:
+            inherited_path = _validated_inherited_task_dir(inherited_candidate)
+        elif inherited_candidate.is_dir():
+            inherited_path = inherited_candidate
+        else:
+            inherited_path = None
+        if inherited_path is not None:
+            return TaskCwdResolution(
+                task_cwd=inherited_path,
+                source="inherited-task-dir",
+                work_item=selected_work_id or ambient_selected_work_id,
+                warning=stale_warning,
+            )
 
-    if ambient_selected_work_id is not None:
+    if selected_work_id is None and ambient_selected_work_id is not None:
         ambient_path = _active_task_dir_for_item(
             project_state_dir=project_state_dir,
             work_id=ambient_selected_work_id,
@@ -284,13 +321,15 @@ def resolve_task_cwd(
                 source="ambient-work-authority-root",
                 work_item=ambient_selected_work_id,
             )
-        return TaskCwdResolution(
-            task_cwd=_validated_task_dir(
-                task_dir=ambient_path,
-                work_id=ambient_selected_work_id,
-            ),
-            source="ambient-work-task-dir",
-            work_item=ambient_selected_work_id,
+        if ambient_path.is_dir():
+            return TaskCwdResolution(
+                task_cwd=ambient_path,
+                source="ambient-work-task-dir",
+                work_item=ambient_selected_work_id,
+            )
+        stale_warning = _stale_work_task_dir_warning(
+            task_dir=ambient_path,
+            work_id=ambient_selected_work_id,
         )
 
     inferred_caller_cwd = _infer_caller_cwd_outside_project(
@@ -301,11 +340,25 @@ def resolve_task_cwd(
         return TaskCwdResolution(
             task_cwd=inferred_caller_cwd,
             source="ambient-cwd",
-            work_item=None,
+            work_item=selected_work_id or ambient_selected_work_id,
+            warning=stale_warning,
         )
 
     return TaskCwdResolution(
-        task_cwd=resolved_authority_root,
-        source="authority-root",
-        work_item=None,
+        task_cwd=(
+            _require_fallback_root(resolved_authority_root, stale_warning)
+            if stale_warning is not None
+            else resolved_authority_root
+        ),
+        source=(
+            "explicit-work-authority-root"
+            if selected_work_id is not None
+            else (
+                "ambient-work-authority-root"
+                if ambient_selected_work_id is not None
+                else "authority-root"
+            )
+        ),
+        work_item=selected_work_id or ambient_selected_work_id,
+        warning=stale_warning,
     )

--- a/src/meridian/lib/launch/cwd.py
+++ b/src/meridian/lib/launch/cwd.py
@@ -98,16 +98,16 @@ def _stale_work_task_dir_message(
     task_dir: Path,
     work_id: str,
 ) -> str:
-    return (
-        f"Work item '{work_id}' has a configured task_dir that does not exist: "
-        f"{task_dir}."
-    )
+    return f"Work item '{work_id}' task_dir no longer exists: {task_dir}."
 
 
 def _fallback_warning(message: str | None, destination: Path) -> str | None:
     if message is None:
         return None
-    return f"{message} Falling back to {destination} (work state unchanged)."
+    return (
+        f"{message} Using {destination} instead; "
+        "run 'meridian work task-dir <dir>' to update it."
+    )
 
 
 def _require_fallback_root(project_root: Path, message: str) -> Path:

--- a/src/meridian/lib/launch/resolve.py
+++ b/src/meridian/lib/launch/resolve.py
@@ -203,7 +203,7 @@ def format_missing_skills_warning(missing_skills: tuple[str, ...]) -> str:
     expected_lines.extend(f"         {path}" for path in expected_paths[1:])
     return "\n".join(
         (
-            f"Warning: Skipped unavailable skills: {', '.join(missing_skills)}",
+            f"Skipped unavailable skills: {', '.join(missing_skills)}",
             *expected_lines,
             "Run `meridian mars sync` to install missing skills.",
         )

--- a/src/meridian/lib/ops/context.py
+++ b/src/meridian/lib/ops/context.py
@@ -193,6 +193,7 @@ class TaskDirOutput(BaseModel):
     task_dir: str
     source: str
     spawn_id: str | None = None
+    warning: str | None = None
 
     def format_text(self, ctx: FormatContext | None = None) -> str:
         _ = ctx
@@ -347,6 +348,7 @@ def _resolve_effective_task_dir_output() -> TaskDirOutput:
         task_dir=effective.task_dir.as_posix(),
         source=effective.source,
         spawn_id=str(runtime_ctx.spawn_id) if runtime_ctx.spawn_id is not None else None,
+        warning=effective.warning,
     )
 
 

--- a/src/meridian/lib/ops/spawn/models.py
+++ b/src/meridian/lib/ops/spawn/models.py
@@ -381,8 +381,6 @@ class SpawnActionOutput(BaseModel):
         if self.duration_secs is not None:
             duration_suffix = f" ({self.duration_secs:.1f}s)"
         lines = [f"{self.spawn_id} {self.status}{duration_suffix}"]
-        if self.warning:
-            lines.append(f"Warning: {self.warning}")
         if self.error:
             lines.append(f"Error: {self.error}")
         if self._has_distinct_task_cwd():
@@ -417,10 +415,7 @@ class SpawnActionOutput(BaseModel):
             and self.spawn_id
             and not self.message
         ):
-            text = _background_wait_note(self.spawn_id)
-            if self.warning:
-                text = f"{text}\nWarning: {self.warning}"
-            return text
+            return _background_wait_note(self.spawn_id)
 
         lines: list[str] = []
         if self.message:
@@ -471,8 +466,6 @@ class SpawnActionOutput(BaseModel):
                 lines.append(goal_contract_preview)
         if self.error:
             lines.append(f"Error: {self.error}")
-        if self.warning:
-            lines.append(f"Warning: {self.warning}")
         if self.cli_command:
             lines.append(shlex.join(self.cli_command))
         if self.exit_code is not None:

--- a/src/meridian/lib/ops/spawn/pre_init.py
+++ b/src/meridian/lib/ops/spawn/pre_init.py
@@ -7,6 +7,7 @@ from typing import TypeVar
 
 import structlog
 
+from meridian.lib.launch.cwd import WorkTaskDirMissing
 from meridian.lib.launch.request import SpawnRequest
 
 from .models import SpawnActionOutput, SpawnCreateInput
@@ -87,6 +88,20 @@ def pre_init_failed_output(
     )
 
 
+def work_task_dir_missing_output(
+    *,
+    payload: SpawnCreateInput,
+    exc: WorkTaskDirMissing,
+    request: SpawnRequest | None = None,
+) -> SpawnActionOutput:
+    return _pre_init_output(
+        payload=payload,
+        request=request,
+        message=f"Work task directory is missing and no fallback is available: {exc}",
+        error="work_task_dir_missing",
+    )
+
+
 def unexpected_pre_init_failed_output(
     *,
     payload: SpawnCreateInput,
@@ -112,6 +127,13 @@ def run_pre_init_boundary(
 ) -> _T | SpawnActionOutput:
     try:
         return operation()
+    except WorkTaskDirMissing as exc:
+        failure_payload = payload() if callable(payload) else payload
+        return work_task_dir_missing_output(
+            payload=failure_payload,
+            request=request,
+            exc=exc,
+        )
     except PreInitFailure as exc:
         failure_payload = payload() if callable(payload) else payload
         return pre_init_failed_output(payload=failure_payload, request=request, exc=exc)

--- a/src/meridian/lib/ops/spawn/prepare.py
+++ b/src/meridian/lib/ops/spawn/prepare.py
@@ -154,7 +154,7 @@ def build_create_payload(
         )
         inherited_for_child = (
             None
-            if _is_exact_continue(payload)
+            if _is_exact_continue(payload) or (payload.task_dir or "").strip()
             else derive_inheritable_task_dir(
                 project_root=project_root,
                 project_state_dir=project_state_dir,
@@ -221,7 +221,15 @@ def build_create_payload(
             goal=payload.goal,
             work_id_hint=resolved_work_id_hint,
             inherited_context_work_id=launch_resolution.context_work_id,
-            warning=preflight_warning.strip() if preflight_warning is not None else None,
+            warning="\n".join(
+                warning
+                for warning in (
+                    preflight_warning.strip() if preflight_warning is not None else None,
+                    launch_resolution.task_cwd_resolution.warning,
+                )
+                if warning
+            )
+            or None,
             authority_root=launch_resolution.directory_context.authority_root.as_posix(),
             task_cwd=launch_resolution.directory_context.logical_task_cwd.as_posix(),
             reference_anchor=launch_resolution.directory_context.reference_anchor.as_posix(),

--- a/tests/integration/cli/test_artifact_cli.py
+++ b/tests/integration/cli/test_artifact_cli.py
@@ -419,6 +419,27 @@ def test_patched_cli_serve_list_stop_gc(
     assert "Garbage-collected 0" in capsys.readouterr().out
 
 
+def test_artifact_list_routes_url_warning_through_cli_sink(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def unavailable_dns_name() -> str:
+        raise service.ArtifactError("tailscale unavailable")
+
+    monkeypatch.setattr(store, "serves_path", lambda: tmp_path / "serves.json")
+    store.save_serves([_serve("report", 50000)])
+    monkeypatch.setattr(service, "tailscale_dns_name", unavailable_dns_name)
+    monkeypatch.setattr(service, "pid_alive", lambda _pid, _created: True)
+
+    _invoke_artifact(["list"])
+
+    captured = capsys.readouterr()
+    assert "report" in captured.out
+    assert "Warning:" not in captured.out
+    assert captured.err == "warning: artifact URLs unavailable: tailscale unavailable\n"
+
+
 @pytest.mark.parametrize("slug", ["", "/", "..", "a/b", " white ", "a--b", "x\nroot"])
 def test_invalid_persisted_slugs_are_dropped_without_tailscale_calls(
     slug: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/integration/launch/test_cwd.py
+++ b/tests/integration/launch/test_cwd.py
@@ -31,6 +31,13 @@ def _work_with_task_dir(state_dir: Path, tmp_path: Path, name: str) -> str:
     return item.name
 
 
+def _work_with_stale_task_dir(state_dir: Path, tmp_path: Path, name: str) -> tuple[str, Path]:
+    item = work_repository.create_work_item(state_dir, name, "", None)
+    stale = tmp_path / f"{name}-removed-task-dir"
+    work_repository.update_work_item_task_dir(state_dir, item.name, task_dir=stale.as_posix())
+    return item.name, stale.resolve()
+
+
 def _publish_spawn(project_root: Path, spawn_id: str = "p1") -> None:
     start_spawn(
         resolve_project_runtime_root_for_write(project_root),
@@ -56,6 +63,24 @@ def test_resolve_task_cwd_uses_explicit_task_dir_override_first(tmp_path: Path) 
 
     assert resolved.task_cwd == explicit.resolve()
     assert resolved.source == "explicit-task-dir"
+
+
+def test_resolve_task_cwd_explicit_task_dir_wins_over_stale_work_item(tmp_path: Path) -> None:
+    authority_root, state_dir = _roots(tmp_path)
+    work_id, _ = _work_with_stale_task_dir(state_dir, tmp_path, "stale-work")
+    explicit = tmp_path / "explicit-task"
+    explicit.mkdir()
+
+    resolved = resolve_task_cwd(
+        authority_root,
+        project_state_dir=state_dir,
+        explicit_task_dir=explicit,
+        ambient_work_id=work_id,
+    )
+
+    assert resolved.task_cwd == explicit.resolve()
+    assert resolved.source == "explicit-task-dir"
+    assert resolved.warning is None
 
 
 def test_resolve_task_cwd_rejects_missing_explicit_task_dir(tmp_path: Path) -> None:
@@ -114,6 +139,23 @@ def test_resolve_task_cwd_ambient_work_uses_task_dir(tmp_path: Path) -> None:
     assert resolved.task_cwd == (tmp_path / "ambient-work-task-dir").resolve()
     assert resolved.source == "ambient-work-task-dir"
     assert resolved.work_item == ambient_id
+
+
+def test_resolve_task_cwd_stale_ambient_work_falls_back_with_warning(tmp_path: Path) -> None:
+    authority_root, state_dir = _roots(tmp_path)
+    work_id, stale = _work_with_stale_task_dir(state_dir, tmp_path, "stale-work")
+
+    resolved = resolve_task_cwd(
+        authority_root,
+        project_state_dir=state_dir,
+        ambient_work_id=work_id,
+    )
+
+    assert resolved.task_cwd == authority_root.resolve()
+    assert resolved.source == "ambient-work-authority-root"
+    assert resolved.work_item == work_id
+    assert resolved.warning is not None
+    assert stale.as_posix() in resolved.warning
 
 
 def test_resolve_task_cwd_uses_caller_cwd_outside_project_tree(tmp_path: Path) -> None:
@@ -336,3 +378,19 @@ def test_resolve_effective_task_dir_tombstone_skips_inherited(tmp_path: Path) ->
         task_dir=project_root.resolve(),
         source="project-root",
     )
+
+
+def test_resolve_effective_task_dir_stale_work_falls_back_with_warning(tmp_path: Path) -> None:
+    project_root, state_dir = _roots(tmp_path)
+    work_id, stale = _work_with_stale_task_dir(state_dir, tmp_path, "stale-work")
+
+    effective = resolve_effective_task_dir(
+        project_root=project_root,
+        project_state_dir=state_dir,
+        work_id=work_id,
+    )
+
+    assert effective.task_dir == project_root.resolve()
+    assert effective.source == "project-root"
+    assert effective.warning is not None
+    assert stale.as_posix() in effective.warning

--- a/tests/integration/launch/test_launch_resolution_runtime.py
+++ b/tests/integration/launch/test_launch_resolution_runtime.py
@@ -383,7 +383,7 @@ def test_primary_launch_stale_work_task_dir_warning_reaches_dry_run_result(
 
     assert result.warning is not None
     assert stale.as_posix() in result.warning
-    assert f"Falling back to {project_root.resolve()}" in result.warning
+    assert f"Using {project_root.resolve()} instead" in result.warning
 
 
 def test_primary_launch_invalid_reference_does_not_create_explicit_work(

--- a/tests/integration/launch/test_launch_resolution_runtime.py
+++ b/tests/integration/launch/test_launch_resolution_runtime.py
@@ -339,6 +339,53 @@ def test_primary_launch_resolves_reference_files_from_explicit_task_dir(
     assert "project shadow" not in prompt
 
 
+@pytest.mark.parametrize("work_source", ["explicit", "ambient"])
+def test_primary_launch_stale_work_task_dir_warning_reaches_dry_run_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    work_source: str,
+) -> None:
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    monkeypatch.chdir(project_root)
+    _write_minimal_mars_config(project_root)
+    project_state_dir = resolve_project_paths(project_root).root_dir
+    work = work_repository.create_work_item(project_state_dir, "stale-work", "", None)
+    stale = tmp_path / "removed-worktree"
+    work_repository.update_work_item_task_dir(
+        project_state_dir,
+        work.name,
+        task_dir=stale.as_posix(),
+    )
+    stub_bundle_request_and_resolve(
+        monkeypatch,
+        model="gpt-5.4-mini",
+        harness=HarnessId.CODEX,
+    )
+    monkeypatch.delenv("MERIDIAN_TASK_DIR", raising=False)
+    if work_source == "ambient":
+        monkeypatch.setenv("MERIDIAN_ACTIVE_WORK_ID", work.name)
+        explicit_work_id = None
+    else:
+        monkeypatch.delenv("MERIDIAN_ACTIVE_WORK_ID", raising=False)
+        explicit_work_id = work.name
+
+    result = launch_primary(
+        project_root=project_root,
+        request=PrimaryLaunchRequest(
+            model="gpt-5.4-mini",
+            harness=HarnessId.CODEX.value,
+            work_id=explicit_work_id,
+            dry_run=True,
+        ),
+        harness_registry=get_default_harness_registry(),
+    )
+
+    assert result.warning is not None
+    assert stale.as_posix() in result.warning
+    assert f"Falling back to {project_root.resolve()}" in result.warning
+
+
 def test_primary_launch_invalid_reference_does_not_create_explicit_work(
     tmp_path: Path,
 ) -> None:

--- a/tests/integration/ops/test_spawn_api_create.py
+++ b/tests/integration/ops/test_spawn_api_create.py
@@ -15,12 +15,13 @@ from structlog.testing import capture_logs
 
 import meridian.lib.ops.spawn.api as spawn_api
 import meridian.lib.ops.spawn.pre_init as pre_init_module
+import meridian.lib.ops.spawn.prepare as spawn_prepare
 from meridian.lib.bootstrap.services import prepare_for_runtime_write
 from meridian.lib.core.context import RuntimeContext
 from meridian.lib.core.types import HarnessId
 from meridian.lib.launch import bundle_adapter
-from meridian.lib.launch.cwd import WorkTaskDirMissing
 from meridian.lib.launch.launch_types import ResolvedExecutionPolicy
+from meridian.lib.ops.runtime import build_runtime
 from meridian.lib.ops.spawn.models import SpawnCreateInput
 from meridian.lib.state import spawn_store, work_repository, work_store
 from meridian.lib.state.paths import resolve_project_paths, resolve_spawn_log_dir
@@ -586,20 +587,43 @@ def test_spawn_create_unresolvable_work_task_dir_has_distinct_error(
     project_root.mkdir()
     (project_root / ".git").mkdir()
     (project_root / "mars.toml").write_text("", encoding="utf-8")
-
-    def _raise(*_args: object, **_kwargs: object) -> object:
-        raise WorkTaskDirMissing("stale task dir and missing project root")
-
-    monkeypatch.setattr(spawn_api, "build_create_payload", _raise)
+    runtime = build_runtime(project_root)
+    project_paths = resolve_project_paths(project_root)
+    work = work_repository.create_work_item(
+        project_paths.root_dir, "unresolvable-work", "", None
+    )
+    stale = tmp_path / "removed-worktree"
+    work_repository.update_work_item_task_dir(
+        project_paths.root_dir,
+        work.name,
+        task_dir=stale.as_posix(),
+    )
+    missing_root = tmp_path / "removed-project-root"
+    missing_authority = runtime.authority.model_copy(update={"project_root": missing_root})
+    monkeypatch.setattr(
+        spawn_api,
+        "resolve_runtime_authority_for_read",
+        lambda _project_root: missing_authority,
+    )
+    monkeypatch.setattr(
+        spawn_prepare,
+        "resolve_runtime_authority_for_read",
+        lambda _project_root: missing_authority,
+    )
+    monkeypatch.setattr(spawn_api, "resolve_project_paths", lambda _root: project_paths)
+    monkeypatch.setattr(spawn_prepare, "resolve_project_paths", lambda _root: project_paths)
 
     result = spawn_api.spawn_create_sync(
         SpawnCreateInput(
             prompt="run",
             model="gpt-5.4-mini",
-            project_root=project_root.as_posix(),
+            project_root=missing_root.as_posix(),
+            work=work.name,
             dry_run=True,
         )
     )
 
     assert result.status == "failed"
     assert result.error == "work_task_dir_missing"
+    assert stale.as_posix() in result.message
+    assert missing_root.as_posix() in result.message

--- a/tests/integration/ops/test_spawn_api_create.py
+++ b/tests/integration/ops/test_spawn_api_create.py
@@ -19,6 +19,7 @@ from meridian.lib.bootstrap.services import prepare_for_runtime_write
 from meridian.lib.core.context import RuntimeContext
 from meridian.lib.core.types import HarnessId
 from meridian.lib.launch import bundle_adapter
+from meridian.lib.launch.cwd import WorkTaskDirMissing
 from meridian.lib.launch.launch_types import ResolvedExecutionPolicy
 from meridian.lib.ops.spawn.models import SpawnCreateInput
 from meridian.lib.state import spawn_store, work_repository, work_store
@@ -496,3 +497,109 @@ def test_spawn_create_dry_run_uses_ambient_work_item_task_dir(
     assert result.task_cwd == ambient_task_dir.as_posix()
     assert result.reference_anchor == ambient_task_dir.as_posix()
     assert result.task_cwd_work_item == work.name
+
+
+def test_spawn_create_stale_ambient_work_falls_back_with_warning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    (project_root / ".git").mkdir()
+    (project_root / "mars.toml").write_text("", encoding="utf-8")
+    monkeypatch.chdir(project_root)
+    stub_bundle_request_and_resolve(
+        monkeypatch,
+        model="gpt-5.4-mini",
+        harness=HarnessId.CODEX,
+    )
+    project_state_dir = resolve_project_paths(project_root).root_dir
+    work = work_repository.create_work_item(project_state_dir, "stale-work", "", None)
+    stale = tmp_path / "removed-worktree"
+    work_repository.update_work_item_task_dir(
+        project_state_dir, work.name, task_dir=stale.as_posix()
+    )
+
+    result = spawn_api.spawn_create_sync(
+        SpawnCreateInput(
+            prompt="run",
+            model="gpt-5.4-mini",
+            project_root=project_root.as_posix(),
+            dry_run=True,
+        ),
+        ctx=RuntimeContext(work_id=work.name),
+    )
+
+    assert result.status == "dry-run"
+    assert result.task_cwd == project_root.resolve().as_posix()
+    assert result.task_cwd_source == "ambient-work-authority-root"
+    assert result.task_cwd_work_item == work.name
+    assert result.warning is not None
+    assert stale.as_posix() in result.warning
+
+
+def test_spawn_create_explicit_task_dir_wins_before_stale_ambient_derivation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    (project_root / ".git").mkdir()
+    (project_root / "mars.toml").write_text("", encoding="utf-8")
+    explicit = tmp_path / "explicit-worktree"
+    explicit.mkdir()
+    monkeypatch.chdir(project_root)
+    stub_bundle_request_and_resolve(
+        monkeypatch,
+        model="gpt-5.4-mini",
+        harness=HarnessId.CODEX,
+    )
+    project_state_dir = resolve_project_paths(project_root).root_dir
+    work = work_repository.create_work_item(project_state_dir, "stale-work", "", None)
+    stale = tmp_path / "removed-worktree"
+    work_repository.update_work_item_task_dir(
+        project_state_dir, work.name, task_dir=stale.as_posix()
+    )
+
+    result = spawn_api.spawn_create_sync(
+        SpawnCreateInput(
+            prompt="run",
+            model="gpt-5.4-mini",
+            project_root=project_root.as_posix(),
+            task_dir=explicit.as_posix(),
+            dry_run=True,
+        ),
+        ctx=RuntimeContext(work_id=work.name),
+    )
+
+    assert result.status == "dry-run"
+    assert result.task_cwd == explicit.resolve().as_posix()
+    assert result.task_cwd_source == "explicit-task-dir"
+    assert result.warning is None or stale.as_posix() not in result.warning
+
+
+def test_spawn_create_unresolvable_work_task_dir_has_distinct_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    (project_root / ".git").mkdir()
+    (project_root / "mars.toml").write_text("", encoding="utf-8")
+
+    def _raise(*_args: object, **_kwargs: object) -> object:
+        raise WorkTaskDirMissing("stale task dir and missing project root")
+
+    monkeypatch.setattr(spawn_api, "build_create_payload", _raise)
+
+    result = spawn_api.spawn_create_sync(
+        SpawnCreateInput(
+            prompt="run",
+            model="gpt-5.4-mini",
+            project_root=project_root.as_posix(),
+            dry_run=True,
+        )
+    )
+
+    assert result.status == "failed"
+    assert result.error == "work_task_dir_missing"

--- a/tests/integration/ops/test_spawn_execute_report_output.py
+++ b/tests/integration/ops/test_spawn_execute_report_output.py
@@ -46,8 +46,14 @@ class RecordingOutputSink:
     def warning(self, message: str) -> None:
         _ = message
 
-    def error(self, message: str, exit_code: int = 1) -> None:
-        _ = (message, exit_code)
+    def error(
+        self,
+        message: str,
+        *,
+        exit_code: int = 1,
+        name: str | None = None,
+    ) -> None:
+        _ = (message, exit_code, name)
 
     def heartbeat(self, message: str) -> None:
         _ = message

--- a/tests/integration/ops/test_task_dir_commands.py
+++ b/tests/integration/ops/test_task_dir_commands.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
 
+import meridian.lib.ops.context as context_ops
 from meridian.lib.ops.context import (
     TaskDirClearInput,
     TaskDirInput,
@@ -85,6 +87,87 @@ def test_task_dir_query_stale_work_falls_back_with_warning(
     assert output.source == "project-root"
     assert output.warning is not None
     assert stale.as_posix() in output.warning
+
+
+def test_task_dir_cli_stale_work_warns_and_prints_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    project_root = _seed_project(tmp_path)
+    monkeypatch.chdir(project_root)
+    runtime = build_runtime(project_root)
+    item = work_repository.create_work_item(
+        runtime.authority.project_state_dir, "stale-cli-work", "", None
+    )
+    stale = tmp_path / "removed-cli-worktree"
+    work_repository.update_work_item_task_dir(
+        runtime.authority.project_state_dir,
+        item.name,
+        task_dir=stale.as_posix(),
+    )
+    monkeypatch.setenv("MERIDIAN_ACTIVE_WORK_ID", item.name)
+    monkeypatch.delenv("MERIDIAN_TASK_DIR", raising=False)
+
+    from meridian.cli.main import main
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(["task-dir"])
+
+    assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    assert captured.out.strip() == project_root.resolve().as_posix()
+    assert f"Falling back to {project_root.resolve()}" in captured.err
+    assert captured.err.startswith("warning:")
+
+
+@pytest.mark.parametrize("json_mode", [False, True], ids=["human", "json"])
+def test_task_dir_cli_unresolvable_work_returns_named_error_without_traceback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    json_mode: bool,
+) -> None:
+    project_root = _seed_project(tmp_path)
+    monkeypatch.chdir(project_root)
+    runtime = build_runtime(project_root)
+    item = work_repository.create_work_item(
+        runtime.authority.project_state_dir, "missing-root-work", "", None
+    )
+    stale = tmp_path / "removed-worktree"
+    work_repository.update_work_item_task_dir(
+        runtime.authority.project_state_dir,
+        item.name,
+        task_dir=stale.as_posix(),
+    )
+    missing_root = tmp_path / "removed-project-root"
+    authority = runtime.authority.model_copy(update={"project_root": missing_root})
+    monkeypatch.setattr(
+        context_ops,
+        "resolve_runtime_authority_for_read",
+        lambda: authority,
+    )
+    monkeypatch.setenv("MERIDIAN_ACTIVE_WORK_ID", item.name)
+    monkeypatch.delenv("MERIDIAN_TASK_DIR", raising=False)
+
+    from meridian.cli.main import main
+
+    argv = ["--json", "task-dir"] if json_mode else ["task-dir"]
+    with pytest.raises(SystemExit) as exc_info:
+        main(argv)
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "Traceback" not in captured.err
+    assert stale.as_posix() in captured.err
+    assert missing_root.as_posix() in captured.err
+    if json_mode:
+        error = json.loads(captured.err)
+        assert error["error"] == "work_task_dir_missing"
+        assert "No fallback project directory exists" in error["message"]
+    else:
+        assert captured.err.startswith("error:")
 
 
 def test_task_dir_set_then_query_reflects_scope_override(

--- a/tests/integration/ops/test_task_dir_commands.py
+++ b/tests/integration/ops/test_task_dir_commands.py
@@ -117,7 +117,7 @@ def test_task_dir_cli_stale_work_warns_and_prints_fallback(
     assert exc_info.value.code == 0
     captured = capsys.readouterr()
     assert captured.out.strip() == project_root.resolve().as_posix()
-    assert f"Falling back to {project_root.resolve()}" in captured.err
+    assert f"Using {project_root.resolve()} instead" in captured.err
     assert captured.err.startswith("warning:")
 
 

--- a/tests/integration/ops/test_task_dir_commands.py
+++ b/tests/integration/ops/test_task_dir_commands.py
@@ -61,6 +61,32 @@ def test_task_dir_query_uses_inherited_env_when_no_scope(
     assert output.source == "inherited"
 
 
+def test_task_dir_query_stale_work_falls_back_with_warning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = _seed_project(tmp_path)
+    monkeypatch.chdir(project_root)
+    runtime = build_runtime(project_root)
+    item = work_repository.create_work_item(
+        runtime.authority.project_state_dir, "stale-work", "", None
+    )
+    stale = tmp_path / "removed-worktree"
+    work_repository.update_work_item_task_dir(
+        runtime.authority.project_state_dir,
+        item.name,
+        task_dir=stale.as_posix(),
+    )
+    monkeypatch.setenv("MERIDIAN_ACTIVE_WORK_ID", item.name)
+
+    output = task_dir_sync(TaskDirInput())
+
+    assert output.task_dir == project_root.resolve().as_posix()
+    assert output.source == "project-root"
+    assert output.warning is not None
+    assert stale.as_posix() in output.warning
+
+
 def test_task_dir_set_then_query_reflects_scope_override(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integration/state/test_reaper_reconciliation.py
+++ b/tests/integration/state/test_reaper_reconciliation.py
@@ -585,8 +585,14 @@ def test_reserve_then_prepare_mid_prep_kill_leaves_queued_row_reconciled(
         def warning(self, message: str) -> None:
             _ = message
 
-        def error(self, message: str, exit_code: int = 1) -> None:
-            _ = (message, exit_code)
+        def error(
+            self,
+            message: str,
+            *,
+            exit_code: int = 1,
+            name: str | None = None,
+        ) -> None:
+            _ = (message, exit_code, name)
 
         def heartbeat(self, message: str) -> None:
             _ = message

--- a/tests/smoke/spawn-dry-run.md
+++ b/tests/smoke/spawn-dry-run.md
@@ -198,7 +198,9 @@ uv run meridian spawn -a reviewer -p "stale worktree" --work smoke-task-dir --dr
 uv run meridian spawn -a reviewer -p "override stale worktree" \
   --work smoke-task-dir --task-dir "$OVERRIDE_DIR" --dry-run --json
 ```
-- [ ] First command exits 0, reports the project root as `task_cwd`, and includes a warning naming both stale `$TASK_DIR` and the project-root fallback destination
+- [ ] First command exits 0, reports the project root as `task_cwd`, and includes a
+      structured `warning` field naming both stale `$TASK_DIR` and the project-root
+      fallback destination; JSON mode writes no extra warning text to stderr
 - [ ] First command reports `task_cwd_source == "explicit-work-authority-root"`
 - [ ] Second command exits 0 with `task_cwd == "$OVERRIDE_DIR"` and no stale-path warning
 

--- a/tests/smoke/spawn-dry-run.md
+++ b/tests/smoke/spawn-dry-run.md
@@ -190,6 +190,18 @@ uv run meridian spawn -a reviewer -p "prefer explicit task dir" \
 - [ ] `task_cwd_source == "explicit-task-dir"`
 - [ ] resolved `reference_files` entry points at `$OVERRIDE_DIR/override.md`
 
+## Removed work-item task_dir falls back; explicit override still wins
+
+```bash
+rm -rf "$TASK_DIR"
+uv run meridian spawn -a reviewer -p "stale worktree" --work smoke-task-dir --dry-run --json
+uv run meridian spawn -a reviewer -p "override stale worktree" \
+  --work smoke-task-dir --task-dir "$OVERRIDE_DIR" --dry-run --json
+```
+- [ ] First command exits 0, reports the project root as `task_cwd`, and includes a warning naming `$TASK_DIR`
+- [ ] First command reports `task_cwd_source == "explicit-work-authority-root"`
+- [ ] Second command exits 0 with `task_cwd == "$OVERRIDE_DIR"` and no stale-path warning
+
 ## --task-dir requires existing directory
 
 ```bash

--- a/tests/smoke/spawn-dry-run.md
+++ b/tests/smoke/spawn-dry-run.md
@@ -198,7 +198,7 @@ uv run meridian spawn -a reviewer -p "stale worktree" --work smoke-task-dir --dr
 uv run meridian spawn -a reviewer -p "override stale worktree" \
   --work smoke-task-dir --task-dir "$OVERRIDE_DIR" --dry-run --json
 ```
-- [ ] First command exits 0, reports the project root as `task_cwd`, and includes a warning naming `$TASK_DIR`
+- [ ] First command exits 0, reports the project root as `task_cwd`, and includes a warning naming both stale `$TASK_DIR` and the project-root fallback destination
 - [ ] First command reports `task_cwd_source == "explicit-work-authority-root"`
 - [ ] Second command exits 0 with `task_cwd == "$OVERRIDE_DIR"` and no stale-path warning
 

--- a/tests/unit/cli/test_output.py
+++ b/tests/unit/cli/test_output.py
@@ -1,0 +1,41 @@
+"""CLI sink formatting contracts."""
+
+from __future__ import annotations
+
+import io
+import json
+
+from meridian.cli.output import JsonSink, TextSink
+
+
+def test_text_sink_error_ignores_machine_name() -> None:
+    stderr = io.StringIO()
+
+    TextSink(stderr=stderr).error("failed", exit_code=2, name="stable_name")
+
+    assert stderr.getvalue() == "error: failed\n"
+
+
+def test_json_sink_error_preserves_unnamed_and_named_shapes() -> None:
+    stderr = io.StringIO()
+    sink = JsonSink(stderr=stderr)
+
+    sink.error("plain failure", exit_code=2)
+    sink.error("named failure", exit_code=3, name="stable_name")
+
+    lines = [json.loads(line) for line in stderr.getvalue().splitlines()]
+    assert lines == [
+        {"error": "plain failure", "exit_code": 2},
+        {"error": "stable_name", "message": "named failure", "exit_code": 3},
+    ]
+
+
+def test_warning_shapes_match_output_mode() -> None:
+    text_stderr = io.StringIO()
+    json_stderr = io.StringIO()
+
+    TextSink(stderr=text_stderr).warning("heads up")
+    JsonSink(stderr=json_stderr).warning("heads up")
+
+    assert text_stderr.getvalue() == "warning: heads up\n"
+    assert json.loads(json_stderr.getvalue()) == {"warning": "heads up"}

--- a/tests/unit/cli/test_output.py
+++ b/tests/unit/cli/test_output.py
@@ -39,3 +39,31 @@ def test_warning_shapes_match_output_mode() -> None:
 
     assert text_stderr.getvalue() == "warning: heads up\n"
     assert json.loads(json_stderr.getvalue()) == {"warning": "heads up"}
+
+
+def test_json_sink_status_is_single_line_json() -> None:
+    stderr = io.StringIO()
+
+    JsonSink(stderr=stderr).status("first line\nsecond line")
+
+    assert stderr.getvalue() == '{"status":"first line\\nsecond line"}\n'
+    assert json.loads(stderr.getvalue()) == {"status": "first line\nsecond line"}
+
+
+def test_json_sink_heartbeat_is_single_line_json() -> None:
+    stderr = io.StringIO()
+
+    JsonSink(stderr=stderr).heartbeat("still\nworking")
+
+    assert stderr.getvalue() == '{"heartbeat":"still\\nworking"}\n'
+    assert json.loads(stderr.getvalue()) == {"heartbeat": "still\nworking"}
+
+
+def test_text_sink_status_and_heartbeat_remain_prose() -> None:
+    stderr = io.StringIO()
+    sink = TextSink(stderr=stderr)
+
+    sink.status("checking")
+    sink.heartbeat("still working")
+
+    assert stderr.getvalue() == "checking\nstill working\n"


### PR DESCRIPTION
## Why

Fixes #482. A work item's `task_dir` often points at a git worktree that is
removed after its branch merges (the documented post-dev flow). After removal,
every spawn under that work item hard-failed with a misleading
`pre_init_failed`, `meridian task-dir` crashed instead of diagnosing, and an
explicit `--task-dir` on spawn could not rescue the launch even though CLI
flags should win per documented config precedence.

## Goal

A stale work-item `task_dir` degrades gracefully: resolution falls back to the
next valid tier (inherited `MERIDIAN_TASK_DIR`, then project/authority root)
with a warning, explicit `--task-dir` always wins, `meridian task-dir` stays
usable as a diagnostic, and any remaining hard failure is named for what it is.

## Summary

- `resolve_task_cwd()` and `resolve_effective_task_dir()`
  (`src/meridian/lib/launch/cwd.py`) no longer raise on a stale work-item
  path: they skip the stale tier with a warning and fall through
  (inherited dir if valid → project/authority root). Fallback is read-time
  only — work state is never mutated on a read path.
- Root cause of the `--task-dir` precedence failure: `build_create_payload()`
  (`src/meridian/lib/ops/spawn/prepare.py`) derived the inheritable task dir
  before explicit-flag resolution, and that derivation raised on the stale
  work-item value. Explicit task-dir launches now skip the derivation.
- New `WorkTaskDirMissing` exception at the resolution seam, mapped to spawn
  error `work_task_dir_missing` in the pre-init boundary — raised only when
  even the fallback project root does not exist. Stale-task-dir failures no
  longer masquerade as `pre_init_failed`.
- Warnings ride the existing `warning` plumbing: spawn create output and
  `meridian task-dir` stderr.

## Resulting Behavior

With a work item whose `task_dir` was removed:

```
$ meridian task-dir
/home/user/gitrepos/project          # falls back, exit 0
warning: Work item 'x' task_dir no longer exists: /home/user/gitrepos/project.worktrees/merged. Using /home/user/gitrepos/project instead; run 'meridian work task-dir <dir>' to update it.

$ meridian spawn -a coder -p prompt.md            # launches in fallback dir + warning (was: pre_init_failed)
$ meridian spawn -a coder --task-dir ../other -p prompt.md   # explicit dir wins (was: pre_init_failed)
```

How spawn resolution falls back — a stale work-item tier is skipped with a warning instead of aborting the chain; the hard error remains only when every tier below is also gone:

```mermaid
flowchart TD
    S["spawn launch"] --> F{"--task-dir flag?"}
    F -->|"yes (must exist)"| UF["flag dir wins"]
    F -->|"no"| W{"work-item task_dir?"}
    W -->|"exists"| UW["use work-item dir"]
    W -->|"not set"| I{"inherited MERIDIAN_TASK_DIR valid?"}
    W -->|"path removed"| WARN["skip tier, warn"]
    WARN --> I
    I -->|"yes"| UI["use inherited dir"]
    I -->|"no"| C{"caller cwd outside project?"}
    C -->|"yes"| UC["use caller cwd"]
    C -->|"no"| P{"project root exists?"}
    P -->|"yes"| UP["use project root"]
    P -->|"no"| E["work_task_dir_missing"]
    classDef warn stroke:#e67e22,stroke-width:2px
    classDef err stroke:#e74c3c,stroke-width:2px
    WARN:::warn
    E:::err
```

`meridian task-dir` walks the same chain minus the flag and caller-cwd tiers (work item → inherited → project root).

## Changes

- `src/meridian/lib/launch/cwd.py` — fallback tiers + warning threading + `WorkTaskDirMissing`
- `src/meridian/lib/ops/spawn/prepare.py` — skip inheritable-dir derivation on explicit `--task-dir`; merge resolution warning into spawn warning output
- `src/meridian/lib/ops/spawn/pre_init.py` — distinct `work_task_dir_missing` error mapping
- `src/meridian/lib/ops/context.py`, `src/meridian/cli/task_dir_cmd.py` — `meridian task-dir` warns on stderr instead of crashing
- `src/meridian/lib/launch/__init__.py` — primary launches merge the resolution warning into `SpawnRequest.warning` (review finding: it was silently dropped)
- `src/meridian/cli/main.py`, `src/meridian/cli/output.py` — `WorkTaskDirMissing` surfaces through the sink error path with a machine-readable name: structured JSON error / clean `error:` line, no traceback (probe finding)
- Warning message names the fallback destination and the fix command
- CLI output consistency pass (user-requested): one warning convention — lowercase `warning:` on stderr via the sink — across spawn human output (was `Warning:` on stdout), artifact list, and missing-skills composition; JSON-mode stderr emissions are structured records — `{"warning": ...}`, `{"status": ...}`, `{"heartbeat": ...}` — never prose. `error()`/`named_error()` collapsed into one `error(message, exit_code=1, name=None)` on the `OutputSink` protocol — `name` is JSON-only machine metadata, text output byte-identical.
- Follow-up filed, not in this PR: a full output-consistency audit found the same conventions violated across older command surfaces — #488 tracks the sweep.
- Risk: callers relying on the old stale-path `ValueError` no longer see it; all existing valid-path precedence tests pass unchanged. Scripts scraping `Warning:` from spawn stdout must read stderr now.

## Work Item

release-patch-482-481

## Verification

- `uv run ruff check .` — pass
- `uv run pytest-llm` — 1414 passed, 2 skipped
- `uv run --extra dev python -m pyright` — 0 errors (12 pre-existing warnings)
- 11 new integration tests across the two commits: fallback+warn, explicit-wins ×2, effective-resolver fallback, task-dir query fallback, real-resolver `work_task_dir_missing`, primary-launch warning propagation, CLI-level task-dir warn/error (human + JSON). Initial batch written failing-first against the old behavior.
- Live CLI probe (isolated sandbox, real binary) of the original repro: stale worktree → `meridian task-dir` exits 0 with warning; spawn dry-run falls back (JSON + human); explicit `--task-dir` wins; valid-path behavior unchanged
- Independent review lane (correctness/regression): 1 blocking + 2 should-fix findings — all fixed in `bc97b4f8` and re-verified

## Knowledge Updates

- `CHANGELOG.md` `[Unreleased]` entry added
- `tests/smoke/spawn-dry-run.md` updated with the stale-task-dir scenarios
- `src/meridian/cli/.context/FUTURE` deleted — the deferred warning-output inconsistency was fixed in-branch instead
- `src/meridian/lib/launch/.context/CONTEXT.md` — fallback semantics, warning-threading trap (`request_updates` excludes resolver warnings), premature-derivation trap
- KB repo: superseded the old "stale worktree = hard error" decision; corrected 6 stale pages (architecture, troubleshooting, reference-resolution, work-items, index); `work_task_dir_missing` troubleshooting section added

## Spawn Trace

- p5887 explorer — mapped task_dir resolution chain
- p5889 coder — implemented fix + tests
- p5890 reviewer — correctness/regression review (1 blocking, 2 should-fix)
- p5891 prober — live CLI repro of original failure modes (found traceback leak)
- p5892 coder — fix pass for review/probe findings
- p5896 coder — warning/error output consistency pass
- p5897 reviewer — full CLI output-consistency audit (residual drift → #488)
- p5899 coder — JsonSink status/heartbeat structured records
